### PR TITLE
修复：打通模型运行时与自动编译端到端流程

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,19 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # Do not use a WSL-only 127.0.0.1 proxy address here.
 # COMPILE_HTTP_PROXY=http://proxy-host-reachable-from-docker:7897
 # COMPILE_HTTPS_PROXY=http://proxy-host-reachable-from-docker:7897
+# Runtime proxy values are omitted from recorded Docker commands, but remain
+# visible inside the compile container and via docker inspect. Do not include
+# proxy credentials when compiling untrusted repositories. For Docker Desktop
+# bridge networking, use a reachable address such as host.docker.internal.
+# COMPILE_RUNTIME_HTTP_PROXY=http://host.docker.internal:7897
+# COMPILE_RUNTIME_HTTPS_PROXY=http://host.docker.internal:7897
+# COMPILE_RUNTIME_NO_PROXY=localhost,127.0.0.1
+# Host networking exposes WSL loopback services to repository build scripts.
+# Use it only for trusted repositories. 127.0.0.1 reaches a Windows proxy only
+# with mirrored networking; otherwise the proxy must run in the same WSL distro.
+# COMPILE_RUNTIME_NETWORK=host
+# COMPILE_RUNTIME_HTTP_PROXY=http://127.0.0.1:7897
+# COMPILE_RUNTIME_HTTPS_PROXY=http://127.0.0.1:7897
 UV_HTTP_TIMEOUT=600
 
 # FEISHU_APP_ID=your-feishu-app-id

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ make dev            # 启动全部服务，访问 http://localhost:8000
 make dev-daemon     # 后台启动，日志写到 logs/*.log
 make stop           # 停所有本机服务
 make clean          # stop + 清空 backend/.deer-flow/、backend/.langgraph_api/、logs/
-make docker-start   # Docker 开发环境（按 config.yaml 的 sandbox.mode 动态启动）
+make docker-start   # Docker 开发环境（C/C++ 编译容器按会话创建）
 make up             # 生产 docker-compose
 ```
 
@@ -128,7 +128,7 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 
 这是从 DeerFlow 继承下来的、**至今仍生效**的最重要架构不变量。
 
-- **`backend/packages/harness/deerflow/`** 是可发布框架包（`deerflow-harness`，导入前缀 `deerflow.*`）。包含 agent 运行时、中间件、sandbox、tools、MCP、models、skills、config，以及**全部编译核心**。
+- **`backend/packages/harness/deerflow/`** 是可发布框架包（`deerflow-harness`，导入前缀 `deerflow.*`）。包含 agent 运行时、中间件、tools、MCP、models、skills、config，以及**全部编译核心**。
 - **`backend/app/`** 是不发布的应用层（导入前缀 `app.*`）。包含 FastAPI Gateway 路由和 IM 渠道桥接（Feishu/Slack/Telegram）。
 
 **依赖方向**：`app` 可以导 `deerflow`；`deerflow` **严禁**导 `app`。由 `backend/tests/test_harness_boundary.py` 在 CI 强制；越线提交会直接挂。
@@ -139,7 +139,7 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 
 两份文件都在项目根（gitignored，从 `*.example.*` 复制）：
 
-- **`config.yaml`** — 模型、工具、tool groups、sandbox、memory、summarization、subagents、channels 等。有 `config_version` 字段（当前 `5`），schema 改动时在 `config.example.yaml` 里 +1，并提示用户跑 `make config-upgrade`。
+- **`config.yaml`** — 模型、工具、tool groups、memory、summarization、subagents、channels 等。有 `config_version` 字段（当前 `6`），schema 改动时在 `config.example.yaml` 里 +1，并提示用户跑 `make config-upgrade`。
 - **`extensions_config.json`** — MCP 服务器和 skills 开关，可通过 Gateway API 运行时改。
 
 值若以 `$` 开头按环境变量解析（如 `api_key: $OPENAI_API_KEY`）。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@
    ```bash
    make docker-start
    ```
-   `make docker-start` 会读 `config.yaml`，只在 sandbox mode 是 provisioner/Kubernetes 时才起 `provisioner` 容器。
+   `make docker-start` 会启动前端、Gateway、LangGraph 和 nginx；C/C++ 编译容器只在任务执行期间按会话创建。
 
    所有服务 hot-reload：
    - 前端：自动刷新

--- a/Install.md
+++ b/Install.md
@@ -64,6 +64,9 @@ Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。�
 - `make: command not found`：安装 `build-essential`。
 - 构建镜像下载依赖超时：在根目录 `.env` 中按网络情况设置 `NPM_REGISTRY`、`UV_INDEX_URL` 或 `APT_MIRROR`；`UV_HTTP_TIMEOUT` 默认是 600 秒。
 - 编译镜像需要代理时使用 `COMPILE_HTTP_PROXY` / `COMPILE_HTTPS_PROXY`；不要填写容器内不可达的 WSL `127.0.0.1` 代理地址。
+- 会话编译容器需要代理时使用 `COMPILE_RUNTIME_HTTP_PROXY` / `COMPILE_RUNTIME_HTTPS_PROXY` / `COMPILE_RUNTIME_NO_PROXY`。代理值对容器内构建脚本及 `docker inspect` 可见，不要在编译不可信仓库时填入带凭据的代理。
+- Docker Desktop bridge 模式使用容器可达地址。`COMPILE_RUNTIME_NETWORK=host` 只用于可信仓库，因为构建脚本将能访问 WSL 的 loopback 服务；`127.0.0.1` 仅在代理运行于同一 WSL，或 WSL 启用 mirrored networking 时才能到达目标代理。
+- 当前容器内 clone 只验证了公开 HTTPS 仓库，不会继承宿主 Git credential helper、SSH agent 或 `known_hosts`。不要把 token 写进仓库 URL，因为 URL 会进入 session 日志。
 - 不要在启用 Docker Desktop 集成后，再在 WSL 内同时启动第二套 Docker daemon。若明确使用 WSL 原生 Docker，请始终在同一个 WSL 发行版中运行 `make` 和 `docker`；保持该 WSL 会话运行，Windows 侧的 `docker.exe` 看不到这些容器。
 
 **默认优先级**：

--- a/README_zh.md
+++ b/README_zh.md
@@ -211,7 +211,7 @@ repro/build.sh            # 验证通过后生成的可执行构建脚本
 
 - `config.yaml` 在项目根，从 `config.example.yaml` 复制。schema 升级跑 `make config-upgrade`。
 - 至少需要一个可用的 LLM 模型条目（`models[]`）。
-- 编译镜像在 `config.yaml` 的 `sandbox` 段（或在 `compile/manager.py` 的 `DEFAULT_COMPILE_IMAGE` 兜底）。
+- C/C++ 编译会话使用独立的 `autocompiler:gcc13` 镜像；首次运行前执行 `make compile-image`。
 - 宿主机必须设 `HOST_PROJECT_ROOT` 环境变量（本机模式由启动脚本注入；自己手动跑后端时要自己 export）。
 
 ---

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -180,7 +180,7 @@ Lead Agent 的提示词刻意**不**把详细编译流程写进去，避免污�
 
 - 第一次启动后 `get_app_config()` 缓存
 - 文件路径变化或 mtime 变大时自动重载（无需重启）
-- `config_version` 当前 5；schema 改时在 `config.example.yaml` +1，用户跑 `make config-upgrade` 自动合并
+- `config_version` 当前 6；schema 改时在 `config.example.yaml` +1，用户跑 `make config-upgrade` 自动合并
 - `$VAR` 占位符在加载时被环境变量替换
 
 关键段落与其消费者：
@@ -189,7 +189,7 @@ Lead Agent 的提示词刻意**不**把详细编译流程写进去，避免污�
 |---|---|
 | `models[]` | `deerflow.models.factory.create_chat_model` |
 | `tools[]` / `tool_groups[]` | `deerflow.tools.builtins.tool_search`、Lead Agent `get_available_tools` |
-| `sandbox` | `deerflow.sandbox.middleware`、Docker 模式选择 |
+| `sandbox` | v6 兼容字段，应为 `null`；C/C++ 构建隔离由 `deerflow.compile` 管理 |
 | `memory` | `deerflow.agents.memory.*` |
 | `summarization` | Lead Agent 中的 `SummarizationMiddleware` |
 | `subagents` | `deerflow.subagents.config` |

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -191,73 +191,26 @@ tools:
     # api_key: $TAVILY_API_KEY  # Optional
 ```
 
-**Built-in Tools**:
-- `web_search` - Search the web (Tavily)
-- `web_fetch` - Fetch web pages (Jina AI)
-- `ls` - List directory contents
-- `read_file` - Read file contents
-- `write_file` - Write file contents
-- `str_replace` - String replacement in files
-- `bash` - Execute bash commands
+**Built-in Forge tools**:
+- `host_read` - Read a UTF-8 file visible to the service process
+- `host_write` - Write a file visible to the service process
+- `prepare_compile_session` - Create a dedicated C/C++ compile session and container
+- `clone_repository` - Clone a repository into the currently bound compile session
+- `identify_build_system` - Detect CMake, Make, or Autotools metadata
+- `task` - Delegate build execution to the compiler subagent when subagents are enabled
+- `finalize_session` - Finalize logs, artifacts, and the reproduction bundle
 
-### Sandbox
+`host_read` and `host_write` operate directly on the service filesystem and are intended for trusted, single-user deployments. They are registered by the harness and do not need entries under `tools`.
 
-DeerFlow supports multiple sandbox execution modes. Configure your preferred mode in `config.yaml`:
+### Execution Isolation
 
-**Local Execution** (runs sandbox code directly on the host machine):
-```yaml
-sandbox:
-   use: deerflow.sandbox.local:LocalSandboxProvider # Local execution
-   allow_host_bash: false # default; host bash is disabled unless explicitly re-enabled
-```
-
-**Docker Execution** (runs sandbox code in isolated Docker containers):
-```yaml
-sandbox:
-   use: deerflow.community.aio_sandbox:AioSandboxProvider # Docker-based sandbox
-```
-
-**Docker Execution with Kubernetes** (runs sandbox code in Kubernetes pods via provisioner service):
-
-This mode runs each sandbox in an isolated Kubernetes Pod on your **host machine's cluster**. Requires Docker Desktop K8s, OrbStack, or similar local K8s setup.
+Forge no longer ships the legacy general-purpose `deerflow.sandbox` or `AioSandboxProvider` implementations. Keep the compatibility field disabled:
 
 ```yaml
-sandbox:
-   use: deerflow.community.aio_sandbox:AioSandboxProvider
-   provisioner_url: http://provisioner:8002
+sandbox: null
 ```
 
-When using Docker development (`make docker-start`), DeerFlow starts the `provisioner` service only if this provisioner mode is configured. In local or plain Docker sandbox modes, `provisioner` is skipped.
-
-See [Provisioner Setup Guide](../../docker/provisioner/README.md) for detailed configuration, prerequisites, and troubleshooting.
-
-Choose between local execution or Docker-based isolation:
-
-**Option 1: Local Sandbox** (default, simpler setup):
-```yaml
-sandbox:
-  use: deerflow.sandbox.local:LocalSandboxProvider
-  allow_host_bash: false
-```
-
-`allow_host_bash` is intentionally `false` by default. DeerFlow's local sandbox is a host-side convenience mode, not a secure shell isolation boundary. If you need `bash`, prefer `AioSandboxProvider`. Only set `allow_host_bash: true` for fully trusted single-user local workflows.
-
-**Option 2: Docker Sandbox** (isolated, more secure):
-```yaml
-sandbox:
-  use: deerflow.community.aio_sandbox:AioSandboxProvider
-  port: 8080
-  auto_start: true
-  container_prefix: deer-flow-sandbox
-
-  # Optional: Additional mounts
-  mounts:
-    - host_path: /path/on/host
-      container_path: /path/in/container
-      read_only: false
-```
-
-When you configure `sandbox.mounts`, DeerFlow exposes those `container_path` values in the agent prompt so the agent can discover and operate on mounted directories directly instead of assuming everything must live under `/mnt/user-data`.
+C/C++ repository commands do not run through these host file tools. The compile workflow creates a dedicated Docker container for each compile session, binds only its session directories, and exposes the restricted `run_container_bash` and `submit_build_result` tools to the compiler subagent.
 
 ### Skills
 

--- a/backend/docs/SETUP.md
+++ b/backend/docs/SETUP.md
@@ -49,21 +49,16 @@ The backend searches for `config.yaml` in this order:
 
 **Recommended**: Place `config.yaml` in project root (`deer-flow/config.yaml`).
 
-## Sandbox Setup (Optional but Recommended)
+## Compile Image Setup
 
-If you plan to use Docker/Container-based sandbox (configured in `config.yaml` under `sandbox.use: deerflow.community.aio_sandbox:AioSandboxProvider`), it's highly recommended to pre-pull the container image:
+Build the dedicated C/C++ compile-session image before the first agent compilation:
 
 ```bash
 # From project root
-make setup-sandbox
+make compile-image
 ```
 
-**Why pre-pull?**
-- The sandbox image (~500MB+) is pulled on first use, causing a long wait
-- Pre-pulling provides clear progress indication
-- Avoids confusion when first using the agent
-
-If you skip this step, the image will be automatically pulled on first agent execution, which may take several minutes depending on your network speed.
+The resulting `autocompiler:gcc13` image contains GCC, CMake, Make, Autotools, and Git. Compile sessions fail fast with an actionable message if the image is missing.
 
 ## Troubleshooting
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -177,19 +177,23 @@ def _build_subagent_section(max_concurrent: int) -> str:
         "- **compiler**: For isolated C/C++ build execution and post-build verification inside a prepared compile container"
         if bash_available
         else "- **general-purpose**: For ANY non-trivial task - web research, code exploration, file operations, analysis, etc.\n"
-        "- **bash**: Not available in the current sandbox configuration. Use direct file/web tools or switch to AioSandboxProvider for isolated shell access.\n"
+        "- **bash**: Not available in the current runtime. Use direct file/web tools, or the compiler subagent for repository build commands.\n"
         "- **compiler**: For isolated C/C++ build execution and post-build verification inside a prepared compile container"
     )
-    direct_tool_examples = "prepare_workspace, identify_build_system, finalize_session, read_file, web_search, etc."
+    direct_tool_examples = "prepare_compile_session, clone_repository, identify_build_system, finalize_session, host_read, web_search, etc."
     direct_execution_example = (
         '# User asks: "Build this repository"\n'
         "# Thinking: I should treat the lead-agent compile task as living under /workspace/.compile-sessions/<thread_id>/<session_id>, use that path for my own inspection, then delegate build+verify execution to the compiler subagent.\n\n"
-        'prepare_workspace(repo_url="https://example.com/repo.git")\n'
+        'prepare_compile_session(repo_url="https://example.com/repo.git")\n'
+        "clone_repository()\n"
         "identify_build_system()\n"
-        'task(description="build and verify repository", prompt="build the project, run post-build verification, '
-        "and report structured results; note that any subagent-mentioned project directory is informational only "
-        'and does not replace the lead-agent working root /workspace/.compile-sessions/<thread_id>/<session_id>", '
-        'subagent_type="compiler")\n'
+        "task(\n"
+        '    description="build and verify repository",\n'
+        '    prompt="build the project, run post-build verification, and report structured results; '
+        "note that any subagent-mentioned project directory is informational only and does not replace "
+        'the lead-agent working root /workspace/.compile-sessions/<thread_id>/<session_id>",\n'
+        '    subagent_type="compiler",\n'
+        ")\n"
         "finalize_session()"
     )
     return f"""<subagent_system>
@@ -205,7 +209,7 @@ You are running with subagent capabilities enabled. Your role is to be a **task 
 **⛔ HARD CONCURRENCY LIMIT: MAXIMUM {n} `task` CALLS PER RESPONSE. THIS IS NOT OPTIONAL.**
 - Each response, you may include **at most {n}** `task` tool calls. Any excess calls are **silently discarded** by the system — you will lose that work.
 - Before launching subagents, count them explicitly in your thinking.
-- For repository compilation tasks, you must orchestrate the flow yourself: `prepare_workspace` → `identify_build_system` → `task(subagent_type="compiler")` → `finalize_session`.
+- For repository compilation tasks, you must orchestrate the flow yourself: `prepare_compile_session` → `clone_repository` → `identify_build_system` → `task(subagent_type="compiler")` → `finalize_session`.
 - Lead-agent work for each compile task is anchored at `/workspace/.compile-sessions/<thread_id>/<session_id>`.
 - If a compiler subagent reports that the project is located in some other directory, treat that as subagent-side informational output only; it does not redefine the lead agent's working directory.
 - Do not reason about subagent working directories. Tool bindings already encapsulate the correct execution location.
@@ -262,8 +266,8 @@ You are {agent_name}, an open-source compilation-focused agent.
 
 <compile_task_model>
 - For remote repository compilation or build tasks, do not rely on the legacy one-shot workflow as the primary path
-- Use the infrastructure-tool chain: `prepare_workspace`, `identify_build_system`, delegated `task(subagent_type="compiler")`, then `finalize_session`
-- `prepare_workspace`, `identify_build_system`, and `finalize_session` are deterministic infrastructure tools running in the DeerFlow service container
+- Use the infrastructure-tool chain: `prepare_compile_session`, `clone_repository`, `identify_build_system`, delegated `task(subagent_type="compiler")`, then `finalize_session`
+- `prepare_compile_session`, `clone_repository`, `identify_build_system`, and `finalize_session` are deterministic infrastructure tools running in the DeerFlow service container
 - The DeerFlow service container is rooted at `/workspace`; each compile task should be treated as anchored at `/workspace/.compile-sessions/<thread_id>/<session_id>`
 - Lead-agent repository inspection should use the compile-session directory under `/workspace/.compile-sessions/<thread_id>/<session_id>` and must not be re-anchored by subagent-reported paths
 - The `compiler` subagent is responsible for build/dependency work and routine post-build verification; do not rely on the subagent's own directory descriptions for lead-agent reasoning
@@ -283,7 +287,7 @@ You are {agent_name}, an open-source compilation-focused agent.
 {subagent_section}
 
 <compile_analysis_behavior>
-- For repository compilation tasks, first establish the compile workspace, then identify the build system, then delegate build execution to the `compiler` subagent, and always finalize the session afterward
+- For repository compilation tasks, first prepare the compile session, clone the repository, identify the build system, then delegate build execution to the `compiler` subagent, and always finalize the session afterward
 - After compile tools or subagents return log, artifact, or verification paths, use those returned paths to inspect relevant files as needed
 - Prefer targeted log reading over aimless directory traversal
 - If a compiler subagent reports a project path like `/workspace/repo`, treat it as execution-side context only; do not let it replace the lead-agent compile-session root

--- a/backend/packages/harness/deerflow/agents/middlewares/compile_termination_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/compile_termination_middleware.py
@@ -1,0 +1,98 @@
+"""Terminate successful compile tool flows without another model call."""
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import NotRequired, override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware, hook_config
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.runtime import Runtime
+from langgraph.types import Command
+
+
+class CompileTerminationState(AgentState):
+    compile_terminal: NotRequired[bool]
+
+
+class CompileTerminationMiddleware(AgentMiddleware[CompileTerminationState]):
+    """End compiler and lead graphs after their terminal compile tools succeed."""
+
+    state_schema = CompileTerminationState
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    def before_model(
+        self,
+        state: CompileTerminationState,
+        runtime: Runtime,
+    ) -> dict | None:
+        del runtime
+        if not state.get("compile_terminal"):
+            return None
+        return {"compile_terminal": False, "jump_to": "end"}
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    async def abefore_model(
+        self,
+        state: CompileTerminationState,
+        runtime: Runtime,
+    ) -> dict | None:
+        return self.before_model(state, runtime)
+
+    @staticmethod
+    def _terminal_result(request: ToolCallRequest, result: ToolMessage | Command) -> ToolMessage | Command:
+        if not isinstance(result, ToolMessage) or not isinstance(result.content, str):
+            return result
+
+        tool_name = request.tool_call.get("name")
+        if tool_name not in {"submit_build_result", "finalize_session"}:
+            return result
+
+        try:
+            payload = json.loads(result.content)
+        except (TypeError, json.JSONDecodeError):
+            return result
+
+        if tool_name == "submit_build_result":
+            if payload.get("status") != "passed":
+                return result
+            terminal_payload = {
+                "build_status": "success",
+                "proceed_to_verify": False,
+                "verification_status": "passed",
+                "summary": payload["message"],
+                "artifacts": [artifact["path"] for artifact in payload.get("artifacts", [])],
+            }
+        else:
+            if payload.get("status") not in {"completed", "failed", "cancelled", "timed_out"}:
+                return result
+            terminal_payload = payload
+
+        return Command(
+            update={
+                "messages": [
+                    result,
+                    AIMessage(content=json.dumps(terminal_payload, ensure_ascii=False, indent=2)),
+                ],
+                "compile_terminal": True,
+            }
+        )
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return self._terminal_result(request, handler(request))
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        return self._terminal_result(request, await handler(request))

--- a/backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py
@@ -203,6 +203,12 @@ class MemoryMiddleware(AgentMiddleware[MemoryMiddlewareState]):
         Returns:
             None (no state changes needed from this middleware).
         """
+        # Compile-session memory is evaluated as a separate research treatment.
+        # The deterministic baseline must not enqueue another LLM call after finalize.
+        if state.get("compile_session_id"):
+            logger.debug("Compile session detected, skipping general conversation memory update")
+            return None
+
         config = get_memory_config()
         if not config.enabled:
             return None

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -115,10 +115,12 @@ def _build_runtime_middlewares(
         provider = provider_cls(**provider_kwargs)
         middlewares.append(GuardrailMiddleware(provider, fail_closed=guardrails_config.fail_closed, passport=guardrails_config.passport))
 
+    from deerflow.agents.middlewares.compile_termination_middleware import CompileTerminationMiddleware
     from deerflow.agents.middlewares.sandbox_audit_middleware import SandboxAuditMiddleware
 
     middlewares.append(SandboxAuditMiddleware())
     middlewares.append(ToolErrorHandlingMiddleware())
+    middlewares.append(CompileTerminationMiddleware())
     return middlewares
 
 

--- a/backend/packages/harness/deerflow/compile/docker_runtime.py
+++ b/backend/packages/harness/deerflow/compile/docker_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,8 +26,28 @@ class RuntimeConfig:
 
 class CompileDockerRuntime:
     def __init__(self, config: RuntimeConfig | None = None, manager=None):
-        self.config = config or RuntimeConfig()
+        self.config = config or RuntimeConfig(
+            network=os.getenv("COMPILE_RUNTIME_NETWORK") or DEFAULT_NETWORK,
+        )
         self.manager = manager
+
+    @staticmethod
+    def _runtime_proxy_environment() -> tuple[list[str], dict[str, str]]:
+        environment = os.environ.copy()
+        docker_flags: list[str] = []
+        proxy_variables = (
+            ("COMPILE_RUNTIME_HTTP_PROXY", "HTTP_PROXY", "http_proxy"),
+            ("COMPILE_RUNTIME_HTTPS_PROXY", "HTTPS_PROXY", "https_proxy"),
+            ("COMPILE_RUNTIME_NO_PROXY", "NO_PROXY", "no_proxy"),
+        )
+        for source_name, upper_name, lower_name in proxy_variables:
+            value = os.getenv(source_name)
+            if not value:
+                continue
+            environment[upper_name] = value
+            environment[lower_name] = value
+            docker_flags.extend(["-e", upper_name, "-e", lower_name])
+        return docker_flags, environment
 
     def _paths(self) -> Paths:
         manager_paths = getattr(self.manager, "paths", None)
@@ -83,6 +104,7 @@ class CompileDockerRuntime:
         host_artifacts_dir = self._host_artifacts_dir(session)
         host_logs_dir = self._host_logs_dir(session)
         host_repro_dir = self._host_repro_dir(session)
+        proxy_flags, run_environment = self._runtime_proxy_environment()
         container_name = f"deerflow-compile-{session.thread_id[:8]}-{session.session_id[:8]}"
         command = [
             "docker",
@@ -92,6 +114,9 @@ class CompileDockerRuntime:
             container_name,
             "--network",
             self.config.network,
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            *proxy_flags,
             "-v",
             f"{host_workspace_dir}:{CONTAINER_WORKSPACE_DIR}",
             "-v",
@@ -123,7 +148,7 @@ class CompileDockerRuntime:
             docker_command=command,
         )
         started_at = utc_now_iso()
-        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        result = subprocess.run(command, check=True, capture_output=True, text=True, env=run_environment)
         session.container_name = container_name
         session.container_id = result.stdout.strip()
         self._log(
@@ -143,12 +168,17 @@ class CompileDockerRuntime:
             raise ValueError("Compile session container has not been created")
 
         container_workdir = workdir or CONTAINER_REPO_DIR
+        container_timeout = max(1, timeout_seconds)
         exec_command = [
             "docker",
             "exec",
             "-w",
             container_workdir,
             session.container_id,
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            f"{container_timeout}s",
             "bash",
             "-lc",
             command,
@@ -158,13 +188,45 @@ class CompileDockerRuntime:
             "container.exec.started",
             container_id=session.container_id,
             workdir=container_workdir,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=container_timeout,
             log_path=log_path,
             command=command,
             docker_command=exec_command,
         )
         started_at = utc_now_iso()
-        result = subprocess.run(exec_command, capture_output=True, text=True, timeout=timeout_seconds)
+        try:
+            result = subprocess.run(exec_command, capture_output=True, text=True, timeout=container_timeout + 10)
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+            stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+            timeout_message = f"Docker exec did not return after the {container_timeout}-second container timeout."
+            combined_output = stdout + stderr
+            if combined_output and not combined_output.endswith("\n"):
+                combined_output += "\n"
+            combined_output += timeout_message + "\n"
+            if log_path:
+                Path(log_path).write_text(combined_output, encoding="utf-8")
+            self._log(
+                session,
+                "container.exec.timed_out",
+                container_id=session.container_id,
+                workdir=container_workdir,
+                timeout_seconds=container_timeout,
+                log_path=log_path,
+                command=command,
+                started_at=started_at,
+                completed_at=utc_now_iso(),
+                exit_code=124,
+                stdout=stdout,
+                stderr=stderr,
+            )
+            return CommandResult(
+                exit_code=124,
+                stdout=stdout,
+                stderr=stderr,
+                combined_output=combined_output,
+                log_path=log_path,
+            )
         combined_output = (result.stdout or "") + (result.stderr or "")
         if log_path:
             Path(log_path).write_text(combined_output, encoding="utf-8")
@@ -173,7 +235,7 @@ class CompileDockerRuntime:
             "container.exec.completed",
             container_id=session.container_id,
             workdir=container_workdir,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=container_timeout,
             log_path=log_path,
             command=command,
             started_at=started_at,

--- a/backend/packages/harness/deerflow/compile/docker_runtime.py
+++ b/backend/packages/harness/deerflow/compile/docker_runtime.py
@@ -24,6 +24,13 @@ class RuntimeConfig:
     remove_on_cleanup: bool = True
 
 
+@dataclass(frozen=True)
+class ContainerCleanupResult:
+    succeeded: bool
+    stopped: bool
+    removed: bool
+
+
 class CompileDockerRuntime:
     def __init__(self, config: RuntimeConfig | None = None, manager=None):
         self.config = config or RuntimeConfig(
@@ -287,9 +294,9 @@ class CompileDockerRuntime:
         )
         return destination_path
 
-    def stop_and_remove_container(self, session: CompileSession) -> None:
+    def stop_and_remove_container(self, session: CompileSession) -> ContainerCleanupResult:
         if not session.container_id:
-            return
+            return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
         self._log(
             session,
             "container.cleanup.started",
@@ -305,6 +312,7 @@ class CompileDockerRuntime:
             stdout=stop_result.stdout,
             stderr=stop_result.stderr,
         )
+        stop_succeeded = stop_result.returncode == 0 or "No such container" in (stop_result.stderr or "")
         if self.config.remove_on_cleanup:
             rm_result = subprocess.run(["docker", "rm", "-f", session.container_id], check=False, capture_output=True, text=True)
             self._log(
@@ -315,3 +323,14 @@ class CompileDockerRuntime:
                 stdout=rm_result.stdout,
                 stderr=rm_result.stderr,
             )
+            remove_succeeded = rm_result.returncode == 0 or "No such container" in (rm_result.stderr or "")
+            return ContainerCleanupResult(
+                succeeded=remove_succeeded,
+                stopped=stop_succeeded,
+                removed=remove_succeeded,
+            )
+        return ContainerCleanupResult(
+            succeeded=stop_succeeded,
+            stopped=stop_succeeded,
+            removed=False,
+        )

--- a/backend/packages/harness/deerflow/compile/manager.py
+++ b/backend/packages/harness/deerflow/compile/manager.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import tempfile
+import threading
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from deerflow.compile.paths import (
@@ -11,6 +16,7 @@ from deerflow.compile.paths import (
     get_metadata_path,
     get_repro_dir,
     get_session_dir,
+    get_thread_compile_root,
     get_workspace_dir,
 )
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CompileSession, utc_now_iso
@@ -23,6 +29,16 @@ class CompileSessionManager:
     def __init__(self, paths=None, default_image: str = DEFAULT_COMPILE_IMAGE):
         self.paths = paths
         self.default_image = default_image
+        self._session_locks: dict[tuple[str, str], threading.RLock] = {}
+        self._session_locks_guard = threading.Lock()
+
+    @contextmanager
+    def session_lock(self, thread_id: str, session_id: str) -> Iterator[None]:
+        key = (thread_id, session_id)
+        with self._session_locks_guard:
+            lock = self._session_locks.setdefault(key, threading.RLock())
+        with lock:
+            yield
 
     def create_session(
         self,
@@ -30,66 +46,104 @@ class CompileSessionManager:
         repo_url: str,
         branch: str | None = None,
         image: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
     ) -> CompileSession:
-        session_id = uuid.uuid4().hex[:12]
+        session_id = session_id or uuid.uuid4().hex[:12]
         resolved_thread_id = thread_id or "default"
+        with self.session_lock(resolved_thread_id, session_id):
+            session_dir = get_session_dir(session_id, resolved_thread_id, self.paths)
+            workspace_dir = get_workspace_dir(session_id, resolved_thread_id, self.paths)
+            artifacts_dir = get_artifacts_dir(session_id, resolved_thread_id, self.paths)
+            logs_dir = get_logs_dir(session_id, resolved_thread_id, self.paths)
+            repro_dir = get_repro_dir(session_id, resolved_thread_id, self.paths)
+            metadata_path = get_metadata_path(session_id, resolved_thread_id, self.paths)
 
-        session_dir = get_session_dir(session_id, resolved_thread_id, self.paths)
-        workspace_dir = get_workspace_dir(session_id, resolved_thread_id, self.paths)
-        artifacts_dir = get_artifacts_dir(session_id, resolved_thread_id, self.paths)
-        logs_dir = get_logs_dir(session_id, resolved_thread_id, self.paths)
-        repro_dir = get_repro_dir(session_id, resolved_thread_id, self.paths)
-        metadata_path = get_metadata_path(session_id, resolved_thread_id, self.paths)
+            for directory in (session_dir, workspace_dir, artifacts_dir, logs_dir, repro_dir):
+                directory.mkdir(parents=True, exist_ok=True)
 
-        for directory in (session_dir, workspace_dir, artifacts_dir, logs_dir, repro_dir):
-            directory.mkdir(parents=True, exist_ok=True)
+            session = CompileSession(
+                session_id=session_id,
+                thread_id=resolved_thread_id,
+                run_id=run_id,
+                repo_url=repo_url,
+                branch=branch,
+                image=image or self.default_image,
+                status="created",
+                metadata_path=str(metadata_path),
+                leadagent_repo_dir=str(workspace_dir / "repo"),
+                leadagent_artifacts_dir=str(artifacts_dir),
+                leadagent_logs_dir=str(logs_dir),
+                leadagent_repro_dir=str(repro_dir),
+            )
 
-        session = CompileSession(
-            session_id=session_id,
-            thread_id=resolved_thread_id,
-            repo_url=repo_url,
-            branch=branch,
-            image=image or self.default_image,
-            status="created",
-            metadata_path=str(metadata_path),
-            leadagent_repo_dir=str(workspace_dir / "repo"),
-            leadagent_artifacts_dir=str(artifacts_dir),
-            leadagent_logs_dir=str(logs_dir),
-            leadagent_repro_dir=str(repro_dir),
-        )
-
-        self.save_session(session)
-        self.log_event(
-            session,
-            "session.created",
-            repo_url=repo_url,
-            branch=branch,
-            compile_sessions_root=str(session_dir.parent.parent),
-            session_dir=str(session_dir),
-            workspace_dir=str(workspace_dir),
-            artifacts_dir=str(artifacts_dir),
-            logs_dir=str(logs_dir),
-            repro_dir=str(repro_dir),
-            metadata_path=str(metadata_path),
-        )
-        return session
+            self.save_session(session)
+            self.log_event(
+                session,
+                "session.created",
+                run_id=run_id,
+                repo_url=repo_url,
+                branch=branch,
+                compile_sessions_root=str(session_dir.parent.parent),
+                session_dir=str(session_dir),
+                workspace_dir=str(workspace_dir),
+                artifacts_dir=str(artifacts_dir),
+                logs_dir=str(logs_dir),
+                repro_dir=str(repro_dir),
+                metadata_path=str(metadata_path),
+            )
+            return session
 
     def load_session(self, session_id: str, thread_id: str | None = None) -> CompileSession:
-        metadata_path = get_metadata_path(session_id, thread_id or "default", self.paths)
-        data = json.loads(metadata_path.read_text(encoding="utf-8"))
-        return CompileSession.from_dict(data)
+        resolved_thread_id = thread_id or "default"
+        with self.session_lock(resolved_thread_id, session_id):
+            metadata_path = get_metadata_path(session_id, resolved_thread_id, self.paths)
+            data = json.loads(metadata_path.read_text(encoding="utf-8"))
+            return CompileSession.from_dict(data)
+
+    def list_sessions(self, thread_id: str) -> list[CompileSession]:
+        thread_root = get_thread_compile_root(thread_id, self.paths)
+        sessions: list[CompileSession] = []
+        for metadata_path in sorted(thread_root.glob("*/session.json")):
+            try:
+                data = json.loads(metadata_path.read_text(encoding="utf-8"))
+                sessions.append(CompileSession.from_dict(data))
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                continue
+        return sessions
 
     def save_session(self, session: CompileSession) -> None:
-        metadata_file = Path(session.metadata_path)
-        metadata_file.parent.mkdir(parents=True, exist_ok=True)
-        metadata_file.write_text(json.dumps(session.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+        with self.session_lock(session.thread_id, session.session_id):
+            metadata_file = Path(session.metadata_path)
+            metadata_file.parent.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(session.to_dict(), ensure_ascii=False, indent=2)
+            temporary_path: str | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    encoding="utf-8",
+                    dir=metadata_file.parent,
+                    prefix=f".{metadata_file.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as fp:
+                    temporary_path = fp.name
+                    fp.write(payload)
+                    fp.flush()
+                    os.fsync(fp.fileno())
+                os.replace(temporary_path, metadata_file)
+            finally:
+                if temporary_path and os.path.exists(temporary_path):
+                    os.unlink(temporary_path)
 
     def mark_session_status(self, session: CompileSession, status: str, error: str | None = None, summary: str | None = None) -> CompileSession:
         previous_status = session.status
         session.status = status
-        session.completed_at = utc_now_iso() if status in {"completed", "failed", "cancelled"} else session.completed_at
-        if error is not None:
-            session.error = error
+        if status in {"completed", "failed", "cancelled", "timed_out"}:
+            session.completed_at = session.completed_at or utc_now_iso()
+        else:
+            session.completed_at = None
+        session.error = error
         if summary is not None:
             session.summary = summary
         self.save_session(session)
@@ -140,17 +194,19 @@ class CompileSessionManager:
         return self.local_logs_dir(session) / WORKFLOW_LOG_NAME
 
     def log_event(self, session: CompileSession, event: str, **payload) -> None:
-        log_path = self.workflow_log_path(session)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        entry = {
-            "ts": utc_now_iso(),
-            "event": event,
-            "session_id": session.session_id,
-            "thread_id": session.thread_id,
-            **payload,
-        }
-        with log_path.open("a", encoding="utf-8") as fp:
-            fp.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        with self.session_lock(session.thread_id, session.session_id):
+            log_path = self.workflow_log_path(session)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            entry = {
+                "ts": utc_now_iso(),
+                "event": event,
+                "session_id": session.session_id,
+                "thread_id": session.thread_id,
+                "run_id": session.run_id,
+                **payload,
+            }
+            with log_path.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
     def relative_path(self, session: CompileSession, path: str | Path) -> str:
         target = Path(path)

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import struct
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from shlex import quote
+from typing import BinaryIO
 
-from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime
+from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime, ContainerCleanupResult
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationCheck, VerificationResult, utc_now_iso
 
@@ -19,6 +22,29 @@ _ARTIFACT_FILE_EXCLUDES = [
     "*/.*",
     "*/CMakeFiles/*",
 ]
+
+_AR_MAGIC = b"!<arch>\n"
+_ELF_MAGIC = b"\x7fELF"
+_ELF_TYPE_OBJECT = 1
+_ELF_TYPE_EXECUTABLE = 2
+_ELF_TYPE_DYNAMIC = 3
+_ELF_PROGRAM_TYPE_LOAD = 1
+_ELF_PROGRAM_TYPE_DYNAMIC = 2
+_ELF_PROGRAM_TYPE_INTERPRETER = 3
+_ELF_SECTION_TYPE_NULL = 0
+_ELF_SECTION_TYPE_STRTAB = 3
+_ELF_SECTION_TYPE_NOBITS = 8
+_ELF_VERSION_CURRENT = 1
+_ELF32_HEADER_SIZE = 52
+_ELF64_HEADER_SIZE = 64
+_ELF32_PROGRAM_HEADER_SIZE = 32
+_ELF64_PROGRAM_HEADER_SIZE = 56
+_ELF32_SECTION_HEADER_SIZE = 40
+_ELF64_SECTION_HEADER_SIZE = 64
+_MAX_ELF_TABLE_ENTRIES = 4096
+_AR_MEMBER_HEADER_SIZE = 60
+_AR_MEMBER_TRAILER = b"`\n"
+_AR_METADATA_MEMBERS = {"/", "//", "/SYM64/"}
 
 
 @dataclass
@@ -90,29 +116,38 @@ def prepare_compile_session_impl(
     branch: str | None = None,
     task_description: str | None = None,
     owner_id: str | None = None,
+    run_id: str | None = None,
 ) -> CompileSession:
     services = get_compile_services()
-    session = services.manager.create_session(thread_id=thread_id, repo_url=repo_url, branch=branch)
-    session.owner_subagent_id = owner_id
-    if task_description:
-        session.summary = task_description
-    services.manager.save_session(session)
-    services.manager.log_event(
-        session,
-        "prepare.started",
-        owner_id=owner_id,
-        task_description=task_description,
-    )
-    services.runtime.create_container(session)
-    services.manager.save_session(session)
-    services.manager.mark_session_status(session, "ready")
-    services.manager.log_event(
-        session,
-        "prepare.completed",
-        container_id=session.container_id,
-        container_name=session.container_name,
-    )
-    return session
+    session_id = uuid.uuid4().hex[:12]
+    with services.manager.session_lock(thread_id, session_id):
+        session = services.manager.create_session(
+            thread_id=thread_id,
+            repo_url=repo_url,
+            branch=branch,
+            run_id=run_id,
+            session_id=session_id,
+        )
+        session.owner_subagent_id = owner_id
+        if task_description:
+            session.summary = task_description
+        services.manager.save_session(session)
+        services.manager.log_event(
+            session,
+            "prepare.started",
+            owner_id=owner_id,
+            task_description=task_description,
+        )
+        services.runtime.create_container(session)
+        services.manager.save_session(session)
+        services.manager.mark_session_status(session, "ready")
+        services.manager.log_event(
+            session,
+            "prepare.completed",
+            container_id=session.container_id,
+            container_name=session.container_name,
+        )
+        return session
 
 
 def prepare_compile_session_json(
@@ -299,9 +334,19 @@ def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
     base = Path(session.leadagent_artifacts_dir)
     if not base.exists():
         return []
+    try:
+        resolved_base = base.resolve(strict=True)
+    except OSError:
+        return []
     files: list[Path] = []
     for p in base.rglob("*"):
-        if not p.is_file():
+        if p.is_symlink():
+            continue
+        try:
+            resolved_path = p.resolve(strict=True)
+        except OSError:
+            continue
+        if not resolved_path.is_relative_to(resolved_base) or not resolved_path.is_file():
             continue
         rel = p.relative_to(base)
         if any(part.startswith(".") for part in rel.parts):
@@ -310,6 +355,260 @@ def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
             continue
         files.append(p)
     return files
+
+
+def _table_fits(*, offset: int, entry_size: int, entry_count: int, file_size: int, minimum_entry_size: int) -> bool:
+    return offset > 0 and entry_size >= minimum_entry_size and 0 < entry_count <= _MAX_ELF_TABLE_ENTRIES and offset + entry_size * entry_count <= file_size
+
+
+def _has_valid_object_sections(
+    stream: BinaryIO,
+    *,
+    base_offset: int,
+    file_size: int,
+    elf_class: int,
+    byte_prefix: str,
+    section_header_offset: int,
+    section_header_size: int,
+    section_header_count: int,
+    section_name_index: int,
+) -> bool:
+    if section_header_count < 2 or not 0 < section_name_index < section_header_count:
+        return False
+
+    meaningful_section_found = False
+    valid_name_table = False
+    for index in range(section_header_count):
+        stream.seek(base_offset + section_header_offset + index * section_header_size)
+        raw = stream.read(_ELF32_SECTION_HEADER_SIZE if elf_class == 1 else _ELF64_SECTION_HEADER_SIZE)
+        try:
+            if elf_class == 1:
+                fields = struct.unpack(f"{byte_prefix}IIIIIIIIII", raw)
+            else:
+                fields = struct.unpack(f"{byte_prefix}IIQQQQIIQQ", raw)
+        except struct.error:
+            return False
+
+        section_type = fields[1]
+        section_offset = fields[4]
+        section_size = fields[5]
+        if index == 0:
+            if section_type != _ELF_SECTION_TYPE_NULL:
+                return False
+            continue
+        if section_type == _ELF_SECTION_TYPE_NULL:
+            continue
+        if section_type != _ELF_SECTION_TYPE_NOBITS and section_size > 0:
+            if section_offset <= 0 or section_offset + section_size > file_size:
+                return False
+            meaningful_section_found = True
+        elif section_type == _ELF_SECTION_TYPE_NOBITS and section_size > 0:
+            meaningful_section_found = True
+        if index == section_name_index:
+            valid_name_table = section_type == _ELF_SECTION_TYPE_STRTAB and section_size > 0
+
+    return meaningful_section_found and valid_name_table
+
+
+def _classify_elf_stream(stream: BinaryIO, *, base_offset: int, file_size: int) -> str | None:
+    if file_size < _ELF32_HEADER_SIZE:
+        return None
+
+    stream.seek(base_offset)
+    header = stream.read(_ELF64_HEADER_SIZE)
+    if not header.startswith(_ELF_MAGIC) or len(header) < _ELF32_HEADER_SIZE:
+        return None
+
+    elf_class = header[4]
+    data_encoding = header[5]
+    if data_encoding == 1:
+        byte_prefix = "<"
+    elif data_encoding == 2:
+        byte_prefix = ">"
+    else:
+        return None
+    if header[6] != _ELF_VERSION_CURRENT:
+        return None
+
+    try:
+        if elf_class == 1:
+            if len(header) < _ELF32_HEADER_SIZE:
+                return None
+            fields = struct.unpack_from(f"{byte_prefix}HHIIIIIHHHHHH", header, 16)
+            expected_header_size = _ELF32_HEADER_SIZE
+            expected_program_header_size = _ELF32_PROGRAM_HEADER_SIZE
+            expected_section_header_size = _ELF32_SECTION_HEADER_SIZE
+        elif elf_class == 2:
+            if len(header) < _ELF64_HEADER_SIZE:
+                return None
+            fields = struct.unpack_from(f"{byte_prefix}HHIQQQIHHHHHH", header, 16)
+            expected_header_size = _ELF64_HEADER_SIZE
+            expected_program_header_size = _ELF64_PROGRAM_HEADER_SIZE
+            expected_section_header_size = _ELF64_SECTION_HEADER_SIZE
+        else:
+            return None
+    except struct.error:
+        return None
+
+    (
+        elf_type,
+        machine,
+        elf_version,
+        entry_point,
+        program_header_offset,
+        section_header_offset,
+        _flags,
+        header_size,
+        program_header_size,
+        program_header_count,
+        section_header_size,
+        section_header_count,
+        section_name_index,
+    ) = fields
+    if machine == 0 or elf_version != _ELF_VERSION_CURRENT or header_size != expected_header_size:
+        return None
+
+    if elf_type == _ELF_TYPE_OBJECT:
+        if not _table_fits(
+            offset=section_header_offset,
+            entry_size=section_header_size,
+            entry_count=section_header_count,
+            file_size=file_size,
+            minimum_entry_size=expected_section_header_size,
+        ):
+            return None
+        if not _has_valid_object_sections(
+            stream,
+            base_offset=base_offset,
+            file_size=file_size,
+            elf_class=elf_class,
+            byte_prefix=byte_prefix,
+            section_header_offset=section_header_offset,
+            section_header_size=section_header_size,
+            section_header_count=section_header_count,
+            section_name_index=section_name_index,
+        ):
+            return None
+        return "object"
+
+    if elf_type not in {_ELF_TYPE_EXECUTABLE, _ELF_TYPE_DYNAMIC}:
+        return None
+    if not _table_fits(
+        offset=program_header_offset,
+        entry_size=program_header_size,
+        entry_count=program_header_count,
+        file_size=file_size,
+        minimum_entry_size=expected_program_header_size,
+    ):
+        return None
+
+    has_data_load_segment = False
+    has_dynamic_segment = False
+    has_interpreter = False
+    for index in range(program_header_count):
+        offset = base_offset + program_header_offset + index * program_header_size
+        stream.seek(offset)
+        raw = stream.read(expected_program_header_size)
+        try:
+            if elf_class == 1:
+                program_fields = struct.unpack(f"{byte_prefix}IIIIIIII", raw)
+                program_type, segment_offset, _vaddr, _paddr, file_segment_size, memory_segment_size, _segment_flags, _segment_align = program_fields
+            else:
+                program_fields = struct.unpack(f"{byte_prefix}IIQQQQQQ", raw)
+                program_type, _segment_flags, segment_offset, _vaddr, _paddr, file_segment_size, memory_segment_size, _segment_align = program_fields
+        except struct.error:
+            return None
+        if memory_segment_size < file_segment_size:
+            return None
+        if file_segment_size > 0 and (segment_offset < 0 or segment_offset + file_segment_size > file_size):
+            return None
+        if program_type == _ELF_PROGRAM_TYPE_LOAD and file_segment_size > 0:
+            has_data_load_segment = True
+        elif program_type == _ELF_PROGRAM_TYPE_DYNAMIC and file_segment_size > 0:
+            has_dynamic_segment = True
+        elif program_type == _ELF_PROGRAM_TYPE_INTERPRETER:
+            if file_segment_size < 2 or segment_offset <= 0:
+                return None
+            stream.seek(base_offset + segment_offset)
+            interpreter = stream.read(file_segment_size)
+            if len(interpreter) != file_segment_size or not interpreter.endswith(b"\0"):
+                return None
+            has_interpreter = True
+
+    if not has_data_load_segment:
+        return None
+    if elf_type == _ELF_TYPE_EXECUTABLE:
+        return "executable" if entry_point != 0 else None
+    if has_interpreter or entry_point != 0:
+        return "executable"
+    return "shared_library" if has_dynamic_segment else None
+
+
+def _classify_archive_stream(stream: BinaryIO, *, file_size: int) -> str | None:
+    if file_size < len(_AR_MAGIC) + _AR_MEMBER_HEADER_SIZE:
+        return None
+
+    offset = len(_AR_MAGIC)
+    compiled_member_found = False
+    while offset < file_size:
+        if offset + _AR_MEMBER_HEADER_SIZE > file_size:
+            return None
+        stream.seek(offset)
+        member_header = stream.read(_AR_MEMBER_HEADER_SIZE)
+        if len(member_header) != _AR_MEMBER_HEADER_SIZE or member_header[58:60] != _AR_MEMBER_TRAILER:
+            return None
+        try:
+            member_size = int(member_header[48:58].decode("ascii").strip())
+            member_name = member_header[:16].decode("ascii").strip()
+        except (UnicodeDecodeError, ValueError):
+            return None
+        if member_size < 0:
+            return None
+
+        payload_offset = offset + _AR_MEMBER_HEADER_SIZE
+        payload_size = member_size
+        payload_end = payload_offset + payload_size
+        if payload_end > file_size:
+            return None
+
+        if member_name.startswith("#1/"):
+            try:
+                embedded_name_size = int(member_name[3:])
+            except ValueError:
+                return None
+            if embedded_name_size < 0 or embedded_name_size > payload_size:
+                return None
+            payload_offset += embedded_name_size
+            payload_size -= embedded_name_size
+
+        if member_name not in _AR_METADATA_MEMBERS:
+            member_type = _classify_elf_stream(
+                stream,
+                base_offset=payload_offset,
+                file_size=payload_size,
+            )
+            compiled_member_found = compiled_member_found or member_type == "object"
+
+        offset = payload_end + (member_size % 2)
+        if offset > file_size:
+            return None
+
+    return "static_library" if compiled_member_found else None
+
+
+def _classify_compiled_artifact(path: Path) -> str | None:
+    """Classify supported Linux C/C++ outputs from file contents."""
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None
+        file_size = path.stat().st_size
+        with path.open("rb") as stream:
+            magic = stream.read(len(_AR_MAGIC))
+            if magic == _AR_MAGIC:
+                return _classify_archive_stream(stream, file_size=file_size)
+            return _classify_elf_stream(stream, base_offset=0, file_size=file_size)
+    except OSError:
+        return None
 
 
 def _record_submit_check(
@@ -360,6 +659,11 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
             rel_posix = rel.as_posix()
             container_candidate = f"/artifacts/{rel_posix}" if rel_posix else "/artifacts"
 
+            artifact_type = _classify_compiled_artifact(candidate_path)
+            if artifact_type is None:
+                notes.append(f"Ignored non-compiled file '{rel_posix}' in /artifacts.")
+                continue
+
             exists = candidate_path.exists()
             _record_submit_check(
                 checks=checks,
@@ -383,8 +687,7 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
             if not non_empty:
                 continue
 
-            executable = candidate_path.is_file() and bool(candidate_path.stat().st_mode & 0o111)
-            if executable:
+            if artifact_type == "executable":
                 smoke_passed = False
                 for smoke_command in (
                     f"{shell_quote(container_candidate)} -version",
@@ -416,11 +719,14 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
             artifacts.append(
                 BuildArtifact(
                     path=services.manager.relative_path(session, candidate_path),
-                    artifact_type="executable" if executable else "build_output",
+                    artifact_type=artifact_type,
                     size_bytes=size_bytes,
                     source_path=container_candidate,
                 )
             )
+
+    if discovered_files and not artifacts:
+        notes.append("Error: Verification failed. No recognized compiled artifacts were found in /artifacts.")
 
     failed_checks = sum(1 for check in checks if not check.passed)
     status = "passed" if artifacts and failed_checks == 0 else "failed"
@@ -447,6 +753,10 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         completed_at,
     )
 
+    failure_message = next(
+        (note for note in notes if note.startswith("Error:")),
+        "Error: Verification failed. The submitted artifacts in /artifacts did not pass validation.",
+    )
     payload = {
         "exit_code": 0 if status == "passed" else 1,
         "status": status,
@@ -460,7 +770,7 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
             }
             for artifact in artifacts
         ],
-        "message": ("Build artifacts accepted from /artifacts." if status == "passed" else (notes[0] if notes else "Error: Verification failed. The submitted artifacts in /artifacts did not pass validation.")),
+        "message": "Build artifacts accepted from /artifacts." if status == "passed" else failure_message,
     }
     Path(summary_log_path).write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     services.manager.log_event(
@@ -474,11 +784,24 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     )
 
     if status == "passed":
-        finalize_compile_session_impl(session=session, status="completed", generate_repro_bundle=True)
+        _write_repro_bundle(session)
+        services.manager.mark_session_status(session, "verified")
+        services.manager.log_event(session, "verification.accepted", artifact_count=len(artifacts))
     else:
         services.manager.mark_session_status(session, "verification_failed", error=payload["message"])
 
     return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _write_repro_bundle(session: CompileSession) -> Path:
+    repro_dir = Path(session.metadata_path).parent / "repro"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    build_lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
+    for command in session.commands:
+        build_lines.append(command.command)
+    build_path = repro_dir / "build.sh"
+    build_path.write_text("\n".join(build_lines) + "\n", encoding="utf-8")
+    return build_path
 
 
 def finalize_compile_session_impl(
@@ -486,25 +809,138 @@ def finalize_compile_session_impl(
     session: CompileSession,
     summary: str | None = None,
     status: str = "completed",
+    error: str | None = None,
     generate_repro_bundle: bool = True,
 ) -> CompileSession:
     services = get_compile_services()
-    if generate_repro_bundle:
-        repro_dir = Path(session.metadata_path).parent / "repro"
-        repro_dir.mkdir(parents=True, exist_ok=True)
-        build_lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
-        for command in session.commands:
-            build_lines.append(command.command)
-        (repro_dir / "build.sh").write_text("\n".join(build_lines) + "\n", encoding="utf-8")
-    services.manager.mark_session_status(session, status, summary=summary)
-    services.manager.log_event(
-        session,
-        "finalize.completed",
-        status=status,
-        summary=summary,
-        generate_repro_bundle=generate_repro_bundle,
-    )
-    return session
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        try:
+            current = services.manager.load_session(session.session_id, session.thread_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            current = session
+
+        if current.finalized_at is None:
+            if generate_repro_bundle:
+                _write_repro_bundle(current)
+            current.finalized_at = utc_now_iso()
+            services.manager.mark_session_status(current, status, error=error, summary=summary)
+            services.manager.log_event(
+                current,
+                "finalize.completed",
+                status=status,
+                summary=summary,
+                finalized_at=current.finalized_at,
+                generate_repro_bundle=generate_repro_bundle,
+            )
+
+        session.__dict__.update(current.__dict__)
+        return session
+
+
+def cleanup_and_finalize_compile_session_impl(
+    *,
+    session: CompileSession,
+    interrupted_status: str | None = None,
+    error: str | None = None,
+) -> tuple[CompileSession, ContainerCleanupResult]:
+    """Clean a session container and persist a terminal result only after cleanup succeeds."""
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        try:
+            current = services.manager.load_session(session.session_id, session.thread_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            current = session
+
+        if current.finalized_at is not None:
+            session.__dict__.update(current.__dict__)
+            return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+        cleanup_result = services.runtime.stop_and_remove_container(current)
+        if not cleanup_result.succeeded:
+            cleanup_error = error or "Compile container cleanup failed."
+            if "cleanup failed" not in cleanup_error.lower():
+                cleanup_error = f"{cleanup_error} Compile container cleanup failed."
+            services.manager.mark_session_status(current, "failed", error=cleanup_error, summary=cleanup_error)
+            services.manager.log_event(
+                current,
+                "finalize.deferred",
+                reason="container_cleanup_failed",
+                stopped=cleanup_result.stopped,
+                removed=cleanup_result.removed,
+            )
+            session.__dict__.update(current.__dict__)
+            return session, cleanup_result
+
+        verification_passed = current.status == "verified" and current.verification is not None and current.verification.status == "passed" and bool(current.artifacts)
+        if interrupted_status is not None:
+            final_status = interrupted_status
+            final_error = error or f"Parent run ended with status {interrupted_status}."
+        elif verification_passed:
+            final_status = "completed"
+            final_error = None
+        elif current.status in {"failed", "cancelled", "timed_out"}:
+            final_status = current.status
+            final_error = current.error or f"Compile session ended with status {current.status}."
+        else:
+            final_status = "failed"
+            final_error = current.error or "Compile session finalized before artifact verification passed."
+
+        updated = finalize_compile_session_impl(
+            session=current,
+            status=final_status,
+            summary=final_error,
+            error=final_error,
+        )
+        session.__dict__.update(updated.__dict__)
+        return session, cleanup_result
+
+
+def cleanup_compile_session_container_impl(
+    *,
+    session: CompileSession,
+) -> tuple[CompileSession, ContainerCleanupResult]:
+    """Reload and clean a session container under the session lifecycle lock."""
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        try:
+            current = services.manager.load_session(session.session_id, session.thread_id)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            current = session
+        if current.finalized_at is not None:
+            session.__dict__.update(current.__dict__)
+            return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+        cleanup_result = services.runtime.stop_and_remove_container(current)
+        session.__dict__.update(current.__dict__)
+        return session, cleanup_result
+
+
+def finalize_unfinished_thread_sessions_impl(
+    *,
+    thread_id: str,
+    run_id: str | None = None,
+    interrupted_status: str | None = None,
+    error: str | None = None,
+) -> list[CompileSession]:
+    """Clean and finalize sessions left behind when a parent run exits."""
+    services = get_compile_services()
+    finalized: list[CompileSession] = []
+    for discovered_session in services.manager.list_sessions(thread_id):
+        if run_id is not None and discovered_session.run_id != run_id:
+            continue
+        with services.manager.session_lock(thread_id, discovered_session.session_id):
+            try:
+                session = services.manager.load_session(discovered_session.session_id, thread_id)
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                session = discovered_session
+            if session.finalized_at is not None or (run_id is not None and session.run_id != run_id):
+                continue
+            updated, _cleanup_result = cleanup_and_finalize_compile_session_impl(
+                session=session,
+                interrupted_status=interrupted_status,
+                error=error,
+            )
+            finalized.append(updated)
+    return finalized
 
 
 def finalize_compile_session_json(
@@ -512,12 +948,14 @@ def finalize_compile_session_json(
     session: CompileSession,
     summary: str | None = None,
     status: str = "completed",
+    error: str | None = None,
     generate_repro_bundle: bool = True,
 ) -> str:
     updated = finalize_compile_session_impl(
         session=session,
         summary=summary,
         status=status,
+        error=error,
         generate_repro_bundle=generate_repro_bundle,
     )
     return json.dumps(updated.to_dict(), ensure_ascii=False, indent=2)

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import json
-import shutil
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from shlex import quote
 
-from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationCheck, VerificationResult, utc_now_iso
 
@@ -146,18 +144,13 @@ def clone_repository_impl(
     services = get_compile_services()
 
     repo_dir = Path(session.leadagent_repo_dir)
-    workspace_dir = repo_dir.parent
 
-    clone_command_parts = ["git", "clone", "--depth", str(depth)]
+    clone_command_parts = ["git clone", f"--depth {depth}"]
     if branch:
-        clone_command_parts.extend(["--branch", branch])
-    clone_command_parts.extend([repo_url, str(repo_dir)])
-
-    clone_parts_for_record = [f"git clone --depth {depth}"]
-    if branch:
-        clone_parts_for_record.append(f"--branch {shell_quote(branch)}")
-    clone_parts_for_record.append(f"{shell_quote(repo_url)} {shell_quote(str(repo_dir))}")
-    clone_command_for_record = " ".join(clone_parts_for_record)
+        clone_command_parts.append(f"--branch {shell_quote(branch)}")
+    clone_command_parts.append(f"{shell_quote(repo_url)} {shell_quote(CONTAINER_REPO_DIR)}")
+    clone_command = " ".join(clone_command_parts)
+    attempt_command = f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)} && {clone_command}"
 
     retries = max(1, max_retries)
     last_result: CommandResult | None = None
@@ -178,34 +171,18 @@ def clone_repository_impl(
         )
         started_at = utc_now_iso()
 
-        if repo_dir.exists():
-            shutil.rmtree(repo_dir)
-
-        run_result = subprocess.run(
-            clone_command_parts,
-            cwd=str(workspace_dir),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        completed_at = utc_now_iso()
-        stdout = run_result.stdout or ""
-        stderr = run_result.stderr or ""
-        combined_output = stdout + stderr
-        Path(log_path).write_text(combined_output, encoding="utf-8")
-
-        result = CommandResult(
-            exit_code=run_result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            combined_output=combined_output,
+        result = services.runtime.exec(
+            session,
+            attempt_command,
+            workdir=CONTAINER_WORKSPACE_DIR,
             log_path=log_path,
         )
+        completed_at = utc_now_iso()
         append_command_record(
             session,
             "clone",
-            clone_command_for_record,
-            str(workspace_dir),
+            attempt_command,
+            CONTAINER_WORKSPACE_DIR,
             log_path,
             result.exit_code,
             started_at,
@@ -214,13 +191,12 @@ def clone_repository_impl(
         last_result = result
 
         if result.exit_code == 0:
-            sha = subprocess.run(
-                ["git", "-C", str(repo_dir), "rev-parse", "HEAD"],
-                capture_output=True,
-                text=True,
-                check=False,
+            sha = services.runtime.exec(
+                session,
+                f"git config --global --replace-all safe.directory {shell_quote(CONTAINER_REPO_DIR)} && git -C {shell_quote(CONTAINER_REPO_DIR)} rev-parse HEAD",
+                workdir=CONTAINER_WORKSPACE_DIR,
             )
-            if sha.returncode == 0:
+            if sha.exit_code == 0:
                 session.commit_sha = (sha.stdout or "").strip()
                 services.manager.save_session(session)
 

--- a/backend/packages/harness/deerflow/compile/schemas.py
+++ b/backend/packages/harness/deerflow/compile/schemas.py
@@ -66,8 +66,10 @@ class CompileSession:
     branch: str | None
     image: str
     status: str
+    run_id: str | None = None
     created_at: str = field(default_factory=utc_now_iso)
     completed_at: str | None = None
+    finalized_at: str | None = None
     owner_subagent_id: str | None = None
     commit_sha: str | None = None
     container_id: str | None = None
@@ -89,6 +91,7 @@ class CompileSession:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CompileSession:
+        data = {"run_id": None, **data}
         commands = [BuildCommandRecord(**item) for item in data.get("commands", [])]
         artifacts = [BuildArtifact(**item) for item in data.get("artifacts", [])]
         verification_data = data.get("verification")

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -89,12 +89,13 @@ async def run_agent(
 
         # Inject runtime context so middlewares can access thread_id
         # (langgraph-cli does this automatically; we must do it manually)
-        runtime = Runtime(context={"thread_id": thread_id}, store=store)
+        runtime = Runtime(context={"thread_id": thread_id, "run_id": run_id}, store=store)
         # If the caller already set a ``context`` key (LangGraph >= 0.6.0
         # prefers it over ``configurable`` for thread-level data), make
         # sure ``thread_id`` is available there too.
         if "context" in config and isinstance(config["context"], dict):
             config["context"].setdefault("thread_id", thread_id)
+            config["context"].setdefault("run_id", run_id)
         config.setdefault("configurable", {})["__pregel_runtime"] = runtime
 
         runnable_config = RunnableConfig(**config)
@@ -211,6 +212,29 @@ async def run_agent(
         )
 
     finally:
+        try:
+            from deerflow.compile.operations import finalize_unfinished_thread_sessions_impl
+
+            interrupted_status = None
+            cleanup_error = None
+            if record.status == RunStatus.interrupted:
+                interrupted_status = "cancelled"
+                cleanup_error = "Parent run was cancelled."
+            elif record.status == RunStatus.timeout:
+                interrupted_status = "timed_out"
+                cleanup_error = "Parent run timed out."
+            elif record.status == RunStatus.error:
+                interrupted_status = "failed"
+                cleanup_error = record.error or "Parent run failed."
+            await asyncio.to_thread(
+                finalize_unfinished_thread_sessions_impl,
+                thread_id=thread_id,
+                run_id=run_id,
+                interrupted_status=interrupted_status,
+                error=cleanup_error,
+            )
+        except Exception:
+            logger.exception("Failed to clean unfinished compile sessions for run %s", run_id)
         await bridge.publish_end(run_id)
         asyncio.create_task(bridge.cleanup(run_id, delay=60))
 

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -9,16 +9,20 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langchain.agents import create_agent
 from langchain.tools import BaseTool
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 
-from deerflow.agents.thread_state import SandboxState, ThreadDataState, ThreadState
 from deerflow.models import create_chat_model
 from deerflow.subagents.config import SubagentConfig
+
+if TYPE_CHECKING:
+    from deerflow.agents.thread_state import SandboxState, ThreadDataState
+else:
+    SandboxState = ThreadDataState = Any
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +53,11 @@ class SubagentResult:
     completed_at: datetime | None = None
     ai_messages: list[dict[str, Any]] | None = None
     cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    worker_done_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _status_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _handle_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _loop: asyncio.AbstractEventLoop | None = field(default=None, repr=False)
+    _asyncio_task: asyncio.Task[Any] | None = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.ai_messages is None:
@@ -89,6 +97,24 @@ def _mark_execution_complete(result: SubagentResult) -> None:
         else:
             result.status = SubagentStatus.COMPLETED
         result.completed_at = datetime.now()
+
+
+def _cancel_running_coroutine(result: SubagentResult, *, force: bool = False) -> bool:
+    with result._status_lock:
+        if result.status in _TERMINAL_STATUSES and not force:
+            return False
+        result.cancel_event.set()
+    with result._handle_lock:
+        loop = result._loop
+        task = result._asyncio_task
+    if loop is None or task is None or task.done():
+        return True
+    try:
+        loop.call_soon_threadsafe(task.cancel)
+    except RuntimeError:
+        # The isolated event loop may have completed between the snapshot and call.
+        pass
+    return True
 
 
 def _extract_text_content(content: Any) -> str:
@@ -174,6 +200,8 @@ class SubagentExecutor:
         )
 
     def _create_agent(self):
+        from deerflow.agents.thread_state import ThreadState
+
         model_name = _get_model_name(self.config, self.parent_model)
         model = create_chat_model(name=model_name, thinking_enabled=False)
 
@@ -280,12 +308,34 @@ class SubagentExecutor:
             _mark_execution_complete(result)
         except Exception as e:
             logger.exception("[trace=%s] Subagent %s async execution failed", self.trace_id, self.config.name)
-            _mark_terminal(result, SubagentStatus.FAILED, str(e))
+            if result.cancel_event.is_set():
+                _mark_terminal(result, SubagentStatus.CANCELLED, result.error or "Cancelled by user")
+            else:
+                _mark_terminal(result, SubagentStatus.FAILED, str(e))
 
         return result
 
     def _run_with_isolated_loop(self, task: str, result_holder: SubagentResult) -> SubagentResult:
-        return asyncio.run(self._aexecute(task, result_holder))
+        async def run_isolated() -> SubagentResult:
+            loop = asyncio.get_running_loop()
+            execution_task = asyncio.create_task(self._aexecute(task, result_holder))
+            with result_holder._handle_lock:
+                result_holder._loop = loop
+                result_holder._asyncio_task = execution_task
+            if result_holder.cancel_event.is_set():
+                execution_task.cancel()
+            try:
+                return await execution_task
+            except asyncio.CancelledError:
+                _mark_terminal(result_holder, SubagentStatus.CANCELLED, result_holder.error or "Cancelled by user")
+                return result_holder
+            finally:
+                with result_holder._handle_lock:
+                    result_holder._asyncio_task = None
+                    result_holder._loop = None
+                result_holder.worker_done_event.set()
+
+        return asyncio.run(run_isolated())
 
     def _execute_with_timeout(self, task: str, result_holder: SubagentResult) -> SubagentResult:
         future = _isolated_loop_pool.submit(self._run_with_isolated_loop, task, result_holder)
@@ -301,6 +351,7 @@ class SubagentExecutor:
                 result_holder.status = SubagentStatus.TIMED_OUT
                 result_holder.error = timeout_error
                 result_holder.completed_at = datetime.now()
+            _cancel_running_coroutine(result_holder, force=True)
             future.cancel()
             return result_holder
         except Exception as exc:
@@ -359,5 +410,11 @@ def request_cancel_background_task(task_id: str) -> bool:
         result = _background_tasks.get(task_id)
         if result is None:
             return False
-        result.cancel_event.set()
+    return _cancel_running_coroutine(result)
+
+
+async def wait_for_background_task_shutdown(task_id: str, timeout_seconds: float) -> bool:
+    result = get_background_task_result(task_id)
+    if result is None:
         return True
+    return await asyncio.to_thread(result.worker_done_event.wait, timeout_seconds)

--- a/backend/packages/harness/deerflow/tools/bound_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/bound_compile_tools.py
@@ -76,7 +76,7 @@ def _run_container_bash_impl(
             timeout_seconds=timeout_seconds,
             log_path=log_path,
         )
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         completed_at = utc_now_iso()
         timeout_message = _build_timeout_message(command, timeout_seconds)
         _record_bash_command(
@@ -96,13 +96,17 @@ def _run_container_bash_impl(
             timeout_seconds=timeout_seconds,
             log_path=log_path,
         )
-
-        # 直接返回给 Agent，而不是抛出异常
-        message = (
-            f"exit_code=124 (Timeout)\n"
-            f"workdir={effective_workdir}\n"
-            f"error: {timeout_message}\n"
-            f"output_tail:\n{_truncate_output_tail(result.combined_output)}"  # 即使超时也尽可能返回已输出的内容
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        combined_output = stdout + stderr
+        # Return a structured timeout to the agent instead of raising.
+        message = f"exit_code=124 (Timeout)\nworkdir={effective_workdir}\nerror: {timeout_message}\noutput_tail:\n{_truncate_output_tail(combined_output)}"
+        result = CommandResult(
+            exit_code=124,
+            stdout=stdout,
+            stderr=stderr or timeout_message,
+            combined_output=combined_output or timeout_message,
+            log_path=log_path,
         )
         return result, message
 

--- a/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from typing import Annotated
+import json
+from typing import TYPE_CHECKING, Annotated, Any
 
 from langchain.tools import InjectedToolCallId, ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 from langgraph.typing import ContextT
 
-from deerflow.agents.thread_state import ThreadState
-from deerflow.compile.operations import clone_repository_impl, finalize_compile_session_impl, get_bound_session, get_compile_services, inspect_build_system_impl, prepare_compile_session_impl
+from deerflow.compile.operations import cleanup_and_finalize_compile_session_impl, clone_repository_impl, get_bound_session, inspect_build_system_impl, prepare_compile_session_impl
+
+if TYPE_CHECKING:
+    from deerflow.agents.thread_state import ThreadState
+else:
+    ThreadState = Any
 
 COMPILE_SESSION_STATE_KEY = "compile_session_id"
 COMPILE_CONTAINER_STATE_KEY = "compile_container_id"
@@ -21,6 +26,13 @@ def _get_thread_id(runtime: ToolRuntime[ContextT, ThreadState]) -> str:
     if thread_id is None:
         thread_id = runtime.config.get("configurable", {}).get("thread_id")
     return thread_id or "default"
+
+
+def _get_run_id(runtime: ToolRuntime[ContextT, ThreadState]) -> str | None:
+    run_id = runtime.context.get("run_id") if runtime.context else None
+    if run_id is None:
+        run_id = runtime.config.get("configurable", {}).get("run_id")
+    return run_id
 
 
 def _get_state_value(runtime: ToolRuntime[ContextT, ThreadState], key: str) -> str | None:
@@ -65,6 +77,7 @@ def prepare_compile_session(
         thread_id=_get_thread_id(runtime),
         repo_url=repo_url,
         branch=branch,
+        run_id=_get_run_id(runtime),
     )
     message = f"Compile session prepared. Next call clone_repository() using the bound session. session_id={session.session_id}, container_id={session.container_id}, container_repo_path={COMPILE_CONTAINER_REPO_PATH}"
     update = _build_compile_state_update(
@@ -180,12 +193,39 @@ def finalize_session(
     """
     effective_session_id = session_id or _get_state_value(runtime, COMPILE_SESSION_STATE_KEY)
     if not effective_session_id:
-        return "No compile session is currently bound. Call prepare_compile_session() first."
+        return json.dumps(
+            {
+                "status": "error",
+                "message": "No compile session is currently bound. Call prepare_compile_session() first.",
+            }
+        )
 
     thread_id = _get_thread_id(runtime)
     session = get_bound_session(session_id=effective_session_id, thread_id=thread_id)
-    updated = finalize_compile_session_impl(session=session)
-    services = get_compile_services()
-    services.runtime.stop_and_remove_container(session)
+    updated, cleanup_result = cleanup_and_finalize_compile_session_impl(
+        session=session,
+    )
 
-    return f"Session finalized. session_id={updated.session_id}, status={updated.status}, action=destroy, lead_repro_bundle_path=none, host_repro_bundle_path=none, artifact_count={len(updated.artifacts)}"
+    final_payload = {
+        "status": updated.status,
+        "session_id": updated.session_id,
+        "commit_sha": updated.commit_sha,
+        "build_system": updated.build_system,
+        "commands": [command.command for command in updated.commands],
+        "verification": updated.verification.status if updated.verification else "not_run",
+        "artifacts": [
+            {
+                "path": artifact.path,
+                "artifact_type": artifact.artifact_type,
+                "size_bytes": artifact.size_bytes,
+            }
+            for artifact in updated.artifacts
+        ],
+        "repro_script": f"{updated.leadagent_repro_dir}/build.sh",
+        "container_stopped": cleanup_result.stopped,
+        "container_removed": cleanup_result.removed,
+        "error": updated.error,
+        "completed_at": updated.completed_at,
+        "finalized_at": updated.finalized_at,
+    }
+    return json.dumps(final_payload, ensure_ascii=False, indent=2)

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -1,6 +1,7 @@
 """Task tool for delegating work to subagents."""
 
 import asyncio
+import inspect
 import logging
 import uuid
 from dataclasses import replace
@@ -13,7 +14,13 @@ from langgraph.typing import ContextT
 from deerflow.agents.lead_agent.prompt import get_skills_prompt_section
 from deerflow.agents.thread_state import ThreadState
 from deerflow.subagents import SubagentExecutor, get_available_subagent_names, get_subagent_config
-from deerflow.subagents.executor import SubagentStatus, cleanup_background_task, get_background_task_result, request_cancel_background_task
+from deerflow.subagents.executor import (
+    SubagentStatus,
+    cleanup_background_task,
+    get_background_task_result,
+    request_cancel_background_task,
+    wait_for_background_task_shutdown,
+)
 from deerflow.tools.builtins.agent_compile_tools import (
     COMPILE_BUILD_SYSTEM_STATE_KEY,
     COMPILE_CONTAINER_STATE_KEY,
@@ -21,6 +28,12 @@ from deerflow.tools.builtins.agent_compile_tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_max_turns_override(config, *, subagent_type: str, requested_max_turns: int | None):
+    if requested_max_turns is None or subagent_type == "compiler":
+        return config
+    return replace(config, max_turns=requested_max_turns)
 
 
 def _get_compile_state(runtime: ToolRuntime[ContextT, ThreadState]) -> dict[str, str]:
@@ -36,6 +49,74 @@ def _get_compile_state(runtime: ToolRuntime[ContextT, ThreadState]) -> dict[str,
         if value:
             compile_state[key] = value
     return compile_state
+
+
+async def _cancel_and_reap_task(
+    *,
+    task_id: str,
+    subagent_type: str,
+    compile_state: dict[str, str],
+    thread_id: str | None,
+    terminal_status: str,
+    error: str,
+    shutdown_timeout_seconds: float,
+) -> bool:
+    request_cancel_background_task(task_id)
+    cleanup_result = None
+
+    if subagent_type == "compiler" and thread_id:
+        session_id = compile_state.get(COMPILE_SESSION_STATE_KEY)
+        if session_id:
+            from deerflow.agents.middlewares.tool_error_handling_middleware import load_bound_session_async
+            from deerflow.compile.operations import cleanup_compile_session_container_impl
+
+            try:
+                session = await load_bound_session_async(session_id=session_id, thread_id=thread_id)
+                _updated, cleanup_result = await asyncio.to_thread(
+                    cleanup_compile_session_container_impl,
+                    session=session,
+                )
+            except Exception:
+                logger.exception("Failed to stop compile container while terminating task %s", task_id)
+
+    shutdown_result = wait_for_background_task_shutdown(task_id, shutdown_timeout_seconds)
+    worker_stopped = await shutdown_result if inspect.isawaitable(shutdown_result) else bool(shutdown_result)
+    if not worker_stopped:
+        logger.error("Task %s did not stop within %.1fs after cancellation", task_id, shutdown_timeout_seconds)
+        return False
+
+    if subagent_type == "compiler" and thread_id:
+        session_id = compile_state.get(COMPILE_SESSION_STATE_KEY)
+        if session_id:
+            from deerflow.agents.middlewares.tool_error_handling_middleware import load_bound_session_async
+            from deerflow.compile.operations import finalize_compile_session_impl, get_compile_services
+
+            try:
+                session = await load_bound_session_async(session_id=session_id, thread_id=thread_id)
+                cleanup_succeeded = cleanup_result is not None and cleanup_result.succeeded
+                if cleanup_succeeded:
+                    await asyncio.to_thread(
+                        finalize_compile_session_impl,
+                        session=session,
+                        status=terminal_status,
+                        summary=error,
+                        error=error,
+                    )
+                else:
+                    services = get_compile_services()
+                    cleanup_error = f"{error} Compile container cleanup failed."
+                    await asyncio.to_thread(
+                        services.manager.mark_session_status,
+                        session,
+                        "failed",
+                        error=cleanup_error,
+                        summary=cleanup_error,
+                    )
+            except Exception:
+                logger.exception("Failed to finalize compile session while terminating task %s", task_id)
+
+    cleanup_background_task(task_id)
+    return True
 
 
 @tool("task", parse_docstring=True)
@@ -92,11 +173,13 @@ async def task_tool(
     if skills_section:
         overrides["system_prompt"] = config.system_prompt + "\n\n" + skills_section
 
-    if max_turns is not None:
-        overrides["max_turns"] = max_turns
-
     if overrides:
         config = replace(config, **overrides)
+    config = _apply_max_turns_override(
+        config,
+        subagent_type=subagent_type,
+        requested_max_turns=max_turns,
+    )
 
     sandbox_state = None
     thread_data = None
@@ -151,6 +234,7 @@ async def task_tool(
     last_status = None
     last_message_count = 0
     max_poll_count = (config.timeout_seconds + 60) // 5
+    shutdown_timeout_seconds = max(30.0, min(float(config.timeout_seconds), 180.0))
 
     logger.info(f"[trace={trace_id}] Started background task {task_id} (subagent={subagent_type}, timeout={config.timeout_seconds}s, polling_limit={max_poll_count} polls)")
 
@@ -164,7 +248,15 @@ async def task_tool(
             if result is None:
                 logger.error(f"[trace={trace_id}] Task {task_id} not found in background tasks")
                 writer({"type": "task_failed", "task_id": task_id, "error": "Task disappeared from background tasks"})
-                cleanup_background_task(task_id)
+                await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="failed",
+                    error="Compiler task disappeared from background task tracking.",
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
                 return f"Error: Task {task_id} disappeared from background tasks"
 
             if result.status != last_status:
@@ -195,17 +287,41 @@ async def task_tool(
             elif result.status == SubagentStatus.FAILED:
                 writer({"type": "task_failed", "task_id": task_id, "error": result.error})
                 logger.error(f"[trace={trace_id}] Task {task_id} failed: {result.error}")
-                cleanup_background_task(task_id)
+                await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="failed",
+                    error=result.error or "Compiler task failed.",
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
                 return f"Task failed. Error: {result.error}"
             elif result.status == SubagentStatus.CANCELLED:
                 writer({"type": "task_cancelled", "task_id": task_id, "error": result.error})
                 logger.info(f"[trace={trace_id}] Task {task_id} cancelled: {result.error}")
-                cleanup_background_task(task_id)
+                await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="cancelled",
+                    error=result.error or "Compiler task cancelled by user.",
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
                 return "Task cancelled by user."
             elif result.status == SubagentStatus.TIMED_OUT:
                 writer({"type": "task_timed_out", "task_id": task_id, "error": result.error})
                 logger.warning(f"[trace={trace_id}] Task {task_id} timed out: {result.error}")
-                cleanup_background_task(task_id)
+                await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="timed_out",
+                    error=result.error or "Compiler task timed out.",
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
                 return f"Task timed out. Error: {result.error}"
 
             await asyncio.sleep(5)
@@ -215,38 +331,24 @@ async def task_tool(
                 timeout_minutes = config.timeout_seconds // 60
                 logger.error(f"[trace={trace_id}] Task {task_id} polling timed out after {poll_count} polls (should have been caught by thread pool timeout)")
                 writer({"type": "task_timed_out", "task_id": task_id})
+                await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="timed_out",
+                    error=f"Compiler task polling timed out after {timeout_minutes} minutes.",
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
                 return f"Task polling timed out after {timeout_minutes} minutes. This may indicate the background task is stuck. Status: {result.status.value}"
     except asyncio.CancelledError:
-        request_cancel_background_task(task_id)
-
-        async def cleanup_when_done() -> None:
-            max_cleanup_polls = max_poll_count
-            cleanup_poll_count = 0
-
-            while True:
-                result = get_background_task_result(task_id)
-                if result is None:
-                    return
-
-                if result.status in {SubagentStatus.COMPLETED, SubagentStatus.FAILED, SubagentStatus.CANCELLED, SubagentStatus.TIMED_OUT} or getattr(result, "completed_at", None) is not None:
-                    cleanup_background_task(task_id)
-                    return
-
-                if cleanup_poll_count > max_cleanup_polls:
-                    logger.warning(f"[trace={trace_id}] Deferred cleanup for task {task_id} timed out after {cleanup_poll_count} polls")
-                    return
-
-                await asyncio.sleep(5)
-                cleanup_poll_count += 1
-
-        def log_cleanup_failure(cleanup_task: asyncio.Task[None]) -> None:
-            if cleanup_task.cancelled():
-                return
-
-            exc = cleanup_task.exception()
-            if exc is not None:
-                logger.error(f"[trace={trace_id}] Deferred cleanup failed for task {task_id}: {exc}")
-
-        logger.debug(f"[trace={trace_id}] Scheduling deferred cleanup for cancelled task {task_id}")
-        asyncio.create_task(cleanup_when_done()).add_done_callback(log_cleanup_failure)
+        await _cancel_and_reap_task(
+            task_id=task_id,
+            subagent_type=subagent_type,
+            compile_state=compile_state,
+            thread_id=thread_id,
+            terminal_status="cancelled",
+            error="Compiler task cancelled with its parent run.",
+            shutdown_timeout_seconds=shutdown_timeout_seconds,
+        )
         raise

--- a/backend/tests/test_compile_cancellation.py
+++ b/backend/tests/test_compile_cancellation.py
@@ -1,0 +1,231 @@
+import asyncio
+import importlib
+import sys
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from deerflow.compile.docker_runtime import ContainerCleanupResult
+from deerflow.compile.schemas import CompileSession
+from deerflow.subagents.config import SubagentConfig
+
+task_tool_module = importlib.import_module("deerflow.tools.builtins.task_tool")
+
+_EXECUTOR_IMPORT_MOCKS = [
+    "deerflow.agents",
+    "deerflow.agents.thread_state",
+    "deerflow.agents.middlewares",
+    "deerflow.agents.middlewares.thread_data_middleware",
+    "deerflow.models",
+]
+
+
+@pytest.fixture
+def real_executor_module():
+    original_executor = sys.modules.get("deerflow.subagents.executor")
+    original_modules = {name: sys.modules.get(name) for name in _EXECUTOR_IMPORT_MOCKS}
+    sys.modules.pop("deerflow.subagents.executor", None)
+    for name in _EXECUTOR_IMPORT_MOCKS:
+        sys.modules[name] = MagicMock()
+    module = importlib.import_module("deerflow.subagents.executor")
+    try:
+        yield module
+    finally:
+        sys.modules.pop("deerflow.subagents.executor", None)
+        if original_executor is not None:
+            sys.modules["deerflow.subagents.executor"] = original_executor
+        for name, original in original_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+class BlockingAgent:
+    def __init__(self, started: threading.Event, stopped: threading.Event):
+        self.started = started
+        self.stopped = stopped
+
+    async def astream(self, *args, **kwargs):
+        del args, kwargs
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+            yield {}
+        finally:
+            self.stopped.set()
+
+
+def make_executor(executor_module, *, timeout_seconds: int, started: threading.Event, stopped: threading.Event):
+    executor = executor_module.SubagentExecutor(
+        config=SubagentConfig(
+            name="compiler",
+            description="test compiler",
+            system_prompt="test",
+            max_turns=10,
+            timeout_seconds=timeout_seconds,
+        ),
+        tools=[],
+    )
+    executor._create_agent = lambda: BlockingAgent(started, stopped)
+    return executor
+
+
+def test_background_subagent_cancel_stops_isolated_worker_and_does_not_reinsert_registry_entry(real_executor_module):
+    async def scenario() -> None:
+        started = threading.Event()
+        stopped = threading.Event()
+        executor = make_executor(real_executor_module, timeout_seconds=30, started=started, stopped=stopped)
+        task_id = executor.execute_async("block", task_id="cancel-task")
+
+        started_in_time = await asyncio.to_thread(started.wait, 3)
+        initial_result = real_executor_module.get_background_task_result(task_id)
+        assert started_in_time, (initial_result.status if initial_result else None, initial_result.error if initial_result else None)
+        assert real_executor_module.request_cancel_background_task(task_id) is True
+        assert await real_executor_module.wait_for_background_task_shutdown(task_id, 3)
+        result = real_executor_module.get_background_task_result(task_id)
+        assert result is not None
+        assert result.status == real_executor_module.SubagentStatus.CANCELLED
+        assert stopped.is_set()
+
+        real_executor_module.cleanup_background_task(task_id)
+        await asyncio.sleep(0.05)
+        assert real_executor_module.get_background_task_result(task_id) is None
+
+    asyncio.run(scenario())
+
+
+def test_background_subagent_timeout_cannot_be_overwritten_by_late_completion(real_executor_module):
+    async def scenario() -> None:
+        started = threading.Event()
+        stopped = threading.Event()
+        executor = make_executor(real_executor_module, timeout_seconds=1, started=started, stopped=stopped)
+        task_id = executor.execute_async("block", task_id="timeout-task")
+
+        started_in_time = await asyncio.to_thread(started.wait, 3)
+        initial_result = real_executor_module.get_background_task_result(task_id)
+        assert started_in_time, (initial_result.status if initial_result else None, initial_result.error if initial_result else None)
+        deadline = asyncio.get_running_loop().time() + 4
+        result = real_executor_module.get_background_task_result(task_id)
+        while result is not None and result.status != real_executor_module.SubagentStatus.TIMED_OUT:
+            assert asyncio.get_running_loop().time() < deadline
+            await asyncio.sleep(0.05)
+            result = real_executor_module.get_background_task_result(task_id)
+
+        assert result is not None
+        assert result.status == real_executor_module.SubagentStatus.TIMED_OUT
+        assert await real_executor_module.wait_for_background_task_shutdown(task_id, 3)
+        await asyncio.sleep(0.05)
+        assert result.status == real_executor_module.SubagentStatus.TIMED_OUT
+        assert stopped.is_set()
+        real_executor_module.cleanup_background_task(task_id)
+
+    asyncio.run(scenario())
+
+
+def test_timeout_terminal_transition_blocks_boundary_completion(real_executor_module):
+    result = real_executor_module.SubagentResult(
+        task_id="boundary-task",
+        trace_id="boundary-trace",
+        status=real_executor_module.SubagentStatus.RUNNING,
+    )
+
+    assert real_executor_module._mark_terminal(
+        result,
+        real_executor_module.SubagentStatus.TIMED_OUT,
+        "deadline reached",
+    )
+    real_executor_module._mark_execution_complete(result)
+
+    assert result.status == real_executor_module.SubagentStatus.TIMED_OUT
+    assert result.error == "deadline reached"
+
+
+def test_compiler_task_termination_stops_worker_before_finalizing_session(monkeypatch):
+    session = CompileSession(
+        session_id="session-123",
+        thread_id="thread-123",
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="inspected",
+        container_id="container-123",
+    )
+    events: list[str] = []
+
+    async def load_session(*, session_id: str, thread_id: str):
+        assert session_id == session.session_id
+        assert thread_id == session.thread_id
+        events.append("load")
+        return session
+
+    def stop_container(session_arg):
+        assert session_arg is session
+        events.append("stop")
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    def cleanup_container(*, session: CompileSession):
+        return session, stop_container(session)
+
+    async def wait_for_shutdown(task_id: str, timeout_seconds: float):
+        assert task_id == "task-123"
+        assert timeout_seconds == 30
+        events.append("wait")
+        return True
+
+    def finalize(*, session: CompileSession, status: str, summary: str, error: str):
+        events.append("finalize")
+        assert status == "timed_out"
+        assert summary == "compiler timeout"
+        assert error == "compiler timeout"
+        session.status = status
+        return session
+
+    monkeypatch.setattr(
+        "deerflow.agents.middlewares.tool_error_handling_middleware.load_bound_session_async",
+        load_session,
+    )
+    monkeypatch.setattr("deerflow.compile.operations.cleanup_compile_session_container_impl", cleanup_container)
+    monkeypatch.setattr("deerflow.compile.operations.finalize_compile_session_impl", finalize)
+    monkeypatch.setattr(task_tool_module, "request_cancel_background_task", lambda task_id: events.append("cancel") or True)
+    monkeypatch.setattr(task_tool_module, "wait_for_background_task_shutdown", wait_for_shutdown)
+    monkeypatch.setattr(task_tool_module, "cleanup_background_task", lambda task_id: events.append("registry_cleanup"))
+
+    stopped = asyncio.run(
+        task_tool_module._cancel_and_reap_task(
+            task_id="task-123",
+            subagent_type="compiler",
+            compile_state={task_tool_module.COMPILE_SESSION_STATE_KEY: session.session_id},
+            thread_id=session.thread_id,
+            terminal_status="timed_out",
+            error="compiler timeout",
+            shutdown_timeout_seconds=30,
+        )
+    )
+
+    assert stopped is True
+    assert events == ["cancel", "load", "stop", "wait", "load", "finalize", "registry_cleanup"]
+
+
+def test_compiler_model_cannot_lower_server_owned_turn_limit():
+    config = SubagentConfig(
+        name="compiler",
+        description="compiler",
+        system_prompt="test",
+        max_turns=36,
+    )
+
+    compiler = task_tool_module._apply_max_turns_override(
+        config,
+        subagent_type="compiler",
+        requested_max_turns=10,
+    )
+    general = task_tool_module._apply_max_turns_override(
+        config,
+        subagent_type="general-purpose",
+        requested_max_turns=10,
+    )
+
+    assert compiler.max_turns == 36
+    assert general.max_turns == 10

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -1,11 +1,15 @@
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, RuntimeConfig
 from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices, clone_repository_impl
 from deerflow.compile.paths import get_compile_sessions_root, get_host_session_dir, get_host_workspace_dir, get_metadata_path, get_session_dir
-from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CompileSession
+from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession
 from deerflow.config.paths import Paths
 
 
@@ -95,7 +99,7 @@ def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypat
     paths = make_test_paths(tmp_path, host_workspace_root=str(host_root))
     manager = CompileSessionManager(paths=paths)
     session = manager.create_session(thread_id="thread-runtime", repo_url="https://example.com/repo.git")
-    runtime = CompileDockerRuntime(manager=manager)
+    runtime = CompileDockerRuntime(config=RuntimeConfig(network=DEFAULT_NETWORK), manager=manager)
     commands: list[list[str]] = []
 
     def fake_run(command, **kwargs):
@@ -116,7 +120,7 @@ def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypat
 def test_docker_runtime_creates_missing_network(tmp_path: Path, monkeypatch):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-network", repo_url="https://example.com/repo.git")
-    runtime = CompileDockerRuntime(manager=manager)
+    runtime = CompileDockerRuntime(config=RuntimeConfig(network=DEFAULT_NETWORK), manager=manager)
     commands: list[list[str]] = []
 
     def fake_run(command, **kwargs):
@@ -131,3 +135,153 @@ def test_docker_runtime_creates_missing_network(tmp_path: Path, monkeypatch):
     runtime.create_container(session)
 
     assert ["docker", "network", "create", DEFAULT_NETWORK] in commands
+
+
+def test_docker_runtime_passes_runtime_proxy_values_out_of_band(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-proxy", repo_url="https://example.com/repo.git")
+    proxy_url = "http://127.0.0.1:7897"
+    monkeypatch.setenv("COMPILE_RUNTIME_NETWORK", "host")
+    monkeypatch.setenv("COMPILE_RUNTIME_HTTP_PROXY", proxy_url)
+    monkeypatch.setenv("COMPILE_RUNTIME_HTTPS_PROXY", proxy_url)
+    monkeypatch.setenv("COMPILE_RUNTIME_NO_PROXY", "localhost,127.0.0.1")
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+
+    CompileDockerRuntime(manager=manager).create_container(session)
+
+    commands = [command for command, _ in calls]
+    assert ["docker", "network", "inspect", "host"] in commands
+    docker_command, docker_kwargs = next((command, kwargs) for command, kwargs in calls if command[:2] == ["docker", "run"])
+    assert ["--network", "host"] == docker_command[docker_command.index("--network") : docker_command.index("--network") + 2]
+    assert ["--add-host", "host.docker.internal:host-gateway"] == docker_command[docker_command.index("--add-host") : docker_command.index("--add-host") + 2]
+    assert docker_command.count("-e") == 6
+    assert "HTTP_PROXY" in docker_command
+    assert "http_proxy" in docker_command
+    assert "HTTPS_PROXY" in docker_command
+    assert "https_proxy" in docker_command
+    assert "NO_PROXY" in docker_command
+    assert "no_proxy" in docker_command
+    assert proxy_url not in docker_command
+    assert docker_kwargs["env"]["HTTP_PROXY"] == proxy_url
+    assert docker_kwargs["env"]["https_proxy"] == proxy_url
+    assert docker_kwargs["env"]["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_docker_runtime_exec_enforces_timeout_inside_container(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-exec-timeout", repo_url="https://example.com/repo.git")
+    session.container_id = "container-123"
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="ok\n", stderr="", returncode=0)
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+
+    result = CompileDockerRuntime(manager=manager).exec(session, "echo ok", timeout_seconds=7)
+
+    docker_command, docker_kwargs = calls[0]
+    assert docker_command[-7:] == ["timeout", "--signal=TERM", "--kill-after=5s", "7s", "bash", "-lc", "echo ok"]
+    assert docker_kwargs["timeout"] == 17
+    assert result.exit_code == 0
+
+
+def test_docker_runtime_exec_records_docker_client_timeout(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-client-timeout", repo_url="https://example.com/repo.git")
+    session.container_id = "container-123"
+    log_path = tmp_path / "timeout.log"
+
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"], output="partial output\n", stderr="stalled\n")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+
+    result = CompileDockerRuntime(manager=manager).exec(session, "long-command", timeout_seconds=3, log_path=str(log_path))
+
+    assert result.exit_code == 124
+    assert result.stdout == "partial output\n"
+    assert result.stderr == "stalled\n"
+    assert "3-second container timeout" in result.combined_output
+    assert log_path.read_text(encoding="utf-8") == result.combined_output
+
+
+def test_clone_repository_runs_git_inside_compile_container(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-clone", repo_url="https://example.com/repo.git")
+    session.container_id = "container-123"
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def fake_exec(session_arg, command, workdir=None, timeout_seconds=600, log_path=None):
+        del timeout_seconds
+        assert session_arg is session
+        calls.append((command, workdir, log_path))
+        if "git clone" in command:
+            Path(session.leadagent_repo_dir).mkdir(parents=True)
+            return CommandResult(exit_code=0, stdout="", stderr="", combined_output="", log_path=log_path)
+        return CommandResult(exit_code=0, stdout="abc123\n", stderr="", combined_output="abc123\n")
+
+    services = CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec))
+    monkeypatch.setattr(operations, "_services", services)
+
+    result, message = clone_repository_impl(
+        session=session,
+        repo_url=session.repo_url,
+        branch="release branch",
+        depth=1,
+    )
+
+    assert result.exit_code == 0
+    assert calls[0][0] == "rm -rf -- /workspace/repo && git clone --depth 1 --branch 'release branch' https://example.com/repo.git /workspace/repo"
+    assert calls[0][1] == "/workspace"
+    assert calls[0][2].endswith("001_clone_attempt_1.log")
+    assert calls[1][:2] == (
+        "git config --global --replace-all safe.directory /workspace/repo && git -C /workspace/repo rev-parse HEAD",
+        "/workspace",
+    )
+    assert session.commit_sha == "abc123"
+    assert session.status == "source_ready"
+    assert "Repository cloned successfully" in message
+
+
+def test_clone_repository_retries_with_container_side_cleanup(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-clone-retry", repo_url="https://example.com/repo.git")
+    session.container_id = "container-123"
+    calls: list[tuple[str, str | None, str | None]] = []
+    clone_results = iter(
+        [
+            CommandResult(exit_code=124, stdout="", stderr="timed out", combined_output="timed out"),
+            CommandResult(exit_code=0, stdout="", stderr="", combined_output=""),
+        ]
+    )
+
+    def fake_exec(session_arg, command, workdir=None, timeout_seconds=600, log_path=None):
+        del timeout_seconds
+        assert session_arg is session
+        calls.append((command, workdir, log_path))
+        if "git clone" in command:
+            return next(clone_results)
+        return CommandResult(exit_code=0, stdout="def456\n", stderr="", combined_output="def456\n")
+
+    services = CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec))
+    monkeypatch.setattr(operations, "_services", services)
+
+    result, message = clone_repository_impl(session=session, repo_url=session.repo_url, max_retries=2)
+
+    clone_calls = [call for call in calls if "git clone" in call[0]]
+    assert result.exit_code == 0
+    assert len(clone_calls) == 2
+    assert all(call[0].startswith("rm -rf -- /workspace/repo && git clone") for call in clone_calls)
+    assert clone_calls[0][2].endswith("001_clone_attempt_1.log")
+    assert clone_calls[1][2].endswith("001_clone_attempt_2.log")
+    assert session.commit_sha == "def456"
+    assert session.status == "source_ready"
+    assert "Repository cloned successfully" in message

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -1,15 +1,18 @@
+import json
+import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from deerflow.compile import operations
-from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, RuntimeConfig
+from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, ContainerCleanupResult, RuntimeConfig
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, clone_repository_impl
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, clone_repository_impl, submit_build_result_impl
 from deerflow.compile.paths import get_compile_sessions_root, get_host_session_dir, get_host_workspace_dir, get_metadata_path, get_session_dir
-from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession
+from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
 
 
@@ -26,6 +29,110 @@ def make_test_paths(tmp_path: Path, *, host_workspace_root: str | None = None) -
         workspace_root=tmp_path / "service-workspace",
         host_workspace_root=host_workspace_root or str(tmp_path / "host-workspace"),
     )
+
+
+def write_elf(path: Path, elf_type: int, *, has_interpreter: bool = False, has_entry_point: bool | None = None) -> None:
+    header = bytearray(64)
+    header[:4] = b"\x7fELF"
+    header[4] = 2  # ELF64
+    header[5] = 1  # little-endian
+    header[6] = 1  # ELF version
+    header[16:18] = elf_type.to_bytes(2, byteorder="little")
+    header[18:20] = (62).to_bytes(2, byteorder="little")  # x86-64
+    header[20:24] = (1).to_bytes(4, byteorder="little")
+    header[52:54] = (64).to_bytes(2, byteorder="little")
+    if elf_type == 1:
+        header[40:48] = (64).to_bytes(8, byteorder="little")
+        header[58:60] = (64).to_bytes(2, byteorder="little")
+        header[60:62] = (3).to_bytes(2, byteorder="little")
+        header[62:64] = (2).to_bytes(2, byteorder="little")
+        null_section = bytearray(64)
+        text_section = bytearray(64)
+        text_section[4:8] = (1).to_bytes(4, byteorder="little")
+        text_section[24:32] = (256).to_bytes(8, byteorder="little")
+        text_section[32:40] = (1).to_bytes(8, byteorder="little")
+        names = b"\0.text\0.shstrtab\0"
+        name_section = bytearray(64)
+        name_section[4:8] = (3).to_bytes(4, byteorder="little")
+        name_section[24:32] = (257).to_bytes(8, byteorder="little")
+        name_section[32:40] = len(names).to_bytes(8, byteorder="little")
+        header.extend(null_section + text_section + name_section + b"\x90" + names)
+    else:
+        if has_entry_point is None:
+            has_entry_point = elf_type == 2 or has_interpreter
+        if has_entry_point:
+            header[24:32] = (0x1000).to_bytes(8, byteorder="little")
+        dynamic_payload = b"\0" * 16 if elf_type == 3 and not has_interpreter and not has_entry_point else b""
+        interpreter_payload = b"/lib64/ld-linux-x86-64.so.2\0" if has_interpreter else b""
+        program_count = 1 + int(bool(dynamic_payload or interpreter_payload))
+        file_size = 64 + program_count * 56 + len(dynamic_payload) + len(interpreter_payload)
+        header[32:40] = (64).to_bytes(8, byteorder="little")
+        header[54:56] = (56).to_bytes(2, byteorder="little")
+        header[56:58] = program_count.to_bytes(2, byteorder="little")
+        load_header = bytearray(56)
+        load_header[:4] = (1).to_bytes(4, byteorder="little")
+        load_header[32:40] = file_size.to_bytes(8, byteorder="little")
+        load_header[40:48] = file_size.to_bytes(8, byteorder="little")
+        header.extend(load_header)
+        if has_interpreter:
+            interpreter_header = bytearray(56)
+            interpreter_header[:4] = (3).to_bytes(4, byteorder="little")
+            interpreter_header[8:16] = (64 + program_count * 56).to_bytes(8, byteorder="little")
+            interpreter_header[32:40] = len(interpreter_payload).to_bytes(8, byteorder="little")
+            interpreter_header[40:48] = len(interpreter_payload).to_bytes(8, byteorder="little")
+            header.extend(interpreter_header)
+        elif dynamic_payload:
+            dynamic_header = bytearray(56)
+            dynamic_header[:4] = (2).to_bytes(4, byteorder="little")
+            dynamic_header[8:16] = (64 + program_count * 56).to_bytes(8, byteorder="little")
+            dynamic_header[32:40] = len(dynamic_payload).to_bytes(8, byteorder="little")
+            dynamic_header[40:48] = len(dynamic_payload).to_bytes(8, byteorder="little")
+            header.extend(dynamic_header)
+        header.extend(dynamic_payload + interpreter_payload)
+    path.write_bytes(header)
+
+
+def write_empty_elf(path: Path, elf_type: int) -> None:
+    header = bytearray(64)
+    header[:4] = b"\x7fELF"
+    header[4:7] = bytes((2, 1, 1))
+    header[16:18] = elf_type.to_bytes(2, byteorder="little")
+    header[18:20] = (62).to_bytes(2, byteorder="little")
+    header[20:24] = (1).to_bytes(4, byteorder="little")
+    header[52:54] = (64).to_bytes(2, byteorder="little")
+    if elf_type == 1:
+        header[40:48] = (64).to_bytes(8, byteorder="little")
+        header[58:60] = (64).to_bytes(2, byteorder="little")
+        header[60:62] = (1).to_bytes(2, byteorder="little")
+        header.extend(bytearray(64))
+    else:
+        header[24:32] = (0x1000).to_bytes(8, byteorder="little")
+        header[32:40] = (64).to_bytes(8, byteorder="little")
+        header[54:56] = (56).to_bytes(2, byteorder="little")
+        header[56:58] = (1).to_bytes(2, byteorder="little")
+        load_header = bytearray(56)
+        load_header[:4] = (1).to_bytes(4, byteorder="little")
+        header.extend(load_header)
+    path.write_bytes(header)
+
+
+def write_static_archive(path: Path) -> None:
+    object_path = path.with_suffix(".member.o")
+    write_elf(object_path, 1)
+    payload = object_path.read_bytes()
+    object_path.unlink()
+    member_header = b"".join(
+        [
+            b"member.o/".ljust(16),
+            b"0".ljust(12),
+            b"0".ljust(6),
+            b"0".ljust(6),
+            b"100644".ljust(8),
+            str(len(payload)).encode("ascii").ljust(10),
+            b"`\n",
+        ]
+    )
+    path.write_bytes(b"!<arch>\n" + member_header + payload + (b"\n" if len(payload) % 2 else b""))
 
 
 def test_create_session_creates_expected_directory_layout(tmp_path: Path):
@@ -86,12 +193,274 @@ def test_mark_status_sets_completed_at_for_terminal_state(tmp_path: Path):
     assert session.summary == "ok"
 
 
+def test_mark_status_clears_stale_error_and_preserves_completion_time(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-status", repo_url="https://example.com/repo.git")
+    manager.mark_session_status(session, "verification_failed", error="old failure")
+
+    manager.mark_session_status(session, "verified")
+    assert session.error is None
+    assert session.completed_at is None
+
+    manager.mark_session_status(session, "completed")
+    completed_at = session.completed_at
+    manager.mark_session_status(session, "completed")
+    assert session.completed_at == completed_at
+
+
+def test_finalize_is_idempotent_and_preserves_first_terminal_result(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-finalize", repo_url="https://example.com/repo.git")
+    session.status = "verified"
+    session.artifacts = [BuildArtifact(path="artifacts/hello", artifact_type="executable", size_bytes=128)]
+    session.verification = VerificationResult(status="passed", artifact_count=1)
+    manager.save_session(session)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
+
+    operations.finalize_compile_session_impl(session=session, status="completed")
+    completed_at = session.completed_at
+    finalized_at = session.finalized_at
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    operations.finalize_compile_session_impl(
+        session=reloaded,
+        status="failed",
+        error="must not replace the first result",
+    )
+
+    assert reloaded.status == "completed"
+    assert reloaded.error is None
+    assert reloaded.completed_at == completed_at
+    assert reloaded.finalized_at == finalized_at
+    workflow_log = Path(session.leadagent_logs_dir) / "workflow.log"
+    events = [json.loads(line) for line in workflow_log.read_text(encoding="utf-8").splitlines()]
+    assert sum(event["event"] == "finalize.completed" for event in events) == 1
+    assert sum(event["event"] == "session.status_changed" and event["status"] == "completed" for event in events) == 1
+
+
+def test_concurrent_finalize_with_stale_copies_commits_one_terminal_result(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-concurrent-finalize", repo_url="https://example.com/repo.git")
+    manager.save_session(session)
+    first = manager.load_session(session.session_id, session.thread_id)
+    second = manager.load_session(session.session_id, session.thread_id)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(operations.finalize_compile_session_impl, session=first, status="completed"),
+            pool.submit(
+                operations.finalize_compile_session_impl,
+                session=second,
+                status="failed",
+                error="competing terminal result",
+            ),
+        ]
+        results = [future.result() for future in futures]
+
+    authoritative = manager.load_session(session.session_id, session.thread_id)
+    assert {result.status for result in results} == {authoritative.status}
+    workflow_log = Path(session.leadagent_logs_dir) / "workflow.log"
+    events = [json.loads(line) for line in workflow_log.read_text(encoding="utf-8").splitlines()]
+    assert sum(event["event"] == "finalize.completed" for event in events) == 1
+
+
+def test_parent_run_cleanup_finalizes_unfinished_session_once(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-cancelled", repo_url="https://example.com/repo.git")
+    session.status = "inspected"
+    session.container_id = "container-123"
+    manager.save_session(session)
+    cleanup_calls: list[str] = []
+
+    def cleanup(session_arg):
+        cleanup_calls.append(session_arg.session_id)
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(stop_and_remove_container=cleanup),
+        ),
+    )
+
+    finalized = operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=session.thread_id,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+    repeated = operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=session.thread_id,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+
+    assert len(finalized) == 1
+    assert repeated == []
+    loaded = manager.load_session(session.session_id, session.thread_id)
+    assert loaded.status == "cancelled"
+    assert loaded.error == "Parent run was cancelled."
+    assert loaded.completed_at is not None
+    assert loaded.finalized_at is not None
+    assert cleanup_calls == [session.session_id]
+    workflow_log = Path(loaded.leadagent_logs_dir) / "workflow.log"
+    events = [json.loads(line) for line in workflow_log.read_text(encoding="utf-8").splitlines()]
+    assert sum(event["event"] == "finalize.completed" for event in events) == 1
+
+
+def test_parent_run_cleanup_only_touches_sessions_owned_by_that_run(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    old_session = manager.create_session(
+        thread_id="thread-overlap",
+        run_id="run-old",
+        repo_url="https://example.com/old.git",
+    )
+    new_session = manager.create_session(
+        thread_id="thread-overlap",
+        run_id="run-new",
+        repo_url="https://example.com/new.git",
+    )
+    cleanup_calls: list[str] = []
+
+    def cleanup(session_arg):
+        cleanup_calls.append(session_arg.session_id)
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+
+    finalized = operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=old_session.thread_id,
+        run_id="run-old",
+        interrupted_status="cancelled",
+        error="Old run was replaced.",
+    )
+
+    assert [item.session_id for item in finalized] == [old_session.session_id]
+    assert cleanup_calls == [old_session.session_id]
+    assert manager.load_session(old_session.session_id, old_session.thread_id).finalized_at is not None
+    loaded_new = manager.load_session(new_session.session_id, new_session.thread_id)
+    assert loaded_new.status == "created"
+    assert loaded_new.finalized_at is None
+
+
+def test_cleanup_failure_remains_retryable_until_container_is_removed(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-cleanup-retry",
+        run_id="run-cleanup-retry",
+        repo_url="https://example.com/repo.git",
+    )
+    results = iter(
+        [
+            ContainerCleanupResult(succeeded=False, stopped=False, removed=False),
+            ContainerCleanupResult(succeeded=True, stopped=True, removed=True),
+        ]
+    )
+    cleanup_calls = 0
+
+    def cleanup(_session):
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return next(results)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+
+    operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=session.thread_id,
+        run_id=session.run_id,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+    after_failure = manager.load_session(session.session_id, session.thread_id)
+    assert after_failure.status == "failed"
+    assert after_failure.finalized_at is None
+
+    operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=session.thread_id,
+        run_id=session.run_id,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+    after_retry = manager.load_session(session.session_id, session.thread_id)
+    assert after_retry.status == "cancelled"
+    assert after_retry.finalized_at is not None
+    assert cleanup_calls == 2
+
+
+def test_parent_cleanup_reloads_session_before_stopping_container(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-stale-cleanup",
+        run_id="run-stale-cleanup",
+        repo_url="https://example.com/repo.git",
+    )
+    stale_snapshot = manager.load_session(session.session_id, session.thread_id)
+    session.container_id = "container-created-after-snapshot"
+    manager.save_session(session)
+    cleanup_container_ids: list[str | None] = []
+
+    def cleanup(session_arg):
+        cleanup_container_ids.append(session_arg.container_id)
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(manager, "list_sessions", lambda _thread_id: [stale_snapshot])
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+
+    operations.finalize_unfinished_thread_sessions_impl(
+        thread_id=session.thread_id,
+        run_id=session.run_id,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+
+    assert cleanup_container_ids == ["container-created-after-snapshot"]
+
+
 def test_host_workspace_path_preserves_windows_style(tmp_path: Path):
     paths = make_test_paths(tmp_path, host_workspace_root=r"C:\Users\developer\Forge-AutoCompiler")
     manager = CompileSessionManager(paths=paths)
     session = manager.create_session(thread_id="windows-thread", repo_url="https://example.com/repo.git")
 
     assert get_host_workspace_dir(session.session_id, session.thread_id, paths) == (rf"C:\Users\developer\Forge-AutoCompiler\.compile-sessions\windows-thread\{session.session_id}\workspace")
+
+
+def test_cleanup_reports_stopped_container_without_claiming_removal(monkeypatch):
+    runtime = CompileDockerRuntime(config=RuntimeConfig(remove_on_cleanup=False))
+    session = CompileSession(
+        session_id="session-cleanup",
+        thread_id="thread-cleanup",
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="verified",
+        container_id="container-123",
+    )
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        assert command == ["docker", "stop", "container-123"]
+        return SimpleNamespace(returncode=0, stdout="container-123\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = runtime.stop_and_remove_container(session)
+
+    assert result.succeeded is True
+    assert result.stopped is True
+    assert result.removed is False
 
 
 def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypatch):
@@ -285,3 +654,199 @@ def test_clone_repository_retries_with_container_side_cleanup(tmp_path: Path, mo
     assert session.commit_sha == "def456"
     assert session.status == "source_ready"
     assert "Repository cloned successfully" in message
+
+
+def test_compiled_artifact_classifier_uses_file_format_not_mode(tmp_path: Path):
+    executable = tmp_path / "app"
+    pie_executable = tmp_path / "pie-app"
+    shared_library = tmp_path / "libapp.so"
+    static_pie = tmp_path / "static-pie"
+    object_file = tmp_path / "app.o"
+    static_library = tmp_path / "libapp.a"
+    text_log = tmp_path / "commands.log"
+
+    write_elf(executable, 2)
+    write_elf(pie_executable, 3, has_interpreter=True)
+    write_elf(shared_library, 3)
+    write_elf(static_pie, 3, has_entry_point=True)
+    write_elf(object_file, 1)
+    write_static_archive(static_library)
+    text_log.write_text("echo this must never run\n", encoding="utf-8")
+    text_log.chmod(0o777)
+
+    assert _classify_compiled_artifact(executable) == "executable"
+    assert _classify_compiled_artifact(pie_executable) == "executable"
+    assert _classify_compiled_artifact(shared_library) == "shared_library"
+    assert _classify_compiled_artifact(static_pie) == "executable"
+    assert _classify_compiled_artifact(object_file) == "object"
+    assert _classify_compiled_artifact(static_library) == "static_library"
+    assert _classify_compiled_artifact(text_log) is None
+
+
+def test_compiled_artifact_classifier_rejects_truncated_headers(tmp_path: Path):
+    truncated_elf = tmp_path / "truncated.o"
+    empty_archive = tmp_path / "empty.a"
+    truncated_archive = tmp_path / "truncated.a"
+    truncated_elf.write_bytes(b"\x7fELF" + bytes(60))
+    empty_archive.write_bytes(b"!<arch>\n")
+    truncated_archive.write_bytes(b"!<arch>\nmember.o/")
+
+    assert _classify_compiled_artifact(truncated_elf) is None
+    assert _classify_compiled_artifact(empty_archive) is None
+    assert _classify_compiled_artifact(truncated_archive) is None
+
+
+def test_compiled_artifact_classifier_rejects_empty_structural_shells(tmp_path: Path):
+    executable = tmp_path / "empty-app"
+    object_file = tmp_path / "empty.o"
+    archive = tmp_path / "empty.a"
+    write_empty_elf(executable, 2)
+    write_empty_elf(object_file, 1)
+    payload = object_file.read_bytes()
+    member_header = b"".join(
+        [
+            b"empty.o/".ljust(16),
+            b"0".ljust(12),
+            b"0".ljust(6),
+            b"0".ljust(6),
+            b"100644".ljust(8),
+            str(len(payload)).encode("ascii").ljust(10),
+            b"`\n",
+        ]
+    )
+    archive.write_bytes(b"!<arch>\n" + member_header + payload + (b"\n" if len(payload) % 2 else b""))
+
+    assert _classify_compiled_artifact(executable) is None
+    assert _classify_compiled_artifact(object_file) is None
+    assert _classify_compiled_artifact(archive) is None
+
+
+@pytest.mark.skipif(shutil.which("gcc") is None or shutil.which("ar") is None, reason="requires a C toolchain")
+def test_compiled_artifact_classifier_accepts_real_gcc_and_ar_outputs(tmp_path: Path):
+    source = tmp_path / "artifact.c"
+    executable = tmp_path / "artifact"
+    shared_library = tmp_path / "libartifact.so"
+    object_file = tmp_path / "artifact.o"
+    static_library = tmp_path / "libartifact.a"
+    source.write_text("int value(void) { return 7; }\nint main(void) { return value(); }\n", encoding="utf-8")
+
+    subprocess.run(["gcc", str(source), "-o", str(executable)], check=True, capture_output=True)
+    subprocess.run(["gcc", "-shared", "-fPIC", str(source), "-o", str(shared_library)], check=True, capture_output=True)
+    subprocess.run(["gcc", "-c", str(source), "-o", str(object_file)], check=True, capture_output=True)
+    subprocess.run(["ar", "rcs", str(static_library), str(object_file)], check=True, capture_output=True)
+
+    assert _classify_compiled_artifact(executable) == "executable"
+    assert _classify_compiled_artifact(shared_library) == "shared_library"
+    assert _classify_compiled_artifact(object_file) == "object"
+    assert _classify_compiled_artifact(static_library) == "static_library"
+
+
+@pytest.mark.skipif(shutil.which("gcc") is None, reason="requires gcc")
+def test_compiled_artifact_classifier_recognizes_real_static_pie(tmp_path: Path):
+    source = tmp_path / "static-pie.c"
+    executable = tmp_path / "static-pie"
+    source.write_text("int main(void) { return 0; }\n", encoding="utf-8")
+    result = subprocess.run(["gcc", "-static-pie", str(source), "-o", str(executable)], check=False, capture_output=True)
+    if result.returncode != 0:
+        pytest.skip("toolchain does not support static PIE")
+
+    assert _classify_compiled_artifact(executable) == "executable"
+
+
+def test_submit_rejects_executable_mode_text_without_running_it(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-text-artifact", repo_url="https://example.com/repo.git")
+    text_log = Path(session.leadagent_artifacts_dir) / "commands.log"
+    text_log.write_text("echo this must never run\n", encoding="utf-8")
+    text_log.chmod(0o777)
+
+    def fail_exec(*args, **kwargs):
+        raise AssertionError("Text artifacts must not be executed")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fail_exec)))
+
+    payload = json.loads(submit_build_result_impl(session=session))
+
+    assert payload["status"] == "failed"
+    assert payload["artifact_count"] == 0
+    assert "No recognized compiled artifacts" in payload["message"]
+    assert session.status == "verification_failed"
+
+
+def test_submit_rejects_symlinked_system_executable_without_running_it(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-symlink-artifact", repo_url="https://example.com/repo.git")
+    symlink = Path(session.leadagent_artifacts_dir) / "fake-app"
+    symlink.symlink_to("/bin/true")
+
+    def fail_exec(*args, **kwargs):
+        raise AssertionError("Symlinked artifacts must not be executed")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fail_exec)))
+
+    payload = json.loads(submit_build_result_impl(session=session))
+
+    assert payload["status"] == "failed"
+    assert payload["artifact_count"] == 0
+    assert session.status == "verification_failed"
+
+
+def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-mixed-artifacts", repo_url="https://example.com/repo.git")
+    session.error = "stale verification failure"
+    artifacts_dir = Path(session.leadagent_artifacts_dir)
+    write_elf(artifacts_dir / "hello", 2)
+    text_log = artifacts_dir / "verification.log"
+    text_log.write_text("", encoding="utf-8")
+    text_log.chmod(0o777)
+    calls: list[str] = []
+
+    def fake_exec(session_arg, command, **kwargs):
+        assert session_arg is session
+        calls.append(command)
+        return CommandResult(exit_code=0, stdout="Hello Matt!\n", stderr="", combined_output="Hello Matt!\n")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)))
+
+    payload = json.loads(submit_build_result_impl(session=session))
+
+    assert payload["status"] == "passed"
+    assert payload["artifact_count"] == 1
+    assert payload["artifacts"][0]["artifact_type"] == "executable"
+    assert calls == ["/artifacts/hello -version"]
+    assert session.status == "verified"
+    assert session.error is None
+    assert session.completed_at is None
+    assert (Path(session.metadata_path).parent / "repro" / "build.sh").exists()
+
+
+@pytest.mark.parametrize(
+    ("filename", "file_type", "expected_type"),
+    [
+        ("libapp.so", "shared", "shared_library"),
+        ("app.o", "object", "object"),
+        ("libapp.a", "archive", "static_library"),
+    ],
+)
+def test_submit_accepts_non_executable_compiled_outputs_without_smoke(tmp_path: Path, monkeypatch, filename: str, file_type: str, expected_type: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id=f"thread-{file_type}", repo_url="https://example.com/repo.git")
+    artifact = Path(session.leadagent_artifacts_dir) / filename
+    if file_type == "shared":
+        write_elf(artifact, 3)
+    elif file_type == "object":
+        write_elf(artifact, 1)
+    else:
+        write_static_archive(artifact)
+
+    def fail_exec(*args, **kwargs):
+        raise AssertionError("Non-executable compiled artifacts must not be smoke-tested")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fail_exec)))
+
+    payload = json.loads(submit_build_result_impl(session=session))
+
+    assert payload["status"] == "passed"
+    assert payload["artifacts"][0]["artifact_type"] == expected_type
+    assert session.status == "verified"

--- a/backend/tests/test_compile_terminal_tools.py
+++ b/backend/tests/test_compile_terminal_tools.py
@@ -1,0 +1,300 @@
+import asyncio
+import json
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from langgraph.types import Command
+
+from deerflow.agents.middlewares.compile_termination_middleware import CompileTerminationMiddleware
+from deerflow.agents.middlewares.memory_middleware import MemoryMiddleware
+from deerflow.agents.thread_state import ThreadState
+from deerflow.compile.docker_runtime import ContainerCleanupResult
+from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CompileSession, VerificationResult
+from deerflow.tools import bound_compile_tools
+from deerflow.tools.builtins import agent_compile_tools
+
+
+class SingleToolCallModel(BaseChatModel):
+    calls: int = 0
+    tool_name: str = "submit_build_result"
+
+    @property
+    def _llm_type(self) -> str:
+        return "single-tool-call"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("The model was called after a terminal compile tool")
+        response = AIMessage(
+            content="",
+            tool_calls=[{"name": self.tool_name, "args": {}, "id": "tool-call-graph", "type": "tool_call"}],
+        )
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+
+def make_session() -> CompileSession:
+    return CompileSession(
+        session_id="session-123",
+        thread_id="thread-123",
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="verified",
+        commit_sha="abc123",
+        container_id="container-123",
+        build_system="cmake",
+        metadata_path="/sessions/thread-123/session-123/session.json",
+        leadagent_repo_dir="/sessions/thread-123/session-123/workspace/repo",
+        leadagent_artifacts_dir="/sessions/thread-123/session-123/artifacts",
+        leadagent_logs_dir="/sessions/thread-123/session-123/logs",
+        leadagent_repro_dir="/sessions/thread-123/session-123/repro",
+        commands=[BuildCommandRecord(stage="build", command="cmake --build build", workdir="/workspace/repo")],
+        artifacts=[BuildArtifact(path="thread-123/session-123/artifacts/hello", artifact_type="executable", size_bytes=16504)],
+        verification=VerificationResult(status="passed", artifact_count=1),
+    )
+
+
+def test_successful_bound_submit_returns_machine_readable_result(monkeypatch):
+    session = make_session()
+    submit_payload = {
+        "status": "passed",
+        "message": "Build artifacts accepted from /artifacts.",
+        "artifacts": [{"path": "thread-123/session-123/artifacts/hello"}],
+    }
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", lambda session: json.dumps(submit_payload))
+    submit_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "submit_build_result")
+
+    result = submit_tool.func()
+
+    assert json.loads(result) == submit_payload
+
+
+def test_successful_submit_ends_react_graph_after_one_model_call(monkeypatch):
+    session = make_session()
+    submit_payload = {
+        "status": "passed",
+        "message": "Build artifacts accepted from /artifacts.",
+        "artifacts": [{"path": "thread-123/session-123/artifacts/hello"}],
+    }
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", lambda session: json.dumps(submit_payload))
+    submit_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "submit_build_result")
+    model = SingleToolCallModel()
+    agent = create_agent(model=model, tools=[submit_tool], middleware=[CompileTerminationMiddleware()])
+
+    final_state = agent.invoke({"messages": [HumanMessage(content="Submit the completed build.")]})
+
+    assert model.calls == 1
+    assert json.loads(final_state["messages"][-1].content)["verification_status"] == "passed"
+
+
+def test_successful_submit_ends_async_react_graph_after_one_model_call(monkeypatch):
+    session = make_session()
+    submit_payload = {
+        "status": "passed",
+        "message": "Build artifacts accepted from /artifacts.",
+        "artifacts": [{"path": "thread-123/session-123/artifacts/hello"}],
+    }
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", lambda session: json.dumps(submit_payload))
+    submit_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "submit_build_result")
+    model = SingleToolCallModel()
+    agent = create_agent(model=model, tools=[submit_tool], middleware=[CompileTerminationMiddleware()])
+
+    final_state = asyncio.run(agent.ainvoke({"messages": [HumanMessage(content="Submit the completed build.")]}))
+
+    assert model.calls == 1
+    assert json.loads(final_state["messages"][-1].content)["verification_status"] == "passed"
+
+
+def test_failed_bound_submit_remains_repairable(monkeypatch):
+    session = make_session()
+    submit_payload = {"status": "failed", "message": "No compiled artifacts", "artifacts": []}
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", lambda session: json.dumps(submit_payload))
+    submit_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "submit_build_result")
+
+    result = submit_tool.func()
+
+    assert isinstance(result, str)
+    assert json.loads(result)["status"] == "failed"
+
+
+def test_compile_session_skips_post_run_memory_model_work(monkeypatch):
+    monkeypatch.setattr(
+        "deerflow.agents.middlewares.memory_middleware.get_memory_queue",
+        lambda: (_ for _ in ()).throw(AssertionError("compile runs must not enqueue memory updates")),
+    )
+
+    result = MemoryMiddleware().after_agent(
+        {
+            "messages": [HumanMessage(content="Build the repository")],
+            "compile_session_id": "session-123",
+        },
+        SimpleNamespace(context={"thread_id": "thread-123"}),
+    )
+
+    assert result is None
+
+
+def test_finalize_cleans_container_then_ends_lead_with_deterministic_summary(monkeypatch):
+    session = make_session()
+    events: list[str] = []
+
+    def cleanup_and_finalize(*, session: CompileSession):
+        assert session is session_arg
+        events.append("cleanup")
+        events.append("finalize")
+        session.status = "completed"
+        return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    session_arg = session
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+    monkeypatch.setattr(agent_compile_tools, "cleanup_and_finalize_compile_session_impl", cleanup_and_finalize)
+    runtime = SimpleNamespace(
+        state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+        context={"thread_id": session.thread_id},
+        config={"configurable": {}},
+    )
+
+    result = agent_compile_tools.finalize_session.func(runtime=runtime)
+
+    assert events == ["cleanup", "finalize"]
+    final_payload = json.loads(result)
+    assert final_payload["status"] == "completed"
+    assert final_payload["session_id"] == session.session_id
+    assert final_payload["commands"] == ["cmake --build build"]
+    assert final_payload["verification"] == "passed"
+    assert final_payload["container_stopped"] is True
+    assert final_payload["container_removed"] is True
+    assert final_payload["error"] is None
+
+    request = SimpleNamespace(tool_call={"name": "finalize_session", "id": "tool-call-3", "args": {}})
+    tool_message = ToolMessage(content=result, tool_call_id="tool-call-3", name="finalize_session")
+    terminal = CompileTerminationMiddleware().wrap_tool_call(request, lambda _: tool_message)
+    assert isinstance(terminal, Command)
+    assert terminal.update["compile_terminal"] is True
+    assert isinstance(terminal.update["messages"][-1], AIMessage)
+    assert json.loads(terminal.update["messages"][-1].content) == final_payload
+
+    jump = CompileTerminationMiddleware().before_model(
+        {"messages": terminal.update["messages"], "compile_terminal": True},
+        SimpleNamespace(),
+    )
+    assert jump == {"compile_terminal": False, "jump_to": "end"}
+
+
+def test_finalize_ends_lead_graph_after_one_model_call(monkeypatch):
+    session = make_session()
+    events: list[str] = []
+
+    def cleanup_and_finalize(*, session: CompileSession):
+        events.append("cleanup")
+        events.append("finalize")
+        session.status = "completed"
+        return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+    monkeypatch.setattr(agent_compile_tools, "cleanup_and_finalize_compile_session_impl", cleanup_and_finalize)
+    model = SingleToolCallModel(tool_name="finalize_session")
+    agent = create_agent(
+        model=model,
+        tools=[agent_compile_tools.finalize_session],
+        middleware=[CompileTerminationMiddleware()],
+        state_schema=ThreadState,
+    )
+
+    final_state = agent.invoke(
+        {
+            "messages": [HumanMessage(content="Finalize the verified compile session.")],
+            "compile_session_id": session.session_id,
+            "artifacts": [],
+            "viewed_images": {},
+        },
+        config={"configurable": {"thread_id": session.thread_id}},
+    )
+
+    assert model.calls == 1
+    assert events == ["cleanup", "finalize"]
+    assert json.loads(final_state["messages"][-1].content)["container_removed"] is True
+
+
+def test_finalize_cleans_container_but_fails_unverified_session(monkeypatch):
+    session = make_session()
+    session.status = "verification_failed"
+    session.verification = VerificationResult(status="failed", artifact_count=0, failed_checks=1)
+    session.artifacts = []
+    session.error = "No recognized compiled artifacts were found."
+    events: list[str] = []
+
+    def cleanup_and_finalize(*, session: CompileSession):
+        events.append("cleanup")
+        events.append("finalize")
+        session.status = "failed"
+        return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+    monkeypatch.setattr(agent_compile_tools, "cleanup_and_finalize_compile_session_impl", cleanup_and_finalize)
+    runtime = SimpleNamespace(
+        state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+        context={"thread_id": session.thread_id},
+        config={"configurable": {}},
+    )
+
+    result = json.loads(agent_compile_tools.finalize_session.func(runtime=runtime))
+
+    assert events == ["cleanup", "finalize"]
+    assert result["status"] == "failed"
+    assert result["verification"] == "failed"
+    assert result["artifacts"] == []
+    assert result["container_removed"] is True
+    assert result["error"] == "No recognized compiled artifacts were found."
+
+
+def test_finalize_marks_verified_session_failed_when_container_cleanup_fails(monkeypatch):
+    session = make_session()
+
+    def cleanup_and_finalize(*, session: CompileSession):
+        session.status = "failed"
+        session.error = "Compile container cleanup failed."
+        return session, ContainerCleanupResult(succeeded=False, stopped=False, removed=False)
+
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+    monkeypatch.setattr(agent_compile_tools, "cleanup_and_finalize_compile_session_impl", cleanup_and_finalize)
+    runtime = SimpleNamespace(
+        state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+        context={"thread_id": session.thread_id},
+        config={"configurable": {}},
+    )
+
+    result = json.loads(agent_compile_tools.finalize_session.func(runtime=runtime))
+
+    assert result["status"] == "failed"
+    assert result["verification"] == "passed"
+    assert result["container_stopped"] is False
+    assert result["container_removed"] is False
+    assert result["error"] == "Compile container cleanup failed."
+    assert session.finalized_at is None

--- a/backend/tests/test_config_upgrade_script.py
+++ b/backend/tests/test_config_upgrade_script.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPGRADE_SCRIPT = REPO_ROOT / "scripts" / "config-upgrade.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("uv") is None,
+    reason="config upgrade integration tests require bash and uv",
+)
+
+WEB_TOOLS = [
+    {"name": "web_search", "group": "web", "use": "custom.web:web_search"},
+    {"name": "web_fetch", "group": "web", "use": "custom.web:web_fetch"},
+    {"name": "image_search", "group": "web", "use": "custom.web:image_search"},
+]
+LEGACY_TOOLS = [
+    {"name": "ls", "group": "file:read", "use": "deerflow.sandbox.tools:ls_tool"},
+    {"name": "read_file", "group": "file:read", "use": "deerflow.sandbox.tools:read_file_tool"},
+    {"name": "glob", "group": "file:read", "use": "deerflow.sandbox.tools:glob_tool"},
+    {"name": "grep", "group": "file:read", "use": "deerflow.sandbox.tools:grep_tool"},
+    {"name": "write_file", "group": "file:write", "use": "deerflow.sandbox.tools:write_file_tool"},
+    {"name": "str_replace", "group": "file:write", "use": "deerflow.sandbox.tools:str_replace_tool"},
+    {"name": "bash", "group": "bash", "use": "deerflow.sandbox.tools:bash_tool"},
+]
+
+
+def _run_upgrade(tmp_path: Path, config: dict) -> tuple[subprocess.CompletedProcess[str], Path]:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    env = os.environ.copy()
+    env["DEER_FLOW_CONFIG_PATH"] = str(config_path)
+    result = subprocess.run(
+        ["bash", str(UPGRADE_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    return result, config_path
+
+
+def test_v5_upgrade_removes_obsolete_runtime_and_orphaned_groups(tmp_path: Path) -> None:
+    original = {
+        "config_version": 5,
+        "tool_groups": [{"name": "web"}, {"name": "file:read"}, {"name": "file:write"}, {"name": "bash"}],
+        "tools": WEB_TOOLS + LEGACY_TOOLS,
+        "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider", "allow_host_bash": False},
+        "custom_field": {"preserve": True},
+    }
+
+    result, config_path = _run_upgrade(tmp_path, original)
+
+    assert result.returncode == 0, result.stderr
+    upgraded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert upgraded["config_version"] == 6
+    assert upgraded["sandbox"] is None
+    assert [tool["name"] for tool in upgraded["tools"]] == ["web_search", "web_fetch", "image_search"]
+    assert [group["name"] for group in upgraded["tool_groups"]] == ["web"]
+    assert upgraded["custom_field"] == {"preserve": True}
+
+    backup = yaml.safe_load(config_path.with_suffix(".yaml.bak").read_text(encoding="utf-8"))
+    assert backup == original
+
+    first_upgrade = config_path.read_text(encoding="utf-8")
+    second_env = os.environ.copy()
+    second_env["DEER_FLOW_CONFIG_PATH"] = str(config_path)
+    second = subprocess.run(
+        ["bash", str(UPGRADE_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=second_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert second.returncode == 0, second.stderr
+    assert config_path.read_text(encoding="utf-8") == first_upgrade
+
+
+def test_quoted_version_preserves_custom_provider_and_referenced_legacy_group(tmp_path: Path) -> None:
+    custom_tool = {"name": "custom_reader", "group": "file:read", "use": "custom.tools:reader", "custom_option": "keep"}
+    original = {
+        "config_version": "5",
+        "tool_groups": [{"name": "web"}, {"name": "file:read"}, {"name": "file:write"}, {"name": "bash"}],
+        "tools": WEB_TOOLS + [LEGACY_TOOLS[1], custom_tool],
+        "sandbox": {"use": "custom.sandbox:Provider", "custom_option": "keep"},
+        "tool_search": {"enabled": False, "custom_option": "keep"},
+    }
+
+    result, config_path = _run_upgrade(tmp_path, original)
+
+    assert result.returncode == 0, result.stderr
+    upgraded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert upgraded["config_version"] == 6
+    assert upgraded["sandbox"] == original["sandbox"]
+    assert [tool["name"] for tool in upgraded["tools"]] == ["web_search", "web_fetch", "image_search", "custom_reader"]
+    assert upgraded["tools"][-1]["custom_option"] == "keep"
+    assert [group["name"] for group in upgraded["tool_groups"]] == ["web", "file:read"]
+    assert upgraded["tool_search"]["custom_option"] == "keep"
+
+
+def test_null_version_is_treated_as_pre_versioned_config(tmp_path: Path) -> None:
+    result, config_path = _run_upgrade(
+        tmp_path,
+        {"config_version": None, "tools": [], "tool_groups": [], "sandbox": None, "custom_field": "keep"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    upgraded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert upgraded["config_version"] == 6
+    assert upgraded["custom_field"] == "keep"
+
+
+def test_invalid_version_fails_without_modifying_config(tmp_path: Path) -> None:
+    original = {"config_version": "five", "tools": [], "sandbox": None}
+    result, config_path = _run_upgrade(tmp_path, original)
+
+    assert result.returncode == 2
+    assert "config_version must be a non-negative integer" in result.stderr
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original
+    assert not config_path.with_suffix(".yaml.bak").exists()

--- a/backend/tests/test_docker_compose_compile_paths.py
+++ b/backend/tests/test_docker_compose_compile_paths.py
@@ -35,3 +35,10 @@ def test_backend_build_and_runtime_receive_uv_timeout():
     assert compose.count("UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}") == 2
     assert compose.count("uv sync --frozen") == 4
     assert compose.count("uv run --frozen") == 2
+
+
+def test_backend_services_mount_example_config_for_runtime_validation():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert compose.count("../config.example.yaml:/app/config.example.yaml:ro") == 2
+    assert compose.count("../scripts:/app/scripts:ro") == 2

--- a/backend/tests/test_example_config_runtime.py
+++ b/backend/tests/test_example_config_runtime.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import yaml
+from langchain.tools import BaseTool
+
+from deerflow.reflection import resolve_variable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_example_configured_tool_paths_resolve() -> None:
+    config = yaml.safe_load((REPO_ROOT / "config.example.yaml").read_text(encoding="utf-8"))
+
+    for tool in config.get("tools", []):
+        resolved = resolve_variable(tool["use"], BaseTool)
+        assert resolved.name == tool["name"]
+
+
+def test_example_disables_removed_general_sandbox() -> None:
+    config = yaml.safe_load((REPO_ROOT / "config.example.yaml").read_text(encoding="utf-8"))
+
+    assert config.get("sandbox") is None

--- a/backend/tests/test_lead_agent_prompt.py
+++ b/backend/tests/test_lead_agent_prompt.py
@@ -5,6 +5,35 @@ import anyio
 
 from deerflow.agents.lead_agent import prompt as prompt_module
 from deerflow.skills.types import Skill
+from deerflow.tools.tools import COMPILE_TOOLS
+
+
+def test_compile_tools_register_split_session_flow():
+    assert [tool.name for tool in COMPILE_TOOLS] == [
+        "prepare_compile_session",
+        "clone_repository",
+        "identify_build_system",
+        "finalize_session",
+    ]
+
+
+def test_lead_prompt_uses_registered_compile_workflow(monkeypatch):
+    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda: ["general-purpose", "compiler"])
+
+    subagent_section = prompt_module._build_subagent_section(3)
+    workflow = [
+        "prepare_compile_session",
+        "clone_repository",
+        "identify_build_system",
+        'task(subagent_type="compiler")',
+        "finalize_session",
+    ]
+
+    assert "prepare_workspace" not in subagent_section
+    assert "prepare_workspace" not in prompt_module.SYSTEM_PROMPT_TEMPLATE
+    for prompt_text in (subagent_section, prompt_module.SYSTEM_PROMPT_TEMPLATE):
+        positions = [prompt_text.index(tool_name) for tool_name in workflow]
+        assert positions == sorted(positions)
 
 
 def test_build_custom_mounts_section_returns_empty_when_no_mounts(monkeypatch):
@@ -17,7 +46,7 @@ def test_build_custom_mounts_section_returns_empty_when_no_mounts(monkeypatch):
 def test_build_custom_mounts_section_lists_configured_mounts(monkeypatch):
     mounts = [
         SimpleNamespace(source="/host/shared", target="/home/user/shared"),
-        SimpleNamespace(source="/host/reference", target="/mnt/reference"),
+        SimpleNamespace(host_path="/host/reference", container_path="/mnt/reference"),
     ]
     config = SimpleNamespace(custom_mounts=mounts)
     monkeypatch.setattr("deerflow.config.app_config.get_app_config", lambda: config)
@@ -31,12 +60,9 @@ def test_build_custom_mounts_section_lists_configured_mounts(monkeypatch):
 
 def test_apply_prompt_template_includes_custom_mounts(monkeypatch):
     mounts = [SimpleNamespace(source="/host/shared", target="/home/user/shared")]
-    config = SimpleNamespace(
-        custom_mounts=mounts,
-        skills=SimpleNamespace(container_path="/mnt/skills"),
-    )
+    config = SimpleNamespace(custom_mounts=mounts)
     monkeypatch.setattr("deerflow.config.app_config.get_app_config", lambda: config)
-    monkeypatch.setattr(prompt_module, "_get_enabled_skills", lambda: [])
+    monkeypatch.setattr(prompt_module, "get_skills_prompt_section", lambda available_skills=None: "")
     monkeypatch.setattr(prompt_module, "get_deferred_tools_prompt_section", lambda: "")
     monkeypatch.setattr(prompt_module, "_get_memory_context", lambda agent_name=None: "")
     monkeypatch.setattr(prompt_module, "get_agent_soul", lambda agent_name=None: "")

--- a/backend/tests/test_subagent_prompt_security.py
+++ b/backend/tests/test_subagent_prompt_security.py
@@ -1,4 +1,4 @@
-"""Tests for subagent registry and prompt exposure."""
+"""Tests for Forge subagent availability and prompt exposure."""
 
 from deerflow.agents.lead_agent import prompt as prompt_module
 from deerflow.subagents import registry as registry_module
@@ -11,11 +11,27 @@ def test_get_available_subagent_names_exposes_registered_forge_agents() -> None:
     assert names == ["general-purpose", "bash", "compiler"]
 
 
-def test_build_subagent_section_lists_registered_forge_agents() -> None:
+def test_build_subagent_section_hides_bash_examples_when_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda: ["general-purpose"])
+
+    section = prompt_module._build_subagent_section(3)
+
+    assert "Not available in the current runtime" in section
+    assert "AioSandboxProvider" not in section
+    assert "prepare_compile_session" in section
+    assert "clone_repository" in section
+    assert "finalize_session" in section
+    assert "host_read" in section
+
+
+def test_build_subagent_section_includes_bash_when_available(monkeypatch) -> None:
+    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda: ["general-purpose", "bash", "compiler"])
+
     section = prompt_module._build_subagent_section(3)
 
     assert "For command execution (git, build, test, deploy operations)" in section
     assert "For isolated C/C++ build execution and post-build verification" in section
-    assert 'task(description="build and verify repository"' in section
-    assert "prepare_workspace, identify_build_system, finalize_session" in section
-    assert "Not available in the current sandbox configuration" not in section
+    assert "AioSandboxProvider" not in section
+    assert "prepare_compile_session" in section
+    assert "clone_repository" in section
+    assert "finalize_session" in section

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -383,15 +383,11 @@ def test_cleanup_called_on_timed_out(monkeypatch):
 
 
 def test_cleanup_not_called_on_polling_safety_timeout(monkeypatch):
-    """Verify cleanup_background_task is NOT called on polling safety timeout.
-
-    This prevents race conditions where the background task is still running
-    but the polling loop gives up. The cleanup should happen later when the
-    executor completes and sets a terminal status.
-    """
+    """Polling timeout keeps the registry entry when the worker cannot stop."""
     config = _make_subagent_config(timeout_seconds=1)
     # Keep max_poll_count small for test speed: (1 + 60) // 5 = 12
     events = []
+    cancel_requests = []
     cleanup_calls = []
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
@@ -415,6 +411,16 @@ def test_cleanup_not_called_on_polling_safety_timeout(monkeypatch):
         "cleanup_background_task",
         lambda task_id: cleanup_calls.append(task_id),
     )
+    monkeypatch.setattr(
+        task_tool_module,
+        "request_cancel_background_task",
+        lambda task_id: cancel_requests.append(task_id) or True,
+    )
+    monkeypatch.setattr(
+        task_tool_module,
+        "wait_for_background_task_shutdown",
+        lambda task_id, timeout_seconds: False,
+    )
 
     output = _run_task_tool(
         runtime=_make_runtime(),
@@ -425,27 +431,24 @@ def test_cleanup_not_called_on_polling_safety_timeout(monkeypatch):
     )
 
     assert output.startswith("Task polling timed out after 0 minutes")
-    # cleanup should NOT be called because the task is still RUNNING
+    assert cancel_requests == ["tc-no-cleanup-safety-timeout"]
     assert cleanup_calls == []
 
 
-def test_cleanup_scheduled_on_cancellation(monkeypatch):
-    """Verify cancellation schedules deferred cleanup for the background task."""
+def test_cancellation_waits_for_shutdown_before_cleanup(monkeypatch):
+    """Cancellation reaps the registry entry after the worker stops."""
     config = _make_subagent_config()
     events = []
+    cancel_requests = []
+    shutdown_waits = []
     cleanup_calls = []
-    scheduled_cleanup_coros = []
-    poll_count = 0
-
-    def get_result(_: str):
-        nonlocal poll_count
-        poll_count += 1
-        if poll_count == 1:
-            return _make_result(FakeSubagentStatus.RUNNING, ai_messages=[])
-        return _make_result(FakeSubagentStatus.COMPLETED, result="done")
 
     async def cancel_on_first_sleep(_: float) -> None:
         raise asyncio.CancelledError
+
+    async def wait_for_shutdown(task_id: str, timeout_seconds: float) -> bool:
+        shutdown_waits.append((task_id, timeout_seconds))
+        return True
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(
@@ -455,14 +458,19 @@ def test_cleanup_scheduled_on_cancellation(monkeypatch):
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
     monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
-    monkeypatch.setattr(task_tool_module, "get_background_task_result", get_result)
+    monkeypatch.setattr(
+        task_tool_module,
+        "get_background_task_result",
+        lambda _: _make_result(FakeSubagentStatus.RUNNING, ai_messages=[]),
+    )
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
     monkeypatch.setattr(task_tool_module.asyncio, "sleep", cancel_on_first_sleep)
     monkeypatch.setattr(
-        task_tool_module.asyncio,
-        "create_task",
-        lambda coro: scheduled_cleanup_coros.append(coro) or _DummyScheduledTask(),
+        task_tool_module,
+        "request_cancel_background_task",
+        lambda task_id: cancel_requests.append(task_id) or True,
     )
+    monkeypatch.setattr(task_tool_module, "wait_for_background_task_shutdown", wait_for_shutdown)
     monkeypatch.setattr("deerflow.tools.tools.get_subagent_tools", lambda **kwargs: [])
     monkeypatch.setattr(
         task_tool_module,
@@ -479,20 +487,17 @@ def test_cleanup_scheduled_on_cancellation(monkeypatch):
             tool_call_id="tc-cancelled-cleanup",
         )
 
-    assert cleanup_calls == []
-    assert len(scheduled_cleanup_coros) == 1
-
-    asyncio.run(scheduled_cleanup_coros.pop())
-
+    assert cancel_requests == ["tc-cancelled-cleanup"]
+    assert shutdown_waits == [("tc-cancelled-cleanup", 30.0)]
     assert cleanup_calls == ["tc-cancelled-cleanup"]
 
 
 def test_cancelled_cleanup_stops_after_timeout(monkeypatch):
-    """Verify deferred cleanup gives up after a bounded number of polls."""
+    """Cancellation preserves the registry entry when worker shutdown times out."""
     config = _make_subagent_config(timeout_seconds=1)
     events = []
+    cancel_requests = []
     cleanup_calls = []
-    scheduled_cleanup_coros = []
 
     async def cancel_on_first_sleep(_: float) -> None:
         raise asyncio.CancelledError
@@ -513,9 +518,14 @@ def test_cancelled_cleanup_stops_after_timeout(monkeypatch):
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
     monkeypatch.setattr(task_tool_module.asyncio, "sleep", cancel_on_first_sleep)
     monkeypatch.setattr(
-        task_tool_module.asyncio,
-        "create_task",
-        lambda coro: scheduled_cleanup_coros.append(coro) or _DummyScheduledTask(),
+        task_tool_module,
+        "request_cancel_background_task",
+        lambda task_id: cancel_requests.append(task_id) or True,
+    )
+    monkeypatch.setattr(
+        task_tool_module,
+        "wait_for_background_task_shutdown",
+        lambda task_id, timeout_seconds: False,
     )
     monkeypatch.setattr("deerflow.tools.tools.get_subagent_tools", lambda **kwargs: [])
     monkeypatch.setattr(
@@ -533,12 +543,7 @@ def test_cancelled_cleanup_stops_after_timeout(monkeypatch):
             tool_call_id="tc-cancelled-timeout",
         )
 
-    async def bounded_sleep(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr(task_tool_module.asyncio, "sleep", bounded_sleep)
-    asyncio.run(scheduled_cleanup_coros.pop())
-
+    assert cancel_requests == ["tc-cancelled-timeout"]
     assert cleanup_calls == []
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 5
+config_version: 6
 
 # ============================================================================
 # Logging
@@ -210,9 +210,6 @@ models: []
 
 tool_groups:
   - name: web
-  - name: file:read
-  - name: file:write
-  - name: bash
 
 # ============================================================================
 # Tools Configuration
@@ -235,36 +232,6 @@ tools:
     use: deerflow.community.image_search.tools:image_search_tool
     max_results: 5
 
-  - name: ls
-    group: file:read
-    use: deerflow.sandbox.tools:ls_tool
-
-  - name: read_file
-    group: file:read
-    use: deerflow.sandbox.tools:read_file_tool
-
-  - name: glob
-    group: file:read
-    use: deerflow.sandbox.tools:glob_tool
-    max_results: 200
-
-  - name: grep
-    group: file:read
-    use: deerflow.sandbox.tools:grep_tool
-    max_results: 100
-
-  - name: write_file
-    group: file:write
-    use: deerflow.sandbox.tools:write_file_tool
-
-  - name: str_replace
-    group: file:write
-    use: deerflow.sandbox.tools:str_replace_tool
-
-  - name: bash
-    group: bash
-    use: deerflow.sandbox.tools:bash_tool
-
 # ============================================================================
 # Tool Search Configuration (Deferred Tool Loading)
 # ============================================================================
@@ -278,12 +245,9 @@ tool_search:
 uploads:
   pdf_converter: auto
 
-sandbox:
-  use: deerflow.sandbox.local:LocalSandboxProvider
-  allow_host_bash: false
-  bash_output_max_chars: 20000
-  read_file_output_max_chars: 50000
-  ls_output_max_chars: 20000
+# The legacy general-purpose sandbox was removed from Forge. Repository builds
+# remain isolated by the dedicated compile-session Docker runtime.
+sandbox: null
 
 # ============================================================================
 # Subagents Configuration

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -134,12 +134,14 @@ services:
       # directory above would otherwise shadow it with the (empty) host directory.
       - gateway-venv:/app/backend/.venv
       - ../config.yaml:/app/config.yaml
+      - ../config.example.yaml:/app/config.example.yaml:ro
       - ../extensions_config.json:/app/extensions_config.json
+      - ../scripts:/app/scripts:ro
       - ../skills:/app/skills
       - ../logs:/app/logs
       # Mount uv cache for faster dependency installation
       - ~/.cache/uv:/root/.cache/uv
-      # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
+      # Compile sessions launch sibling containers through the host Docker daemon.
       - /var/run/docker.sock:/var/run/docker.sock
       # CLI auth directories for auto-auth (Claude Code + Codex CLI)
       - type: bind
@@ -199,12 +201,14 @@ services:
       # directory above would otherwise shadow it with the (empty) host directory.
       - langgraph-venv:/app/backend/.venv
       - ../config.yaml:/app/config.yaml
+      - ../config.example.yaml:/app/config.example.yaml:ro
       - ../extensions_config.json:/app/extensions_config.json
+      - ../scripts:/app/scripts:ro
       - ../skills:/app/skills
       - ../logs:/app/logs
       # Mount uv cache for faster dependency installation
       - ~/.cache/uv:/root/.cache/uv
-      # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
+      # Compile sessions launch sibling containers through the host Docker daemon.
       - /var/run/docker.sock:/var/run/docker.sock
       # CLI auth directories for auto-auth (Claude Code + Codex CLI)
       - type: bind

--- a/scripts/config-upgrade.sh
+++ b/scripts/config-upgrade.sh
@@ -60,8 +60,27 @@ with open(config_path, encoding='utf-8') as f:
 with open(example_path, encoding='utf-8') as f:
     example = yaml.safe_load(f) or {}
 
-user_version = user.get('config_version', 0)
-example_version = example.get('config_version', 0)
+def parse_config_version(value, label):
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        value = str(value)
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, str):
+        try:
+            version = int(value.strip())
+        except ValueError:
+            version = -1
+    else:
+        version = -1
+    if version < 0:
+        print(f'ERROR: {label} config_version must be a non-negative integer; got {value!r}.', file=sys.stderr)
+        sys.exit(2)
+    return version
+
+user_version = parse_config_version(user.get('config_version', 0), 'config.yaml')
+example_version = parse_config_version(example.get('config_version', 0), 'config.example.yaml')
 
 if user_version >= example_version:
     print(f'OK config.yaml is already up to date (version {user_version}).')
@@ -85,6 +104,10 @@ MIGRATIONS = {
             ('src.tools.', 'deerflow.tools.'),
         ],
     },
+    6: {
+        'description': 'Remove legacy sandbox providers and tools',
+        'replacements': [],
+    },
     # Future migrations go here:
     # 2: {
     #     'description': '...',
@@ -106,6 +129,46 @@ for version in range(user_version + 1, example_version + 1):
 
 # Re-parse after text migrations
 user = yaml.safe_load(raw_text) or {}
+
+if user_version < 6 <= example_version:
+    obsolete_tool_prefix = 'deerflow.sandbox.tools:'
+    configured_tools = user.get('tools')
+    if isinstance(configured_tools, list):
+        retained_tools = []
+        for tool in configured_tools:
+            use = tool.get('use') if isinstance(tool, dict) else None
+            if isinstance(use, str) and use.startswith(obsolete_tool_prefix):
+                migrated.append(f'removed obsolete tool {use}')
+                continue
+            retained_tools.append(tool)
+        user['tools'] = retained_tools
+
+        retained_group_names = {
+            tool.get('group')
+            for tool in retained_tools
+            if isinstance(tool, dict) and isinstance(tool.get('group'), str)
+        }
+        obsolete_group_names = {'file:read', 'file:write', 'bash'}
+        configured_groups = user.get('tool_groups')
+        if isinstance(configured_groups, list):
+            retained_groups = []
+            for group in configured_groups:
+                name = group.get('name') if isinstance(group, dict) else None
+                if name in obsolete_group_names and name not in retained_group_names:
+                    migrated.append(f'removed orphaned tool group {name}')
+                    continue
+                retained_groups.append(group)
+            user['tool_groups'] = retained_groups
+
+    obsolete_sandbox_providers = {
+        'deerflow.sandbox.local:LocalSandboxProvider',
+        'deerflow.community.aio_sandbox:AioSandboxProvider',
+    }
+    sandbox = user.get('sandbox')
+    if isinstance(sandbox, dict) and sandbox.get('use') in obsolete_sandbox_providers:
+        provider = sandbox.get('use')
+        migrated.append(f'disabled obsolete sandbox provider {provider}')
+        user['sandbox'] = None
 
 if migrated:
     print(f'Applied {len(migrated)} migration(s):')


### PR DESCRIPTION
## 变更内容

- 修复 v6 示例配置与 v5 -> v6 迁移，保留用户自定义字段并清理已废弃的 sandbox 工具。
- 将 Lead Agent 编译流程统一为 `prepare -> clone -> inspect -> compiler -> finalize`，Git clone 与 SHA 获取均在编译容器内完成。
- 补全 WSL/NTFS、容器网络与代理配置兼容；代理值不会写入日志或会话元数据。
- 基于文件结构识别 ELF、共享库、目标文件与 `ar` 归档，拒绝文本、符号链接、截断文件和空壳格式。
- 将产物验收与 Lead 清理解耦，保留编译容器和 clean replay 验证语义。
- 增加 `run_id` 所有权、会话锁、原子元数据写入和幂等 finalize，防止替换运行或并发终态相互覆盖。
- 超时或取消时同步停止子代理协程与编译容器；仅在 worker 确认退出后清理后台任务注册表。
- 编译会话跳过通用 Memory 更新，避免研究实验被非核心状态污染。

## 根因

初始运行时仍引用已移除工具，并假设后端镜像内存在 Git。真实 Agent 端到端运行还暴露了以下问题：

- `/mnt/c` 文件常显示为 `0777`，旧逻辑会把文本日志误判为可执行产物；
- 成功提交后仍需额外一次模型响应才能结束图执行；
- 取消和超时不能可靠停止隔离 worker 与真实编译容器；
- 线程级兜底清理缺少 run 所有权，会与替换运行竞争；
- 旧会话副本可能重复写入或覆盖终态，清理失败也被错误视为已完成。

## 验证

- 后端完整测试：`1332 passed, 15 skipped`；
- 编译运行时、终态工具、取消、SubagentExecutor、Lead prompt、配置迁移等聚焦测试：`135 passed`；
- Ruff check 与 format check 全部通过；
- `bash -n scripts/config-upgrade.sh` 通过；
- `docker compose -f docker/docker-compose-dev.yaml config --quiet` 通过；
- `git diff --check` 通过；
- 增量敏感信息扫描无命中；
- 既有真实 `gpt-5.4` LangGraph E2E 已完成完整状态迁移、生成 ELF 产物与 `repro/build.sh`，且编译容器成功移除。

本 PR 不启动 v6 pilot，也不修改 v1-v5 冻结实验资产。

Closes #2
Closes #5