### PR TITLE
修复：支持 WSL2 Docker 开发并统一编译会话路径

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,18 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # NOVITA_API_KEY=your-novita-api-key  # OpenAI-compatible, see https://novita.ai
 # MINIMAX_API_KEY=your-minimax-api-key  # OpenAI-compatible, see https://platform.minimax.io
 # VLLM_API_KEY=your-vllm-api-key  # OpenAI-compatible
+
+# Optional Docker build mirrors and network timeout. These are useful in WSL2
+# or restricted networks and are consumed by scripts/docker.sh and Compose.
+# APT_MIRROR=mirrors.aliyun.com
+# NPM_REGISTRY=https://registry.npmmirror.com
+# UV_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+# Compile-image proxies must be reachable from inside a Docker build container.
+# Do not use a WSL-only 127.0.0.1 proxy address here.
+# COMPILE_HTTP_PROXY=http://proxy-host-reachable-from-docker:7897
+# COMPILE_HTTPS_PROXY=http://proxy-host-reachable-from-docker:7897
+UV_HTTP_TIMEOUT=600
+
 # FEISHU_APP_ID=your-feishu-app-id
 # FEISHU_APP_SECRET=your-feishu-app-secret
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ extensions_config.json
 coverage.xml
 coverage/
 .deer-flow/
+.compile-sessions/
 .claude/
 skills/custom/*
 logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 `make dev` 拉起 4 个进程，通过 nginx 统一入口：
 
 ```
-浏览器 → nginx :2026 ┬→ frontend (Next.js)   :3000   非 API 请求
+浏览器 → nginx :8000 ┬→ frontend (Next.js)   :3000   非 API 请求
                     ├→ gateway (FastAPI)     :8001   /api/*（models / skills / memory / uploads / threads / artifacts）
                     └→ langgraph server      :2024   /api/langgraph/*（agent 运行时）
 ```
@@ -42,7 +42,7 @@ make check          # 检查 node/pnpm/uv/nginx 是否就位
 make config         # 首次生成 config.yaml（已存在则中止，非幂等）
 make config-upgrade # 把 config.example.yaml 新增字段合并进现有 config.yaml
 make install        # 安装前后端依赖（backend: uv sync，frontend: pnpm install）
-make dev            # 启动全部服务，访问 http://localhost:2026
+make dev            # 启动全部服务，访问 http://localhost:8000
 make dev-daemon     # 后台启动，日志写到 logs/*.log
 make stop           # 停所有本机服务
 make clean          # stop + 清空 backend/.deer-flow/、backend/.langgraph_api/、logs/

--- a/Install.md
+++ b/Install.md
@@ -20,9 +20,55 @@ agent 会自动按下面的流程执行。
 
 在用户机器上以最低风险路径搭出 Forge-AutoCompiler 本地开发工作区。
 
+## Windows + WSL2（推荐路径）
+
+Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。推荐在 WSL2 Ubuntu 中运行仓库命令，由 Docker Desktop 提供 Linux 容器引擎。已有 WSL 原生 Docker Engine 也可以使用，但不要把它和 Docker Desktop daemon 混用：两边的镜像、网络和容器互不可见。
+
+1. 选择一套 Docker daemon。推荐安装并启动 Docker Desktop，在 **Settings > Resources > WSL Integration** 中启用 Ubuntu；若明确使用 WSL 原生 Docker Engine，则确认 Docker 服务和 Compose v2 插件已启动，不要同时混用两套 daemon。
+2. 进入 WSL：
+
+   ```powershell
+   wsl -d Ubuntu
+   ```
+
+3. 在 WSL 中安装最小宿主依赖。此命令需要用户明确执行，不会由脚本静默运行：
+
+   ```bash
+   sudo apt update && sudo apt install -y build-essential git python3
+   ```
+
+4. 在仓库根运行预检：
+
+   ```bash
+   ./scripts/wsl-check.sh
+   # 或 make wsl-check
+   ```
+
+5. 首次生成配置并启动 Docker 开发环境：
+
+   ```bash
+   make config
+   # 编辑 config.yaml，配置至少一个模型和对应环境变量
+   make compile-image
+   make docker-start
+   ```
+
+6. 访问 <http://localhost:8000>。停止服务使用 `make docker-stop`。
+
+仓库放在 `/mnt/c/...`、`/mnt/d/...` 等 Windows 挂载目录时可以运行，但文件监听和依赖安装通常慢于 WSL 自己的 `~/src`。编译 Session 会持久化在仓库根的 `.compile-sessions/`。
+
+常见故障：
+
+- `docker: command not found`：没有为当前发行版启用 Docker Desktop WSL Integration，也没有安装 WSL 原生 Docker Engine。
+- `Docker daemon is not reachable`：Docker Desktop 尚未启动完成，或 WSL 原生 Docker 服务没有启动。
+- `make: command not found`：安装 `build-essential`。
+- 构建镜像下载依赖超时：在根目录 `.env` 中按网络情况设置 `NPM_REGISTRY`、`UV_INDEX_URL` 或 `APT_MIRROR`；`UV_HTTP_TIMEOUT` 默认是 600 秒。
+- 编译镜像需要代理时使用 `COMPILE_HTTP_PROXY` / `COMPILE_HTTPS_PROXY`；不要填写容器内不可达的 WSL `127.0.0.1` 代理地址。
+- 不要在启用 Docker Desktop 集成后，再在 WSL 内同时启动第二套 Docker daemon。若明确使用 WSL 原生 Docker，请始终在同一个 WSL 发行版中运行 `make` 和 `docker`；保持该 WSL 会话运行，Windows 侧的 `docker.exe` 看不到这些容器。
+
 **默认优先级**：
 
-1. Docker 开发环境（推荐）
+1. Docker 开发环境（Windows 上通过 WSL2，推荐）
 2. 本机原生开发环境
 
 **不要假设** API key / 模型凭据已经就位。能安全准备的都准备好，最后简洁汇报还缺什么。
@@ -100,9 +146,13 @@ agent 会自动按下面的流程执行。
 
 ## 关于编译镜像
 
-Forge-AutoCompiler 的编译能力依赖一个 GCC/Clang 工具链镜像，默认 `autocompiler:gcc13`。安装阶段**不要**自动拉这个镜像（它可能很大）；只要在汇报里提醒用户：
+Forge-AutoCompiler 的编译能力依赖 GCC 工具链镜像，默认 `autocompiler:gcc13`。镜像定义已放在 `docker/compile/Dockerfile`，首次编译前运行：
 
-> 第一次跑编译前请确保 `autocompiler:gcc13`（或你在 `config.yaml` 中指定的镜像）已 `docker pull` 到本机。
+```bash
+make compile-image
+```
+
+镜像可能较大，安装 Agent 未获授权时不要自动构建；但不能把“服务已启动”等同于“编译链路已就绪”。
 
 ## 环境变量提示
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # DeerFlow - Unified Development Environment
 
-.PHONY: help config config-upgrade check install dev dev-pro dev-daemon dev-daemon-pro start start-pro start-daemon start-daemon-pro stop up up-pro down clean docker-init docker-start docker-start-pro docker-stop docker-logs docker-logs-frontend docker-logs-gateway
+.PHONY: help config config-upgrade check wsl-check compile-image install dev dev-pro dev-daemon dev-daemon-pro start start-pro start-daemon start-daemon-pro stop up up-pro down clean docker-init docker-start docker-start-pro docker-stop docker-logs docker-logs-frontend docker-logs-gateway
 
 BASH ?= bash
 
@@ -17,6 +17,8 @@ help:
 	@echo "  make config          - Generate local config files (aborts if config already exists)"
 	@echo "  make config-upgrade  - Merge new fields from config.example.yaml into config.yaml"
 	@echo "  make check           - Check if all required tools are installed"
+	@echo "  make wsl-check       - Check WSL2 and Docker prerequisites"
+	@echo "  make compile-image   - Build the C/C++ compile runtime image"
 	@echo "  make install         - Install all dependencies (frontend + backend)"
 	@echo "  make setup-sandbox   - Pre-pull sandbox container image (recommended)"
 	@echo "  make dev             - Start all services in development mode (with hot-reloading)"
@@ -31,13 +33,13 @@ help:
 	@echo "  make clean           - Clean up processes and temporary files"
 	@echo ""
 	@echo "Docker Production Commands:"
-	@echo "  make up              - Build and start production Docker services (localhost:2026)"
+	@echo "  make up              - Build and start production Docker services (localhost:8000)"
 	@echo "  make up-pro          - Build and start production Docker in Gateway mode (experimental)"
 	@echo "  make down            - Stop and remove production Docker containers"
 	@echo ""
 	@echo "Docker Development Commands:"
 	@echo "  make docker-init     - Pull the sandbox image"
-	@echo "  make docker-start    - Start Docker services (mode-aware from config.yaml, localhost:2026)"
+	@echo "  make docker-start    - Start Docker services (mode-aware from config.yaml, localhost:8000)"
 	@echo "  make docker-start-pro - Start Docker in Gateway mode (experimental, no LangGraph container)"
 	@echo "  make docker-stop     - Stop Docker development services"
 	@echo "  make docker-logs     - View Docker development logs"
@@ -53,6 +55,17 @@ config-upgrade:
 # Check required tools
 check:
 	@$(PYTHON) ./scripts/check.py
+
+wsl-check:
+	@$(BASH) ./scripts/wsl-check.sh
+
+compile-image:
+	@set -a; [ ! -f .env ] || . ./.env; set +a; \
+		docker build \
+			--build-arg APT_MIRROR="$${APT_MIRROR:-}" \
+			--build-arg HTTP_PROXY="$${COMPILE_HTTP_PROXY:-}" \
+			--build-arg HTTPS_PROXY="$${COMPILE_HTTPS_PROXY:-}" \
+			-t "$${COMPILE_IMAGE:-autocompiler:gcc13}" docker/compile
 
 # Install all dependencies
 install:

--- a/README_zh.md
+++ b/README_zh.md
@@ -42,6 +42,26 @@
 
 ## 快速开始
 
+### Windows + WSL2
+
+Windows 用户请在 WSL2 Ubuntu 中运行项目。推荐使用 Docker Desktop 的 WSL Integration；也支持有意安装在 WSL 内的 Docker Engine，但所有构建和启动命令必须始终使用同一个 daemon。不要从 PowerShell 直接运行 Linux `.sh` 启动链。
+
+```powershell
+wsl -d Ubuntu
+```
+
+进入 WSL 后，在仓库根执行：
+
+```bash
+./scripts/wsl-check.sh
+make config             # 仅首次
+# 编辑 config.yaml 和所需模型环境变量
+make compile-image      # 首次构建 C/C++ 编译环境
+make docker-start
+```
+
+访问 <http://localhost:8000>。完整安装和故障排查见 [Install.md](Install.md#windows--wsl2推荐路径)。
+
 ### 前置
 
 - Node.js 22+
@@ -65,21 +85,21 @@ make config
 #    config.yaml 中以 $ 开头的值会从环境变量取
 export OPENAI_API_KEY="..."   # 或你用的模型对应的 key
 
-# 4. 编辑 config.yaml 中的 sandbox 段并确保宿主机上有编译镜像
-docker pull autocompiler:gcc13   # 或在 config.yaml 中改成你自己的镜像
+# 4. 构建默认编译镜像（或在任务中指定你自己的镜像）
+make compile-image
 
 # 5. 装依赖
 make install
 
 # 6. 启动
-make dev      # 本机模式，访问 http://localhost:2026
+make dev      # 本机模式，访问 http://localhost:8000
 # 或
 make docker-start   # Docker 开发模式
 ```
 
 ### 第一次跑
 
-打开 http://localhost:2026 ，在欢迎页随便点一张 Action Card（已预填示例任务）：
+打开 http://localhost:8000 ，在欢迎页随便点一张 Action Card（已预填示例任务）：
 
 - "克隆并编译 https://github.com/fmtlib/fmt"（CMake 项目）
 - "克隆并深度解析编译 https://github.com/grpc/grpc"（含 submodule 的复杂项目）
@@ -104,7 +124,7 @@ make clean     # stop 并清理本地缓存（.deer-flow/、logs/）
 ```
 浏览器
   ↓
-nginx :2026 ── 统一反代入口
+nginx :8000 ── 统一反代入口
   ├→ frontend (Next.js) :3000      非 API 请求
   ├→ gateway (FastAPI)   :8001     /api/*（models / skills / memory / uploads / threads / artifacts）
   └→ langgraph server    :2024     /api/langgraph/*（agent 运行时）

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,6 @@ FROM python:3.12-slim-bookworm AS builder
 
 ARG NODE_MAJOR=22
 ARG APT_MIRROR
-ARG UV_INDEX_URL
 
 # Optionally override apt mirror for restricted networks (e.g. APT_MIRROR=mirrors.aliyun.com)
 RUN if [ -n "${APT_MIRROR}" ]; then \
@@ -42,9 +41,12 @@ WORKDIR /app
 # Copy backend source code
 COPY backend ./backend
 
-# Install dependencies with cache mount
+# Install dependencies inside the image layer. This may resolve against a
+# configured mirror, but cannot rewrite the host checkout's lock file.
+ARG UV_INDEX_URL
+ARG UV_HTTP_TIMEOUT=600
 RUN --mount=type=cache,target=/root/.cache/uv \
-    sh -c "cd backend && UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple} uv sync"
+    sh -c "cd backend && UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple} UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT} uv sync"
 
 # ── Stage 2: Dev ──────────────────────────────────────────────────────────────
 # Retains compiler toolchain from builder so startup-time `uv sync` can build

--- a/backend/packages/harness/deerflow/compile/docker_runtime.py
+++ b/backend/packages/harness/deerflow/compile/docker_runtime.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_session_dir, get_host_workspace_dir
 from deerflow.compile.schemas import CommandResult, CompileSession, utc_now_iso
+from deerflow.config.paths import Paths
 
 DEFAULT_NETWORK = "compile_network_wwf_v1"
 CONTAINER_WORKSPACE_DIR = "/workspace"
@@ -13,7 +14,6 @@ CONTAINER_REPO_DIR = "/workspace/repo"
 CONTAINER_ARTIFACTS_DIR = "/artifacts"
 CONTAINER_LOGS_DIR = "/logs"
 CONTAINER_REPRO_DIR = "/repro"
-HOST_COMPILE_SESSIONS_DIRNAME = ".compile-sessions"
 
 
 @dataclass
@@ -28,30 +28,45 @@ class CompileDockerRuntime:
         self.config = config or RuntimeConfig()
         self.manager = manager
 
-    def _host_project_root(self) -> Path:
-        host_project_root = os.environ.get("HOST_PROJECT_ROOT", "").strip()
-        if not host_project_root:
-            raise ValueError("HOST_PROJECT_ROOT is not configured")
-        return Path(host_project_root)
+    def _paths(self) -> Paths:
+        manager_paths = getattr(self.manager, "paths", None)
+        return manager_paths or Paths()
 
-    def _host_session_dir(self, session: CompileSession) -> Path:
-        return self._host_project_root() / HOST_COMPILE_SESSIONS_DIRNAME / session.thread_id / session.session_id
+    def _host_session_dir(self, session: CompileSession) -> str:
+        return get_host_session_dir(session.session_id, session.thread_id, self._paths())
 
-    def _host_workspace_dir(self, session: CompileSession) -> Path:
-        return self._host_session_dir(session) / "workspace"
+    def _host_workspace_dir(self, session: CompileSession) -> str:
+        return get_host_workspace_dir(session.session_id, session.thread_id, self._paths())
 
-    def _host_artifacts_dir(self, session: CompileSession) -> Path:
-        return self._host_session_dir(session) / "artifacts"
+    def _host_artifacts_dir(self, session: CompileSession) -> str:
+        return get_host_artifacts_dir(session.session_id, session.thread_id, self._paths())
 
-    def _host_logs_dir(self, session: CompileSession) -> Path:
-        return self._host_session_dir(session) / "logs"
+    def _host_logs_dir(self, session: CompileSession) -> str:
+        return get_host_logs_dir(session.session_id, session.thread_id, self._paths())
 
-    def _host_repro_dir(self, session: CompileSession) -> Path:
-        return self._host_session_dir(session) / "repro"
+    def _host_repro_dir(self, session: CompileSession) -> str:
+        return get_host_repro_dir(session.session_id, session.thread_id, self._paths())
 
     def _log(self, session: CompileSession, event: str, **payload) -> None:
         if self.manager is not None:
             self.manager.log_event(session, event, **payload)
+
+    def _ensure_network(self) -> None:
+        inspect_command = ["docker", "network", "inspect", self.config.network]
+        inspected = subprocess.run(inspect_command, check=False, capture_output=True, text=True)
+        if inspected.returncode == 0:
+            return
+
+        create_command = ["docker", "network", "create", self.config.network]
+        created = subprocess.run(create_command, check=False, capture_output=True, text=True)
+        if created.returncode == 0:
+            return
+
+        # Another process may have created the network between inspect and create.
+        inspected = subprocess.run(inspect_command, check=False, capture_output=True, text=True)
+        if inspected.returncode != 0:
+            error = created.stderr.strip() or inspected.stderr.strip() or "unknown Docker error"
+            raise RuntimeError(f"Failed to create Docker network {self.config.network!r}: {error}")
 
     def create_container(self, session: CompileSession) -> str:
         if session.container_id:
@@ -63,6 +78,7 @@ class CompileDockerRuntime:
             )
             return session.container_id
 
+        self._ensure_network()
         host_workspace_dir = self._host_workspace_dir(session)
         host_artifacts_dir = self._host_artifacts_dir(session)
         host_logs_dir = self._host_logs_dir(session)

--- a/backend/packages/harness/deerflow/config/paths.py
+++ b/backend/packages/harness/deerflow/config/paths.py
@@ -7,7 +7,6 @@ from pathlib import Path, PureWindowsPath
 # Virtual path prefix seen by agents inside the sandbox
 VIRTUAL_PATH_PREFIX = "/mnt/user-data"
 DEFAULT_WORKSPACE_ROOT = Path("/workspace")
-DEFAULT_HOST_WORKSPACE_ROOT = "/mnt/usr/jyh_wwf/LLM-AutoCompiler-v2"
 
 _SAFE_THREAD_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
@@ -24,16 +23,28 @@ def _default_local_base_dir() -> Path:
     return backend_dir / ".deer-flow"
 
 
+def _default_repo_root() -> Path:
+    """Return the repository root for native development."""
+    return Path(__file__).resolve().parents[5]
+
+
 def _default_workspace_root() -> Path:
-    """Return the mounted workspace root inside the current container."""
-    return DEFAULT_WORKSPACE_ROOT
+    """Return the process-visible workspace root."""
+    if Path(DEFAULT_WORKSPACE_ROOT).is_dir():
+        return DEFAULT_WORKSPACE_ROOT
+    return _default_repo_root()
 
 
 def _default_host_workspace_root_str() -> str:
     """Return the host-visible workspace root corresponding to `/workspace`."""
     if env := os.getenv("DEER_FLOW_HOST_WORKSPACE_ROOT"):
         return env
-    return DEFAULT_HOST_WORKSPACE_ROOT
+    # Backward compatibility for the original compile runtime variable.
+    if legacy_env := os.getenv("HOST_PROJECT_ROOT"):
+        return legacy_env
+    if workspace_env := os.getenv("DEER_FLOW_WORKSPACE_ROOT"):
+        return workspace_env
+    return str(_default_workspace_root())
 
 
 def _validate_thread_id(thread_id: str) -> str:
@@ -76,8 +87,15 @@ def resolve_path(path: str | Path, *, base_dir: str | Path | None = None) -> Pat
 
 
 class Paths:
-    def __init__(self, base_dir: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        base_dir: str | Path | None = None,
+        workspace_root: str | Path | None = None,
+        host_workspace_root: str | None = None,
+    ) -> None:
         self._base_dir = Path(base_dir).resolve() if base_dir is not None else None
+        self._workspace_root_override = Path(workspace_root).resolve() if workspace_root is not None else None
+        self._host_workspace_root_override = host_workspace_root
 
     @property
     def host_base_dir(self) -> Path:
@@ -91,12 +109,20 @@ class Paths:
         return str(self.base_dir)
 
     def _workspace_root(self) -> Path:
+        if self._workspace_root_override is not None:
+            return self._workspace_root_override
         if env_workspace := os.getenv("DEER_FLOW_WORKSPACE_ROOT"):
             return Path(env_workspace).resolve()
         return _default_workspace_root()
 
     def _host_workspace_root_str(self) -> str:
+        if self._host_workspace_root_override is not None:
+            return self._host_workspace_root_override
         return _default_host_workspace_root_str()
+
+    def host_workspace_root_str(self) -> str:
+        """Return the workspace root as seen by the host Docker daemon."""
+        return self._host_workspace_root_str()
 
     @property
     def compile_sessions_dir(self) -> Path:

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -2,8 +2,9 @@ from pathlib import Path
 
 import pytest
 
+from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.paths import get_compile_sessions_root, get_metadata_path, get_session_dir
+from deerflow.compile.paths import get_compile_sessions_root, get_host_session_dir, get_host_workspace_dir, get_metadata_path, get_session_dir
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CompileSession
 from deerflow.config.paths import Paths
 
@@ -15,8 +16,16 @@ def isolate_compile_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("DEER_FLOW_HOST_WORKSPACE_ROOT", str(workspace_root))
 
 
+def make_test_paths(tmp_path: Path, *, host_workspace_root: str | None = None) -> Paths:
+    return Paths(
+        base_dir=tmp_path / ".deer-flow",
+        workspace_root=tmp_path / "service-workspace",
+        host_workspace_root=host_workspace_root or str(tmp_path / "host-workspace"),
+    )
+
+
 def test_create_session_creates_expected_directory_layout(tmp_path: Path):
-    manager = CompileSessionManager(paths=Paths(base_dir=tmp_path / ".deer-flow"))
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
 
     session = manager.create_session(thread_id="thread-1", repo_url="https://example.com/repo.git", branch="main")
 
@@ -30,7 +39,7 @@ def test_create_session_creates_expected_directory_layout(tmp_path: Path):
 
 
 def test_create_session_under_compile_sessions_root(tmp_path: Path):
-    paths = Paths(base_dir=tmp_path / ".deer-flow")
+    paths = make_test_paths(tmp_path)
     manager = CompileSessionManager(paths=paths)
 
     session = manager.create_session(thread_id="abc", repo_url="https://example.com/repo.git")
@@ -38,10 +47,12 @@ def test_create_session_under_compile_sessions_root(tmp_path: Path):
     compile_root = get_compile_sessions_root(paths)
     session_dir = get_session_dir(session.session_id, session.thread_id, paths)
     assert session_dir == compile_root / "abc" / session.session_id
+    assert Path(session.metadata_path).parent == session_dir
+    assert get_host_session_dir(session.session_id, session.thread_id, paths).startswith(paths.host_workspace_root_str())
 
 
 def test_save_and_load_session_roundtrip(tmp_path: Path):
-    manager = CompileSessionManager(paths=Paths(base_dir=tmp_path / ".deer-flow"))
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-2", repo_url="https://example.com/repo.git")
     session.container_id = "container-123"
     session.container_name = "demo-container"
@@ -62,10 +73,61 @@ def test_save_and_load_session_roundtrip(tmp_path: Path):
 
 
 def test_mark_status_sets_completed_at_for_terminal_state(tmp_path: Path):
-    manager = CompileSessionManager(paths=Paths(base_dir=tmp_path / ".deer-flow"))
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-3", repo_url="https://example.com/repo.git")
 
     manager.mark_session_status(session, "completed", summary="ok")
 
     assert session.completed_at is not None
     assert session.summary == "ok"
+
+
+def test_host_workspace_path_preserves_windows_style(tmp_path: Path):
+    paths = make_test_paths(tmp_path, host_workspace_root=r"C:\Users\developer\Forge-AutoCompiler")
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="windows-thread", repo_url="https://example.com/repo.git")
+
+    assert get_host_workspace_dir(session.session_id, session.thread_id, paths) == (rf"C:\Users\developer\Forge-AutoCompiler\.compile-sessions\windows-thread\{session.session_id}\workspace")
+
+
+def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypatch):
+    host_root = tmp_path / "docker-host"
+    paths = make_test_paths(tmp_path, host_workspace_root=str(host_root))
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-runtime", repo_url="https://example.com/repo.git")
+    runtime = CompileDockerRuntime(manager=manager)
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+
+    runtime.create_container(session)
+
+    docker_command = next(command for command in commands if command[:2] == ["docker", "run"])
+    assert ["docker", "network", "inspect", DEFAULT_NETWORK] in commands
+    assert f"{host_root / '.compile-sessions' / session.thread_id / session.session_id / 'workspace'}:/workspace" in docker_command
+    assert "HOST_PROJECT_ROOT" not in docker_command
+
+
+def test_docker_runtime_creates_missing_network(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-network", repo_url="https://example.com/repo.git")
+    runtime = CompileDockerRuntime(manager=manager)
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        if command[:3] == ["docker", "network", "inspect"]:
+            return type("Result", (), {"stdout": "", "stderr": "not found", "returncode": 1})()
+        return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+
+    runtime.create_container(session)
+
+    assert ["docker", "network", "create", DEFAULT_NETWORK] in commands

--- a/backend/tests/test_config_version.py
+++ b/backend/tests/test_config_version.py
@@ -123,3 +123,12 @@ def test_newer_user_version_no_warning(caplog):
                 config_path,
             )
         assert "outdated" not in caplog.text
+
+
+def test_example_config_is_valid_app_config():
+    """The checked-in template must be loadable before users copy it."""
+    config_path = Path(__file__).resolve().parents[2] / "config.example.yaml"
+
+    config = AppConfig.from_file(str(config_path))
+
+    assert config.models == []

--- a/backend/tests/test_docker_compose_compile_paths.py
+++ b/backend/tests/test_docker_compose_compile_paths.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose-dev.yaml"
+
+
+def test_compile_session_mount_and_path_contract_are_applied_to_both_runtimes():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert compose.count("${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions") == 2
+    assert compose.count("DEER_FLOW_WORKSPACE_ROOT=/workspace") == 2
+    assert compose.count("DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}") == 2
+    assert compose.count("HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}") == 2
+
+
+def test_documented_docker_port_matches_compose_mapping():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert '"8000:8000"' in compose
+    assert "localhost:2026" not in compose
+
+
+def test_langgraph_runtime_variables_are_not_expanded_by_compose():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert "$${LANGGRAPH_ALLOW_BLOCKING:-0}" in compose
+    assert "$${allow_blocking}" in compose
+    assert "$${LANGGRAPH_JOBS_PER_WORKER:-10}" in compose
+
+
+def test_backend_build_and_runtime_receive_uv_timeout():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert compose.count("UV_HTTP_TIMEOUT: ${UV_HTTP_TIMEOUT:-600}") == 2
+    assert compose.count("UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}") == 2
+    assert compose.count("uv sync --frozen") == 4
+    assert compose.count("uv run --frozen") == 2

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,7 +33,7 @@ token_usage:
 # ============================================================================
 # Configure available LLM models for the agent to use
 
-models:
+models: []
   # Example: Volcengine (Doubao) model
   # - name: doubao-seed-1.8
   #   display_name: Doubao-Seed-1.8

--- a/docker/compile/Dockerfile
+++ b/docker/compile/Dockerfile
@@ -1,0 +1,79 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_MIRROR=
+ARG HTTP_PROXY=
+ARG HTTPS_PROXY=
+
+ENV TZ=Asia/Shanghai \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    CC=gcc-13 \
+    CXX=g++-13
+
+RUN set -eux; \
+    if [ -n "$APT_MIRROR" ]; then \
+      sed -i \
+        -e "s|http://archive.ubuntu.com/ubuntu|http://$APT_MIRROR/ubuntu|g" \
+        -e "s|http://security.ubuntu.com/ubuntu|http://$APT_MIRROR/ubuntu|g" \
+        /etc/apt/sources.list.d/ubuntu.sources; \
+    fi; \
+    if [ -n "$HTTP_PROXY" ]; then \
+      printf 'Acquire::http::Proxy "%s";\n' "$HTTP_PROXY" > /etc/apt/apt.conf.d/90proxy; \
+    fi; \
+    if [ -n "$HTTPS_PROXY" ]; then \
+      printf 'Acquire::https::Proxy "%s";\n' "$HTTPS_PROXY" >> /etc/apt/apt.conf.d/90proxy; \
+    fi; \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "120";\nAcquire::https::Timeout "120";\n' > /etc/apt/apt.conf.d/80-retries; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      autoconf \
+      automake \
+      bash \
+      bison \
+      build-essential \
+      ca-certificates \
+      ccache \
+      cmake \
+      curl \
+      file \
+      flex \
+      g++-13 \
+      gcc-13 \
+      gdb \
+      gettext \
+      git \
+      libbz2-dev \
+      libcurl4-openssl-dev \
+      libffi-dev \
+      liblzma-dev \
+      libncurses-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libtool \
+      libxml2-dev \
+      libxslt1-dev \
+      m4 \
+      make \
+      meson \
+      ninja-build \
+      patch \
+      pkg-config \
+      python3 \
+      python3-pip \
+      python3-venv \
+      rsync \
+      tar \
+      unzip \
+      uuid-dev \
+      wget \
+      xz-utils \
+      zlib1g-dev; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130; \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 130; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -11,7 +11,7 @@
 # Prerequisites:
 #   - Kubernetes cluster + kubeconfig are only required when using provisioner mode.
 #
-# Access: http://localhost:2026
+# Access: http://localhost:8000
 
 services:
   # ── Sandbox Provisioner ────────────────────────────────────────────────
@@ -122,10 +122,14 @@ services:
         APT_MIRROR: ${APT_MIRROR:-}
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
+        UV_HTTP_TIMEOUT: ${UV_HTTP_TIMEOUT:-600}
     container_name: deer-flow-gateway
-    command: sh -c "{ cd backend && (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env'; } > /app/logs/gateway.log 2>&1"
+    command: sh -c "{ cd backend && (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && PYTHONPATH=. uv run --frozen uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env'; } > /app/logs/gateway.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
+      # CompileSessionManager writes through /workspace while compile containers
+      # bind the same directory using the host-visible DEER_FLOW_ROOT path.
+      - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - gateway-venv:/app/backend/.venv
@@ -154,6 +158,11 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - DEER_FLOW_WORKSPACE_ROOT=/workspace
+      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
+      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}
+      - UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple}
+      - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}
       - DEER_FLOW_CHANNELS_LANGGRAPH_URL=${DEER_FLOW_CHANNELS_LANGGRAPH_URL:-http://langgraph:2024}
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
@@ -179,10 +188,13 @@ services:
         APT_MIRROR: ${APT_MIRROR:-}
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
+        UV_HTTP_TIMEOUT: ${UV_HTTP_TIMEOUT:-600}
     container_name: deer-flow-langgraph
-    command: sh -c "cd backend && { (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && allow_blocking='' && if [ \"\${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run langgraph dev --no-browser \${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker \${LANGGRAPH_JOBS_PER_WORKER:-10}; } > /app/logs/langgraph.log 2>&1"
+    command: sh -c "cd backend && { (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && allow_blocking='' && if [ \"$${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run --frozen langgraph dev --no-browser $${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker $${LANGGRAPH_JOBS_PER_WORKER:-10}; } > /app/logs/langgraph.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
+      # Keep service-side session state and host Docker bind mounts aligned.
+      - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - langgraph-venv:/app/backend/.venv
@@ -211,6 +223,11 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - DEER_FLOW_WORKSPACE_ROOT=/workspace
+      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
+      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}
+      - UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple}
+      - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -12,6 +12,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DOCKER_DIR="$PROJECT_ROOT/docker"
 
+# The Compose services and nested compile containers both need the same path as
+# seen by the host Docker daemon. In WSL2 this is the WSL path to the checkout.
+export DEER_FLOW_ROOT="${DEER_FLOW_ROOT:-$PROJECT_ROOT}"
+
+# Load optional mirror and timeout settings used by Compose build arguments.
+# The same file is also injected into services through compose env_file.
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$PROJECT_ROOT/.env"
+    set +a
+fi
+
 # Docker Compose command with project name
 COMPOSE_CMD="docker compose -p deer-flow-dev -f docker-compose-dev.yaml"
 
@@ -166,6 +179,15 @@ start() {
     echo "=========================================="
     echo ""
 
+    if ! docker_available; then
+        echo -e "${YELLOW}Docker is not reachable.${NC}"
+        echo "Start Docker Desktop with WSL integration, or start the native WSL Docker service."
+        echo "Then rerun: make docker-start"
+        exit 1
+    fi
+
+    mkdir -p "$PROJECT_ROOT/.compile-sessions"
+
     sandbox_mode="$(detect_sandbox_mode)"
 
     if $gateway_mode; then
@@ -191,12 +213,8 @@ start() {
     fi
     echo ""
     
-    # Set DEER_FLOW_ROOT for provisioner if not already set
-    if [ -z "$DEER_FLOW_ROOT" ]; then
-        export DEER_FLOW_ROOT="$PROJECT_ROOT"
-        echo -e "${BLUE}Setting DEER_FLOW_ROOT=$DEER_FLOW_ROOT${NC}"
-        echo ""
-    fi
+    echo -e "${BLUE}Host workspace root: $DEER_FLOW_ROOT${NC}"
+    echo ""
     
     # Ensure config.yaml exists before starting.
     if [ ! -f "$PROJECT_ROOT/config.yaml" ]; then
@@ -244,13 +262,13 @@ start() {
     echo "  DeerFlow Docker is starting!"
     echo "=========================================="
     echo ""
-    echo "  🌐 Application: http://localhost:2026"
-    echo "  📡 API Gateway: http://localhost:2026/api/*"
+    echo "  🌐 Application: http://localhost:8000"
+    echo "  📡 API Gateway: http://localhost:8000/api/*"
     if $gateway_mode; then
         echo "  🤖 Runtime:     Gateway embedded"
         echo "  API:            /api/langgraph/* → Gateway (compat)"
     else
-        echo "  🤖 LangGraph:   http://localhost:2026/api/langgraph/*"
+        echo "  🤖 LangGraph:   http://localhost:8000/api/langgraph/*"
     fi
     echo ""
     echo "  📋 View logs: make docker-logs"
@@ -317,7 +335,7 @@ restart() {
     echo ""
     echo -e "${GREEN}✓ Docker services restarted${NC}"
     echo ""
-    echo "  🌐 Application: http://localhost:2026"
+    echo "  🌐 Application: http://localhost:8000"
     echo "  📋 View logs: make docker-logs"
     echo ""
 }

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -33,6 +33,13 @@ set -e
 REPO_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
 cd "$REPO_ROOT"
 
+# Native services and the host Docker daemon must agree on the compile-session
+# root. Docker Compose overrides the process-visible root with /workspace.
+export DEER_FLOW_WORKSPACE_ROOT="${DEER_FLOW_WORKSPACE_ROOT:-$REPO_ROOT}"
+export DEER_FLOW_HOST_WORKSPACE_ROOT="${DEER_FLOW_HOST_WORKSPACE_ROOT:-$DEER_FLOW_WORKSPACE_ROOT}"
+# Keep the legacy variable available for older extensions and local configs.
+export HOST_PROJECT_ROOT="${HOST_PROJECT_ROOT:-$DEER_FLOW_HOST_WORKSPACE_ROOT}"
+
 if [ -f "$REPO_ROOT/.env" ]; then
     set -a
     source "$REPO_ROOT/.env"

--- a/scripts/wsl-check.sh
+++ b/scripts/wsl-check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+missing=()
+
+echo "=========================================="
+echo "  Forge-AutoCompiler WSL2 Preflight"
+echo "=========================================="
+echo ""
+
+if ! grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null; then
+    echo "ERROR: This command must run inside WSL2."
+    echo "From PowerShell, enter WSL with: wsl -d Ubuntu"
+    exit 1
+fi
+
+echo "Distribution: ${WSL_DISTRO_NAME:-unknown}"
+echo "Repository:   $PROJECT_ROOT"
+echo ""
+
+for command in git make python3 docker; do
+    if command -v "$command" >/dev/null 2>&1; then
+        echo "OK: $command ($(command -v "$command"))"
+    else
+        echo "MISSING: $command"
+        missing+=("$command")
+    fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo ""
+    if [[ " ${missing[*]} " == *" make "* ]] || [[ " ${missing[*]} " == *" python3 "* ]] || [[ " ${missing[*]} " == *" git "* ]]; then
+        echo "Install the missing Linux prerequisites explicitly:"
+        echo "  sudo apt update && sudo apt install -y build-essential git python3"
+    fi
+    if [[ " ${missing[*]} " == *" docker "* ]]; then
+        echo "Enable Docker Desktop > Settings > Resources > WSL Integration for ${WSL_DISTRO_NAME:-this distribution},"
+        echo "or intentionally install Docker Engine inside this WSL distribution."
+    fi
+    exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+    echo "ERROR: Docker Compose v2 is unavailable in WSL."
+    echo "Enable Docker Desktop WSL integration or install the Compose v2 plugin for the WSL Docker Engine."
+    exit 1
+fi
+echo "OK: docker compose"
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: The Linux Docker daemon is not reachable from this WSL distribution."
+    echo "Start Docker Desktop, or start the native WSL Docker service, and rerun this check."
+    exit 1
+fi
+docker_os="$(docker info --format '{{.OperatingSystem}}' 2>/dev/null || echo unknown)"
+docker_context="$(docker context show 2>/dev/null || echo unknown)"
+echo "OK: Docker daemon ($docker_os; context=$docker_context)"
+echo "NOTE: Run all Forge Docker commands against this same daemon; Docker Desktop and native WSL images are not shared."
+
+if docker image inspect autocompiler:gcc13 >/dev/null 2>&1; then
+    echo "OK: compile image (autocompiler:gcc13)"
+else
+    echo "MISSING: compile image autocompiler:gcc13"
+    echo "Build it before the first compile task: make compile-image"
+fi
+
+if [[ "$PROJECT_ROOT" == /mnt/* ]]; then
+    echo ""
+    echo "NOTE: The repository is on a Windows-mounted drive ($PROJECT_ROOT)."
+    echo "This is supported, but cloning under ~/src usually gives faster file watching and dependency installs."
+fi
+
+echo ""
+echo "WSL2 + Docker prerequisites are ready."
+echo "Next: make config (first run), make compile-image, then make docker-start"


### PR DESCRIPTION
## 关联

Closes #1

## 根因

Windows 11 + WSL2 + Docker Desktop 的开发路径此前只完成了部分接线。Forge 主服务看到的 Compile Session 目录与宿主 Docker daemon 用于 bind mount 的目录可能不一致，`gateway`、`langgraph` 和独立编译容器因此无法稳定共享同一份工作区。同时，启动脚本缺少 WSL2 预检、Docker 可达性检查和编译镜像准备说明。

## 变更

- 增加幂等的 WSL2 预检脚本，检查 Linux 工具、Docker Compose v2、Docker daemon 和 `autocompiler:gcc13`。
- 统一 service workspace 与 host-visible workspace 路径契约，并兼容旧 `HOST_PROJECT_ROOT` 环境变量。
- 让 Gateway、LangGraph 与宿主 Docker daemon 共享 `${DEER_FLOW_ROOT}/.compile-sessions`。
- 编译容器启动前按需创建独立 Docker 网络，保留 DooD、Compile Session 与 clean replay 架构。
- 增加可追踪的 GCC 13 编译镜像及 Windows 路径、Docker bind mount、网络和 Compose 契约测试。
- 修正文档、开发端口、Compose 变量转义和依赖下载超时配置。

## 验证

- 聚焦测试：`18 passed`
- 后端全量测试：`1299 passed, 14 skipped`
- 后端 Ruff：check 与 format 均通过
- Shell：`docker.sh`、`serve.sh`、`wsl-check.sh` 语法检查通过
- Compose：`docker compose config --quiet` 通过
- 当前电脑 WSL2 预检通过，Ubuntu、Docker daemon、Compose v2 与 `autocompiler:gcc13` 均可用
- 原始 WSL2 验证中，嵌套 CMake 编译已生成 15,960 字节产物并输出 `forge-wsl-e2e-ok`
- `git diff --check` 与敏感信息扫描通过

## 边界

- 仍采用 WSL2 + Docker Compose/DooD 控制面。
- 每次编译继续使用独立编译容器，并保留 clean replay 验证。
- 不启动 v6 pilot，不修改 v1-v5 manifest、Schema、validator、runner 或 ledger。
- 不提交任何模型密钥。