### PR TITLE
修复：生成固定提交且可移植的编译复现脚本

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@
 3. 自动识别构建系统（CMake / Make / Autotools）
 4. 由 **compiler 子代理**在容器内反复尝试 configure / build / 补依赖，直到产出可执行物
 5. 把最终产物 `cp` 到 `/artifacts`
-6. 系统对 `/artifacts` 做强制验证（exists / non-empty / smoke test `--version` 等）
-7. 验证通过后生成 `repro/build.sh` 复现脚本，session 标记 completed
+6. 系统对 `/artifacts` 做强制验证（ELF/`ar` 结构识别与 executable smoke test）
+7. 提交验证同时生成固定源码 commit 的 `repro/build.sh`；全部通过后 session 先标记 `verified`
+8. 容器清理与 finalize 成功后，session 才标记 `completed`
 
 项目 fork 自 DeerFlow 2.0（一个通用 LangGraph Agent Harness）。许多 DeerFlow 时代的能力（IM channels、20+ skills、memory、MCP）**仍在代码中**，但**与编译核心无关**，是历史遗留。文档中明确标注 “非编译核心”，今后可能裁剪。
 
@@ -82,7 +83,7 @@ Lead Agent
   ├─ task(subagent_type="compiler", prompt=...)
   │    → 委派给 compiler 子代理（迭代 build + submit_build_result）
   └─ finalize_session()
-       → 停并删容器，session 状态置为 completed/failed
+       → 停并删容器；仅已验证且有产物的 session 置为 completed，否则保留失败/中断终态
 ```
 
 **compiler 子代理**：只有 `run_container_bash` 和 `submit_build_result` 两个工具，被禁止使用 `task` / `ask_clarification` / `view_image` 等。它必须：
@@ -95,9 +96,11 @@ Lead Agent
 **验证（`submit_build_result_impl`）**：逐文件检查
 1. `exists`：文件存在
 2. `non_empty`：size > 0
-3. 若是可执行：smoke test 依次尝试 `--version` / `-version` / `--help`，任一退出 0 即通过
+3. 结构：只接受有效 ELF executable/shared library/object 或有效 `ar` static archive
+4. 若是可执行：smoke test 依次尝试 `-version` / `--version` / `--help`，任一退出 0 即通过
+5. `repro_bundle`：必须能从远端 `repo_url` 检出完整 `commit_sha`，并安全渲染成功构建步骤
 
-全部通过 → session 状态 `completed`，自动生成 `repro/build.sh`（按记录的命令序列回放）。
+全部通过 → session 状态 `verified`。`repro/build.sh` 只按记录顺序回放 `stage == "bash" && exit_code == 0` 的命令，并在各自容器 `workdir` 中独立执行；cleanup/finalize 成功后才进入 `completed`。
 
 ### 4.3 会话目录布局（宿主机）
 
@@ -110,7 +113,7 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 │   ├── workflow.log         # JSONL 事件流（session.created、command.recorded、…）
 │   ├── 001_clone.log        # 每条命令的 stdout+stderr 全量
 │   └── ...
-└── repro/build.sh           # 验证通过后生成的复现脚本
+└── repro/build.sh           # submit 验证（含 replay bundle check）通过后生成
 ```
 
 容器侧统一挂载到 `/workspace`、`/artifacts`、`/logs`、`/repro`。容器内仓库根永远是 `/workspace/repo`。
@@ -122,6 +125,11 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 - **`HOST_PROJECT_ROOT` 必须设置**：`CompileDockerRuntime._host_project_root()` 在缺失时会抛错
 - **容器 network 固定 `compile_network_wwf_v1`**：若改名需同步 `RuntimeConfig.network`
 - **smoke test 仅尝试 3 个旗标**：不要随便加，会污染验证语义
+- **replay 固定完整 commit**：只接受 40/64 位十六进制 SHA 与不含持久凭据的远端 URL
+- **replay 只消费成功 bash 记录**：失败尝试、clone/inspect 与 submit 审计记录不进入脚本
+- **replay workdir 只允许容器路径**：必须位于 `/workspace` 或 `/artifacts`；拒绝 Windows、WSL 宿主路径和 `.compile-sessions` 路径
+- **replay 会清空挂载目录**：脚本从空 `/workspace` 与 `/artifacts` 开始，验收时必须挂载专用临时目录
+- **生成不等于独立 replay 通过**：`repro_bundle` check 只验证候选脚本可安全生成且至少有一个成功 bash 步骤；研究基线必须再做 README 中的新容器验收，自动执行与产物比较跟踪在 Issue #7
 - **compiler 子代理的 system prompt 是产品契约**：改它等同于改产品行为，需要同时改 `compiler_agent.py` 和对应测试
 
 ## 5. 架构约束：Harness / App 分层

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,11 @@ make nginx
 
 - **`compiler_agent.py` 的 system prompt 是产品契约**，改它等同于改产品行为。务必同步改 `tests/test_compile_runtime.py`。
 - **路径常量双重维护**：宿主机路径在 `compile/paths.py`，容器路径在 `compile/docker_runtime.py` 顶部常量。改一边要改另一边。
-- **新增编译阶段**必须沿用 `append_command_record()`，否则 `repro/build.sh` 复现脚本会缺步骤。
+- **命令记录是审计轨迹**：`repro/build.sh` 只消费 `stage == "bash" && exit_code == 0` 的记录，并保留记录顺序与容器 `workdir`。
+- **可 replay 步骤必须走 `run_container_bash`**：`workdir` 只能是 `/workspace` 或 `/artifacts` 下的绝对容器路径，不得写入宿主机、WSL `/mnt/<drive>` 或 `.compile-sessions` 路径。
+- **submit 不是 shell command**：`submit_build_result` 只写 `submit.*` 事件、summary log 和 verification checks，不得追加到 `session.commands`；replay 生成失败必须落为 `verification_failed`。
+- **修改 replay 契约必须补测试**：命令过滤、workdir、commit/URL 校验、shell quoting 与宿主路径隔离应同步覆盖 `tests/test_compile_runtime.py`。
+- **候选生成不等于 clean replay**：失败命令可能留下持久副作用；研究结果必须在新容器和空挂载中实际执行脚本，自动验证与产物比较见 Issue #7。
 - **状态机变更**（`CompileSession.status`）要更新 `logs/workflow.log` 的事件命名约定。
 
 ## 架构约束

--- a/README_zh.md
+++ b/README_zh.md
@@ -21,8 +21,8 @@
 3. **识别构建系统**：按 `CMakeLists.txt` / `Makefile` / `configure` 顺序探测
 4. **委派 compiler 子代理**：子代理在容器内反复 `configure` / `build`，遇到依赖错误自动 `apt install`、清缓存重试
 5. **拷贝产物到 `/artifacts`**：只拷最终可执行物/库，不整目录倾倒
-6. **强制验证**：逐文件检查 exists / non-empty / smoke test（`--version` / `-version` / `--help` 任一过即可）
-7. **生成复现脚本**：验证通过后自动写出 `repro/build.sh`，回放整套命令
+6. **强制验证**：识别 ELF/`ar` 结构，并对 executable 做 smoke test（`-version` / `--version` / `--help` 任一过即可）
+7. **生成复现脚本**：提交验证同时写出 `repro/build.sh`；脚本检出记录的完整 commit SHA，并按原 workdir 回放成功的 `run_container_bash` 命令
 
 整个过程通过 Web 工作台（基于 Next.js）或后端 SDK 调用。
 
@@ -160,9 +160,9 @@ Compiler:  run_container_bash("cmake ...")  ← 反复迭代
            run_container_bash("make -j")
            ...                              ← 失败必改策略，禁止盲目重试
            run_container_bash("cp .../app /artifacts/")
-           submit_build_result()             ← 触发验证
+           submit_build_result()             ← 验证产物并生成 commit-pinned replay，状态置为 verified
        ↓
-Lead:  finalize_session()  ← 停容器、写复现脚本
+Lead:  finalize_session()  ← 停并删除容器；验证通过且有产物时状态置为 completed
 ```
 
 更详细的：
@@ -186,10 +186,34 @@ logs/
 ├── workflow.log          # JSONL 事件流（session.created、command.recorded、...）
 ├── 001_clone.log         # 每条命令的完整 stdout+stderr
 └── ...
-repro/build.sh            # 验证通过后生成的可执行构建脚本
+repro/build.sh            # submit 验证（含 replay bundle check）通过后生成
 ```
 
-**复现脚本是这套系统的核心交付物**——任何一次成功编译都能用 `repro/build.sh` 在同样的镜像里复现。
+**复现脚本是这套系统的核心交付物**。它从 `repo_url` 检出 session 记录的完整 `commit_sha`，只按原顺序和 workdir 回放成功的 `run_container_bash` 命令；失败尝试、clone/inspect 和 submit 审计事件不会进入脚本。它是一份可审计的重建配方，不承诺在镜像或外部依赖变化后仍得到字节级相同的产物。
+
+`submit_build_result` 的 `repro_bundle` check 验证候选脚本能够安全生成且包含成功构建步骤，但不会自动启动第二个容器执行它。失败命令可能留下未进入候选脚本的持久副作用，因此研究基线必须执行下面的全新容器验收；自动执行、超时清理和产物比较跟踪在 [Issue #7](https://github.com/WWFXL/Forge-AutoCompiler/issues/7)。
+
+### 在 WSL2 的全新容器中 replay
+
+请在 WSL shell 中运行。`build.sh` 启动时会清空挂载的 `/workspace` 和 `/artifacts`，因此必须使用专用临时目录，不能挂载包含其他数据的路径：
+
+```bash
+SESSION_DIR="$PWD/.compile-sessions/<thread_id>/<session_id>"
+REPLAY_RUN="$(mktemp -d)"
+IMAGE=autocompiler:gcc13  # 应与 session.json 中记录的 image 一致
+
+mkdir -p "$REPLAY_RUN/workspace" "$REPLAY_RUN/artifacts"
+docker run --rm \
+  --mount "type=bind,src=$(realpath "$SESSION_DIR/repro"),dst=/repro,readonly" \
+  --mount "type=bind,src=$(realpath "$REPLAY_RUN/workspace"),dst=/workspace" \
+  --mount "type=bind,src=$(realpath "$REPLAY_RUN/artifacts"),dst=/artifacts" \
+  "$IMAGE" bash /repro/build.sh
+
+file "$REPLAY_RUN"/artifacts/*
+sha256sum "$REPLAY_RUN"/artifacts/*
+```
+
+`--rm` 会在脚本退出后删除 replay 容器。若脚本、产物类型或预期输出检查失败，本次编译不能记为可独立复现。
 
 ---
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -59,31 +59,37 @@ backend/
 `CompileSession.status` 取值：
 
 ```
-created → ready → source_ready → inspected → (compiler 子代理执行) → completed
-                                                                    ↓
-                                                       verification_failed / failed / cancelled
+created → ready → source_ready → inspected → (compiler 子代理执行) → verified → completed
+                                                                    ↘ verification_failed
+任意非终态 ────────────────────────────────────────────────────────→ failed / cancelled / timed_out
 ```
 
 - `created`：`prepare_compile_session_impl` 创建 session 但未起容器
 - `ready`：容器起来了
 - `source_ready`：clone 成功
 - `inspected`：识别完构建系统
-- `completed`：`submit_build_result` 验证通过、`finalize_compile_session_impl` 完成
-- `verification_failed`：`submit_build_result` 验证失败（产物不存在/空/smoke 失败）
+- `verified`：`submit_build_result` 的产物检查与 commit-pinned replay bundle 检查均通过；此时 `completed_at` 仍为空
+- `completed`：已验证 session 的编译容器清理成功，并由 finalize 写入终态
+- `verification_failed`：`submit_build_result` 验证失败（产物无效、smoke 失败或 replay bundle 无法安全生成）
 - `failed`：clone 失败或其他不可恢复错误
 
 每次状态切换都会写一条 `session.status_changed` 事件进 `logs/workflow.log`，**改状态机时务必同步事件日志的语义**。
 
 ### 2.2 命令记录
 
-每条在容器内执行的命令会经 `append_command_record()`：
+`session.commands` 是完整的命令审计轨迹。clone、inspect 和 `run_container_bash` 等阶段会记录：
 
 - 记录到 `session.commands`（持久化到 `session.json`）
 - 写一份完整 stdout+stderr 到独立 log（命名 `{index:03d}_{stage}.log`）
 - `workflow.log` 写一条 `command.recorded` JSONL 事件
-- finalize 时按 `session.commands` 的顺序生成 `repro/build.sh`
 
-**如果你新增编译阶段**：必须沿用 `append_command_record()`，否则复现脚本会缺失对应步骤。
+`submit_build_result` 是验证/审计事件：它写 `submit.*` 事件、summary log 和 verification checks，但不伪装成 shell command 写入 `session.commands`。
+
+成功 submit 时生成 `repro/build.sh`。生成器只消费 `stage == "bash" && exit_code == 0` 的记录，保持顺序与各自容器 `workdir`，并用独立 `bash -lc` 执行。clone/inspect、失败或超时尝试以及 submit 审计均不进入 replay。
+
+需要进入 replay 的构建步骤必须通过 `run_container_bash` 执行；`workdir` 必须是 `/workspace` 或 `/artifacts` 下的绝对容器路径。生成器还要求完整 40/64 位 commit SHA、无持久凭据的远端 URL，并拒绝 Windows/WSL 宿主路径、`.compile-sessions` 路径和 session 标识。修改过滤或安全规则时必须同步 `tests/test_compile_runtime.py`。
+
+`repro_bundle` verification check 只证明候选脚本可安全生成且非空，不证明任意探索历史都能从空目录重放。失败命令可能留下未进入候选脚本的持久副作用，因此研究基线必须按 README 在新容器中执行脚本并检查产物；自动 clean replay verifier 跟踪在 Issue #7。
 
 ### 2.3 路径双重映射
 

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import re
 import struct
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from shlex import quote
 from typing import BinaryIO
+from urllib.parse import urlsplit
 
 from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime, ContainerCleanupResult
 from deerflow.compile.manager import CompileSessionManager
@@ -45,6 +47,12 @@ _MAX_ELF_TABLE_ENTRIES = 4096
 _AR_MEMBER_HEADER_SIZE = 60
 _AR_MEMBER_TRAILER = b"`\n"
 _AR_METADATA_MEMBERS = {"/", "//", "/SYM64/"}
+_REPLAY_WORKDIR_ROOTS = (
+    PurePosixPath(CONTAINER_WORKSPACE_DIR),
+    PurePosixPath("/artifacts"),
+)
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9_])(?:[A-Z]:[\\/]|\\\\)")
+_WSL_HOST_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9_])/mnt/[A-Z](?:/|$)")
 
 
 @dataclass
@@ -179,10 +187,14 @@ def clone_repository_impl(
     services = get_compile_services()
 
     repo_dir = Path(session.leadagent_repo_dir)
+    effective_branch = branch if branch is not None else session.branch
+    session.repo_url = repo_url
+    session.branch = effective_branch
+    services.manager.save_session(session)
 
     clone_command_parts = ["git clone", f"--depth {depth}"]
-    if branch:
-        clone_command_parts.append(f"--branch {shell_quote(branch)}")
+    if effective_branch:
+        clone_command_parts.append(f"--branch {shell_quote(effective_branch)}")
     clone_command_parts.append(f"{shell_quote(repo_url)} {shell_quote(CONTAINER_REPO_DIR)}")
     clone_command = " ".join(clone_command_parts)
     attempt_command = f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)} && {clone_command}"
@@ -197,7 +209,7 @@ def clone_repository_impl(
             session,
             "clone.started",
             repo_url=repo_url,
-            branch=branch,
+            branch=effective_branch,
             depth=depth,
             attempt=attempt,
             max_retries=retries,
@@ -636,6 +648,9 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     services = get_compile_services()
     submit_index = len(session.commands) + 1
     summary_log_path = local_log_path(session, f"{submit_index:03d}_submit.log")
+    while Path(summary_log_path).exists():
+        submit_index += 1
+        summary_log_path = local_log_path(session, f"{submit_index:03d}_submit.log")
     services.manager.log_event(
         session,
         "submit.started",
@@ -643,8 +658,6 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         container_artifacts_dir="/artifacts",
         log_path=summary_log_path,
     )
-    started_at = utc_now_iso()
-
     discovered_files = sorted(_list_leadagent_artifact_files(session), key=lambda p: p.as_posix())
     checks: list[VerificationCheck] = []
     artifacts: list[BuildArtifact] = []
@@ -728,6 +741,28 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     if discovered_files and not artifacts:
         notes.append("Error: Verification failed. No recognized compiled artifacts were found in /artifacts.")
 
+    if artifacts and all(check.passed for check in checks):
+        try:
+            _write_repro_bundle(session)
+        except (OSError, ValueError) as exc:
+            message = f"Error: Verification failed. Could not generate a commit-pinned replay bundle: {exc}"
+            notes.append(message)
+            _record_submit_check(
+                checks=checks,
+                name="repro_bundle",
+                target="repro/build.sh",
+                passed=False,
+                summary=message,
+            )
+        else:
+            _record_submit_check(
+                checks=checks,
+                name="repro_bundle",
+                target="repro/build.sh",
+                passed=True,
+                summary="Generated a commit-pinned replay script from successful container commands.",
+            )
+
     failed_checks = sum(1 for check in checks if not check.passed)
     status = "passed" if artifacts and failed_checks == 0 else "failed"
     verification = VerificationResult(
@@ -740,18 +775,6 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     session.artifacts = artifacts
     session.verification = verification
     services.manager.save_session(session)
-
-    completed_at = utc_now_iso()
-    append_command_record(
-        session,
-        "submit",
-        "submit build result from /artifacts",
-        str(Path(session.metadata_path).parent),
-        summary_log_path,
-        0 if status == "passed" else 1,
-        started_at,
-        completed_at,
-    )
 
     failure_message = next(
         (note for note in notes if note.startswith("Error:")),
@@ -784,7 +807,6 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     )
 
     if status == "passed":
-        _write_repro_bundle(session)
         services.manager.mark_session_status(session, "verified")
         services.manager.log_event(session, "verification.accepted", artifact_count=len(artifacts))
     else:
@@ -793,14 +815,124 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
+def _validate_replay_workdir(workdir: str) -> str:
+    if not workdir or any(character in workdir for character in ("\0", "\r", "\n")):
+        raise ValueError("Invalid replay workdir.")
+
+    path = PurePosixPath(workdir)
+    if not path.is_absolute() or ".." in path.parts or ".compile-sessions" in path.parts:
+        raise ValueError(f"Invalid replay workdir: {workdir!r}.")
+    if not any(path == root or root in path.parents for root in _REPLAY_WORKDIR_ROOTS):
+        raise ValueError(f"Unsupported replay workdir outside compile-container roots: {workdir!r}.")
+    return path.as_posix()
+
+
+def _validate_replay_command(session: CompileSession, command: str) -> None:
+    if not command.strip() or "\0" in command or "\r" in command:
+        raise ValueError("Invalid replay command.")
+
+    forbidden_fragments = {
+        ".compile-sessions",
+        str(Path(session.metadata_path).parent),
+        session.leadagent_repo_dir,
+        session.leadagent_artifacts_dir,
+        session.leadagent_logs_dir,
+        session.leadagent_repro_dir,
+    }
+    if len(session.session_id) >= 8:
+        forbidden_fragments.add(session.session_id)
+    if len(session.thread_id) >= 8:
+        forbidden_fragments.add(session.thread_id)
+
+    if any(fragment and fragment in command for fragment in forbidden_fragments):
+        raise ValueError("Invalid replay command containing a host or session path.")
+    if _WINDOWS_ABSOLUTE_PATH_RE.search(command) or _WSL_HOST_PATH_RE.search(command):
+        raise ValueError("Invalid replay command containing a host path.")
+
+
+def _validate_replay_repo_url(repo_url: str) -> None:
+    if not repo_url or repo_url != repo_url.strip() or any(character in repo_url for character in ("\0", "\r", "\n")):
+        raise ValueError("A valid repo_url is required to generate a replay bundle.")
+    if "?" in repo_url or "#" in repo_url:
+        raise ValueError("Query parameters and fragments must not be embedded in repo_url for a persistent replay bundle.")
+    if _WINDOWS_ABSOLUTE_PATH_RE.search(repo_url) or _WSL_HOST_PATH_RE.search(repo_url) or repo_url.startswith(("/", "./", "../", "~")):
+        raise ValueError("A remote repo_url is required to generate a replay bundle.")
+
+    parsed = urlsplit(repo_url)
+    scheme = parsed.scheme.lower()
+    if scheme:
+        if scheme not in {"git", "git+ssh", "http", "https", "ssh"} or not parsed.hostname:
+            raise ValueError("An HTTP(S), SSH, or Git repo_url is required to generate a replay bundle.")
+        if parsed.password is not None or (scheme in {"http", "https"} and parsed.username is not None):
+            raise ValueError("Credentials must not be embedded in repo_url for a persistent replay bundle.")
+        return
+
+    if not re.fullmatch(r"[^@\s/:]+@[^:\s/]+:.+", repo_url):
+        raise ValueError("A remote repo_url is required to generate a replay bundle.")
+
+
 def _write_repro_bundle(session: CompileSession) -> Path:
     repro_dir = Path(session.metadata_path).parent / "repro"
-    repro_dir.mkdir(parents=True, exist_ok=True)
-    build_lines = ["#!/usr/bin/env bash", "set -euo pipefail", ""]
-    for command in session.commands:
-        build_lines.append(command.command)
     build_path = repro_dir / "build.sh"
-    build_path.write_text("\n".join(build_lines) + "\n", encoding="utf-8")
+    build_path.unlink(missing_ok=True)
+
+    commit_sha = (session.commit_sha or "").strip().lower()
+    if not re.fullmatch(r"[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64}", commit_sha):
+        raise ValueError("A full commit_sha is required to generate a replay bundle.")
+    _validate_replay_repo_url(session.repo_url)
+
+    git_init_command = 'git init --quiet "$REPO_DIR"' if len(commit_sha) == 40 else 'git init --object-format=sha256 --quiet "$REPO_DIR"'
+    build_lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        f"REPO_URL={shell_quote(session.repo_url)}",
+        f"COMMIT_SHA={shell_quote(commit_sha)}",
+        f"WORKSPACE_DIR={shell_quote(CONTAINER_WORKSPACE_DIR)}",
+        f"REPO_DIR={shell_quote(CONTAINER_REPO_DIR)}",
+        "ARTIFACTS_DIR=/artifacts",
+        "",
+        'mkdir -p -- "$WORKSPACE_DIR" "$ARTIFACTS_DIR"',
+        'find "$WORKSPACE_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
+        'find "$ARTIFACTS_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
+        git_init_command,
+        'git config --global --add safe.directory "$REPO_DIR"',
+        "(",
+        'cd -- "$REPO_DIR"',
+        'git remote add origin "$REPO_URL"',
+        'git fetch --depth 1 origin "$COMMIT_SHA"',
+        'git checkout --detach "$COMMIT_SHA"',
+        'test "$(git rev-parse HEAD)" = "$COMMIT_SHA"',
+        ")",
+        "",
+    ]
+    replay_index = 0
+    for command in session.commands:
+        if command.stage != "bash" or command.exit_code != 0:
+            continue
+        workdir = _validate_replay_workdir(command.workdir)
+        _validate_replay_command(session, command.command)
+        replay_index += 1
+        build_lines.extend(
+            [
+                f"# Successful build command {replay_index}",
+                "(",
+                f"cd -- {shell_quote(workdir)}",
+                f"bash -lc {shell_quote(command.command)}",
+                ")",
+                "",
+            ]
+        )
+    if replay_index == 0:
+        raise ValueError("At least one successful bash command is required to generate a replay bundle.")
+
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    temporary_path = repro_dir / f".build.sh.{uuid.uuid4().hex}.tmp"
+    try:
+        temporary_path.write_text("\n".join(build_lines) + "\n", encoding="utf-8")
+        temporary_path.replace(build_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
     return build_path
 
 
@@ -820,7 +952,8 @@ def finalize_compile_session_impl(
             current = session
 
         if current.finalized_at is None:
-            if generate_repro_bundle:
+            should_generate_repro = generate_repro_bundle and current.verification is not None and current.verification.status == "passed"
+            if should_generate_repro:
                 _write_repro_bundle(current)
             current.finalized_at = utc_now_iso()
             services.manager.mark_session_status(current, status, error=error, summary=summary)
@@ -830,7 +963,7 @@ def finalize_compile_session_impl(
                 status=status,
                 summary=summary,
                 finalized_at=current.finalized_at,
-                generate_repro_bundle=generate_repro_bundle,
+                generate_repro_bundle=should_generate_repro,
             )
 
         session.__dict__.update(current.__dict__)

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -10,7 +10,7 @@ import pytest
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, ContainerCleanupResult, RuntimeConfig
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, clone_repository_impl, submit_build_result_impl
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, submit_build_result_impl
 from deerflow.compile.paths import get_compile_sessions_root, get_host_session_dir, get_host_workspace_dir, get_metadata_path, get_session_dir
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
@@ -28,6 +28,17 @@ def make_test_paths(tmp_path: Path, *, host_workspace_root: str | None = None) -
         base_dir=tmp_path / ".deer-flow",
         workspace_root=tmp_path / "service-workspace",
         host_workspace_root=host_workspace_root or str(tmp_path / "host-workspace"),
+    )
+
+
+def add_replayable_build_command(session: CompileSession, command: str = "cmake --build build") -> None:
+    session.commands.append(
+        BuildCommandRecord(
+            stage="bash",
+            command=command,
+            workdir="/workspace/repo",
+            exit_code=0,
+        )
     )
 
 
@@ -212,8 +223,10 @@ def test_finalize_is_idempotent_and_preserves_first_terminal_result(tmp_path: Pa
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-finalize", repo_url="https://example.com/repo.git")
     session.status = "verified"
+    session.commit_sha = "a" * 40
     session.artifacts = [BuildArtifact(path="artifacts/hello", artifact_type="executable", size_bytes=128)]
     session.verification = VerificationResult(status="passed", artifact_count=1)
+    add_replayable_build_command(session)
     manager.save_session(session)
     monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
 
@@ -235,6 +248,17 @@ def test_finalize_is_idempotent_and_preserves_first_terminal_result(tmp_path: Pa
     events = [json.loads(line) for line in workflow_log.read_text(encoding="utf-8").splitlines()]
     assert sum(event["event"] == "finalize.completed" for event in events) == 1
     assert sum(event["event"] == "session.status_changed" and event["status"] == "completed" for event in events) == 1
+
+
+def test_finalize_failed_session_does_not_generate_repro_bundle(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-failed-finalize", repo_url="https://example.com/repo.git")
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
+
+    operations.finalize_compile_session_impl(session=session, status="failed", error="clone failed")
+
+    assert session.status == "failed"
+    assert not (Path(session.metadata_path).parent / "repro" / "build.sh").exists()
 
 
 def test_concurrent_finalize_with_stale_copies_commits_one_terminal_result(tmp_path: Path, monkeypatch):
@@ -656,6 +680,40 @@ def test_clone_repository_retries_with_container_side_cleanup(tmp_path: Path, mo
     assert "Repository cloned successfully" in message
 
 
+def test_clone_repository_persists_effective_source_for_replay(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-clone-override",
+        repo_url="https://example.com/old.git",
+        branch="prepared-branch",
+    )
+    session.container_id = "container-123"
+    actual_repo_url = "https://example.com/actual.git"
+    commit_sha = "0123456789abcdef0123456789abcdef01234567"
+    calls: list[str] = []
+
+    def fake_exec(session_arg, command, **kwargs):
+        del kwargs
+        assert session_arg is session
+        calls.append(command)
+        if "git clone" in command:
+            return CommandResult(exit_code=0, stdout="", stderr="", combined_output="")
+        return CommandResult(exit_code=0, stdout=f"{commit_sha}\n", stderr="", combined_output=f"{commit_sha}\n")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)))
+
+    result, _ = clone_repository_impl(session=session, repo_url=actual_repo_url)
+
+    assert result.exit_code == 0
+    assert calls[0] == "rm -rf -- /workspace/repo && git clone --depth 1 --branch prepared-branch https://example.com/actual.git /workspace/repo"
+    assert session.repo_url == actual_repo_url
+    assert session.branch == "prepared-branch"
+    assert session.commit_sha == commit_sha
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert reloaded.repo_url == actual_repo_url
+    assert reloaded.branch == "prepared-branch"
+
+
 def test_compiled_artifact_classifier_uses_file_format_not_mode(tmp_path: Path):
     executable = tmp_path / "app"
     pie_executable = tmp_path / "pie-app"
@@ -753,6 +811,251 @@ def test_compiled_artifact_classifier_recognizes_real_static_pie(tmp_path: Path)
     assert _classify_compiled_artifact(executable) == "executable"
 
 
+def test_repro_bundle_pins_commit_and_renders_only_successful_bash_commands(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-repro-contract",
+        repo_url="https://example.com/O'Reilly/repo.git",
+    )
+    session.commit_sha = "0123456789abcdef0123456789abcdef01234567"
+    session.commands = [
+        BuildCommandRecord(
+            stage="clone",
+            command="rm -rf /workspace/repo && git clone https://moving.example/repo.git /workspace/repo",
+            workdir="/workspace",
+            exit_code=0,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake -S . -B 'build dir'",
+            workdir="/workspace/repo",
+            exit_code=0,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake --build broken",
+            workdir="/workspace/repo",
+            exit_code=1,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake --build timed-out",
+            workdir="/workspace/repo",
+            exit_code=124,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake --build unfinished",
+            workdir="/workspace/repo",
+            exit_code=None,
+        ),
+        BuildCommandRecord(
+            stage="inspect",
+            command="echo inspect-only",
+            workdir="/workspace/repo",
+            exit_code=0,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake --build . && cp hello /artifacts/hello",
+            workdir="/workspace/repo/build dir",
+            exit_code=0,
+        ),
+        BuildCommandRecord(
+            stage="bash",
+            command="test -f hello",
+            workdir="/artifacts",
+            exit_code=0,
+        ),
+        BuildCommandRecord(
+            stage="submit",
+            command="submit build result from /artifacts",
+            workdir=str(Path(session.metadata_path).parent),
+            exit_code=0,
+        ),
+    ]
+
+    build_path = _write_repro_bundle(session)
+    script = build_path.read_text(encoding="utf-8")
+
+    assert f"REPO_URL={operations.shell_quote(session.repo_url)}" in script
+    assert f"COMMIT_SHA={session.commit_sha}" in script
+    assert 'git fetch --depth 1 origin "$COMMIT_SHA"' in script
+    assert 'test "$(git rev-parse HEAD)" = "$COMMIT_SHA"' in script
+    assert 'find "$WORKSPACE_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +' in script
+    assert 'find "$ARTIFACTS_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +' in script
+    assert 'git init --quiet "$REPO_DIR"' in script
+    assert 'git config --global --add safe.directory "$REPO_DIR"' in script
+    assert f"bash -lc {operations.shell_quote("cmake -S . -B 'build dir'")}" in script
+    assert "cd -- '/workspace/repo/build dir'" in script
+    assert f"bash -lc {operations.shell_quote('cmake --build . && cp hello /artifacts/hello')}" in script
+    assert "cd -- /artifacts" in script
+    assert "bash -lc 'test -f hello'" in script
+    assert "cmake --build broken" not in script
+    assert "cmake --build timed-out" not in script
+    assert "cmake --build unfinished" not in script
+    assert "inspect-only" not in script
+    assert "submit build result" not in script
+    assert "moving.example" not in script
+    assert session.session_id not in script
+    assert ".compile-sessions" not in script
+    subprocess.run(["bash", "-n", str(build_path)], check=True, capture_output=True)
+
+
+@pytest.mark.parametrize(
+    "workdir",
+    [
+        "relative/repo",
+        "/workspace/../etc",
+        "/workspace/.compile-sessions/thread/session/workspace/repo",
+        r"C:\Users\YiWei\Forge\repo",
+    ],
+)
+def test_repro_bundle_rejects_non_container_workdir(tmp_path: Path, workdir: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-repro-workdir", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    session.commands = [
+        BuildCommandRecord(
+            stage="bash",
+            command="cmake --build .",
+            workdir=workdir,
+            exit_code=0,
+        )
+    ]
+
+    with pytest.raises(ValueError, match="replay workdir"):
+        _write_repro_bundle(session)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cp /workspace/.compile-sessions/thread/session/artifacts/hello /artifacts/hello",
+        r"cp C:\Users\YiWei\Forge\hello /artifacts/hello",
+        "printf x >/mnt/c/Users/YiWei/out",
+        r"printf x >C:\Users\YiWei\out",
+        "PATH=/tmp:/mnt/c/Windows cmake --build .",
+    ],
+)
+def test_repro_bundle_rejects_host_path_in_command(tmp_path: Path, command: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-repro-command", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    session.commands = [
+        BuildCommandRecord(
+            stage="bash",
+            command=command,
+            workdir="/workspace/repo",
+            exit_code=0,
+        )
+    ]
+
+    with pytest.raises(ValueError, match="replay command"):
+        _write_repro_bundle(session)
+
+
+def test_repro_bundle_requires_commit_sha(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-repro-commit", repo_url="https://example.com/repo.git")
+
+    with pytest.raises(ValueError, match="commit_sha"):
+        _write_repro_bundle(session)
+
+
+def test_repro_bundle_rejects_empty_successful_recipe_and_removes_stale_script(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-empty-repro", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    build_path = Path(session.metadata_path).parent / "repro" / "build.sh"
+    build_path.parent.mkdir(parents=True, exist_ok=True)
+    build_path.write_text("stale unsafe replay\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="successful bash command"):
+        _write_repro_bundle(session)
+
+    assert not build_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("commit_sha", "expected_init"),
+    [
+        ("A" * 40, 'git init --quiet "$REPO_DIR"'),
+        ("B" * 64, 'git init --object-format=sha256 --quiet "$REPO_DIR"'),
+    ],
+)
+def test_repro_bundle_normalizes_commit_sha_and_selects_git_object_format(tmp_path: Path, commit_sha: str, expected_init: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-repro-object-format", repo_url="https://example.com/repo.git")
+    session.commit_sha = commit_sha
+    add_replayable_build_command(session)
+
+    script = _write_repro_bundle(session).read_text(encoding="utf-8")
+
+    assert f"COMMIT_SHA={commit_sha.lower()}" in script
+    assert expected_init in script
+
+
+@pytest.mark.parametrize(
+    "commit_sha",
+    [
+        "main",
+        "a" * 39,
+        "a" * 40 + "; touch /tmp/pwned",
+    ],
+)
+def test_repro_bundle_rejects_invalid_commit_sha(tmp_path: Path, commit_sha: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-invalid-commit", repo_url="https://example.com/repo.git")
+    session.commit_sha = commit_sha
+
+    with pytest.raises(ValueError, match="commit_sha"):
+        _write_repro_bundle(session)
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "https://token@example.com/private/repo.git",
+        "https://example.com/private/repo.git?token=secret",
+        "ssh://git@example.com/private/repo.git?token=secret",
+        "git@example.com:private/repo.git?token=secret",
+        "git@example.com:private/repo.git#main",
+        "file:///tmp/repo",
+        "/mnt/c/Users/YiWei/repo",
+        r"C:\Users\YiWei\repo",
+    ],
+)
+def test_repro_bundle_rejects_credentialed_or_local_repo_url(tmp_path: Path, repo_url: str):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-invalid-repo-url", repo_url=repo_url)
+    session.commit_sha = "a" * 40
+
+    with pytest.raises(ValueError, match="repo_url"):
+        _write_repro_bundle(session)
+
+
+def test_submit_rejects_artifact_when_repro_bundle_is_not_commit_pinned(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-unpinned-repro", repo_url="https://example.com/repo.git")
+    write_elf(Path(session.leadagent_artifacts_dir) / "hello", 2)
+
+    def fake_exec(*args, **kwargs):
+        return CommandResult(exit_code=0, stdout="Hello Matt!\n", stderr="", combined_output="Hello Matt!\n")
+
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)))
+
+    payload = json.loads(submit_build_result_impl(session=session))
+
+    assert payload["status"] == "failed"
+    assert "replay bundle" in payload["message"].lower()
+    assert session.status == "verification_failed"
+    assert session.verification is not None
+    assert session.verification.failed_checks == 1
+    assert any(check.name == "repro_bundle" and not check.passed for check in session.verification.checks)
+    assert not (Path(session.metadata_path).parent / "repro" / "build.sh").exists()
+
+
 def test_submit_rejects_executable_mode_text_without_running_it(tmp_path: Path, monkeypatch):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-text-artifact", repo_url="https://example.com/repo.git")
@@ -794,6 +1097,8 @@ def test_submit_rejects_symlinked_system_executable_without_running_it(tmp_path:
 def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monkeypatch):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-mixed-artifacts", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    add_replayable_build_command(session, "cmake --build build && cp build/hello /artifacts/hello")
     session.error = "stale verification failure"
     artifacts_dir = Path(session.leadagent_artifacts_dir)
     write_elf(artifacts_dir / "hello", 2)
@@ -818,6 +1123,7 @@ def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monk
     assert session.status == "verified"
     assert session.error is None
     assert session.completed_at is None
+    assert all(command.stage != "submit" for command in session.commands)
     assert (Path(session.metadata_path).parent / "repro" / "build.sh").exists()
 
 
@@ -832,6 +1138,8 @@ def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monk
 def test_submit_accepts_non_executable_compiled_outputs_without_smoke(tmp_path: Path, monkeypatch, filename: str, file_type: str, expected_type: str):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id=f"thread-{file_type}", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    add_replayable_build_command(session, f"cmake --build build && cp build/{filename} /artifacts/{filename}")
     artifact = Path(session.leadagent_artifacts_dir) / filename
     if file_type == "shared":
         write_elf(artifact, 3)


### PR DESCRIPTION
## 变更内容

- `repro/build.sh` 只按记录顺序回放成功的容器 bash 命令，并保留各命令的容器内工作目录。
- 使用实际克隆 URL 和完整的 40/64 位 commit SHA 重建源码，避免分支头漂移。
- 拒绝本地路径、带凭据或 query/fragment 的 URL，以及 Windows、WSL、Session 宿主路径。
- 空配方或不安全配方会使 submit verification 失败；submit 审计事件不再进入 shell history。
- 文档补充 WSL2 新容器 replay 流程，并明确 `verified -> completed` 生命周期。

## 根因

旧生成器会串联全部审计记录，包括失败尝试和伪造为 shell 命令的 submit 记录；同时忽略 workdir，并从移动的分支头重新克隆。结果是产物验证可能通过，但保留的复现脚本无法独立重建该产物。

## 影响

生成的 `repro/build.sh` 可以从空 `/workspace` 和 `/artifacts` 开始，检出记录的精确提交，并在不依赖 Forge 后端、模型访问或原 Session 状态的情况下回放成功构建路径。

本 PR 只生成 candidate recipe。自动创建干净容器执行 recipe、处理超时清理并比较原始/重放产物，仍由 #7 负责。

## 验证

- replay/runtime、terminal tools、cancellation：`73 passed`
- 后端全量：`1360 passed, 15 skipped`
- Ruff check 与 format check 通过
- 两份 Docker Compose 配置解析通过
- `git diff --check`、敏感信息扫描与补丁 `range-diff` 通过
- `bash -n` 由 replay bundle 单测覆盖并通过
- 原补丁曾在两个独立的 `autocompiler:gcc13` 干净容器中回放 `MattClarkson/CMakeHelloWorld@6fda0b169299b1241ed883c8d4af8519da30ce52`，均退出 0、输出 `Hello Matt!`，并生成 SHA-256 为 `33114a53b889e9b6d810929a1420a24c33ac04b3646a26e180cfca62b93a0c20` 的 16,504 字节 ELF PIE；本次 rebase 经 `range-diff` 确认补丁等价。

Closes #6