### PR TITLE
功能：在干净容器中验证候选编译配方

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # COMPILE_RUNTIME_HTTP_PROXY=http://host.docker.internal:7897
 # COMPILE_RUNTIME_HTTPS_PROXY=http://host.docker.internal:7897
 # COMPILE_RUNTIME_NO_PROXY=localhost,127.0.0.1
+# Maximum execution/verification time for one automatic clean replay attempt.
+# Network/image inspection, recipe execution, artifact scanning/hashing, and
+# smoke checks share this deadline. The value is persisted with replay evidence.
+# COMPILE_REPLAY_TIMEOUT_SECONDS=1200
+# Bound individual Docker control calls outside a replay-wide deadline.
+# COMPILE_DOCKER_CONTROL_TIMEOUT_SECONDS=30
+# Separate bounded budget for stop/force-remove cleanup after replay execution.
+# COMPILE_DOCKER_CLEANUP_TIMEOUT_SECONDS=20
 # Host networking exposes WSL loopback services to repository build scripts.
 # Use it only for trusted repositories. 127.0.0.1 reaches a Windows proxy only
 # with mirrored networking; otherwise the proxy must run in the same WSL distro.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@
 4. 由 **compiler 子代理**在容器内反复尝试 configure / build / 补依赖，直到产出可执行物
 5. 把最终产物 `cp` 到 `/artifacts`
 6. 系统对 `/artifacts` 做强制验证（ELF/`ar` 结构识别与 executable smoke test）
-7. 提交验证同时生成固定源码 commit 的 `repro/build.sh`；全部通过后 session 先标记 `verified`
-8. 容器清理与 finalize 成功后，session 才标记 `completed`
+7. 提交验证先生成固定源码 commit 的候选 `repro/build.sh`，再用原容器的不可变 `image_id` 在全新容器和空挂载中自动 replay
+8. 系统结构化比较产物集合、类型、大小、SHA-256 与 smoke 结果；全部通过后 session 才标记 `verified`
+9. 容器清理与 finalize 成功后，session 才标记 `completed`
 
 项目 fork 自 DeerFlow 2.0（一个通用 LangGraph Agent Harness）。许多 DeerFlow 时代的能力（IM channels、20+ skills、memory、MCP）**仍在代码中**，但**与编译核心无关**，是历史遗留。文档中明确标注 “非编译核心”，今后可能裁剪。
 
@@ -99,8 +100,9 @@ Lead Agent
 3. 结构：只接受有效 ELF executable/shared library/object 或有效 `ar` static archive
 4. 若是可执行：smoke test 依次尝试 `-version` / `--version` / `--help`，任一退出 0 即通过
 5. `repro_bundle`：必须能从远端 `repo_url` 检出完整 `commit_sha`，并安全渲染成功构建步骤
+6. `clean_replay`：使用原容器记录的完整 `image_id`，在唯一 attempt 的空 workspace/artifacts 中执行候选脚本，并比较产物集合、类型、大小、SHA-256 和 smoke 结果
 
-全部通过 → session 状态 `verified`。`repro/build.sh` 只按记录顺序回放 `stage == "bash" && exit_code == 0` 的命令，并在各自容器 `workdir` 中独立执行；cleanup/finalize 成功后才进入 `completed`。
+两层检查全部通过 → session 状态 `verified`。`repro/build.sh` 只按记录顺序回放 `stage == "bash" && exit_code == 0` 的命令，并在各自容器 `workdir` 中独立执行；候选生成成功本身不构成验证通过。cleanup/finalize 成功后才进入 `completed`。
 
 ### 4.3 会话目录布局（宿主机）
 
@@ -113,7 +115,12 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 │   ├── workflow.log         # JSONL 事件流（session.created、command.recorded、…）
 │   ├── 001_clone.log        # 每条命令的 stdout+stderr 全量
 │   └── ...
-└── repro/build.sh           # submit 验证（含 replay bundle check）通过后生成
+├── repro/build.sh           # submit 的候选 replay bundle
+└── replay/{attempt_id}/     # 每次自动 clean replay 的独立证据
+    ├── recipe/build.sh
+    ├── workspace/
+    ├── artifacts/
+    └── logs/
 ```
 
 容器侧统一挂载到 `/workspace`、`/artifacts`、`/logs`、`/repro`。容器内仓库根永远是 `/workspace/repo`。
@@ -128,8 +135,11 @@ $HOST_PROJECT_ROOT/.compile-sessions/{thread_id}/{session_id}/
 - **replay 固定完整 commit**：只接受 40/64 位十六进制 SHA 与不含持久凭据的远端 URL
 - **replay 只消费成功 bash 记录**：失败尝试、clone/inspect 与 submit 审计记录不进入脚本
 - **replay workdir 只允许容器路径**：必须位于 `/workspace` 或 `/artifacts`；拒绝 Windows、WSL 宿主路径和 `.compile-sessions` 路径
-- **replay 会清空挂载目录**：脚本从空 `/workspace` 与 `/artifacts` 开始，验收时必须挂载专用临时目录
-- **生成不等于独立 replay 通过**：`repro_bundle` check 只验证候选脚本可安全生成且至少有一个成功 bash 步骤；研究基线必须再做 README 中的新容器验收，自动执行与产物比较跟踪在 Issue #7
+- **replay 固定原始镜像 ID**：原容器创建后记录完整 `image_id`；自动 replay 只能在同一 Docker daemon 中使用该 ID，不得重新解析 tag，也不承诺跨主机/跨架构复现
+- **replay 只能清空 attempt 专用目录**：每次创建唯一的 `replay/{attempt_id}/{recipe,workspace,artifacts,logs}`；脚本从空 `/workspace` 与 `/artifacts` 开始，严禁挂载原 session 目录
+- **候选生成不等于 clean replay 通过**：`repro_bundle` 只证明脚本安全且非空；自动 replay 还必须执行成功，并让产物集合、类型、大小、SHA-256 与 smoke 命令/退出码/有限预览/完整输出哈希全部匹配，session 才能进入 `verified`。删除原 compile container 后还要重新核对交付产物，才能进入 `completed`
+- **replay 有执行/验证 deadline**：`COMPILE_REPLAY_TIMEOUT_SECONDS` 默认 `1200` 秒，覆盖 Docker control、脚本、产物遍历/分类/哈希和 smoke；cleanup 使用独立短时限。实际时限、日志、duration、image identity 与 failure classification 必须随 attempt 持久化
+- **replay 清理有两条路径**：正常/异常返回由 `finally` 删除容器；父任务取消在 worker 停止前后都重新加载 authoritative session，并按 container name/ID 幂等删除。创建握手必须持有 session lock 且有短时限；worker 保存不得覆盖父级写入的 `cancelled`。任何路径都不能覆盖原 workspace/artifacts，也不能把模型凭据传进 replay 容器
 - **compiler 子代理的 system prompt 是产品契约**：改它等同于改产品行为，需要同时改 `compiler_agent.py` 和对应测试
 
 ## 5. 架构约束：Harness / App 分层

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,11 @@ make nginx
 - **可 replay 步骤必须走 `run_container_bash`**：`workdir` 只能是 `/workspace` 或 `/artifacts` 下的绝对容器路径，不得写入宿主机、WSL `/mnt/<drive>` 或 `.compile-sessions` 路径。
 - **submit 不是 shell command**：`submit_build_result` 只写 `submit.*` 事件、summary log 和 verification checks，不得追加到 `session.commands`；replay 生成失败必须落为 `verification_failed`。
 - **修改 replay 契约必须补测试**：命令过滤、workdir、commit/URL 校验、shell quoting 与宿主路径隔离应同步覆盖 `tests/test_compile_runtime.py`。
-- **候选生成不等于 clean replay**：失败命令可能留下持久副作用；研究结果必须在新容器和空挂载中实际执行脚本，自动验证与产物比较见 Issue #7。
+- **候选生成与 clean replay 是两层检查**：`repro_bundle` 通过只说明候选脚本安全且非空；`submit_build_result` 还必须自动在新容器中执行并比较产物，只有 clean replay 通过才能进入 `verified`。
+- **replay 固定实际镜像身份**：创建原编译容器后必须持久化完整 `image_id`，replay 只能使用该 ID，不能重新解析可变 tag；这保证同一 Docker daemon 内的镜像一致性，不代表跨主机可拉取或复现。
+- **replay attempt 必须隔离**：每次使用唯一的 `replay/<attempt_id>/{recipe,workspace,artifacts,logs}`，workspace/artifacts 初始为空，严禁挂载或清空原 session 的目录。
+- **比较结果必须结构化**：至少持久化产物相对路径集合、类型、大小、SHA-256，以及 executable smoke 的命令、退出码、有限预览和完整输出 SHA-256；任一集合差异或字段不匹配均为验证失败。原 compile container 删除后、写入 `completed` 前必须再次核对最终产物。
+- **超时与取消必须清理**：执行/验证 deadline 由 `COMPILE_REPLAY_TIMEOUT_SECONDS` 控制（默认 `1200` 秒），所有 replay Docker control、产物遍历/分类/哈希和 smoke 都必须消费 remaining time；cleanup 使用独立短时限。内部 `finally` 和父任务等待 worker 前后的两次路径都必须重新加载 authoritative session，并按 replay container name/ID 幂等删除容器。
 - **状态机变更**（`CompileSession.status`）要更新 `logs/workflow.log` 的事件命名约定。
 
 ## 架构约束

--- a/README_zh.md
+++ b/README_zh.md
@@ -22,7 +22,8 @@
 4. **委派 compiler 子代理**：子代理在容器内反复 `configure` / `build`，遇到依赖错误自动 `apt install`、清缓存重试
 5. **拷贝产物到 `/artifacts`**：只拷最终可执行物/库，不整目录倾倒
 6. **强制验证**：识别 ELF/`ar` 结构，并对 executable 做 smoke test（`-version` / `--version` / `--help` 任一过即可）
-7. **生成复现脚本**：提交验证同时写出 `repro/build.sh`；脚本检出记录的完整 commit SHA，并按原 workdir 回放成功的 `run_container_bash` 命令
+7. **生成候选复现脚本**：提交验证先写出 `repro/build.sh`；脚本检出记录的完整 commit SHA，并按原 workdir 回放成功的 `run_container_bash` 命令
+8. **自动 clean replay**：用原编译容器记录的不可变 `image_id` 启动新容器，在独立空目录中执行候选脚本，并比较产物集合、类型、大小、SHA-256 与 smoke 结果；只有全部通过才标记为 `verified`
 
 整个过程通过 Web 工作台（基于 Next.js）或后端 SDK 调用。
 
@@ -160,7 +161,7 @@ Compiler:  run_container_bash("cmake ...")  ← 反复迭代
            run_container_bash("make -j")
            ...                              ← 失败必改策略，禁止盲目重试
            run_container_bash("cp .../app /artifacts/")
-           submit_build_result()             ← 验证产物并生成 commit-pinned replay，状态置为 verified
+           submit_build_result()             ← 验证原产物、生成候选脚本并自动 clean replay；全部通过才置为 verified
        ↓
 Lead:  finalize_session()  ← 停并删除容器；验证通过且有产物时状态置为 completed
 ```
@@ -186,34 +187,53 @@ logs/
 ├── workflow.log          # JSONL 事件流（session.created、command.recorded、...）
 ├── 001_clone.log         # 每条命令的完整 stdout+stderr
 └── ...
-repro/build.sh            # submit 验证（含 replay bundle check）通过后生成
+repro/build.sh            # submit 生成的 commit-pinned 候选 bundle
+replay/<attempt_id>/       # 每次自动 clean replay 的独立证据目录
+├── recipe/build.sh       # 本次实际执行的候选脚本副本
+├── workspace/            # 空白源码工作区，不复用原 session workspace
+├── artifacts/            # replay 产生的产物，不覆盖原始 artifacts
+└── logs/                 # replay 执行日志
 ```
 
-**复现脚本是这套系统的核心交付物**。它从 `repo_url` 检出 session 记录的完整 `commit_sha`，只按原顺序和 workdir 回放成功的 `run_container_bash` 命令；失败尝试、clone/inspect 和 submit 审计事件不会进入脚本。它是一份可审计的重建配方，不承诺在镜像或外部依赖变化后仍得到字节级相同的产物。
+**复现脚本和 clean replay 证据是这套系统的核心交付物**。`repro/build.sh` 从 `repo_url` 检出 session 记录的完整 `commit_sha`，只按原顺序和 workdir 回放成功的 `run_container_bash` 命令；失败尝试、clone/inspect 和 submit 审计事件不会进入脚本。脚本生成只是候选配方，不单独证明构建可从空环境复现。
 
-`submit_build_result` 的 `repro_bundle` check 验证候选脚本能够安全生成且包含成功构建步骤，但不会自动启动第二个容器执行它。失败命令可能留下未进入候选脚本的持久副作用，因此研究基线必须执行下面的全新容器验收；自动执行、超时清理和产物比较跟踪在 [Issue #7](https://github.com/WWFXL/Forge-AutoCompiler/issues/7)。
+`submit_build_result` 会把两层结果分开记录：`repro_bundle` check 只表示候选脚本安全且非空；随后系统自动创建唯一的 `replay/<attempt_id>/`，使用原编译容器解析出的完整 `image_id` 和空白挂载执行脚本。自动 replay 的执行/验证 deadline 由 `COMPILE_REPLAY_TIMEOUT_SECONDS` 控制，默认 `1200` 秒，覆盖网络与镜像检查、容器创建、脚本执行、产物遍历/分类/哈希和 smoke。系统以结构化 check 比较原始与 replay 产物的相对路径集合、ELF/`ar` 类型、字节大小、SHA-256，以及 executable 的 smoke 命令、退出码、有限预览和完整输出 SHA-256。任一执行、比较或清理步骤失败，session 都不会进入 `verified`。
 
-### 在 WSL2 的全新容器中 replay
+Replay 容器不需要 Forge 后端或模型密钥，也不会挂载原 session 的 workspace/artifacts。容器创建握手在 session lifecycle lock 内完成并使用短时限；正常返回走 `finally` 清理，父任务取消会在 worker 停止前后各重新加载一次并按名称/ID 幂等清理。清理由独立的 `COMPILE_DOCKER_CLEANUP_TIMEOUT_SECONDS` 控制，默认 `20` 秒，stop 卡住时仍会尝试 bounded `rm -f`。原编译容器删除后、session 进入 `completed` 前，系统还会重新核对最终 `/artifacts` 的路径集合、类型、大小和 SHA-256，拒绝 replay 通过后的后台改写。`image_id` 只保证同一 Docker daemon 上的精确镜像身份：镜像被清理、换 daemon、换架构或外部依赖变化后，不承诺跨主机复现。
 
-请在 WSL shell 中运行。`build.sh` 启动时会清空挂载的 `/workspace` 和 `/artifacts`，因此必须使用专用临时目录，不能挂载包含其他数据的路径：
+### 在 WSL2 中手动诊断 replay
+
+自动验证失败时，可以用下面的命令诊断。它不会替代或改写 `session.json` 中的自动 replay 结果。必须进入运行 Forge 的同一个 WSL 发行版，并连接同一个 Docker daemon；不要在 PowerShell 的另一套 Docker context 中执行。`build.sh` 会清空挂载的 `/workspace` 和 `/artifacts`，因此只能使用新建的专用临时目录：
 
 ```bash
+set -euo pipefail
 SESSION_DIR="$PWD/.compile-sessions/<thread_id>/<session_id>"
 REPLAY_RUN="$(mktemp -d)"
-IMAGE=autocompiler:gcc13  # 应与 session.json 中记录的 image 一致
+REPLAY_NAME="forge-manual-replay-$$"
+REPLAY_TIMEOUT="${COMPILE_REPLAY_TIMEOUT_SECONDS:-1200}"
+NETWORK="${COMPILE_RUNTIME_NETWORK:-compile_network_wwf_v1}"
+IMAGE_ID="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["image_id"])' "$SESSION_DIR/session.json")"
+
+cleanup() {
+  docker rm -f "$REPLAY_NAME" >/dev/null 2>&1 || true
+  rm -rf "$REPLAY_RUN"
+}
+trap cleanup EXIT INT TERM
 
 mkdir -p "$REPLAY_RUN/workspace" "$REPLAY_RUN/artifacts"
-docker run --rm \
+docker image inspect "$IMAGE_ID" >/dev/null
+docker run --rm --name "$REPLAY_NAME" \
+  --network "$NETWORK" \
   --mount "type=bind,src=$(realpath "$SESSION_DIR/repro"),dst=/repro,readonly" \
   --mount "type=bind,src=$(realpath "$REPLAY_RUN/workspace"),dst=/workspace" \
   --mount "type=bind,src=$(realpath "$REPLAY_RUN/artifacts"),dst=/artifacts" \
-  "$IMAGE" bash /repro/build.sh
+  "$IMAGE_ID" timeout --signal=TERM --kill-after=5s "${REPLAY_TIMEOUT}s" bash /repro/build.sh
 
 file "$REPLAY_RUN"/artifacts/*
 sha256sum "$REPLAY_RUN"/artifacts/*
 ```
 
-`--rm` 会在脚本退出后删除 replay 容器。若脚本、产物类型或预期输出检查失败，本次编译不能记为可独立复现。
+`--rm` 与 shell trap 共同覆盖正常退出和手动中断；自动验证还会在父任务取消时独立清理。若记录的 `image_id` 在当前 daemon 中不存在，应恢复原镜像，而不是退回同名可变 tag。
 
 ---
 
@@ -236,6 +256,7 @@ sha256sum "$REPLAY_RUN"/artifacts/*
 - `config.yaml` 在项目根，从 `config.example.yaml` 复制。schema 升级跑 `make config-upgrade`。
 - 至少需要一个可用的 LLM 模型条目（`models[]`）。
 - C/C++ 编译会话使用独立的 `autocompiler:gcc13` 镜像；首次运行前执行 `make compile-image`。
+- 自动 clean replay 的执行/验证时限由 `COMPILE_REPLAY_TIMEOUT_SECONDS` 设置，默认 `1200` 秒；清理另有默认 `20` 秒的 bounded budget。实际时限、duration 和镜像身份会写入 replay 证据。
 - 宿主机必须设 `HOST_PROJECT_ROOT` 环境变量（本机模式由启动脚本注入；自己手动跑后端时要自己 export）。
 
 ---

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -68,9 +68,9 @@ created → ready → source_ready → inspected → (compiler 子代理执行) 
 - `ready`：容器起来了
 - `source_ready`：clone 成功
 - `inspected`：识别完构建系统
-- `verified`：`submit_build_result` 的产物检查与 commit-pinned replay bundle 检查均通过；此时 `completed_at` 仍为空
+- `verified`：`submit_build_result` 的原始产物检查、commit-pinned 候选 bundle 和自动 clean replay 比较均通过；此时 `completed_at` 仍为空
 - `completed`：已验证 session 的编译容器清理成功，并由 finalize 写入终态
-- `verification_failed`：`submit_build_result` 验证失败（产物无效、smoke 失败或 replay bundle 无法安全生成）
+- `verification_failed`：`submit_build_result` 验证失败（产物无效、smoke 失败、候选 bundle 无法安全生成、clean replay 执行/比较失败或 replay 容器清理失败）
 - `failed`：clone 失败或其他不可恢复错误
 
 每次状态切换都会写一条 `session.status_changed` 事件进 `logs/workflow.log`，**改状态机时务必同步事件日志的语义**。
@@ -89,7 +89,9 @@ created → ready → source_ready → inspected → (compiler 子代理执行) 
 
 需要进入 replay 的构建步骤必须通过 `run_container_bash` 执行；`workdir` 必须是 `/workspace` 或 `/artifacts` 下的绝对容器路径。生成器还要求完整 40/64 位 commit SHA、无持久凭据的远端 URL，并拒绝 Windows/WSL 宿主路径、`.compile-sessions` 路径和 session 标识。修改过滤或安全规则时必须同步 `tests/test_compile_runtime.py`。
 
-`repro_bundle` verification check 只证明候选脚本可安全生成且非空，不证明任意探索历史都能从空目录重放。失败命令可能留下未进入候选脚本的持久副作用，因此研究基线必须按 README 在新容器中执行脚本并检查产物；自动 clean replay verifier 跟踪在 Issue #7。
+`repro_bundle` verification check 只证明候选脚本可安全生成且非空。随后 `submit_build_result` 自动用 session 保存的完整 `image_id` 创建唯一 `replay/<attempt_id>/`，把候选脚本复制到只读 recipe mount，并从空 workspace/artifacts 执行。原容器的 tag 仅作说明，replay 不得重新解析它；`image_id` 只保证同一 Docker daemon 内的精确镜像身份。
+
+每个 replay attempt 独立持久化实际 timeout、执行日志、duration、image identity、failure classification，以及原始/replay 产物的相对路径集合、类型、大小、SHA-256、smoke 命令、退出码、有限预览和完整输出 SHA-256。只有执行、全部比较和容器清理均成功才能把 session 标为 `verified`；删除原 compile container 后还要重新核对最终产物集合、类型、大小和 SHA-256，才能标为 `completed`。执行/验证 deadline 来自 `COMPILE_REPLAY_TIMEOUT_SECONDS`（默认 `1200` 秒），覆盖 Docker control 与本地 artifact 工作；cleanup 使用独立短时限。创建握手必须在 session lock 内完成，父任务取消在 worker 停止前后都要重新加载并按 name/ID 幂等清理，worker 不得用 stale session 覆盖 `cancelled`。Replay 目录不得与原 workspace/artifacts 重合，容器不得继承模型凭据。
 
 ### 2.3 路径双重映射
 
@@ -97,6 +99,8 @@ created → ready → source_ready → inspected → (compiler 子代理执行) 
 
 - **Python 层视角**：`compile/paths.py` 给出宿主机绝对路径（`get_session_dir`、`get_workspace_dir` 等）
 - **容器视角**：固定 `/workspace/repo`、`/artifacts`、`/logs`、`/repro`
+
+自动 replay 还维护服务进程可见与 Docker daemon 可见的两套 `replay/<attempt_id>/{recipe,workspace,artifacts,logs}` 路径。Docker-in-Docker-out 模式必须从 host-path helper 取得 bind source，不能把 backend 容器内普通 `tempfile` 路径直接交给宿主 daemon。
 
 `CompileDockerRuntime` 在 `create_container()` 把宿主机路径以 `-v` 挂进容器，挂载点由 `docker_runtime.py` 顶部常量定义（`CONTAINER_WORKSPACE_DIR` 等）。**改任何一边的路径都要同步另一边**。
 

--- a/backend/packages/harness/deerflow/compile/docker_runtime.py
+++ b/backend/packages/harness/deerflow/compile/docker_runtime.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import math
 import os
+import re
 import subprocess
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
-from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_session_dir, get_host_workspace_dir
+from deerflow.compile.paths import (
+    get_host_artifacts_dir,
+    get_host_logs_dir,
+    get_host_replay_artifacts_dir,
+    get_host_replay_logs_dir,
+    get_host_replay_recipe_dir,
+    get_host_replay_workspace_dir,
+    get_host_repro_dir,
+    get_host_session_dir,
+    get_host_workspace_dir,
+    get_replay_artifacts_dir,
+    get_replay_logs_dir,
+    get_replay_recipe_dir,
+    get_replay_workspace_dir,
+)
 from deerflow.compile.schemas import CommandResult, CompileSession, utc_now_iso
 from deerflow.config.paths import Paths
 
@@ -15,6 +32,23 @@ CONTAINER_REPO_DIR = "/workspace/repo"
 CONTAINER_ARTIFACTS_DIR = "/artifacts"
 CONTAINER_LOGS_DIR = "/logs"
 CONTAINER_REPRO_DIR = "/repro"
+DEFAULT_REPLAY_TIMEOUT_SECONDS = 1200
+DEFAULT_DOCKER_CONTROL_TIMEOUT_SECONDS = 30
+DEFAULT_DOCKER_CLEANUP_TIMEOUT_SECONDS = 20
+_REPLAY_CREATE_RECONCILE_COMMAND_TIMEOUT_SECONDS = 2.0
+_REPLAY_CREATE_RECONCILE_POLL_SECONDS = 0.5
+_IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def _positive_int_from_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
 
 
 @dataclass
@@ -22,6 +56,24 @@ class RuntimeConfig:
     image: str = "autocompiler:gcc13"
     network: str = DEFAULT_NETWORK
     remove_on_cleanup: bool = True
+    replay_timeout_seconds: int = field(
+        default_factory=lambda: _positive_int_from_env(
+            "COMPILE_REPLAY_TIMEOUT_SECONDS",
+            DEFAULT_REPLAY_TIMEOUT_SECONDS,
+        )
+    )
+    docker_control_timeout_seconds: int = field(
+        default_factory=lambda: _positive_int_from_env(
+            "COMPILE_DOCKER_CONTROL_TIMEOUT_SECONDS",
+            DEFAULT_DOCKER_CONTROL_TIMEOUT_SECONDS,
+        )
+    )
+    cleanup_timeout_seconds: int = field(
+        default_factory=lambda: _positive_int_from_env(
+            "COMPILE_DOCKER_CLEANUP_TIMEOUT_SECONDS",
+            DEFAULT_DOCKER_CLEANUP_TIMEOUT_SECONDS,
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -29,6 +81,13 @@ class ContainerCleanupResult:
     succeeded: bool
     stopped: bool
     removed: bool
+
+
+@dataclass(frozen=True)
+class ReplayContainerHandle:
+    container_id: str
+    container_name: str
+    image_id: str
 
 
 class CompileDockerRuntime:
@@ -75,34 +134,186 @@ class CompileDockerRuntime:
     def _host_repro_dir(self, session: CompileSession) -> str:
         return get_host_repro_dir(session.session_id, session.thread_id, self._paths())
 
+    def _host_replay_recipe_dir(self, session: CompileSession, attempt_id: str) -> str:
+        return get_host_replay_recipe_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            self._paths(),
+        )
+
+    def _host_replay_workspace_dir(self, session: CompileSession, attempt_id: str) -> str:
+        return get_host_replay_workspace_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            self._paths(),
+        )
+
+    def _host_replay_artifacts_dir(self, session: CompileSession, attempt_id: str) -> str:
+        return get_host_replay_artifacts_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            self._paths(),
+        )
+
+    def _host_replay_logs_dir(self, session: CompileSession, attempt_id: str) -> str:
+        return get_host_replay_logs_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            self._paths(),
+        )
+
     def _log(self, session: CompileSession, event: str, **payload) -> None:
         if self.manager is not None:
             self.manager.log_event(session, event, **payload)
 
-    def _ensure_network(self) -> None:
+    @staticmethod
+    def _validate_image_id(image_id: str) -> str:
+        normalized = image_id.strip().lower()
+        if not _IMAGE_ID_RE.fullmatch(normalized):
+            raise RuntimeError(f"Docker returned an invalid immutable image ID: {image_id!r}")
+        return normalized
+
+    @staticmethod
+    def _remaining_timeout(deadline: float, *, command: list[str], timeout_budget: int) -> int:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired(command, timeout_budget)
+        return max(1, math.ceil(remaining))
+
+    @staticmethod
+    def _timeout_output(value: str | bytes | None) -> str:
+        if isinstance(value, bytes):
+            return value.decode(errors="replace")
+        return value or ""
+
+    def inspect_container_image_id(
+        self,
+        container_reference: str,
+        *,
+        timeout_seconds: int | None = None,
+    ) -> str:
+        command = ["docker", "inspect", "--format", "{{.Image}}", container_reference]
+        effective_timeout = max(1, timeout_seconds or self.config.docker_control_timeout_seconds)
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+        )
+        if result.returncode != 0:
+            error = result.stderr.strip() or result.stdout.strip() or "unknown Docker error"
+            raise RuntimeError(f"Failed to inspect immutable image ID for container {container_reference!r}: {error}")
+        return self._validate_image_id(result.stdout)
+
+    def _reconcile_timed_out_replay_create(
+        self,
+        session: CompileSession,
+        *,
+        container_name: str,
+    ) -> None:
+        timeout_budget = max(1, self.config.cleanup_timeout_seconds)
+        deadline = time.monotonic() + timeout_budget
+        del session
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            command = ["docker", "rm", "-f", container_name]
+            command_timeout = min(_REPLAY_CREATE_RECONCILE_COMMAND_TIMEOUT_SECONDS, remaining)
+            try:
+                result = subprocess.run(
+                    command,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=command_timeout,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+            else:
+                if result.returncode == 0:
+                    break
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(_REPLAY_CREATE_RECONCILE_POLL_SECONDS, remaining))
+
+    @staticmethod
+    def replay_container_name(session: CompileSession, attempt_id: str) -> str:
+        safe_thread_id = re.sub(r"[^A-Za-z0-9_.-]", "-", session.thread_id)[:8]
+        safe_session_id = re.sub(r"[^A-Za-z0-9_.-]", "-", session.session_id)[:8]
+        safe_attempt_id = re.sub(r"[^A-Za-z0-9_.-]", "-", attempt_id)[:12]
+        if not safe_thread_id or not safe_session_id or not safe_attempt_id:
+            raise ValueError("A replay attempt ID is required to create a replay container")
+        return f"deerflow-replay-{safe_thread_id}-{safe_session_id}-{safe_attempt_id}"
+
+    def _ensure_network(self, *, timeout_seconds: int | None = None) -> None:
+        effective_timeout = max(1, timeout_seconds or self.config.docker_control_timeout_seconds)
+        deadline = time.monotonic() + effective_timeout
         inspect_command = ["docker", "network", "inspect", self.config.network]
-        inspected = subprocess.run(inspect_command, check=False, capture_output=True, text=True)
+        inspected = subprocess.run(
+            inspect_command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=self._remaining_timeout(
+                deadline,
+                command=inspect_command,
+                timeout_budget=effective_timeout,
+            ),
+        )
         if inspected.returncode == 0:
             return
 
         create_command = ["docker", "network", "create", self.config.network]
-        created = subprocess.run(create_command, check=False, capture_output=True, text=True)
+        created = subprocess.run(
+            create_command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=self._remaining_timeout(
+                deadline,
+                command=create_command,
+                timeout_budget=effective_timeout,
+            ),
+        )
         if created.returncode == 0:
             return
 
         # Another process may have created the network between inspect and create.
-        inspected = subprocess.run(inspect_command, check=False, capture_output=True, text=True)
+        inspected = subprocess.run(
+            inspect_command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=self._remaining_timeout(
+                deadline,
+                command=inspect_command,
+                timeout_budget=effective_timeout,
+            ),
+        )
         if inspected.returncode != 0:
             error = created.stderr.strip() or inspected.stderr.strip() or "unknown Docker error"
             raise RuntimeError(f"Failed to create Docker network {self.config.network!r}: {error}")
 
     def create_container(self, session: CompileSession) -> str:
         if session.container_id:
+            inspected_image_id = self.inspect_container_image_id(session.container_id)
+            if session.image_id and self._validate_image_id(session.image_id) != inspected_image_id:
+                raise RuntimeError("The existing compile container image does not match the recorded immutable image ID")
+            session.image_id = inspected_image_id
             self._log(
                 session,
                 "container.reused",
                 container_id=session.container_id,
                 container_name=session.container_name,
+                image_id=session.image_id,
             )
             return session.container_id
 
@@ -158,11 +369,25 @@ class CompileDockerRuntime:
         result = subprocess.run(command, check=True, capture_output=True, text=True, env=run_environment)
         session.container_name = container_name
         session.container_id = result.stdout.strip()
+        try:
+            session.image_id = self.inspect_container_image_id(session.container_id)
+        except BaseException:
+            self.stop_and_remove_container_reference(
+                session,
+                container_id=session.container_id,
+                container_name=session.container_name,
+                role="compile",
+                force_remove=True,
+            )
+            session.container_id = None
+            session.container_name = None
+            raise
         self._log(
             session,
             "container.create.completed",
             container_id=session.container_id,
             container_name=container_name,
+            image_id=session.image_id,
             started_at=started_at,
             completed_at=utc_now_iso(),
             stdout=result.stdout,
@@ -170,10 +395,197 @@ class CompileDockerRuntime:
         )
         return session.container_id
 
-    def exec(self, session: CompileSession, command: str, workdir: str | None = None, timeout_seconds: int = 600, log_path: str | None = None) -> CommandResult:
-        if not session.container_id:
-            raise ValueError("Compile session container has not been created")
+    def create_replay_container(
+        self,
+        session: CompileSession,
+        *,
+        attempt_id: str,
+        timeout_seconds: int | None = None,
+    ) -> ReplayContainerHandle:
+        effective_timeout = max(1, timeout_seconds or self.config.replay_timeout_seconds)
+        deadline = time.monotonic() + effective_timeout
+        image_id = self._validate_image_id(session.image_id or "")
+        paths = self._paths()
+        recipe_dir = get_replay_recipe_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            paths,
+        )
+        workspace_dir = get_replay_workspace_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            paths,
+        )
+        artifacts_dir = get_replay_artifacts_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            paths,
+        )
+        logs_dir = get_replay_logs_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            paths,
+        )
+        for directory in (recipe_dir, workspace_dir, artifacts_dir, logs_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        recipe_path = recipe_dir / "build.sh"
+        if recipe_path.is_symlink() or not recipe_path.is_file():
+            raise ValueError("Replay recipe/build.sh must be a regular file before container creation")
+        for directory in (workspace_dir, artifacts_dir, logs_dir):
+            if any(directory.iterdir()):
+                raise ValueError(f"Replay {directory.name} directory must be empty before container creation")
 
+        self._ensure_network(
+            timeout_seconds=self._remaining_timeout(
+                deadline,
+                command=["docker", "network", "inspect", self.config.network],
+                timeout_budget=effective_timeout,
+            )
+        )
+        host_recipe_dir = self._host_replay_recipe_dir(session, attempt_id)
+        host_workspace_dir = self._host_replay_workspace_dir(session, attempt_id)
+        host_artifacts_dir = self._host_replay_artifacts_dir(session, attempt_id)
+        host_logs_dir = self._host_replay_logs_dir(session, attempt_id)
+        proxy_flags, run_environment = self._runtime_proxy_environment()
+        container_name = self.replay_container_name(session, attempt_id)
+        command = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "--label",
+            "deerflow.compile.role=replay",
+            "--label",
+            f"deerflow.compile.session_id={session.session_id}",
+            "--label",
+            f"deerflow.compile.thread_id={session.thread_id}",
+            "--label",
+            f"deerflow.compile.attempt_id={attempt_id}",
+            "--network",
+            self.config.network,
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            *proxy_flags,
+            "-v",
+            f"{host_recipe_dir}:{CONTAINER_REPRO_DIR}:ro",
+            "-v",
+            f"{host_workspace_dir}:{CONTAINER_WORKSPACE_DIR}",
+            "-v",
+            f"{host_artifacts_dir}:{CONTAINER_ARTIFACTS_DIR}",
+            "-v",
+            f"{host_logs_dir}:{CONTAINER_LOGS_DIR}",
+            "-w",
+            CONTAINER_WORKSPACE_DIR,
+            image_id,
+            "tail",
+            "-f",
+            "/dev/null",
+        ]
+        self._log(
+            session,
+            "replay.container.create.started",
+            attempt_id=attempt_id,
+            container_name=container_name,
+            image=session.image,
+            image_id=image_id,
+            network=self.config.network,
+            timeout_seconds=effective_timeout,
+            mounts={
+                host_recipe_dir: f"{CONTAINER_REPRO_DIR}:ro",
+                host_workspace_dir: CONTAINER_WORKSPACE_DIR,
+                host_artifacts_dir: CONTAINER_ARTIFACTS_DIR,
+                host_logs_dir: CONTAINER_LOGS_DIR,
+            },
+            docker_command=command,
+        )
+        started_at = utc_now_iso()
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=run_environment,
+                timeout=self._remaining_timeout(
+                    deadline,
+                    command=command,
+                    timeout_budget=effective_timeout,
+                ),
+            )
+        except subprocess.TimeoutExpired:
+            try:
+                self._reconcile_timed_out_replay_create(
+                    session,
+                    container_name=container_name,
+                )
+            except Exception:
+                pass
+            raise
+        container_id = result.stdout.strip()
+        if not container_id:
+            self.stop_and_remove_replay_container(
+                session,
+                container_name=container_name,
+            )
+            raise RuntimeError("Docker did not return a replay container ID")
+
+        try:
+            actual_image_id = self.inspect_container_image_id(
+                container_id,
+                timeout_seconds=self._remaining_timeout(
+                    deadline,
+                    command=["docker", "inspect", "--format", "{{.Image}}", container_id],
+                    timeout_budget=effective_timeout,
+                ),
+            )
+            if actual_image_id != image_id:
+                raise RuntimeError("Replay container image does not match the recorded immutable image ID")
+        except BaseException:
+            self.stop_and_remove_replay_container(
+                session,
+                container_id=container_id,
+                container_name=container_name,
+            )
+            raise
+
+        handle = ReplayContainerHandle(
+            container_id=container_id,
+            container_name=container_name,
+            image_id=actual_image_id,
+        )
+        self._log(
+            session,
+            "replay.container.create.completed",
+            attempt_id=attempt_id,
+            container_id=container_id,
+            container_name=container_name,
+            image=session.image,
+            image_id=actual_image_id,
+            started_at=started_at,
+            completed_at=utc_now_iso(),
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+        return handle
+
+    def exec_container(
+        self,
+        session: CompileSession,
+        *,
+        container_id: str,
+        command: str,
+        workdir: str | None = None,
+        timeout_seconds: int = 600,
+        log_path: str | None = None,
+        event_prefix: str = "container.exec",
+    ) -> CommandResult:
+        if not container_id:
+            raise ValueError("A container ID is required to execute a compile command")
         container_workdir = workdir or CONTAINER_REPO_DIR
         container_timeout = max(1, timeout_seconds)
         exec_command = [
@@ -181,7 +593,7 @@ class CompileDockerRuntime:
             "exec",
             "-w",
             container_workdir,
-            session.container_id,
+            container_id,
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
@@ -192,8 +604,8 @@ class CompileDockerRuntime:
         ]
         self._log(
             session,
-            "container.exec.started",
-            container_id=session.container_id,
+            f"{event_prefix}.started",
+            container_id=container_id,
             workdir=container_workdir,
             timeout_seconds=container_timeout,
             log_path=log_path,
@@ -212,11 +624,13 @@ class CompileDockerRuntime:
                 combined_output += "\n"
             combined_output += timeout_message + "\n"
             if log_path:
-                Path(log_path).write_text(combined_output, encoding="utf-8")
+                log_file = Path(log_path)
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+                log_file.write_text(combined_output, encoding="utf-8")
             self._log(
                 session,
-                "container.exec.timed_out",
-                container_id=session.container_id,
+                f"{event_prefix}.timed_out",
+                container_id=container_id,
                 workdir=container_workdir,
                 timeout_seconds=container_timeout,
                 log_path=log_path,
@@ -236,11 +650,13 @@ class CompileDockerRuntime:
             )
         combined_output = (result.stdout or "") + (result.stderr or "")
         if log_path:
-            Path(log_path).write_text(combined_output, encoding="utf-8")
+            log_file = Path(log_path)
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            log_file.write_text(combined_output, encoding="utf-8")
         self._log(
             session,
-            "container.exec.completed",
-            container_id=session.container_id,
+            f"{event_prefix}.completed",
+            container_id=container_id,
             workdir=container_workdir,
             timeout_seconds=container_timeout,
             log_path=log_path,
@@ -257,6 +673,47 @@ class CompileDockerRuntime:
             stderr=result.stderr,
             combined_output=combined_output,
             log_path=log_path,
+        )
+
+    def exec(
+        self,
+        session: CompileSession,
+        command: str,
+        workdir: str | None = None,
+        timeout_seconds: int = 600,
+        log_path: str | None = None,
+    ) -> CommandResult:
+        if not session.container_id:
+            raise ValueError("Compile session container has not been created")
+        return self.exec_container(
+            session,
+            container_id=session.container_id,
+            command=command,
+            workdir=workdir,
+            timeout_seconds=timeout_seconds,
+            log_path=log_path,
+        )
+
+    def exec_replay_container(
+        self,
+        session: CompileSession,
+        handle: ReplayContainerHandle,
+        command: str = "bash /repro/build.sh",
+        workdir: str = CONTAINER_WORKSPACE_DIR,
+        timeout_seconds: int | None = None,
+        log_path: str | None = None,
+    ) -> CommandResult:
+        recorded_image_id = self._validate_image_id(session.image_id or "")
+        if recorded_image_id != handle.image_id:
+            raise ValueError("Replay container image does not match the compile session image identity")
+        return self.exec_container(
+            session,
+            container_id=handle.container_id,
+            command=command,
+            workdir=workdir,
+            timeout_seconds=timeout_seconds or self.config.replay_timeout_seconds,
+            log_path=log_path,
+            event_prefix="replay.container.exec",
         )
 
     def copy_artifact_to_session(self, session: CompileSession, source_path: str, destination_filename: str | None = None) -> str:
@@ -294,36 +751,103 @@ class CompileDockerRuntime:
         )
         return destination_path
 
-    def stop_and_remove_container(self, session: CompileSession) -> ContainerCleanupResult:
-        if not session.container_id:
+    def stop_and_remove_container_reference(
+        self,
+        session: CompileSession,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+        role: str = "compile",
+        force_remove: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> ContainerCleanupResult:
+        container_reference = container_id or container_name
+        if not container_reference:
             return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+        event_prefix = "container.cleanup" if role == "compile" else f"{role}.container.cleanup"
+        should_remove = force_remove or self.config.remove_on_cleanup
+        effective_timeout = max(2, timeout_seconds or self.config.cleanup_timeout_seconds)
+        deadline = time.monotonic() + effective_timeout
         self._log(
             session,
-            "container.cleanup.started",
-            container_id=session.container_id,
-            remove_on_cleanup=self.config.remove_on_cleanup,
+            f"{event_prefix}.started",
+            container_id=container_id,
+            container_name=container_name,
+            container_reference=container_reference,
+            force_remove=force_remove,
+            remove_on_cleanup=should_remove,
         )
-        stop_result = subprocess.run(["docker", "stop", session.container_id], check=False, capture_output=True, text=True)
+        stop_command = ["docker", "stop", container_reference]
+        stop_timeout = min(
+            self._remaining_timeout(
+                deadline,
+                command=stop_command,
+                timeout_budget=effective_timeout,
+            ),
+            max(1, effective_timeout // 2),
+        )
+        try:
+            stop_result = subprocess.run(
+                stop_command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=stop_timeout,
+            )
+            stop_returncode = stop_result.returncode
+            stop_stdout = stop_result.stdout
+            stop_stderr = stop_result.stderr
+        except subprocess.TimeoutExpired as exc:
+            stop_returncode = 124
+            stop_stdout = self._timeout_output(exc.stdout)
+            stop_stderr = self._timeout_output(exc.stderr)
         self._log(
             session,
-            "container.cleanup.stopped",
-            container_id=session.container_id,
-            exit_code=stop_result.returncode,
-            stdout=stop_result.stdout,
-            stderr=stop_result.stderr,
+            f"{event_prefix}.stopped",
+            container_id=container_id,
+            container_name=container_name,
+            container_reference=container_reference,
+            exit_code=stop_returncode,
+            stdout=stop_stdout,
+            stderr=stop_stderr,
+            timeout_seconds=stop_timeout,
         )
-        stop_succeeded = stop_result.returncode == 0 or "No such container" in (stop_result.stderr or "")
-        if self.config.remove_on_cleanup:
-            rm_result = subprocess.run(["docker", "rm", "-f", session.container_id], check=False, capture_output=True, text=True)
+        stop_succeeded = stop_returncode == 0 or "No such container" in stop_stderr
+        if should_remove:
+            rm_command = ["docker", "rm", "-f", container_reference]
+            try:
+                rm_timeout = self._remaining_timeout(
+                    deadline,
+                    command=rm_command,
+                    timeout_budget=effective_timeout,
+                )
+                rm_result = subprocess.run(
+                    rm_command,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=rm_timeout,
+                )
+                rm_returncode = rm_result.returncode
+                rm_stdout = rm_result.stdout
+                rm_stderr = rm_result.stderr
+            except subprocess.TimeoutExpired as exc:
+                rm_timeout = getattr(exc, "timeout", effective_timeout)
+                rm_returncode = 124
+                rm_stdout = self._timeout_output(exc.stdout)
+                rm_stderr = self._timeout_output(exc.stderr)
             self._log(
                 session,
-                "container.cleanup.removed",
-                container_id=session.container_id,
-                exit_code=rm_result.returncode,
-                stdout=rm_result.stdout,
-                stderr=rm_result.stderr,
+                f"{event_prefix}.removed",
+                container_id=container_id,
+                container_name=container_name,
+                container_reference=container_reference,
+                exit_code=rm_returncode,
+                stdout=rm_stdout,
+                stderr=rm_stderr,
+                timeout_seconds=rm_timeout,
             )
-            remove_succeeded = rm_result.returncode == 0 or "No such container" in (rm_result.stderr or "")
+            remove_succeeded = rm_returncode == 0 or "No such container" in rm_stderr
             return ContainerCleanupResult(
                 succeeded=remove_succeeded,
                 stopped=stop_succeeded,
@@ -333,4 +857,43 @@ class CompileDockerRuntime:
             succeeded=stop_succeeded,
             stopped=stop_succeeded,
             removed=False,
+        )
+
+    def stop_and_remove_replay_container(
+        self,
+        session: CompileSession,
+        handle: ReplayContainerHandle | None = None,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+        timeout_seconds: int | None = None,
+    ) -> ContainerCleanupResult:
+        if handle is not None:
+            if container_id and container_id != handle.container_id:
+                raise ValueError("Replay cleanup received conflicting container IDs")
+            if container_name and container_name != handle.container_name:
+                raise ValueError("Replay cleanup received conflicting container names")
+            container_id = handle.container_id
+            container_name = handle.container_name
+        return self.stop_and_remove_container_reference(
+            session,
+            container_id=container_id,
+            container_name=container_name,
+            role="replay",
+            force_remove=True,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def stop_and_remove_container(
+        self,
+        session: CompileSession,
+        *,
+        timeout_seconds: int | None = None,
+    ) -> ContainerCleanupResult:
+        return self.stop_and_remove_container_reference(
+            session,
+            container_id=session.container_id,
+            container_name=session.container_name,
+            role="compile",
+            timeout_seconds=timeout_seconds,
         )

--- a/backend/packages/harness/deerflow/compile/manager.py
+++ b/backend/packages/harness/deerflow/compile/manager.py
@@ -23,6 +23,7 @@ from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CompileS
 
 DEFAULT_COMPILE_IMAGE = "autocompiler:gcc13"
 WORKFLOW_LOG_NAME = "workflow.log"
+TERMINAL_SESSION_STATUSES = {"completed", "failed", "cancelled", "timed_out"}
 
 
 class CompileSessionManager:
@@ -84,6 +85,7 @@ class CompileSessionManager:
                 run_id=run_id,
                 repo_url=repo_url,
                 branch=branch,
+                image=session.image,
                 compile_sessions_root=str(session_dir.parent.parent),
                 session_dir=str(session_dir),
                 workspace_dir=str(workspace_dir),
@@ -112,10 +114,59 @@ class CompileSessionManager:
                 continue
         return sessions
 
-    def save_session(self, session: CompileSession) -> None:
+    @staticmethod
+    def _read_persisted_session(metadata_file: Path) -> CompileSession | None:
+        if not metadata_file.is_file():
+            return None
+        try:
+            return CompileSession.from_dict(json.loads(metadata_file.read_text(encoding="utf-8")))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def _merge_finalized_replay_cleanup(
+        authoritative: CompileSession,
+        proposed: CompileSession,
+    ) -> None:
+        proposed_by_id = {attempt.attempt_id: attempt for attempt in proposed.replay_attempts}
+        for attempt in authoritative.replay_attempts:
+            update = proposed_by_id.get(attempt.attempt_id)
+            if update is None:
+                continue
+            if attempt.status in {"pending", "running"} and update.status == "cancelled":
+                attempt.status = "cancelled"
+                attempt.failure_classification = attempt.failure_classification or "cancelled"
+                attempt.completed_at = attempt.completed_at or update.completed_at
+                attempt.duration_seconds = attempt.duration_seconds if attempt.duration_seconds is not None else update.duration_seconds
+            if attempt.cleanup_succeeded is True or update.cleanup_succeeded is True:
+                attempt.cleanup_succeeded = True
+            elif update.cleanup_succeeded is False:
+                attempt.cleanup_succeeded = False
+            for note in update.notes:
+                if note.startswith(("Parent replay cleanup raised an error:", "Replay was stopped by the parent compile-session cleanup path.")) and note not in attempt.notes:
+                    attempt.notes.append(note)
+            for check in update.checks:
+                if check.name == "parent_container_cleanup" and check not in attempt.checks:
+                    attempt.checks.append(check)
+
+    def save_session(
+        self,
+        session: CompileSession,
+        *,
+        allow_lifecycle_fenced: bool = False,
+        merge_finalized_replay_cleanup: bool = False,
+    ) -> bool:
         with self.session_lock(session.thread_id, session.session_id):
             metadata_file = Path(session.metadata_path)
             metadata_file.parent.mkdir(parents=True, exist_ok=True)
+            authoritative = self._read_persisted_session(metadata_file)
+            termination_fenced = authoritative is not None and authoritative.termination_requested_at is not None and not allow_lifecycle_fenced
+            if authoritative is not None and authoritative.finalized_at is not None and merge_finalized_replay_cleanup:
+                self._merge_finalized_replay_cleanup(authoritative, session)
+                session.__dict__.update(authoritative.__dict__)
+            elif authoritative is not None and (authoritative.finalized_at is not None or termination_fenced):
+                session.__dict__.update(authoritative.__dict__)
+                return False
             payload = json.dumps(session.to_dict(), ensure_ascii=False, indent=2)
             temporary_path: str | None = None
             try:
@@ -135,56 +186,76 @@ class CompileSessionManager:
             finally:
                 if temporary_path and os.path.exists(temporary_path):
                     os.unlink(temporary_path)
+            return True
 
     def mark_session_status(self, session: CompileSession, status: str, error: str | None = None, summary: str | None = None) -> CompileSession:
-        previous_status = session.status
-        session.status = status
-        if status in {"completed", "failed", "cancelled", "timed_out"}:
-            session.completed_at = session.completed_at or utc_now_iso()
-        else:
-            session.completed_at = None
-        session.error = error
-        if summary is not None:
-            session.summary = summary
-        self.save_session(session)
-        self.log_event(
-            session,
-            "session.status_changed",
-            previous_status=previous_status,
-            status=status,
-            error=error,
-            summary=summary,
-            completed_at=session.completed_at,
-        )
-        return session
+        with self.session_lock(session.thread_id, session.session_id):
+            authoritative = self._read_persisted_session(Path(session.metadata_path))
+            termination_blocks_transition = authoritative is not None and authoritative.termination_requested_at is not None and status not in TERMINAL_SESSION_STATUSES
+            if authoritative is not None and (authoritative.finalized_at is not None or termination_blocks_transition):
+                session.__dict__.update(authoritative.__dict__)
+                return session
+
+            target = session
+            if authoritative is not None and authoritative.termination_requested_at is not None:
+                target = authoritative
+                if session.termination_requested_at == authoritative.termination_requested_at and session.finalized_at is not None:
+                    target.finalized_at = session.finalized_at
+
+            previous_status = target.status
+            target.status = status
+            if status in TERMINAL_SESSION_STATUSES:
+                target.completed_at = target.completed_at if previous_status == status and target.completed_at is not None else utc_now_iso()
+            else:
+                target.completed_at = None
+            target.error = error
+            if summary is not None:
+                target.summary = summary
+            if not self.save_session(
+                target,
+                allow_lifecycle_fenced=(authoritative is not None and authoritative.termination_requested_at is not None and status in TERMINAL_SESSION_STATUSES),
+            ):
+                session.__dict__.update(target.__dict__)
+                return session
+            self.log_event(
+                target,
+                "session.status_changed",
+                previous_status=previous_status,
+                status=status,
+                error=error,
+                summary=summary,
+                completed_at=target.completed_at,
+            )
+            session.__dict__.update(target.__dict__)
+            return session
 
     def record_command(self, session: CompileSession, command: BuildCommandRecord) -> CompileSession:
         session.commands.append(command)
-        self.save_session(session)
-        self.log_event(
-            session,
-            "command.recorded",
-            stage=command.stage,
-            command=command.command,
-            workdir=command.workdir,
-            started_at=command.started_at,
-            completed_at=command.completed_at,
-            exit_code=command.exit_code,
-            log_path=command.log_path,
-        )
+        if self.save_session(session):
+            self.log_event(
+                session,
+                "command.recorded",
+                stage=command.stage,
+                command=command.command,
+                workdir=command.workdir,
+                started_at=command.started_at,
+                completed_at=command.completed_at,
+                exit_code=command.exit_code,
+                log_path=command.log_path,
+            )
         return session
 
     def record_artifact(self, session: CompileSession, artifact: BuildArtifact) -> CompileSession:
         session.artifacts.append(artifact)
-        self.save_session(session)
-        self.log_event(
-            session,
-            "artifact.recorded",
-            path=artifact.path,
-            artifact_type=artifact.artifact_type,
-            size_bytes=artifact.size_bytes,
-            source_path=artifact.source_path,
-        )
+        if self.save_session(session):
+            self.log_event(
+                session,
+                "artifact.recorded",
+                path=artifact.path,
+                artifact_type=artifact.artifact_type,
+                size_bytes=artifact.size_bytes,
+                source_path=artifact.source_path,
+            )
         return session
 
     def local_logs_dir(self, session: CompileSession) -> Path:

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 import re
+import shutil
 import struct
+import subprocess
+import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path, PurePosixPath
 from shlex import quote
 from typing import BinaryIO
 from urllib.parse import urlsplit
 
-from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime, ContainerCleanupResult
+from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime, ContainerCleanupResult, ReplayContainerHandle
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationCheck, VerificationResult, utc_now_iso
+from deerflow.compile.paths import get_replay_artifacts_dir, get_replay_logs_dir, get_replay_recipe_dir, get_replay_workspace_dir
+from deerflow.compile.schemas import (
+    BuildArtifact,
+    BuildCommandRecord,
+    CommandResult,
+    CompileSession,
+    ReplayArtifactComparison,
+    ReplayVerificationResult,
+    VerificationCheck,
+    VerificationResult,
+    utc_now_iso,
+)
 
 _BUILD_SYSTEM_MARKERS = {
     "cmake": "CMakeLists.txt",
@@ -53,6 +70,10 @@ _REPLAY_WORKDIR_ROOTS = (
 )
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9_])(?:[A-Z]:[\\/]|\\\\)")
 _WSL_HOST_PATH_RE = re.compile(r"(?i)(?<![A-Za-z0-9_])/mnt/[A-Z](?:/|$)")
+_REPLAY_SMOKE_TIMEOUT_SECONDS = 30
+_REPLAY_CONTAINER_CREATE_TIMEOUT_SECONDS = 30
+_MAX_PERSISTED_SMOKE_OUTPUT = 4000
+_TERMINAL_SESSION_STATUSES = {"completed", "failed", "cancelled", "timed_out"}
 
 
 @dataclass
@@ -70,6 +91,49 @@ _services = CompileOperationsServices(
 
 def get_compile_services() -> CompileOperationsServices:
     return _services
+
+
+def _load_authoritative_session(session: CompileSession) -> CompileSession:
+    services = get_compile_services()
+    try:
+        return services.manager.load_session(session.session_id, session.thread_id)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return session
+
+
+def _session_lifecycle_fenced(session: CompileSession) -> bool:
+    return session.finalized_at is not None or session.termination_requested_at is not None or session.status in _TERMINAL_SESSION_STATUSES
+
+
+def _abort_submit_for_lifecycle(session: CompileSession, *, stage: str) -> str:
+    services = get_compile_services()
+    status = session.termination_status or session.status
+    if status not in _TERMINAL_SESSION_STATUSES:
+        status = "cancelled"
+    message = f"Compile session is terminating or finalized with status {status}; submit was ignored."
+    services.manager.log_event(
+        session,
+        "submit.aborted",
+        stage=stage,
+        status=status,
+        finalized_at=session.finalized_at,
+        termination_requested_at=session.termination_requested_at,
+    )
+    return json.dumps(
+        {
+            "exit_code": 1,
+            "status": status,
+            "candidate_status": "not_committed",
+            "replay_status": "not_run",
+            "replay_attempt_id": None,
+            "image_id": session.image_id,
+            "artifact_count": 0,
+            "artifacts": [],
+            "message": message,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
 
 
 def get_bound_session(session_id: str | None, thread_id: str, owner_id: str | None = None) -> CompileSession:
@@ -154,6 +218,7 @@ def prepare_compile_session_impl(
             "prepare.completed",
             container_id=session.container_id,
             container_name=session.container_name,
+            image_id=session.image_id,
         )
         return session
 
@@ -342,8 +407,13 @@ def inspect_build_system_json(*, session: CompileSession) -> str:
     )
 
 
-def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
-    base = Path(session.leadagent_artifacts_dir)
+def _check_replay_deadline(deadline: float | None) -> None:
+    if deadline is not None and time.monotonic() >= deadline:
+        raise _ReplayVerificationFailure("timeout", "Clean replay exceeded its total timeout.")
+
+
+def _list_artifact_files(base: Path, *, deadline: float | None = None) -> list[Path]:
+    _check_replay_deadline(deadline)
     if not base.exists():
         return []
     try:
@@ -352,6 +422,7 @@ def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
         return []
     files: list[Path] = []
     for p in base.rglob("*"):
+        _check_replay_deadline(deadline)
         if p.is_symlink():
             continue
         try:
@@ -369,6 +440,28 @@ def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
     return files
 
 
+def _list_leadagent_artifact_files(session: CompileSession) -> list[Path]:
+    return _list_artifact_files(Path(session.leadagent_artifacts_dir))
+
+
+def _sha256_file(path: Path, *, deadline: float | None = None) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            _check_replay_deadline(deadline)
+            digest.update(chunk)
+    _check_replay_deadline(deadline)
+    return digest.hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _persisted_output(output: str) -> str:
+    return output[:_MAX_PERSISTED_SMOKE_OUTPUT]
+
+
 def _table_fits(*, offset: int, entry_size: int, entry_count: int, file_size: int, minimum_entry_size: int) -> bool:
     return offset > 0 and entry_size >= minimum_entry_size and 0 < entry_count <= _MAX_ELF_TABLE_ENTRIES and offset + entry_size * entry_count <= file_size
 
@@ -384,6 +477,7 @@ def _has_valid_object_sections(
     section_header_size: int,
     section_header_count: int,
     section_name_index: int,
+    deadline: float | None = None,
 ) -> bool:
     if section_header_count < 2 or not 0 < section_name_index < section_header_count:
         return False
@@ -391,6 +485,7 @@ def _has_valid_object_sections(
     meaningful_section_found = False
     valid_name_table = False
     for index in range(section_header_count):
+        _check_replay_deadline(deadline)
         stream.seek(base_offset + section_header_offset + index * section_header_size)
         raw = stream.read(_ELF32_SECTION_HEADER_SIZE if elf_class == 1 else _ELF64_SECTION_HEADER_SIZE)
         try:
@@ -422,7 +517,14 @@ def _has_valid_object_sections(
     return meaningful_section_found and valid_name_table
 
 
-def _classify_elf_stream(stream: BinaryIO, *, base_offset: int, file_size: int) -> str | None:
+def _classify_elf_stream(
+    stream: BinaryIO,
+    *,
+    base_offset: int,
+    file_size: int,
+    deadline: float | None = None,
+) -> str | None:
+    _check_replay_deadline(deadline)
     if file_size < _ELF32_HEADER_SIZE:
         return None
 
@@ -499,6 +601,7 @@ def _classify_elf_stream(stream: BinaryIO, *, base_offset: int, file_size: int) 
             section_header_size=section_header_size,
             section_header_count=section_header_count,
             section_name_index=section_name_index,
+            deadline=deadline,
         ):
             return None
         return "object"
@@ -518,6 +621,7 @@ def _classify_elf_stream(stream: BinaryIO, *, base_offset: int, file_size: int) 
     has_dynamic_segment = False
     has_interpreter = False
     for index in range(program_header_count):
+        _check_replay_deadline(deadline)
         offset = base_offset + program_header_offset + index * program_header_size
         stream.seek(offset)
         raw = stream.read(expected_program_header_size)
@@ -556,13 +660,19 @@ def _classify_elf_stream(stream: BinaryIO, *, base_offset: int, file_size: int) 
     return "shared_library" if has_dynamic_segment else None
 
 
-def _classify_archive_stream(stream: BinaryIO, *, file_size: int) -> str | None:
+def _classify_archive_stream(
+    stream: BinaryIO,
+    *,
+    file_size: int,
+    deadline: float | None = None,
+) -> str | None:
     if file_size < len(_AR_MAGIC) + _AR_MEMBER_HEADER_SIZE:
         return None
 
     offset = len(_AR_MAGIC)
     compiled_member_found = False
     while offset < file_size:
+        _check_replay_deadline(deadline)
         if offset + _AR_MEMBER_HEADER_SIZE > file_size:
             return None
         stream.seek(offset)
@@ -598,6 +708,7 @@ def _classify_archive_stream(stream: BinaryIO, *, file_size: int) -> str | None:
                 stream,
                 base_offset=payload_offset,
                 file_size=payload_size,
+                deadline=deadline,
             )
             compiled_member_found = compiled_member_found or member_type == "object"
 
@@ -608,17 +719,18 @@ def _classify_archive_stream(stream: BinaryIO, *, file_size: int) -> str | None:
     return "static_library" if compiled_member_found else None
 
 
-def _classify_compiled_artifact(path: Path) -> str | None:
+def _classify_compiled_artifact(path: Path, *, deadline: float | None = None) -> str | None:
     """Classify supported Linux C/C++ outputs from file contents."""
     try:
+        _check_replay_deadline(deadline)
         if path.is_symlink() or not path.is_file():
             return None
         file_size = path.stat().st_size
         with path.open("rb") as stream:
             magic = stream.read(len(_AR_MAGIC))
             if magic == _AR_MAGIC:
-                return _classify_archive_stream(stream, file_size=file_size)
-            return _classify_elf_stream(stream, base_offset=0, file_size=file_size)
+                return _classify_archive_stream(stream, file_size=file_size, deadline=deadline)
+            return _classify_elf_stream(stream, base_offset=0, file_size=file_size, deadline=deadline)
     except OSError:
         return None
 
@@ -630,6 +742,8 @@ def _record_submit_check(
     target: str,
     passed: bool,
     summary: str,
+    expected=None,
+    actual=None,
 ) -> None:
     checks.append(
         VerificationCheck(
@@ -640,12 +754,41 @@ def _record_submit_check(
             exit_code=0 if passed else 1,
             log_path=None,
             summary=summary,
+            expected=expected,
+            actual=actual,
         )
     )
 
 
+def _commit_submit_verification(
+    *,
+    session: CompileSession,
+    artifacts: list[BuildArtifact],
+    verification: VerificationResult,
+    status: str,
+    error: str | None,
+) -> bool:
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _load_authoritative_session(session)
+        if _session_lifecycle_fenced(current):
+            session.__dict__.update(current.__dict__)
+            return False
+        current.artifacts = list(artifacts)
+        current.verification = verification
+        services.manager.mark_session_status(current, status, error=error)
+        session.__dict__.update(current.__dict__)
+        return True
+
+
 def submit_build_result_impl(*, session: CompileSession) -> str:
     services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _load_authoritative_session(session)
+        if _session_lifecycle_fenced(current):
+            session.__dict__.update(current.__dict__)
+            return _abort_submit_for_lifecycle(session, stage="entry")
+        session.__dict__.update(current.__dict__)
     submit_index = len(session.commands) + 1
     summary_log_path = local_log_path(session, f"{submit_index:03d}_submit.log")
     while Path(summary_log_path).exists():
@@ -700,6 +843,9 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
             if not non_empty:
                 continue
 
+            artifact_sha256 = _sha256_file(candidate_path)
+            smoke_command_used: str | None = None
+            smoke_result_used: CommandResult | None = None
             if artifact_type == "executable":
                 smoke_passed = False
                 for smoke_command in (
@@ -714,6 +860,8 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
                     )
                     if smoke_result.exit_code == 0:
                         smoke_passed = True
+                        smoke_command_used = smoke_command
+                        smoke_result_used = smoke_result
                         break
                 _record_submit_check(
                     checks=checks,
@@ -735,36 +883,86 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
                     artifact_type=artifact_type,
                     size_bytes=size_bytes,
                     source_path=container_candidate,
+                    sha256=artifact_sha256,
+                    smoke_command=smoke_command_used,
+                    smoke_exit_code=smoke_result_used.exit_code if smoke_result_used else None,
+                    smoke_output=_persisted_output(smoke_result_used.combined_output) if smoke_result_used else None,
+                    smoke_output_sha256=_sha256_text(smoke_result_used.combined_output) if smoke_result_used else None,
                 )
             )
 
     if discovered_files and not artifacts:
         notes.append("Error: Verification failed. No recognized compiled artifacts were found in /artifacts.")
 
+    candidate_status = "failed"
+    replay_attempt: ReplayVerificationResult | None = None
+    candidate_lifecycle_fenced = False
     if artifacts and all(check.passed for check in checks):
-        try:
-            _write_repro_bundle(session)
-        except (OSError, ValueError) as exc:
-            message = f"Error: Verification failed. Could not generate a commit-pinned replay bundle: {exc}"
-            notes.append(message)
-            _record_submit_check(
-                checks=checks,
-                name="repro_bundle",
-                target="repro/build.sh",
-                passed=False,
-                summary=message,
-            )
-        else:
-            _record_submit_check(
-                checks=checks,
-                name="repro_bundle",
-                target="repro/build.sh",
-                passed=True,
-                summary="Generated a commit-pinned replay script from successful container commands.",
-            )
+        with services.manager.session_lock(session.thread_id, session.session_id):
+            current = _load_authoritative_session(session)
+            if _session_lifecycle_fenced(current):
+                session.__dict__.update(current.__dict__)
+                candidate_lifecycle_fenced = True
+            else:
+                session.__dict__.update(current.__dict__)
+                try:
+                    _write_repro_bundle(session)
+                except (OSError, ValueError) as exc:
+                    message = f"Error: Verification failed. Could not generate a commit-pinned replay bundle: {exc}"
+                    notes.append(message)
+                    _record_submit_check(
+                        checks=checks,
+                        name="repro_bundle",
+                        target="repro/build.sh",
+                        passed=False,
+                        summary=message,
+                    )
+                else:
+                    candidate_status = "passed"
+                    _record_submit_check(
+                        checks=checks,
+                        name="repro_bundle",
+                        target="repro/build.sh",
+                        passed=True,
+                        summary="Generated a commit-pinned replay script from successful container commands.",
+                    )
+                    current.artifacts = list(artifacts)
+                    current.verification = VerificationResult(
+                        status="candidate_ready",
+                        checks=list(checks),
+                        artifact_count=len(artifacts),
+                        failed_checks=0,
+                        notes=list(notes),
+                    )
+                    services.manager.save_session(current)
+                    session.__dict__.update(current.__dict__)
+
+    if candidate_lifecycle_fenced:
+        return _abort_submit_for_lifecycle(session, stage="candidate_checkpoint")
+
+    candidate_failed_checks = sum(1 for check in checks if not check.passed)
+    if candidate_status == "passed" and artifacts and candidate_failed_checks == 0:
+        replay_attempt = verify_clean_replay_impl(session=session)
+        replay_passed = replay_attempt.status == "passed" and replay_attempt.cleanup_succeeded is True
+        replay_summary = (
+            "Candidate recipe rebuilt matching artifacts in a clean container and cleanup succeeded."
+            if replay_passed
+            else f"Error: Verification failed. Clean replay did not pass ({replay_attempt.failure_classification or replay_attempt.status})."
+        )
+        _record_submit_check(
+            checks=checks,
+            name="clean_replay",
+            target=f"replay/{replay_attempt.attempt_id}",
+            passed=replay_passed,
+            summary=replay_summary,
+            expected="passed",
+            actual=replay_attempt.status,
+        )
+        if not replay_passed:
+            notes.append(replay_summary)
 
     failed_checks = sum(1 for check in checks if not check.passed)
-    status = "passed" if artifacts and failed_checks == 0 else "failed"
+    status = "passed" if artifacts and candidate_status == "passed" and replay_attempt is not None and replay_attempt.status == "passed" and replay_attempt.cleanup_succeeded is True and failed_checks == 0 else "failed"
     verification = VerificationResult(
         status=status,
         checks=checks,
@@ -772,17 +970,28 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         failed_checks=failed_checks,
         notes=notes,
     )
-    session.artifacts = artifacts
-    session.verification = verification
-    services.manager.save_session(session)
-
     failure_message = next(
         (note for note in notes if note.startswith("Error:")),
         "Error: Verification failed. The submitted artifacts in /artifacts did not pass validation.",
     )
+    target_status = "verified" if status == "passed" else "verification_failed"
+    target_error = None if status == "passed" else failure_message
+    if not _commit_submit_verification(
+        session=session,
+        artifacts=artifacts,
+        verification=verification,
+        status=target_status,
+        error=target_error,
+    ):
+        return _abort_submit_for_lifecycle(session, stage="final_checkpoint")
+
     payload = {
         "exit_code": 0 if status == "passed" else 1,
         "status": status,
+        "candidate_status": candidate_status,
+        "replay_status": replay_attempt.status if replay_attempt else "not_run",
+        "replay_attempt_id": replay_attempt.attempt_id if replay_attempt else None,
+        "image_id": session.image_id,
         "artifact_count": len(artifacts),
         "artifacts": [
             {
@@ -790,10 +999,11 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
                 "source_path": artifact.source_path,
                 "artifact_type": artifact.artifact_type,
                 "size_bytes": artifact.size_bytes,
+                "sha256": artifact.sha256,
             }
             for artifact in artifacts
         ],
-        "message": "Build artifacts accepted from /artifacts." if status == "passed" else failure_message,
+        "message": "Build artifacts and clean replay accepted." if status == "passed" else failure_message,
     }
     Path(summary_log_path).write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     services.manager.log_event(
@@ -804,13 +1014,18 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         artifact_count=len(artifacts),
         artifacts=[artifact.path for artifact in artifacts],
         failed_checks=failed_checks,
+        candidate_status=candidate_status,
+        replay_status=replay_attempt.status if replay_attempt else "not_run",
+        replay_attempt_id=replay_attempt.attempt_id if replay_attempt else None,
     )
 
     if status == "passed":
-        services.manager.mark_session_status(session, "verified")
-        services.manager.log_event(session, "verification.accepted", artifact_count=len(artifacts))
-    else:
-        services.manager.mark_session_status(session, "verification_failed", error=payload["message"])
+        services.manager.log_event(
+            session,
+            "verification.accepted",
+            artifact_count=len(artifacts),
+            replay_attempt_id=replay_attempt.attempt_id if replay_attempt else None,
+        )
 
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
@@ -936,6 +1151,662 @@ def _write_repro_bundle(session: CompileSession) -> Path:
     return build_path
 
 
+class _ReplayVerificationFailure(RuntimeError):
+    def __init__(self, classification: str, message: str):
+        super().__init__(message)
+        self.classification = classification
+
+
+def _record_replay_check(
+    attempt: ReplayVerificationResult,
+    *,
+    name: str,
+    target: str,
+    passed: bool,
+    summary: str,
+    expected=None,
+    actual=None,
+    exit_code: int | None = None,
+    log_path: str | None = None,
+) -> None:
+    attempt.checks.append(
+        VerificationCheck(
+            name=name,
+            target=target,
+            command="clean_replay",
+            passed=passed,
+            exit_code=exit_code if exit_code is not None else (0 if passed else 1),
+            log_path=log_path,
+            summary=summary,
+            expected=expected,
+            actual=actual,
+        )
+    )
+
+
+def _remaining_replay_timeout(deadline: float) -> int:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _ReplayVerificationFailure("timeout", "Clean replay exceeded its total timeout.")
+    return max(1, math.ceil(remaining))
+
+
+def _artifact_relative_path(artifact: BuildArtifact) -> str:
+    source_path = PurePosixPath(artifact.source_path or "")
+    artifacts_root = PurePosixPath("/artifacts")
+    if not source_path.is_absolute() or artifacts_root not in source_path.parents:
+        raise ValueError(f"Artifact {artifact.path!r} does not have a valid /artifacts source path.")
+    relative_path = source_path.relative_to(artifacts_root)
+    if not relative_path.parts or ".." in relative_path.parts:
+        raise ValueError(f"Artifact {artifact.path!r} does not have a safe relative path.")
+    return relative_path.as_posix()
+
+
+def _run_replay_smoke(
+    *,
+    session: CompileSession,
+    handle: ReplayContainerHandle,
+    relative_path: str,
+    expected: BuildArtifact | None,
+    deadline: float,
+    log_path: Path,
+) -> tuple[str | None, CommandResult | None]:
+    services = get_compile_services()
+    container_path = f"/artifacts/{relative_path}"
+    expected_command = expected.smoke_command if expected else None
+    smoke_commands = (
+        (expected_command,)
+        if expected_command
+        else (
+            f"{shell_quote(container_path)} -version",
+            f"{shell_quote(container_path)} --version",
+            f"{shell_quote(container_path)} --help",
+        )
+    )
+    last_command: str | None = None
+    last_result: CommandResult | None = None
+    for smoke_command in smoke_commands:
+        if smoke_command is None:
+            continue
+        timeout_seconds = min(_REPLAY_SMOKE_TIMEOUT_SECONDS, _remaining_replay_timeout(deadline))
+        last_command = smoke_command
+        last_result = services.runtime.exec_replay_container(
+            session,
+            handle,
+            command=smoke_command,
+            workdir=CONTAINER_WORKSPACE_DIR,
+            timeout_seconds=timeout_seconds,
+            log_path=str(log_path),
+        )
+        if last_result.exit_code == 0:
+            break
+        if last_result.exit_code == 124:
+            raise _ReplayVerificationFailure("timeout", f"Smoke test for {relative_path!r} timed out.")
+    return last_command, last_result
+
+
+def _compare_replay_artifacts(
+    *,
+    session: CompileSession,
+    attempt: ReplayVerificationResult,
+    handle: ReplayContainerHandle,
+    deadline: float,
+) -> str | None:
+    services = get_compile_services()
+    replay_artifacts_dir = get_replay_artifacts_dir(
+        session.session_id,
+        session.thread_id,
+        attempt.attempt_id,
+        services.manager.paths,
+    )
+    replay_logs_dir = get_replay_logs_dir(
+        session.session_id,
+        session.thread_id,
+        attempt.attempt_id,
+        services.manager.paths,
+    )
+    expected_artifacts = {_artifact_relative_path(artifact): artifact for artifact in session.artifacts}
+    actual_files: dict[str, Path] = {}
+    actual_types: dict[str, str] = {}
+    for path in _list_artifact_files(replay_artifacts_dir, deadline=deadline):
+        artifact_type = _classify_compiled_artifact(path, deadline=deadline)
+        if artifact_type is None:
+            continue
+        relative_path = path.relative_to(replay_artifacts_dir).as_posix()
+        actual_files[relative_path] = path
+        actual_types[relative_path] = artifact_type
+    expected_paths = sorted(expected_artifacts)
+    actual_paths = sorted(actual_files)
+    artifact_set_matches = expected_paths == actual_paths
+    _record_replay_check(
+        attempt,
+        name="artifact_set",
+        target="/artifacts",
+        passed=artifact_set_matches,
+        summary=("Replay produced the same relative artifact paths." if artifact_set_matches else "Replay artifact paths differ from the accepted build."),
+        expected=expected_paths,
+        actual=actual_paths,
+    )
+
+    first_failure = None if artifact_set_matches else "artifact_set_mismatch"
+    for artifact_index, relative_path in enumerate(sorted(set(expected_paths) | set(actual_paths)), start=1):
+        expected = expected_artifacts.get(relative_path)
+        actual_path = actual_files.get(relative_path)
+        actual_type = actual_types.get(relative_path)
+        _check_replay_deadline(deadline)
+        actual_size = actual_path.stat().st_size if actual_path else None
+        actual_sha256 = _sha256_file(actual_path, deadline=deadline) if actual_path else None
+        actual_smoke_command: str | None = None
+        actual_smoke_result: CommandResult | None = None
+        if actual_path is not None and actual_type == "executable":
+            smoke_log_path = replay_logs_dir / f"smoke_{artifact_index:03d}.log"
+            actual_smoke_command, actual_smoke_result = _run_replay_smoke(
+                session=session,
+                handle=handle,
+                relative_path=relative_path,
+                expected=expected,
+                deadline=deadline,
+                log_path=smoke_log_path,
+            )
+
+        type_matches = expected is not None and actual_path is not None and expected.artifact_type == actual_type
+        size_matches = expected is not None and actual_path is not None and expected.size_bytes == actual_size
+        sha256_matches = expected is not None and actual_path is not None and expected.sha256 == actual_sha256
+        expected_requires_smoke = expected is not None and expected.artifact_type == "executable"
+        if expected_requires_smoke:
+            actual_smoke_output = _persisted_output(actual_smoke_result.combined_output) if actual_smoke_result else None
+            actual_smoke_output_sha256 = _sha256_text(actual_smoke_result.combined_output) if actual_smoke_result else None
+            smoke_output_matches = expected.smoke_output_sha256 == actual_smoke_output_sha256 if expected.smoke_output_sha256 is not None else expected.smoke_output == actual_smoke_output
+            smoke_matches = actual_smoke_result is not None and expected.smoke_command == actual_smoke_command and expected.smoke_exit_code == actual_smoke_result.exit_code and smoke_output_matches
+        else:
+            actual_smoke_output = _persisted_output(actual_smoke_result.combined_output) if actual_smoke_result else None
+            actual_smoke_output_sha256 = _sha256_text(actual_smoke_result.combined_output) if actual_smoke_result else None
+            smoke_matches = actual_smoke_result is None
+
+        mismatches: list[str] = []
+        if expected is None:
+            mismatches.append("unexpected_artifact")
+        if actual_path is None:
+            mismatches.append("missing_artifact")
+        if not type_matches:
+            mismatches.append("type")
+        if not size_matches:
+            mismatches.append("size")
+        if not sha256_matches:
+            mismatches.append("sha256")
+        if not smoke_matches:
+            mismatches.append("smoke")
+        comparison_passed = not mismatches
+        comparison = ReplayArtifactComparison(
+            path=relative_path,
+            expected_type=expected.artifact_type if expected else None,
+            actual_type=actual_type,
+            expected_size_bytes=expected.size_bytes if expected else None,
+            actual_size_bytes=actual_size,
+            expected_sha256=expected.sha256 if expected else None,
+            actual_sha256=actual_sha256,
+            expected_smoke_command=expected.smoke_command if expected else None,
+            actual_smoke_command=actual_smoke_command,
+            expected_smoke_exit_code=expected.smoke_exit_code if expected else None,
+            actual_smoke_exit_code=actual_smoke_result.exit_code if actual_smoke_result else None,
+            expected_smoke_output=expected.smoke_output if expected else None,
+            actual_smoke_output=actual_smoke_output,
+            expected_smoke_output_sha256=expected.smoke_output_sha256 if expected else None,
+            actual_smoke_output_sha256=actual_smoke_output_sha256,
+            type_matches=type_matches,
+            size_matches=size_matches,
+            sha256_matches=sha256_matches,
+            smoke_matches=smoke_matches,
+            passed=comparison_passed,
+            mismatches=mismatches,
+        )
+        attempt.artifacts.append(comparison)
+        for check_name, expected_value, actual_value, passed in (
+            ("type", comparison.expected_type, comparison.actual_type, type_matches),
+            ("size", comparison.expected_size_bytes, comparison.actual_size_bytes, size_matches),
+            ("sha256", comparison.expected_sha256, comparison.actual_sha256, sha256_matches),
+            (
+                "smoke",
+                {
+                    "command": comparison.expected_smoke_command,
+                    "exit_code": comparison.expected_smoke_exit_code,
+                    "output": comparison.expected_smoke_output,
+                    "output_sha256": comparison.expected_smoke_output_sha256,
+                },
+                {
+                    "command": comparison.actual_smoke_command,
+                    "exit_code": comparison.actual_smoke_exit_code,
+                    "output": comparison.actual_smoke_output,
+                    "output_sha256": comparison.actual_smoke_output_sha256,
+                },
+                smoke_matches,
+            ),
+        ):
+            _record_replay_check(
+                attempt,
+                name=f"artifact_{artifact_index}_{check_name}",
+                target=relative_path,
+                passed=passed,
+                summary=f"Replay artifact {check_name} {'matches' if passed else 'does not match'} the accepted build.",
+                expected=expected_value,
+                actual=actual_value,
+                exit_code=comparison.actual_smoke_exit_code if check_name == "smoke" else None,
+            )
+
+        if first_failure is None and not type_matches:
+            first_failure = "type_mismatch"
+        if first_failure is None and not size_matches:
+            first_failure = "size_mismatch"
+        if first_failure is None and not sha256_matches:
+            first_failure = "sha256_mismatch"
+        if first_failure is None and not smoke_matches:
+            first_failure = "smoke_mismatch"
+    return first_failure
+
+
+def _merge_authoritative_replay_cancellation(
+    attempt: ReplayVerificationResult,
+    authoritative: ReplayVerificationResult,
+) -> None:
+    if authoritative.status != "cancelled":
+        return
+    attempt.container_id = attempt.container_id or authoritative.container_id
+    attempt.container_name = attempt.container_name or authoritative.container_name
+    attempt.completed_at = authoritative.completed_at or attempt.completed_at
+    attempt.duration_seconds = attempt.duration_seconds if attempt.duration_seconds is not None else authoritative.duration_seconds
+    if authoritative.cleanup_succeeded is True or attempt.cleanup_succeeded is True:
+        attempt.cleanup_succeeded = True
+    elif authoritative.cleanup_succeeded is False:
+        attempt.cleanup_succeeded = False
+    for check in authoritative.checks:
+        if check not in attempt.checks:
+            attempt.checks.append(check)
+    for note in authoritative.notes:
+        if note not in attempt.notes:
+            attempt.notes.append(note)
+    attempt.status = "cancelled"
+    attempt.failure_classification = authoritative.failure_classification or "cancelled"
+
+
+def _persist_replay_attempt(
+    *,
+    session: CompileSession,
+    attempt: ReplayVerificationResult,
+) -> ReplayVerificationResult:
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _load_authoritative_session(session)
+        existing_attempt: ReplayVerificationResult | None = None
+        for index, existing in enumerate(current.replay_attempts):
+            if existing.attempt_id != attempt.attempt_id:
+                continue
+            existing_attempt = existing
+            _merge_authoritative_replay_cancellation(attempt, existing)
+            current.replay_attempts[index] = attempt
+            break
+        else:
+            if _session_lifecycle_fenced(current):
+                attempt.status = "cancelled"
+                attempt.failure_classification = attempt.failure_classification or "session_terminated"
+                attempt.cleanup_succeeded = attempt.cleanup_succeeded if attempt.cleanup_succeeded is not None else True
+                session.__dict__.update(current.__dict__)
+                return attempt
+            current.replay_attempts.append(attempt)
+        if _session_lifecycle_fenced(current):
+            if existing_attempt is not None and existing_attempt.status != "cancelled":
+                attempt.status = "cancelled"
+                attempt.failure_classification = "session_terminated"
+            if current.finalized_at is not None:
+                session.__dict__.update(current.__dict__)
+                return attempt
+        services.manager.save_session(current, allow_lifecycle_fenced=True)
+        session.__dict__.update(current.__dict__)
+    return attempt
+
+
+def verify_clean_replay_impl(
+    *,
+    session: CompileSession,
+    timeout_seconds: int | None = None,
+) -> ReplayVerificationResult:
+    services = get_compile_services()
+    configured_timeout = getattr(getattr(services.runtime, "config", None), "replay_timeout_seconds", 1200)
+    effective_timeout = max(1, timeout_seconds or configured_timeout)
+    started_monotonic = time.monotonic()
+    deadline = started_monotonic + effective_timeout
+    attempt_id = uuid.uuid4().hex[:12]
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _load_authoritative_session(session)
+        session.__dict__.update(current.__dict__)
+        attempt = ReplayVerificationResult(
+            attempt_id=attempt_id,
+            status="pending",
+            image=session.image,
+            image_id=session.image_id or "",
+            commit_sha=session.commit_sha or "",
+            recipe_sha256="",
+            timeout_seconds=effective_timeout,
+        )
+        if _session_lifecycle_fenced(session):
+            attempt.status = "cancelled"
+            attempt.failure_classification = "session_terminated"
+            attempt.cleanup_succeeded = True
+            attempt.completed_at = utc_now_iso()
+            attempt.duration_seconds = round(time.monotonic() - started_monotonic, 6)
+            attempt.notes.append("Clean replay was not started because the compile session is terminating or finalized.")
+            return attempt
+        session.replay_attempts.append(attempt)
+        services.manager.save_session(session)
+    services.manager.log_event(
+        session,
+        "replay.started",
+        attempt_id=attempt_id,
+        image=session.image,
+        image_id=session.image_id,
+        commit_sha=session.commit_sha,
+        timeout_seconds=effective_timeout,
+    )
+
+    handle: ReplayContainerHandle | None = None
+    pending_base_exception: BaseException | None = None
+    try:
+        recipe_dir = get_replay_recipe_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            services.manager.paths,
+        )
+        workspace_dir = get_replay_workspace_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            services.manager.paths,
+        )
+        artifacts_dir = get_replay_artifacts_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            services.manager.paths,
+        )
+        logs_dir = get_replay_logs_dir(
+            session.session_id,
+            session.thread_id,
+            attempt_id,
+            services.manager.paths,
+        )
+        for directory in (recipe_dir, workspace_dir, artifacts_dir, logs_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        recipe_path = recipe_dir / "build.sh"
+        source_recipe_path = Path(session.leadagent_repro_dir) / "build.sh"
+        source_recipe_sha256 = _sha256_file(source_recipe_path, deadline=deadline)
+        _check_replay_deadline(deadline)
+        shutil.copy2(source_recipe_path, recipe_path)
+        attempt.recipe_sha256 = _sha256_file(recipe_path, deadline=deadline)
+        attempt.log_path = services.manager.relative_path(session, logs_dir / "build.log")
+        recipe_snapshot_matches = source_recipe_sha256 == attempt.recipe_sha256
+        _record_replay_check(
+            attempt,
+            name="recipe_snapshot",
+            target="recipe/build.sh",
+            passed=recipe_snapshot_matches,
+            summary="Snapshotted the generated candidate recipe for this replay attempt.",
+            expected=source_recipe_sha256,
+            actual=attempt.recipe_sha256,
+        )
+        if not recipe_snapshot_matches:
+            raise _ReplayVerificationFailure(
+                "recipe_snapshot_mismatch",
+                "Candidate recipe changed while the replay snapshot was being created.",
+            )
+        if not session.image_id:
+            raise _ReplayVerificationFailure(
+                "image_identity_unavailable",
+                "The original compile container did not record an immutable image ID.",
+            )
+        _record_replay_check(
+            attempt,
+            name="image_identity",
+            target=session.image,
+            passed=True,
+            summary="Replay will use the original container's immutable image ID.",
+            expected=session.image_id,
+            actual=session.image_id,
+        )
+        attempt.container_name = services.runtime.replay_container_name(session, attempt_id)
+        attempt.status = "running"
+        with services.manager.session_lock(session.thread_id, session.session_id):
+            current = _load_authoritative_session(session)
+            authoritative = next(
+                (item for item in current.replay_attempts if item.attempt_id == attempt.attempt_id),
+                None,
+            )
+            if _session_lifecycle_fenced(current) or (authoritative is not None and authoritative.status == "cancelled"):
+                if authoritative is not None:
+                    _merge_authoritative_replay_cancellation(attempt, authoritative)
+                if attempt.status != "cancelled":
+                    attempt.status = "cancelled"
+                    attempt.failure_classification = "session_terminated"
+                current.replay_attempts = [attempt if item.attempt_id == attempt.attempt_id else item for item in current.replay_attempts]
+                if current.finalized_at is None:
+                    services.manager.save_session(current, allow_lifecycle_fenced=True)
+                session.__dict__.update(current.__dict__)
+                raise _ReplayVerificationFailure(
+                    attempt.failure_classification or "cancelled",
+                    "Clean replay was cancelled before its container could be created because the compile session is terminating.",
+                )
+            current.replay_attempts = [attempt if item.attempt_id == attempt.attempt_id else item for item in current.replay_attempts]
+            services.manager.mark_session_status(current, "replay_verifying")
+            session.__dict__.update(current.__dict__)
+            handle = services.runtime.create_replay_container(
+                session,
+                attempt_id=attempt_id,
+                timeout_seconds=min(
+                    _REPLAY_CONTAINER_CREATE_TIMEOUT_SECONDS,
+                    _remaining_replay_timeout(deadline),
+                ),
+            )
+            attempt.container_id = handle.container_id
+            attempt.container_name = handle.container_name
+            current.replay_attempts = [attempt if item.attempt_id == attempt.attempt_id else item for item in current.replay_attempts]
+            services.manager.save_session(current)
+            session.__dict__.update(current.__dict__)
+        build_log_path = logs_dir / "build.log"
+        build_result = services.runtime.exec_replay_container(
+            session,
+            handle,
+            timeout_seconds=_remaining_replay_timeout(deadline),
+            log_path=str(build_log_path),
+        )
+        attempt.exit_code = build_result.exit_code
+        execution_passed = build_result.exit_code == 0
+        _record_replay_check(
+            attempt,
+            name="recipe_execution",
+            target="recipe/build.sh",
+            passed=execution_passed,
+            summary=("Candidate recipe completed successfully in the clean replay container." if execution_passed else "Candidate recipe failed in the clean replay container."),
+            expected=0,
+            actual=build_result.exit_code,
+            exit_code=build_result.exit_code,
+            log_path=attempt.log_path,
+        )
+        if build_result.exit_code == 124:
+            raise _ReplayVerificationFailure("timeout", "Clean replay recipe execution timed out.")
+        if build_result.exit_code != 0:
+            raise _ReplayVerificationFailure(
+                "recipe_execution_failed",
+                f"Clean replay recipe exited with code {build_result.exit_code}.",
+            )
+        failure_classification = _compare_replay_artifacts(
+            session=session,
+            attempt=attempt,
+            handle=handle,
+            deadline=deadline,
+        )
+        if failure_classification is not None:
+            raise _ReplayVerificationFailure(
+                failure_classification,
+                "Replay artifacts did not match the accepted build.",
+            )
+    except _ReplayVerificationFailure as exc:
+        attempt.failure_classification = exc.classification
+        attempt.notes.append(str(exc))
+    except subprocess.TimeoutExpired as exc:
+        attempt.failure_classification = "timeout"
+        attempt.notes.append(f"Docker replay operation timed out: {exc}")
+    except Exception as exc:
+        attempt.failure_classification = "internal_error"
+        attempt.notes.append(f"Clean replay verification failed: {exc}")
+    except BaseException as exc:
+        attempt.failure_classification = "cancelled"
+        attempt.notes.append(f"Clean replay was cancelled by {type(exc).__name__}.")
+        pending_base_exception = exc
+    finally:
+        if attempt.container_name:
+            try:
+                cleanup_result = services.runtime.stop_and_remove_replay_container(
+                    session,
+                    handle,
+                    container_id=attempt.container_id,
+                    container_name=attempt.container_name,
+                )
+            except Exception as exc:
+                cleanup_result = ContainerCleanupResult(succeeded=False, stopped=False, removed=False)
+                attempt.notes.append(f"Replay container cleanup raised an error: {exc}")
+        else:
+            cleanup_result = ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+        attempt.cleanup_succeeded = cleanup_result.succeeded and cleanup_result.removed
+        _record_replay_check(
+            attempt,
+            name="container_cleanup",
+            target=attempt.container_name or "replay-container",
+            passed=attempt.cleanup_succeeded,
+            summary=("Replay container was removed." if attempt.cleanup_succeeded else "Replay container cleanup did not complete successfully."),
+            expected={"stopped": True, "removed": True},
+            actual={"stopped": cleanup_result.stopped, "removed": cleanup_result.removed},
+        )
+        if not attempt.cleanup_succeeded:
+            attempt.failure_classification = "cleanup_failed"
+        if pending_base_exception is not None:
+            attempt.status = "cancelled"
+        elif attempt.failure_classification == "timeout":
+            attempt.status = "timed_out"
+        elif attempt.failure_classification == "cancelled":
+            attempt.status = "cancelled"
+        elif attempt.failure_classification is None and attempt.cleanup_succeeded:
+            attempt.status = "passed"
+        else:
+            attempt.status = "failed"
+        attempt.completed_at = utc_now_iso()
+        attempt.duration_seconds = round(time.monotonic() - started_monotonic, 6)
+        _persist_replay_attempt(session=session, attempt=attempt)
+        services.manager.log_event(
+            session,
+            "replay.completed",
+            attempt_id=attempt.attempt_id,
+            status=attempt.status,
+            failure_classification=attempt.failure_classification,
+            exit_code=attempt.exit_code,
+            cleanup_succeeded=attempt.cleanup_succeeded,
+            duration_seconds=attempt.duration_seconds,
+            timeout_seconds=attempt.timeout_seconds,
+            image_id=attempt.image_id,
+            recipe_sha256=attempt.recipe_sha256,
+            completed_by="replay_worker",
+        )
+    if pending_base_exception is not None:
+        raise pending_base_exception
+    return attempt
+
+
+def _latest_replay_passed(session: CompileSession) -> bool:
+    if not session.replay_attempts:
+        return False
+    latest = session.replay_attempts[-1]
+    build_path = Path(session.leadagent_repro_dir) / "build.sh"
+    try:
+        recipe_sha256 = _sha256_file(build_path)
+    except OSError:
+        return False
+    return latest.status == "passed" and latest.cleanup_succeeded is True and latest.image_id == session.image_id and latest.commit_sha == session.commit_sha and latest.recipe_sha256 == recipe_sha256
+
+
+def _accepted_artifacts_still_match(session: CompileSession) -> tuple[bool, dict]:
+    base = Path(session.leadagent_artifacts_dir)
+    try:
+        resolved_base = base.resolve(strict=True)
+    except OSError as exc:
+        return False, {"mismatches": [f"artifacts_root_unavailable: {exc}"]}
+
+    expected: dict[str, BuildArtifact] = {}
+    actual: dict[str, dict] = {}
+    mismatches: list[str] = []
+    for artifact in session.artifacts:
+        try:
+            relative_path = _artifact_relative_path(artifact)
+        except ValueError as exc:
+            mismatches.append(str(exc))
+            continue
+        if relative_path in expected:
+            mismatches.append(f"duplicate_recorded_path:{relative_path}")
+            continue
+        expected[relative_path] = artifact
+        candidate = base.joinpath(*PurePosixPath(relative_path).parts)
+        current_component = base
+        symlink_found = False
+        for part in PurePosixPath(relative_path).parts:
+            current_component /= part
+            if current_component.is_symlink():
+                symlink_found = True
+                break
+        if symlink_found:
+            mismatches.append(f"symlink:{relative_path}")
+            continue
+        try:
+            resolved_candidate = candidate.resolve(strict=True)
+        except OSError:
+            mismatches.append(f"missing:{relative_path}")
+            continue
+        if not resolved_candidate.is_relative_to(resolved_base) or not resolved_candidate.is_file():
+            mismatches.append(f"path_escape_or_not_file:{relative_path}")
+            continue
+        artifact_type = _classify_compiled_artifact(resolved_candidate)
+        size_bytes = resolved_candidate.stat().st_size
+        sha256 = _sha256_file(resolved_candidate)
+        actual[relative_path] = {
+            "artifact_type": artifact_type,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+        }
+        if artifact_type != artifact.artifact_type:
+            mismatches.append(f"type:{relative_path}")
+        if size_bytes != artifact.size_bytes:
+            mismatches.append(f"size:{relative_path}")
+        if sha256 != artifact.sha256:
+            mismatches.append(f"sha256:{relative_path}")
+
+    actual_compiled_paths: set[str] = set()
+    for candidate in _list_artifact_files(base):
+        artifact_type = _classify_compiled_artifact(candidate)
+        if artifact_type is not None:
+            actual_compiled_paths.add(candidate.relative_to(base).as_posix())
+    expected_paths = set(expected)
+    if actual_compiled_paths != expected_paths:
+        for missing_path in sorted(expected_paths - actual_compiled_paths):
+            mismatch = f"missing_compiled_artifact:{missing_path}"
+            if mismatch not in mismatches:
+                mismatches.append(mismatch)
+        for extra_path in sorted(actual_compiled_paths - expected_paths):
+            mismatches.append(f"unexpected_compiled_artifact:{extra_path}")
+
+    return not mismatches, {
+        "expected_paths": sorted(expected_paths),
+        "actual_paths": sorted(actual_compiled_paths),
+        "actual": actual,
+        "mismatches": mismatches,
+    }
+
+
 def finalize_compile_session_impl(
     *,
     session: CompileSession,
@@ -952,9 +1823,11 @@ def finalize_compile_session_impl(
             current = session
 
         if current.finalized_at is None:
-            should_generate_repro = generate_repro_bundle and current.verification is not None and current.verification.status == "passed"
-            if should_generate_repro:
-                _write_repro_bundle(current)
+            if current.termination_requested_at is not None:
+                status = current.termination_status or status
+                error = current.termination_error or error
+                summary = current.termination_error or summary
+            replay_verified = _latest_replay_passed(current)
             current.finalized_at = utc_now_iso()
             services.manager.mark_session_status(current, status, error=error, summary=summary)
             services.manager.log_event(
@@ -963,11 +1836,120 @@ def finalize_compile_session_impl(
                 status=status,
                 summary=summary,
                 finalized_at=current.finalized_at,
-                generate_repro_bundle=should_generate_repro,
+                generate_repro_bundle=False,
+                generate_repro_bundle_requested=generate_repro_bundle,
+                replay_verified=replay_verified,
             )
 
         session.__dict__.update(current.__dict__)
         return session
+
+
+def _cleanup_pending_replay_containers(session: CompileSession) -> ContainerCleanupResult:
+    services = get_compile_services()
+    pending_attempts = [attempt for attempt in session.replay_attempts if attempt.status in {"pending", "running"} or (attempt.cleanup_succeeded is not True and (attempt.container_id or attempt.container_name))]
+    if not pending_attempts:
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    cleanup_results: list[ContainerCleanupResult] = []
+    completed_attempts: list[tuple[ReplayVerificationResult, str]] = []
+    for attempt in pending_attempts:
+        was_active = attempt.status in {"pending", "running"}
+        previous_cleanup_succeeded = attempt.cleanup_succeeded
+        if attempt.container_id or attempt.container_name:
+            try:
+                cleanup_result = services.runtime.stop_and_remove_replay_container(
+                    session,
+                    container_id=attempt.container_id,
+                    container_name=attempt.container_name,
+                )
+            except Exception as exc:
+                cleanup_result = ContainerCleanupResult(succeeded=False, stopped=False, removed=False)
+                attempt.notes.append(f"Parent replay cleanup raised an error: {exc}")
+        else:
+            cleanup_result = ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+        attempt.cleanup_succeeded = cleanup_result.succeeded and cleanup_result.removed
+        if was_active:
+            attempt.status = "cancelled"
+            attempt.failure_classification = attempt.failure_classification or "cancelled"
+            attempt.completed_at = attempt.completed_at or utc_now_iso()
+            if attempt.duration_seconds is None:
+                try:
+                    elapsed = datetime.fromisoformat(attempt.completed_at) - datetime.fromisoformat(attempt.started_at)
+                    attempt.duration_seconds = round(max(0.0, elapsed.total_seconds()), 6)
+                except ValueError:
+                    attempt.duration_seconds = None
+            attempt.notes.append("Replay was stopped by the parent compile-session cleanup path.")
+            completed_attempts.append((attempt, "parent_cleanup"))
+        elif previous_cleanup_succeeded is not True and attempt.cleanup_succeeded:
+            completed_attempts.append((attempt, "parent_cleanup_retry"))
+        _record_replay_check(
+            attempt,
+            name="parent_container_cleanup",
+            target=attempt.container_name or attempt.container_id or "replay-container",
+            passed=attempt.cleanup_succeeded,
+            summary=("Parent cleanup removed the replay container." if attempt.cleanup_succeeded else "Parent cleanup could not remove the replay container."),
+            expected={"stopped": True, "removed": True},
+            actual={"stopped": cleanup_result.stopped, "removed": cleanup_result.removed},
+        )
+        cleanup_results.append(cleanup_result)
+    services.manager.save_session(
+        session,
+        allow_lifecycle_fenced=True,
+        merge_finalized_replay_cleanup=True,
+    )
+    for attempt, completed_by in completed_attempts:
+        services.manager.log_event(
+            session,
+            "replay.completed",
+            attempt_id=attempt.attempt_id,
+            status=attempt.status,
+            failure_classification=attempt.failure_classification,
+            exit_code=attempt.exit_code,
+            cleanup_succeeded=attempt.cleanup_succeeded,
+            duration_seconds=attempt.duration_seconds,
+            timeout_seconds=attempt.timeout_seconds,
+            image_id=attempt.image_id,
+            recipe_sha256=attempt.recipe_sha256,
+            completed_by=completed_by,
+        )
+    return ContainerCleanupResult(
+        succeeded=all(result.succeeded for result in cleanup_results),
+        stopped=all(result.stopped for result in cleanup_results),
+        removed=all(result.removed for result in cleanup_results),
+    )
+
+
+def _combined_cleanup_result(
+    replay_cleanup: ContainerCleanupResult,
+    compile_cleanup: ContainerCleanupResult,
+) -> ContainerCleanupResult:
+    return ContainerCleanupResult(
+        succeeded=replay_cleanup.succeeded and compile_cleanup.succeeded,
+        stopped=replay_cleanup.stopped and compile_cleanup.stopped,
+        removed=replay_cleanup.removed and compile_cleanup.removed,
+    )
+
+
+def _request_session_termination(
+    session: CompileSession,
+    *,
+    status: str,
+    error: str | None = None,
+) -> None:
+    services = get_compile_services()
+    if session.termination_requested_at is not None:
+        return
+    session.termination_requested_at = utc_now_iso()
+    session.termination_status = status
+    session.termination_error = error
+    services.manager.save_session(session)
+    services.manager.log_event(
+        session,
+        "session.termination_requested",
+        status=status,
+        termination_requested_at=session.termination_requested_at,
+    )
 
 
 def cleanup_and_finalize_compile_session_impl(
@@ -985,10 +1967,16 @@ def cleanup_and_finalize_compile_session_impl(
             current = session
 
         if current.finalized_at is not None:
+            replay_cleanup_result = _cleanup_pending_replay_containers(current)
+            compile_cleanup_result = services.runtime.stop_and_remove_container(current)
             session.__dict__.update(current.__dict__)
-            return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+            return session, _combined_cleanup_result(replay_cleanup_result, compile_cleanup_result)
+        if interrupted_status is not None:
+            _request_session_termination(current, status=interrupted_status, error=error)
 
-        cleanup_result = services.runtime.stop_and_remove_container(current)
+        replay_cleanup_result = _cleanup_pending_replay_containers(current)
+        compile_cleanup_result = services.runtime.stop_and_remove_container(current)
+        cleanup_result = _combined_cleanup_result(replay_cleanup_result, compile_cleanup_result)
         if not cleanup_result.succeeded:
             cleanup_error = error or "Compile container cleanup failed."
             if "cleanup failed" not in cleanup_error.lower():
@@ -1004,10 +1992,53 @@ def cleanup_and_finalize_compile_session_impl(
             session.__dict__.update(current.__dict__)
             return session, cleanup_result
 
-        verification_passed = current.status == "verified" and current.verification is not None and current.verification.status == "passed" and bool(current.artifacts)
-        if interrupted_status is not None:
-            final_status = interrupted_status
-            final_error = error or f"Parent run ended with status {interrupted_status}."
+        replay_and_verification_passed = current.status == "verified" and current.verification is not None and current.verification.status == "passed" and bool(current.artifacts) and _latest_replay_passed(current)
+        artifact_integrity_error: str | None = None
+        artifact_integrity_passed = False
+        if interrupted_status is None and current.termination_requested_at is None and replay_and_verification_passed:
+            artifact_integrity_passed, artifact_integrity_details = _accepted_artifacts_still_match(current)
+            current.verification.checks.append(
+                VerificationCheck(
+                    name="accepted_artifacts_unchanged_after_cleanup",
+                    target="/artifacts",
+                    command="finalize",
+                    passed=artifact_integrity_passed,
+                    exit_code=0 if artifact_integrity_passed else 1,
+                    summary=(
+                        "Accepted artifacts still match their verified type, size, and SHA-256 after compile-container cleanup."
+                        if artifact_integrity_passed
+                        else "Accepted artifacts changed after clean replay verification and before finalization."
+                    ),
+                    expected={
+                        artifact.source_path: {
+                            "artifact_type": artifact.artifact_type,
+                            "size_bytes": artifact.size_bytes,
+                            "sha256": artifact.sha256,
+                        }
+                        for artifact in current.artifacts
+                    },
+                    actual=artifact_integrity_details,
+                )
+            )
+            if not artifact_integrity_passed:
+                artifact_integrity_error = "Accepted artifacts changed after clean replay verification; finalization was rejected."
+                current.verification.status = "failed"
+                current.verification.failed_checks += 1
+                current.verification.notes.append(artifact_integrity_error)
+            services.manager.save_session(current)
+            services.manager.log_event(
+                current,
+                "artifact.finalization_recheck",
+                passed=artifact_integrity_passed,
+                details=artifact_integrity_details,
+            )
+        verification_passed = replay_and_verification_passed and artifact_integrity_passed
+        if current.termination_requested_at is not None:
+            final_status = current.termination_status or interrupted_status or "cancelled"
+            final_error = current.termination_error or error or f"Parent run ended with status {final_status}."
+        elif interrupted_status is not None:
+            final_status = current.termination_status or interrupted_status
+            final_error = current.termination_error or error or f"Parent run ended with status {final_status}."
         elif verification_passed:
             final_status = "completed"
             final_error = None
@@ -1016,7 +2047,7 @@ def cleanup_and_finalize_compile_session_impl(
             final_error = current.error or f"Compile session ended with status {current.status}."
         else:
             final_status = "failed"
-            final_error = current.error or "Compile session finalized before artifact verification passed."
+            final_error = artifact_integrity_error or current.error or "Compile session finalized before artifact verification passed."
 
         updated = finalize_compile_session_impl(
             session=current,
@@ -1031,6 +2062,8 @@ def cleanup_and_finalize_compile_session_impl(
 def cleanup_compile_session_container_impl(
     *,
     session: CompileSession,
+    interrupted_status: str | None = None,
+    error: str | None = None,
 ) -> tuple[CompileSession, ContainerCleanupResult]:
     """Reload and clean a session container under the session lifecycle lock."""
     services = get_compile_services()
@@ -1040,9 +2073,15 @@ def cleanup_compile_session_container_impl(
         except (OSError, TypeError, ValueError, json.JSONDecodeError):
             current = session
         if current.finalized_at is not None:
+            replay_cleanup_result = _cleanup_pending_replay_containers(current)
+            compile_cleanup_result = services.runtime.stop_and_remove_container(current)
             session.__dict__.update(current.__dict__)
-            return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
-        cleanup_result = services.runtime.stop_and_remove_container(current)
+            return session, _combined_cleanup_result(replay_cleanup_result, compile_cleanup_result)
+        if interrupted_status is not None:
+            _request_session_termination(current, status=interrupted_status, error=error)
+        replay_cleanup_result = _cleanup_pending_replay_containers(current)
+        compile_cleanup_result = services.runtime.stop_and_remove_container(current)
+        cleanup_result = _combined_cleanup_result(replay_cleanup_result, compile_cleanup_result)
         session.__dict__.update(current.__dict__)
         return session, cleanup_result
 

--- a/backend/packages/harness/deerflow/compile/paths.py
+++ b/backend/packages/harness/deerflow/compile/paths.py
@@ -74,5 +74,115 @@ def get_host_repro_dir(session_id: str, thread_id: str | None, paths: Paths | No
     return join_host_path(get_host_session_dir(session_id, thread_id, paths), "repro")
 
 
+def get_replay_root(session_id: str, thread_id: str | None, paths: Paths | None = None) -> Path:
+    return get_session_dir(session_id, thread_id, paths) / "replay"
+
+
+def get_host_replay_root(session_id: str, thread_id: str | None, paths: Paths | None = None) -> str:
+    return join_host_path(get_host_session_dir(session_id, thread_id, paths), "replay")
+
+
+def get_replay_attempt_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> Path:
+    return get_replay_root(session_id, thread_id, paths) / attempt_id
+
+
+def get_host_replay_attempt_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> str:
+    return join_host_path(get_host_replay_root(session_id, thread_id, paths), attempt_id)
+
+
+def get_replay_recipe_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> Path:
+    return get_replay_attempt_dir(session_id, thread_id, attempt_id, paths) / "recipe"
+
+
+def get_host_replay_recipe_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> str:
+    return join_host_path(
+        get_host_replay_attempt_dir(session_id, thread_id, attempt_id, paths),
+        "recipe",
+    )
+
+
+def get_replay_workspace_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> Path:
+    return get_replay_attempt_dir(session_id, thread_id, attempt_id, paths) / "workspace"
+
+
+def get_host_replay_workspace_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> str:
+    return join_host_path(
+        get_host_replay_attempt_dir(session_id, thread_id, attempt_id, paths),
+        "workspace",
+    )
+
+
+def get_replay_artifacts_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> Path:
+    return get_replay_attempt_dir(session_id, thread_id, attempt_id, paths) / "artifacts"
+
+
+def get_host_replay_artifacts_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> str:
+    return join_host_path(
+        get_host_replay_attempt_dir(session_id, thread_id, attempt_id, paths),
+        "artifacts",
+    )
+
+
+def get_replay_logs_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> Path:
+    return get_replay_attempt_dir(session_id, thread_id, attempt_id, paths) / "logs"
+
+
+def get_host_replay_logs_dir(
+    session_id: str,
+    thread_id: str | None,
+    attempt_id: str,
+    paths: Paths | None = None,
+) -> str:
+    return join_host_path(
+        get_host_replay_attempt_dir(session_id, thread_id, attempt_id, paths),
+        "logs",
+    )
+
+
 def get_metadata_path(session_id: str, thread_id: str | None, paths: Paths | None = None) -> Path:
     return get_session_dir(session_id, thread_id, paths) / "session.json"

--- a/backend/packages/harness/deerflow/compile/schemas.py
+++ b/backend/packages/harness/deerflow/compile/schemas.py
@@ -27,6 +27,11 @@ class BuildArtifact:
     artifact_type: str
     size_bytes: int | None = None
     source_path: str | None = None
+    sha256: str | None = None
+    smoke_command: str | None = None
+    smoke_exit_code: int | None = None
+    smoke_output: str | None = None
+    smoke_output_sha256: str | None = None
 
 
 @dataclass
@@ -38,6 +43,8 @@ class VerificationCheck:
     exit_code: int | None = None
     log_path: str | None = None
     summary: str | None = None
+    expected: Any | None = None
+    actual: Any | None = None
 
 
 @dataclass
@@ -46,6 +53,54 @@ class VerificationResult:
     checks: list[VerificationCheck] = field(default_factory=list)
     artifact_count: int = 0
     failed_checks: int = 0
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReplayArtifactComparison:
+    path: str
+    expected_type: str | None = None
+    actual_type: str | None = None
+    expected_size_bytes: int | None = None
+    actual_size_bytes: int | None = None
+    expected_sha256: str | None = None
+    actual_sha256: str | None = None
+    expected_smoke_command: str | None = None
+    actual_smoke_command: str | None = None
+    expected_smoke_exit_code: int | None = None
+    actual_smoke_exit_code: int | None = None
+    expected_smoke_output: str | None = None
+    actual_smoke_output: str | None = None
+    expected_smoke_output_sha256: str | None = None
+    actual_smoke_output_sha256: str | None = None
+    type_matches: bool = False
+    size_matches: bool = False
+    sha256_matches: bool = False
+    smoke_matches: bool = False
+    passed: bool = False
+    mismatches: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ReplayVerificationResult:
+    attempt_id: str
+    status: str
+    image: str
+    image_id: str
+    commit_sha: str
+    recipe_sha256: str
+    timeout_seconds: int | None = None
+    started_at: str = field(default_factory=utc_now_iso)
+    completed_at: str | None = None
+    duration_seconds: float | None = None
+    container_id: str | None = None
+    container_name: str | None = None
+    log_path: str | None = None
+    exit_code: int | None = None
+    cleanup_succeeded: bool | None = None
+    failure_classification: str | None = None
+    checks: list[VerificationCheck] = field(default_factory=list)
+    artifacts: list[ReplayArtifactComparison] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
 
 
@@ -67,9 +122,13 @@ class CompileSession:
     image: str
     status: str
     run_id: str | None = None
+    image_id: str | None = None
     created_at: str = field(default_factory=utc_now_iso)
     completed_at: str | None = None
     finalized_at: str | None = None
+    termination_requested_at: str | None = None
+    termination_status: str | None = None
+    termination_error: str | None = None
     owner_subagent_id: str | None = None
     commit_sha: str | None = None
     container_id: str | None = None
@@ -85,13 +144,14 @@ class CompileSession:
     commands: list[BuildCommandRecord] = field(default_factory=list)
     artifacts: list[BuildArtifact] = field(default_factory=list)
     verification: VerificationResult | None = None
+    replay_attempts: list[ReplayVerificationResult] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CompileSession:
-        data = {"run_id": None, **data}
+        data = {"run_id": None, "image_id": None, "replay_attempts": [], **data}
         commands = [BuildCommandRecord(**item) for item in data.get("commands", [])]
         artifacts = [BuildArtifact(**item) for item in data.get("artifacts", [])]
         verification_data = data.get("verification")
@@ -100,8 +160,26 @@ class CompileSession:
             checks = [VerificationCheck(**item) for item in verification_data.get("checks", [])]
             verification_payload = {k: v for k, v in verification_data.items() if k != "checks"}
             verification = VerificationResult(checks=checks, **verification_payload)
-        payload = {k: v for k, v in data.items() if k not in {"commands", "artifacts", "verification"}}
-        return cls(commands=commands, artifacts=artifacts, verification=verification, **payload)
+        replay_attempts = []
+        for replay_data in data.get("replay_attempts", []):
+            replay_checks = [VerificationCheck(**item) for item in replay_data.get("checks", [])]
+            replay_artifacts = [ReplayArtifactComparison(**item) for item in replay_data.get("artifacts", [])]
+            replay_payload = {k: v for k, v in replay_data.items() if k not in {"checks", "artifacts"}}
+            replay_attempts.append(
+                ReplayVerificationResult(
+                    checks=replay_checks,
+                    artifacts=replay_artifacts,
+                    **replay_payload,
+                )
+            )
+        payload = {k: v for k, v in data.items() if k not in {"commands", "artifacts", "verification", "replay_attempts"}}
+        return cls(
+            commands=commands,
+            artifacts=artifacts,
+            verification=verification,
+            replay_attempts=replay_attempts,
+            **payload,
+        )
 
     @property
     def metadata_file(self) -> Path:

--- a/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
@@ -210,14 +210,19 @@ def finalize_session(
         "status": updated.status,
         "session_id": updated.session_id,
         "commit_sha": updated.commit_sha,
+        "image": updated.image,
+        "image_id": updated.image_id,
         "build_system": updated.build_system,
         "commands": [command.command for command in updated.commands],
         "verification": updated.verification.status if updated.verification else "not_run",
+        "replay_verification": updated.replay_attempts[-1].status if updated.replay_attempts else "not_run",
+        "replay_attempt_id": updated.replay_attempts[-1].attempt_id if updated.replay_attempts else None,
         "artifacts": [
             {
                 "path": artifact.path,
                 "artifact_type": artifact.artifact_type,
                 "size_bytes": artifact.size_bytes,
+                "sha256": artifact.sha256,
             }
             for artifact in updated.artifacts
         ],

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -75,6 +75,8 @@ async def _cancel_and_reap_task(
                 _updated, cleanup_result = await asyncio.to_thread(
                     cleanup_compile_session_container_impl,
                     session=session,
+                    interrupted_status=terminal_status,
+                    error=error,
                 )
             except Exception:
                 logger.exception("Failed to stop compile container while terminating task %s", task_id)
@@ -89,10 +91,16 @@ async def _cancel_and_reap_task(
         session_id = compile_state.get(COMPILE_SESSION_STATE_KEY)
         if session_id:
             from deerflow.agents.middlewares.tool_error_handling_middleware import load_bound_session_async
-            from deerflow.compile.operations import finalize_compile_session_impl, get_compile_services
+            from deerflow.compile.operations import cleanup_compile_session_container_impl, finalize_compile_session_impl, get_compile_services
 
             try:
                 session = await load_bound_session_async(session_id=session_id, thread_id=thread_id)
+                session, cleanup_result = await asyncio.to_thread(
+                    cleanup_compile_session_container_impl,
+                    session=session,
+                    interrupted_status=terminal_status,
+                    error=error,
+                )
                 cleanup_succeeded = cleanup_result is not None and cleanup_result.succeeded
                 if cleanup_succeeded:
                     await asyncio.to_thread(

--- a/backend/tests/test_compile_cancellation.py
+++ b/backend/tests/test_compile_cancellation.py
@@ -2,12 +2,18 @@ import asyncio
 import importlib
 import sys
 import threading
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
+from deerflow.compile import operations
 from deerflow.compile.docker_runtime import ContainerCleanupResult
-from deerflow.compile.schemas import CompileSession
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.compile.schemas import CompileSession, ReplayVerificationResult
+from deerflow.config.paths import Paths
 from deerflow.subagents.config import SubagentConfig
 
 task_tool_module = importlib.import_module("deerflow.tools.builtins.task_tool")
@@ -142,31 +148,63 @@ def test_timeout_terminal_transition_blocks_boundary_completion(real_executor_mo
     assert result.error == "deadline reached"
 
 
-def test_compiler_task_termination_stops_worker_before_finalizing_session(monkeypatch):
-    session = CompileSession(
+def test_compiler_task_termination_stops_worker_before_finalizing_session(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(
+        paths=Paths(
+            base_dir=tmp_path / ".deer-flow",
+            workspace_root=tmp_path / "service-workspace",
+            host_workspace_root=str(tmp_path / "host-workspace"),
+        )
+    )
+    session = manager.create_session(
         session_id="session-123",
         thread_id="thread-123",
         repo_url="https://example.com/repo.git",
-        branch=None,
-        image="autocompiler:gcc13",
-        status="inspected",
-        container_id="container-123",
     )
+    session.status = "inspected"
+    session.container_id = "container-123"
+    session.container_name = "compile-container-123"
+    session.image_id = f"sha256:{'1' * 64}"
+    session.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="replay-attempt",
+            status="running",
+            image=session.image,
+            image_id=session.image_id,
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            timeout_seconds=30,
+            container_id="replay-container-123",
+            container_name="replay-name-123",
+        )
+    )
+    manager.save_session(session)
     events: list[str] = []
 
     async def load_session(*, session_id: str, thread_id: str):
         assert session_id == session.session_id
         assert thread_id == session.thread_id
         events.append("load")
-        return session
+        return manager.load_session(session_id, thread_id)
 
-    def stop_container(session_arg):
-        assert session_arg is session
+    def stop_container(session_arg: CompileSession):
+        assert session_arg.container_id == session.container_id
         events.append("stop")
         return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
 
-    def cleanup_container(*, session: CompileSession):
-        return session, stop_container(session)
+    def stop_replay_container(
+        session_arg: CompileSession,
+        handle=None,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+    ):
+        assert handle is None
+        assert session_arg.session_id == session.session_id
+        assert container_id == "replay-container-123"
+        assert container_name == "replay-name-123"
+        events.append("stop_replay")
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
 
     async def wait_for_shutdown(task_id: str, timeout_seconds: float):
         assert task_id == "task-123"
@@ -186,7 +224,17 @@ def test_compiler_task_termination_stops_worker_before_finalizing_session(monkey
         "deerflow.agents.middlewares.tool_error_handling_middleware.load_bound_session_async",
         load_session,
     )
-    monkeypatch.setattr("deerflow.compile.operations.cleanup_compile_session_container_impl", cleanup_container)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(
+                stop_and_remove_container=stop_container,
+                stop_and_remove_replay_container=stop_replay_container,
+            ),
+        ),
+    )
     monkeypatch.setattr("deerflow.compile.operations.finalize_compile_session_impl", finalize)
     monkeypatch.setattr(task_tool_module, "request_cancel_background_task", lambda task_id: events.append("cancel") or True)
     monkeypatch.setattr(task_tool_module, "wait_for_background_task_shutdown", wait_for_shutdown)
@@ -205,7 +253,143 @@ def test_compiler_task_termination_stops_worker_before_finalizing_session(monkey
     )
 
     assert stopped is True
-    assert events == ["cancel", "load", "stop", "wait", "load", "finalize", "registry_cleanup"]
+    assert events == [
+        "cancel",
+        "load",
+        "stop_replay",
+        "stop",
+        "wait",
+        "load",
+        "stop",
+        "finalize",
+        "registry_cleanup",
+    ]
+    replay_attempt = manager.load_session(session.session_id, session.thread_id).replay_attempts[-1]
+    assert replay_attempt.status == "cancelled"
+    assert replay_attempt.failure_classification == "cancelled"
+    assert replay_attempt.cleanup_succeeded is True
+    assert replay_attempt.timeout_seconds == 30
+    assert replay_attempt.duration_seconds is not None
+    assert any(check.name == "parent_container_cleanup" and check.passed for check in replay_attempt.checks)
+    workflow_log = manager.workflow_log_path(manager.load_session(session.session_id, session.thread_id)).read_text(encoding="utf-8")
+    assert '"event": "replay.completed"' in workflow_log
+    assert '"completed_by": "parent_cleanup"' in workflow_log
+
+
+def test_compiler_cancellation_rejects_late_worker_metadata_without_repeating_successful_replay_cleanup(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(
+        paths=Paths(
+            base_dir=tmp_path / ".deer-flow",
+            workspace_root=tmp_path / "service-workspace",
+            host_workspace_root=str(tmp_path / "host-workspace"),
+        )
+    )
+    session = manager.create_session(
+        session_id="session-race",
+        thread_id="thread-race",
+        repo_url="https://example.com/repo.git",
+    )
+    session.container_id = "compile-container-race"
+    session.container_name = "compile-name-race"
+    session.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="attempt-race",
+            status="running",
+            image=session.image,
+            image_id=f"sha256:{'1' * 64}",
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            container_name="replay-name-race",
+        )
+    )
+    manager.save_session(session)
+    replay_cleanup_ids: list[str | None] = []
+    events: list[str] = []
+
+    async def load_session(*, session_id: str, thread_id: str):
+        events.append("load")
+        return manager.load_session(session_id, thread_id)
+
+    def stop_compile(_session: CompileSession):
+        events.append("stop_compile")
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    def stop_replay(
+        _session: CompileSession,
+        handle=None,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+    ):
+        assert handle is None
+        assert container_name == "replay-name-race"
+        replay_cleanup_ids.append(container_id)
+        events.append("stop_replay")
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    async def wait_for_shutdown(_task_id: str, _timeout_seconds: float):
+        events.append("wait")
+        stale_worker_state = manager.load_session(session.session_id, session.thread_id)
+        attempt = stale_worker_state.replay_attempts[-1]
+        attempt.status = "running"
+        attempt.failure_classification = None
+        attempt.cleanup_succeeded = None
+        attempt.container_id = "container-created-after-first-cleanup"
+        manager.save_session(stale_worker_state)
+        return True
+
+    def finalize(*, session: CompileSession, **_kwargs):
+        events.append("finalize")
+        return session
+
+    monkeypatch.setattr(
+        "deerflow.agents.middlewares.tool_error_handling_middleware.load_bound_session_async",
+        load_session,
+    )
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(
+                stop_and_remove_container=stop_compile,
+                stop_and_remove_replay_container=stop_replay,
+            ),
+        ),
+    )
+    monkeypatch.setattr("deerflow.compile.operations.finalize_compile_session_impl", finalize)
+    monkeypatch.setattr(task_tool_module, "request_cancel_background_task", lambda _task_id: True)
+    monkeypatch.setattr(task_tool_module, "wait_for_background_task_shutdown", wait_for_shutdown)
+    monkeypatch.setattr(task_tool_module, "cleanup_background_task", lambda _task_id: events.append("registry_cleanup"))
+
+    stopped = asyncio.run(
+        task_tool_module._cancel_and_reap_task(
+            task_id="task-race",
+            subagent_type="compiler",
+            compile_state={task_tool_module.COMPILE_SESSION_STATE_KEY: session.session_id},
+            thread_id=session.thread_id,
+            terminal_status="cancelled",
+            error="parent cancelled",
+            shutdown_timeout_seconds=30,
+        )
+    )
+
+    assert stopped is True
+    assert replay_cleanup_ids == [None]
+    assert events == [
+        "load",
+        "stop_replay",
+        "stop_compile",
+        "wait",
+        "load",
+        "stop_compile",
+        "finalize",
+        "registry_cleanup",
+    ]
+    replay_attempt = manager.load_session(session.session_id, session.thread_id).replay_attempts[-1]
+    assert replay_attempt.status == "cancelled"
+    assert replay_attempt.failure_classification == "cancelled"
+    assert replay_attempt.cleanup_succeeded is True
 
 
 def test_compiler_model_cannot_lower_server_owned_turn_limit():

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -1,0 +1,268 @@
+"""Opt-in Docker integration coverage for clean compile replay.
+
+Run explicitly with FORGE_RUN_DOCKER_INTEGRATION=1 after building
+the autocompiler:gcc13 image. The default backend test suite skips this file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, verify_clean_replay_impl
+from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
+from deerflow.config.paths import Paths
+
+REPO_URL = "https://github.com/MattClarkson/CMakeHelloWorld.git"
+COMMIT_SHA = "6fda0b169299b1241ed883c8d4af8519da30ce52"
+COMPILE_IMAGE = "autocompiler:gcc13"
+DOCKER_INTEGRATION_ENABLED = os.getenv("FORGE_RUN_DOCKER_INTEGRATION") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_INTEGRATION_ENABLED,
+    reason="set FORGE_RUN_DOCKER_INTEGRATION=1 to run real Docker replay tests",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_docker_and_compile_image():
+    if not DOCKER_INTEGRATION_ENABLED:
+        yield
+        return
+
+    if shutil.which("docker") is None:
+        pytest.fail("FORGE_RUN_DOCKER_INTEGRATION=1 requires the docker CLI")
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Docker daemon is unavailable: {daemon.stderr.strip()}")
+    image = subprocess.run(
+        ["docker", "image", "inspect", COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _run_checked(
+    runtime: CompileDockerRuntime,
+    session: CompileSession,
+    command: str,
+    *,
+    workdir: str,
+    expected_exit_code: int = 0,
+    timeout_seconds: int = 600,
+) -> CommandResult:
+    result = runtime.exec(
+        session,
+        command,
+        workdir=workdir,
+        timeout_seconds=timeout_seconds,
+    )
+    assert result.exit_code == expected_exit_code, result.combined_output
+    return result
+
+
+def _record_build_command(
+    manager: CompileSessionManager,
+    session: CompileSession,
+    command: str,
+    result: CommandResult,
+) -> None:
+    manager.record_command(
+        session,
+        BuildCommandRecord(
+            stage="bash",
+            command=command,
+            workdir="/workspace/repo",
+            exit_code=result.exit_code,
+        ),
+    )
+
+
+def _prepare_original_build(
+    manager: CompileSessionManager,
+    runtime: CompileDockerRuntime,
+    session: CompileSession,
+    *,
+    failed_configure_side_effect: bool,
+) -> None:
+    clone_command = (
+        "rm -rf -- /workspace/repo && "
+        "git config --global --add safe.directory /workspace/repo && "
+        f"git clone --no-checkout {REPO_URL} /workspace/repo && "
+        f"git -C /workspace/repo checkout --detach {COMMIT_SHA} && "
+        f'test "$(git -C /workspace/repo rev-parse HEAD)" = {COMMIT_SHA}'
+    )
+    _run_checked(runtime, session, clone_command, workdir="/workspace")
+
+    configure_command = "cmake -S . -B build"
+    expected_configure_exit = 0
+    if failed_configure_side_effect:
+        configure_command += " && false"
+        expected_configure_exit = 1
+    configure_result = _run_checked(
+        runtime,
+        session,
+        configure_command,
+        workdir="/workspace/repo",
+        expected_exit_code=expected_configure_exit,
+    )
+    _record_build_command(manager, session, configure_command, configure_result)
+
+    build_command = "cmake --build build --parallel && cp build/hello /artifacts/hello"
+    build_result = _run_checked(
+        runtime,
+        session,
+        build_command,
+        workdir="/workspace/repo",
+    )
+    _record_build_command(manager, session, build_command, build_result)
+
+    artifact_path = Path(session.leadagent_artifacts_dir) / "hello"
+    assert artifact_path.is_file()
+    assert _classify_compiled_artifact(artifact_path) == "executable"
+    smoke_command = "/artifacts/hello -version"
+    smoke_result = _run_checked(
+        runtime,
+        session,
+        smoke_command,
+        workdir="/workspace",
+        timeout_seconds=30,
+    )
+    artifact_bytes = artifact_path.read_bytes()
+    session.artifacts = [
+        BuildArtifact(
+            path=manager.relative_path(session, artifact_path),
+            artifact_type="executable",
+            size_bytes=len(artifact_bytes),
+            source_path="/artifacts/hello",
+            sha256=hashlib.sha256(artifact_bytes).hexdigest(),
+            smoke_command=smoke_command,
+            smoke_exit_code=smoke_result.exit_code,
+            smoke_output=smoke_result.combined_output[:4000],
+            smoke_output_sha256=hashlib.sha256(smoke_result.combined_output.encode()).hexdigest(),
+        )
+    ]
+    session.verification = VerificationResult(
+        status="candidate_ready",
+        artifact_count=1,
+    )
+    session.commit_sha = COMMIT_SHA
+    _write_repro_bundle(session)
+    manager.save_session(session)
+
+
+def _assert_no_replay_container(session: CompileSession) -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+            "label=deerflow.compile.role=replay",
+            "--filter",
+            f"label=deerflow.compile.session_id={session.session_id}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def _run_replay_scenario(monkeypatch, *, failed_configure_side_effect: bool):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-replay-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        assert session.image_id is not None
+        assert session.image_id.startswith("sha256:")
+        _prepare_original_build(
+            manager,
+            runtime,
+            session,
+            failed_configure_side_effect=failed_configure_side_effect,
+        )
+        script = (Path(session.leadagent_repro_dir) / "build.sh").read_text(encoding="utf-8")
+        assert "cmake --build build --parallel && cp build/hello /artifacts/hello" in script
+        if failed_configure_side_effect:
+            assert "cmake -S . -B build && false" not in script
+        original_artifact = Path(session.leadagent_artifacts_dir) / "hello"
+        original_sha256 = hashlib.sha256(original_artifact.read_bytes()).hexdigest()
+
+        attempt = verify_clean_replay_impl(session=session, timeout_seconds=180)
+
+        assert hashlib.sha256(original_artifact.read_bytes()).hexdigest() == original_sha256
+        assert attempt.cleanup_succeeded is True
+        _assert_no_replay_container(session)
+        return attempt
+    finally:
+        compile_cleanup = runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+        assert compile_cleanup.succeeded is True
+        assert compile_cleanup.removed is True
+
+
+def test_clean_replay_rebuilds_pinned_cmake_fixture_in_fresh_container(monkeypatch):
+    attempt = _run_replay_scenario(
+        monkeypatch,
+        failed_configure_side_effect=False,
+    )
+
+    assert attempt.status == "passed"
+    assert attempt.failure_classification is None
+    assert attempt.exit_code == 0
+    assert len(attempt.artifacts) == 1
+    comparison = attempt.artifacts[0]
+    assert comparison.path == "hello"
+    assert comparison.type_matches is True
+    assert comparison.size_matches is True
+    assert comparison.sha256_matches is True
+    assert comparison.smoke_matches is True
+    assert comparison.passed is True
+
+
+def test_clean_replay_rejects_success_recipe_dependent_on_failed_configure_side_effect(monkeypatch):
+    attempt = _run_replay_scenario(
+        monkeypatch,
+        failed_configure_side_effect=True,
+    )
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "recipe_execution_failed"
+    assert attempt.exit_code not in {None, 0}
+    assert not any(check.name == "artifact_set" for check in attempt.checks)

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import shutil
 import subprocess
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,12 +10,28 @@ from types import SimpleNamespace
 import pytest
 
 from deerflow.compile import operations
-from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, ContainerCleanupResult, RuntimeConfig
+from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, ContainerCleanupResult, ReplayContainerHandle, RuntimeConfig
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, submit_build_result_impl
-from deerflow.compile.paths import get_compile_sessions_root, get_host_session_dir, get_host_workspace_dir, get_metadata_path, get_session_dir
-from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, submit_build_result_impl, verify_clean_replay_impl
+from deerflow.compile.paths import (
+    get_compile_sessions_root,
+    get_host_replay_artifacts_dir,
+    get_host_replay_logs_dir,
+    get_host_replay_recipe_dir,
+    get_host_replay_workspace_dir,
+    get_host_session_dir,
+    get_host_workspace_dir,
+    get_metadata_path,
+    get_replay_artifacts_dir,
+    get_replay_logs_dir,
+    get_replay_recipe_dir,
+    get_replay_workspace_dir,
+    get_session_dir,
+)
+from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, ReplayArtifactComparison, ReplayVerificationResult, VerificationCheck, VerificationResult
 from deerflow.config.paths import Paths
+
+VALID_IMAGE_ID = f"sha256:{'1' * 64}"
 
 
 @pytest.fixture(autouse=True)
@@ -40,6 +58,145 @@ def add_replayable_build_command(session: CompileSession, command: str = "cmake 
             exit_code=0,
         )
     )
+
+
+def install_passed_replay_stub(monkeypatch) -> None:
+    def fake_verify_clean_replay(*, session: CompileSession, timeout_seconds: int | None = None) -> ReplayVerificationResult:
+        del timeout_seconds
+        session.image_id = session.image_id or VALID_IMAGE_ID
+        recipe_path = Path(session.leadagent_repro_dir) / "build.sh"
+        result = ReplayVerificationResult(
+            attempt_id="stubbed-pass",
+            status="passed",
+            image=session.image,
+            image_id=session.image_id,
+            commit_sha=session.commit_sha or "",
+            recipe_sha256=hashlib.sha256(recipe_path.read_bytes()).hexdigest(),
+            cleanup_succeeded=True,
+        )
+        session.replay_attempts.append(result)
+        return result
+
+    monkeypatch.setattr(operations, "verify_clean_replay_impl", fake_verify_clean_replay)
+
+
+class FakeReplayRuntime:
+    def __init__(
+        self,
+        manager: CompileSessionManager,
+        *,
+        build_exit_code: int = 0,
+        cleanup_result: ContainerCleanupResult | None = None,
+        build_exception: BaseException | None = None,
+        mutate_replay_artifact=None,
+        smoke_output: str = "Hello Matt!\n",
+    ):
+        self.manager = manager
+        self.config = SimpleNamespace(replay_timeout_seconds=30)
+        self.build_exit_code = build_exit_code
+        self.cleanup_result = cleanup_result or ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+        self.build_exception = build_exception
+        self.mutate_replay_artifact = mutate_replay_artifact
+        self.smoke_output = smoke_output
+        self.attempt_id: str | None = None
+        self.events: list[tuple] = []
+
+    def replay_container_name(self, session: CompileSession, attempt_id: str) -> str:
+        del session
+        return f"replay-{attempt_id}"
+
+    def create_replay_container(self, session: CompileSession, *, attempt_id: str, timeout_seconds: int) -> ReplayContainerHandle:
+        self.attempt_id = attempt_id
+        self.events.append(("create", attempt_id, timeout_seconds))
+        assert (get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, self.manager.paths) / "build.sh").is_file()
+        assert not any(get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, self.manager.paths).iterdir())
+        assert not any(get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, self.manager.paths).iterdir())
+        assert not any(get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, self.manager.paths).iterdir())
+        return ReplayContainerHandle(container_id="replay-container-id", container_name=f"replay-{attempt_id}", image_id=session.image_id or "")
+
+    def exec_replay_container(
+        self,
+        session: CompileSession,
+        handle: ReplayContainerHandle,
+        command: str = "bash /repro/build.sh",
+        workdir: str = "/workspace",
+        timeout_seconds: int | None = None,
+        log_path: str | None = None,
+    ) -> CommandResult:
+        del handle, workdir
+        self.events.append(("exec", command, timeout_seconds, log_path))
+        if command == "bash /repro/build.sh":
+            if self.build_exception is not None:
+                raise self.build_exception
+            if self.build_exit_code == 0:
+                assert self.attempt_id is not None
+                original_dir = Path(session.leadagent_artifacts_dir)
+                replay_dir = get_replay_artifacts_dir(session.session_id, session.thread_id, self.attempt_id, self.manager.paths)
+                for original_path in original_dir.rglob("*"):
+                    if not original_path.is_file():
+                        continue
+                    replay_path = replay_dir / original_path.relative_to(original_dir)
+                    replay_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(original_path, replay_path)
+                if self.mutate_replay_artifact is not None:
+                    self.mutate_replay_artifact(replay_dir / "hello")
+            return CommandResult(
+                exit_code=self.build_exit_code,
+                stdout="",
+                stderr="recipe failed\n" if self.build_exit_code else "",
+                combined_output="recipe failed\n" if self.build_exit_code else "",
+                log_path=log_path,
+            )
+        return CommandResult(
+            exit_code=0,
+            stdout=self.smoke_output,
+            stderr="",
+            combined_output=self.smoke_output,
+            log_path=log_path,
+        )
+
+    def stop_and_remove_replay_container(
+        self,
+        session: CompileSession,
+        handle: ReplayContainerHandle | None = None,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+    ) -> ContainerCleanupResult:
+        del session
+        self.events.append(("cleanup", handle.container_id if handle else container_id, handle.container_name if handle else container_name))
+        return self.cleanup_result
+
+
+def make_replay_ready_session(tmp_path: Path, *, commands: list[BuildCommandRecord] | None = None) -> tuple[CompileSessionManager, CompileSession]:
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-clean-replay", repo_url="https://example.com/repo.git")
+    session.commit_sha = "a" * 40
+    session.image_id = VALID_IMAGE_ID
+    if commands is None:
+        add_replayable_build_command(session, "cmake --build build && cp build/hello /artifacts/hello")
+    else:
+        session.commands = commands
+    _write_repro_bundle(session)
+    artifact_path = Path(session.leadagent_artifacts_dir) / "hello"
+    write_elf(artifact_path, 2)
+    artifact_bytes = artifact_path.read_bytes()
+    session.artifacts = [
+        BuildArtifact(
+            path=manager.relative_path(session, artifact_path),
+            artifact_type="executable",
+            size_bytes=len(artifact_bytes),
+            source_path="/artifacts/hello",
+            sha256=hashlib.sha256(artifact_bytes).hexdigest(),
+            smoke_command="/artifacts/hello -version",
+            smoke_exit_code=0,
+            smoke_output="Hello Matt!\n",
+            smoke_output_sha256=hashlib.sha256(b"Hello Matt!\n").hexdigest(),
+        )
+    ]
+    session.verification = VerificationResult(status="candidate_ready", artifact_count=1)
+    manager.save_session(session)
+    return manager, session
 
 
 def write_elf(path: Path, elf_type: int, *, has_interpreter: bool = False, has_entry_point: bool | None = None) -> None:
@@ -250,6 +407,71 @@ def test_finalize_is_idempotent_and_preserves_first_terminal_result(tmp_path: Pa
     assert sum(event["event"] == "session.status_changed" and event["status"] == "completed" for event in events) == 1
 
 
+def test_manager_rejects_stale_save_and_status_change_after_finalization(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-finalized-write-fence", repo_url="https://example.com/repo.git")
+    stale = manager.load_session(session.session_id, session.thread_id)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
+    operations.finalize_compile_session_impl(session=session, status="cancelled", error="Parent run was cancelled.")
+    terminal_snapshot = session.to_dict()
+
+    stale.status = "verified"
+    stale.finalized_at = None
+    stale.error = None
+    stale.artifacts.append(BuildArtifact(path="artifacts/late", artifact_type="executable", size_bytes=1))
+
+    assert manager.save_session(stale) is False
+    manager.mark_session_status(stale, "verification_failed", error="late submit")
+
+    assert stale.to_dict() == terminal_snapshot
+    assert manager.load_session(session.session_id, session.thread_id).to_dict() == terminal_snapshot
+
+
+def test_stale_terminal_status_update_preserves_termination_fence(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-termination-write-fence", repo_url="https://example.com/repo.git")
+    stale = manager.load_session(session.session_id, session.thread_id)
+    session.termination_requested_at = operations.utc_now_iso()
+    session.termination_status = "cancelled"
+    manager.save_session(session)
+
+    manager.mark_session_status(stale, "failed", error="late worker failed")
+    authoritative = manager.load_session(session.session_id, session.thread_id)
+
+    assert authoritative.status == "failed"
+    assert authoritative.termination_requested_at == session.termination_requested_at
+    assert authoritative.termination_status == "cancelled"
+    manager.mark_session_status(stale, "verified")
+    assert manager.load_session(session.session_id, session.thread_id).status == "failed"
+
+
+def test_normal_finalize_cannot_override_persisted_termination_request(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-termination-finalize", repo_url="https://example.com/repo.git")
+
+    def cleanup(_session: CompileSession) -> ContainerCleanupResult:
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+    operations.cleanup_compile_session_container_impl(
+        session=session,
+        interrupted_status="timed_out",
+        error="Compiler timed out.",
+    )
+
+    operations.finalize_compile_session_impl(session=session, status="completed", summary="late success")
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert reloaded.status == "timed_out"
+    assert reloaded.error == "Compiler timed out."
+    assert reloaded.summary == "Compiler timed out."
+    assert reloaded.termination_status == "timed_out"
+
+
 def test_finalize_failed_session_does_not_generate_repro_bundle(tmp_path: Path, monkeypatch):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-failed-finalize", repo_url="https://example.com/repo.git")
@@ -259,6 +481,201 @@ def test_finalize_failed_session_does_not_generate_repro_bundle(tmp_path: Path, 
 
     assert session.status == "failed"
     assert not (Path(session.metadata_path).parent / "repro" / "build.sh").exists()
+
+
+def test_cleanup_finalized_session_still_reconciles_known_container(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-finalized-cleanup", repo_url="https://example.com/repo.git")
+    session.container_id = "late-container-id"
+    session.container_name = "late-container-name"
+    manager.save_session(session)
+    cleanup_calls: list[tuple[str | None, str | None]] = []
+
+    def cleanup(session_arg: CompileSession) -> ContainerCleanupResult:
+        cleanup_calls.append((session_arg.container_id, session_arg.container_name))
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+    operations.finalize_compile_session_impl(session=session, status="cancelled", error="Parent run was cancelled.")
+
+    updated, cleanup_result = operations.cleanup_compile_session_container_impl(session=session)
+
+    assert updated.status == "cancelled"
+    assert cleanup_result.succeeded is True
+    assert cleanup_calls == [("late-container-id", "late-container-name")]
+
+
+def test_cleanup_finalized_session_persists_replay_cleanup_without_repeating_it(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-finalized-replay-cleanup", repo_url="https://example.com/repo.git")
+    session.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="late-replay",
+            status="running",
+            image=session.image,
+            image_id=VALID_IMAGE_ID,
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            container_id="late-replay-id",
+            container_name="late-replay-name",
+        )
+    )
+    manager.save_session(session)
+    replay_cleanup_calls: list[tuple[str | None, str | None]] = []
+
+    def cleanup_compile(_session: CompileSession) -> ContainerCleanupResult:
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    def cleanup_replay(
+        _session: CompileSession,
+        _handle=None,
+        *,
+        container_id: str | None = None,
+        container_name: str | None = None,
+    ) -> ContainerCleanupResult:
+        replay_cleanup_calls.append((container_id, container_name))
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(
+                stop_and_remove_container=cleanup_compile,
+                stop_and_remove_replay_container=cleanup_replay,
+            ),
+        ),
+    )
+    operations.finalize_compile_session_impl(session=session, status="cancelled", error="Parent run was cancelled.")
+
+    operations.cleanup_compile_session_container_impl(session=session)
+    operations.cleanup_compile_session_container_impl(session=session)
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    attempt = reloaded.replay_attempts[-1]
+    assert attempt.status == "cancelled"
+    assert attempt.cleanup_succeeded is True
+    assert replay_cleanup_calls == [("late-replay-id", "late-replay-name")]
+    workflow_events = [json.loads(line) for line in manager.workflow_log_path(reloaded).read_text(encoding="utf-8").splitlines()]
+    assert sum(event["event"] == "replay.completed" and event.get("completed_by") == "parent_cleanup" for event in workflow_events) == 1
+
+
+def test_finalized_replay_cleanup_merge_ignores_tampered_immutable_evidence(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-finalized-replay-merge", repo_url="https://example.com/repo.git")
+    session.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="authoritative-attempt",
+            status="running",
+            image=session.image,
+            image_id=VALID_IMAGE_ID,
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            container_id="authoritative-container",
+            container_name="authoritative-name",
+        )
+    )
+    manager.save_session(session)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace()))
+    operations.finalize_compile_session_impl(session=session, status="cancelled", error="Parent run was cancelled.")
+    proposed = manager.load_session(session.session_id, session.thread_id)
+    proposed_attempt = proposed.replay_attempts[0]
+    proposed_attempt.status = "cancelled"
+    proposed_attempt.cleanup_succeeded = True
+    proposed_attempt.image_id = f"sha256:{'f' * 64}"
+    proposed_attempt.commit_sha = "c" * 40
+    proposed_attempt.recipe_sha256 = "d" * 64
+    proposed_attempt.container_id = "tampered-container"
+    proposed.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="injected-attempt",
+            status="passed",
+            image=session.image,
+            image_id=VALID_IMAGE_ID,
+            commit_sha="e" * 40,
+            recipe_sha256="f" * 64,
+        )
+    )
+
+    assert manager.save_session(
+        proposed,
+        allow_lifecycle_fenced=True,
+        merge_finalized_replay_cleanup=True,
+    )
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert len(reloaded.replay_attempts) == 1
+    attempt = reloaded.replay_attempts[0]
+    assert attempt.status == "cancelled"
+    assert attempt.cleanup_succeeded is True
+    assert attempt.image_id == VALID_IMAGE_ID
+    assert attempt.commit_sha == "a" * 40
+    assert attempt.recipe_sha256 == "b" * 64
+    assert attempt.container_id == "authoritative-container"
+
+
+def test_replay_cleanup_retry_persists_success_and_emits_retry_event(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-replay-cleanup-retry", repo_url="https://example.com/repo.git")
+    session.replay_attempts.append(
+        ReplayVerificationResult(
+            attempt_id="retry-attempt",
+            status="running",
+            image=session.image,
+            image_id=VALID_IMAGE_ID,
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            container_id="retry-container",
+            container_name="retry-name",
+        )
+    )
+    manager.save_session(session)
+    replay_results = iter(
+        [
+            ContainerCleanupResult(succeeded=False, stopped=False, removed=False),
+            ContainerCleanupResult(succeeded=True, stopped=True, removed=True),
+        ]
+    )
+    replay_cleanup_calls = 0
+
+    def cleanup_compile(_session: CompileSession) -> ContainerCleanupResult:
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    def cleanup_replay(*_args, **_kwargs) -> ContainerCleanupResult:
+        nonlocal replay_cleanup_calls
+        replay_cleanup_calls += 1
+        return next(replay_results)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(
+                stop_and_remove_container=cleanup_compile,
+                stop_and_remove_replay_container=cleanup_replay,
+            ),
+        ),
+    )
+
+    operations.cleanup_compile_session_container_impl(
+        session=session,
+        interrupted_status="cancelled",
+        error="Parent run was cancelled.",
+    )
+    operations.cleanup_compile_session_container_impl(session=session)
+    operations.cleanup_compile_session_container_impl(session=session)
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert reloaded.replay_attempts[-1].cleanup_succeeded is True
+    assert replay_cleanup_calls == 2
+    workflow_events = [json.loads(line) for line in manager.workflow_log_path(reloaded).read_text(encoding="utf-8").splitlines()]
+    assert sum(event["event"] == "replay.completed" and event.get("completed_by") == "parent_cleanup_retry" for event in workflow_events) == 1
 
 
 def test_concurrent_finalize_with_stale_copies_commits_one_terminal_result(tmp_path: Path, monkeypatch):
@@ -401,12 +818,14 @@ def test_cleanup_failure_remains_retryable_until_container_is_removed(tmp_path: 
     operations.finalize_unfinished_thread_sessions_impl(
         thread_id=session.thread_id,
         run_id=session.run_id,
-        interrupted_status="cancelled",
-        error="Parent run was cancelled.",
+        interrupted_status="timed_out",
+        error="Compiler timed out.",
     )
     after_failure = manager.load_session(session.session_id, session.thread_id)
     assert after_failure.status == "failed"
     assert after_failure.finalized_at is None
+    assert after_failure.termination_status == "timed_out"
+    assert after_failure.termination_error == "Compiler timed out."
 
     operations.finalize_unfinished_thread_sessions_impl(
         thread_id=session.thread_id,
@@ -415,7 +834,9 @@ def test_cleanup_failure_remains_retryable_until_container_is_removed(tmp_path: 
         error="Parent run was cancelled.",
     )
     after_retry = manager.load_session(session.session_id, session.thread_id)
-    assert after_retry.status == "cancelled"
+    assert after_retry.status == "timed_out"
+    assert after_retry.error == "Compiler timed out."
+    assert after_retry.termination_status == "timed_out"
     assert after_retry.finalized_at is not None
     assert cleanup_calls == 2
 
@@ -498,6 +919,8 @@ def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypat
     def fake_run(command, **kwargs):
         del kwargs
         commands.append(command)
+        if command[:3] == ["docker", "inspect", "--format"]:
+            return type("Result", (), {"stdout": f"{VALID_IMAGE_ID}\n", "stderr": "", "returncode": 0})()
         return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
 
     monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
@@ -519,6 +942,8 @@ def test_docker_runtime_creates_missing_network(tmp_path: Path, monkeypatch):
     def fake_run(command, **kwargs):
         del kwargs
         commands.append(command)
+        if command[:3] == ["docker", "inspect", "--format"]:
+            return type("Result", (), {"stdout": f"{VALID_IMAGE_ID}\n", "stderr": "", "returncode": 0})()
         if command[:3] == ["docker", "network", "inspect"]:
             return type("Result", (), {"stdout": "", "stderr": "not found", "returncode": 1})()
         return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
@@ -542,6 +967,8 @@ def test_docker_runtime_passes_runtime_proxy_values_out_of_band(tmp_path: Path, 
 
     def fake_run(command, **kwargs):
         calls.append((command, kwargs))
+        if command[:3] == ["docker", "inspect", "--format"]:
+            return type("Result", (), {"stdout": f"{VALID_IMAGE_ID}\n", "stderr": "", "returncode": 0})()
         return type("Result", (), {"stdout": "container-id\n", "stderr": "", "returncode": 0})()
 
     monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
@@ -1100,6 +1527,7 @@ def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monk
     session.commit_sha = "a" * 40
     add_replayable_build_command(session, "cmake --build build && cp build/hello /artifacts/hello")
     session.error = "stale verification failure"
+    manager.save_session(session)
     artifacts_dir = Path(session.leadagent_artifacts_dir)
     write_elf(artifacts_dir / "hello", 2)
     text_log = artifacts_dir / "verification.log"
@@ -1112,6 +1540,7 @@ def test_submit_smokes_only_elf_executable_and_ignores_text(tmp_path: Path, monk
         calls.append(command)
         return CommandResult(exit_code=0, stdout="Hello Matt!\n", stderr="", combined_output="Hello Matt!\n")
 
+    install_passed_replay_stub(monkeypatch)
     monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)))
 
     payload = json.loads(submit_build_result_impl(session=session))
@@ -1140,6 +1569,7 @@ def test_submit_accepts_non_executable_compiled_outputs_without_smoke(tmp_path: 
     session = manager.create_session(thread_id=f"thread-{file_type}", repo_url="https://example.com/repo.git")
     session.commit_sha = "a" * 40
     add_replayable_build_command(session, f"cmake --build build && cp build/{filename} /artifacts/{filename}")
+    manager.save_session(session)
     artifact = Path(session.leadagent_artifacts_dir) / filename
     if file_type == "shared":
         write_elf(artifact, 3)
@@ -1151,6 +1581,7 @@ def test_submit_accepts_non_executable_compiled_outputs_without_smoke(tmp_path: 
     def fail_exec(*args, **kwargs):
         raise AssertionError("Non-executable compiled artifacts must not be smoke-tested")
 
+    install_passed_replay_stub(monkeypatch)
     monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fail_exec)))
 
     payload = json.loads(submit_build_result_impl(session=session))
@@ -1158,3 +1589,889 @@ def test_submit_accepts_non_executable_compiled_outputs_without_smoke(tmp_path: 
     assert payload["status"] == "passed"
     assert payload["artifacts"][0]["artifact_type"] == expected_type
     assert session.status == "verified"
+
+
+def test_submit_resuming_after_parent_finalization_cannot_create_replay_or_overwrite_cancelled_session(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-late-submit", repo_url="https://example.com/repo.git")
+    session.status = "inspected"
+    session.commit_sha = "a" * 40
+    session.image_id = VALID_IMAGE_ID
+    add_replayable_build_command(session, "cmake --build build && cp build/hello /artifacts/hello")
+    manager.save_session(session)
+    write_elf(Path(session.leadagent_artifacts_dir) / "hello", 2)
+    entered = threading.Event()
+    release = threading.Event()
+
+    class GatedSubmitRuntime(FakeReplayRuntime):
+        def exec(self, _session: CompileSession, command: str, **_kwargs) -> CommandResult:
+            assert command == "/artifacts/hello -version"
+            entered.set()
+            assert release.wait(10)
+            return CommandResult(
+                exit_code=0,
+                stdout="Hello Matt!\n",
+                stderr="",
+                combined_output="Hello Matt!\n",
+            )
+
+        def stop_and_remove_container(self, _session: CompileSession) -> ContainerCleanupResult:
+            return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    runtime = GatedSubmitRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(submit_build_result_impl, session=session)
+        try:
+            assert entered.wait(5)
+            parent_session = manager.load_session(session.session_id, session.thread_id)
+            operations.cleanup_and_finalize_compile_session_impl(
+                session=parent_session,
+                interrupted_status="cancelled",
+                error="Parent run was cancelled.",
+            )
+            authoritative = manager.load_session(session.session_id, session.thread_id)
+            terminal_snapshot = (
+                authoritative.status,
+                authoritative.error,
+                authoritative.summary,
+                authoritative.completed_at,
+                authoritative.finalized_at,
+                authoritative.termination_requested_at,
+            )
+        finally:
+            release.set()
+        payload = json.loads(future.result(timeout=10))
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert payload["status"] == "cancelled"
+    assert terminal_snapshot[0] == "cancelled"
+    assert (
+        reloaded.status,
+        reloaded.error,
+        reloaded.summary,
+        reloaded.completed_at,
+        reloaded.finalized_at,
+        reloaded.termination_requested_at,
+    ) == terminal_snapshot
+    assert reloaded.artifacts == []
+    assert reloaded.verification is None
+    assert reloaded.replay_attempts == []
+    assert not any(event[0] == "create" for event in runtime.events)
+    workflow_events = [json.loads(line) for line in (Path(reloaded.leadagent_logs_dir) / "workflow.log").read_text(encoding="utf-8").splitlines()]
+    assert not any(event["event"] in {"replay.started", "verification.accepted"} for event in workflow_events)
+    assert sum(event["event"] == "finalize.completed" for event in workflow_events) == 1
+
+
+def test_clean_replay_matching_executable_persists_structured_checks_and_cleans_up(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    original_artifact = Path(session.leadagent_artifacts_dir) / "hello"
+    original_sha256 = hashlib.sha256(original_artifact.read_bytes()).hexdigest()
+    workspace_sentinel = Path(session.leadagent_repo_dir) / "original-session-state"
+    workspace_sentinel.parent.mkdir(parents=True, exist_ok=True)
+    workspace_sentinel.write_text("must remain untouched\n", encoding="utf-8")
+    runtime = FakeReplayRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session, timeout_seconds=20)
+
+    assert attempt.status == "passed"
+    assert attempt.failure_classification is None
+    assert attempt.exit_code == 0
+    assert attempt.cleanup_succeeded is True
+    assert attempt.image_id == VALID_IMAGE_ID
+    assert attempt.commit_sha == "a" * 40
+    assert attempt.duration_seconds is not None
+    assert attempt.duration_seconds >= 0
+    checks = {check.name: check for check in attempt.checks}
+    expected_checks = {
+        "recipe_snapshot",
+        "image_identity",
+        "recipe_execution",
+        "artifact_set",
+        "artifact_1_type",
+        "artifact_1_size",
+        "artifact_1_sha256",
+        "artifact_1_smoke",
+        "container_cleanup",
+    }
+    assert expected_checks <= checks.keys()
+    assert all(checks[name].passed for name in expected_checks)
+    assert checks["artifact_set"].expected == ["hello"]
+    assert checks["artifact_set"].actual == ["hello"]
+    assert checks["artifact_1_sha256"].expected == original_sha256
+    assert checks["artifact_1_sha256"].actual == original_sha256
+    assert checks["artifact_1_smoke"].actual == {
+        "command": "/artifacts/hello -version",
+        "exit_code": 0,
+        "output": "Hello Matt!\n",
+        "output_sha256": hashlib.sha256(b"Hello Matt!\n").hexdigest(),
+    }
+    assert len(attempt.artifacts) == 1
+    comparison = attempt.artifacts[0]
+    assert comparison.path == "hello"
+    assert comparison.type_matches is True
+    assert comparison.size_matches is True
+    assert comparison.sha256_matches is True
+    assert comparison.smoke_matches is True
+    assert comparison.passed is True
+    assert runtime.events[-1] == ("cleanup", "replay-container-id", f"replay-{attempt.attempt_id}")
+    assert sum(event[0] == "cleanup" for event in runtime.events) == 1
+    assert hashlib.sha256(original_artifact.read_bytes()).hexdigest() == original_sha256
+    assert workspace_sentinel.read_text(encoding="utf-8") == "must remain untouched\n"
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert reloaded.status == "replay_verifying"
+    assert reloaded.replay_attempts[-1].status == "passed"
+
+
+def test_clean_replay_rejects_recipe_that_depends_on_failed_command_side_effect(tmp_path: Path, monkeypatch):
+    failed_configure = BuildCommandRecord(
+        stage="bash",
+        command="cmake -S . -B build && false",
+        workdir="/workspace/repo",
+        exit_code=1,
+    )
+    successful_build = BuildCommandRecord(
+        stage="bash",
+        command="cmake --build build && cp build/hello /artifacts/hello",
+        workdir="/workspace/repo",
+        exit_code=0,
+    )
+    manager, session = make_replay_ready_session(tmp_path, commands=[failed_configure, successful_build])
+    original_history = [record.__dict__.copy() for record in session.commands]
+    script = (Path(session.leadagent_repro_dir) / "build.sh").read_text(encoding="utf-8")
+    assert failed_configure.command not in script
+    assert successful_build.command in script
+    runtime = FakeReplayRuntime(manager, build_exit_code=2)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "recipe_execution_failed"
+    assert attempt.exit_code == 2
+    assert attempt.cleanup_succeeded is True
+    assert next(check for check in attempt.checks if check.name == "recipe_execution").passed is False
+    assert not any(check.name == "artifact_set" for check in attempt.checks)
+    assert [record.__dict__.copy() for record in session.commands] == original_history
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert [record.__dict__.copy() for record in reloaded.commands] == original_history
+
+
+def test_clean_replay_same_type_and_size_sha_mismatch_is_not_verified(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    def mutate_entry_point(path: Path) -> None:
+        payload = bytearray(path.read_bytes())
+        payload[24] ^= 1
+        path.write_bytes(payload)
+        assert _classify_compiled_artifact(path) == "executable"
+
+    runtime = FakeReplayRuntime(manager, mutate_replay_artifact=mutate_entry_point)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "sha256_mismatch"
+    comparison = attempt.artifacts[0]
+    assert comparison.type_matches is True
+    assert comparison.size_matches is True
+    assert comparison.sha256_matches is False
+    assert comparison.smoke_matches is True
+    assert comparison.mismatches == ["sha256"]
+    assert comparison.expected_sha256 != comparison.actual_sha256
+    assert next(check for check in attempt.checks if check.name == "artifact_1_sha256").passed is False
+    assert attempt.cleanup_succeeded is True
+
+
+def test_clean_replay_artifact_set_mismatch_is_not_verified(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    def replace_expected_artifact(path: Path) -> None:
+        path.unlink()
+        write_elf(path.with_name("unexpected"), 2)
+
+    runtime = FakeReplayRuntime(manager, mutate_replay_artifact=replace_expected_artifact)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "artifact_set_mismatch"
+    artifact_set = next(check for check in attempt.checks if check.name == "artifact_set")
+    assert artifact_set.expected == ["hello"]
+    assert artifact_set.actual == ["unexpected"]
+    assert artifact_set.passed is False
+
+
+def test_clean_replay_artifact_type_mismatch_is_not_verified(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    runtime = FakeReplayRuntime(manager, mutate_replay_artifact=lambda path: write_elf(path, 3))
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "type_mismatch"
+    comparison = attempt.artifacts[0]
+    assert comparison.expected_type == "executable"
+    assert comparison.actual_type == "shared_library"
+    assert comparison.type_matches is False
+
+
+def test_clean_replay_artifact_size_mismatch_is_not_verified(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    def append_valid_trailing_bytes(path: Path) -> None:
+        path.write_bytes(path.read_bytes() + b"trailing-bytes")
+        assert _classify_compiled_artifact(path) == "executable"
+
+    runtime = FakeReplayRuntime(manager, mutate_replay_artifact=append_valid_trailing_bytes)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "size_mismatch"
+    comparison = attempt.artifacts[0]
+    assert comparison.type_matches is True
+    assert comparison.size_matches is False
+    assert comparison.actual_size_bytes > comparison.expected_size_bytes
+
+
+@pytest.mark.parametrize("artifact_type", ["shared_library", "static_library"])
+def test_clean_replay_accepts_matching_non_executable_artifacts_without_smoke(tmp_path: Path, monkeypatch, artifact_type: str):
+    manager, session = make_replay_ready_session(tmp_path)
+    artifact_path = Path(session.leadagent_artifacts_dir) / "hello"
+    if artifact_type == "shared_library":
+        write_elf(artifact_path, 3)
+    else:
+        write_static_archive(artifact_path)
+    payload = artifact_path.read_bytes()
+    session.artifacts = [
+        BuildArtifact(
+            path=manager.relative_path(session, artifact_path),
+            artifact_type=artifact_type,
+            size_bytes=len(payload),
+            source_path="/artifacts/hello",
+            sha256=hashlib.sha256(payload).hexdigest(),
+        )
+    ]
+    manager.save_session(session)
+    runtime = FakeReplayRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "passed"
+    comparison = attempt.artifacts[0]
+    assert comparison.actual_type == artifact_type
+    assert comparison.smoke_matches is True
+    assert comparison.actual_smoke_command is None
+    assert [event[1] for event in runtime.events if event[0] == "exec"] == ["bash /repro/build.sh"]
+
+
+def test_clean_replay_timeout_is_classified_and_always_cleaned_up(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    runtime = FakeReplayRuntime(manager, build_exit_code=124)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session, timeout_seconds=7)
+
+    assert attempt.status == "timed_out"
+    assert attempt.failure_classification == "timeout"
+    assert attempt.exit_code == 124
+    assert attempt.cleanup_succeeded is True
+    assert next(check for check in attempt.checks if check.name == "recipe_execution").actual == 124
+    assert not any(check.name == "artifact_set" for check in attempt.checks)
+    create_event = next(event for event in runtime.events if event[0] == "create")
+    build_event = next(event for event in runtime.events if event[:2] == ("exec", "bash /repro/build.sh"))
+    assert 1 <= create_event[2] <= 7
+    assert 1 <= build_event[2] <= 7
+    assert runtime.events[-1][0] == "cleanup"
+
+
+def test_clean_replay_base_exception_persists_cancellation_cleans_up_and_reraises(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    runtime = FakeReplayRuntime(manager, build_exception=KeyboardInterrupt())
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    with pytest.raises(KeyboardInterrupt):
+        verify_clean_replay_impl(session=session)
+
+    assert runtime.events[-1][0] == "cleanup"
+    assert sum(event[0] == "cleanup" for event in runtime.events) == 1
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    attempt = reloaded.replay_attempts[-1]
+    assert attempt.status == "cancelled"
+    assert attempt.failure_classification == "cancelled"
+    assert attempt.cleanup_succeeded is True
+    assert attempt.completed_at is not None
+    assert any("KeyboardInterrupt" in note for note in attempt.notes)
+
+
+def test_clean_replay_cleanup_failure_blocks_an_otherwise_matching_result(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    runtime = FakeReplayRuntime(
+        manager,
+        cleanup_result=ContainerCleanupResult(succeeded=False, stopped=True, removed=False),
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "cleanup_failed"
+    assert attempt.exit_code == 0
+    assert attempt.cleanup_succeeded is False
+    assert attempt.artifacts[0].passed is True
+    cleanup_check = next(check for check in attempt.checks if check.name == "container_cleanup")
+    assert cleanup_check.passed is False
+    assert cleanup_check.actual == {"stopped": True, "removed": False}
+
+
+def test_replay_schema_roundtrip_preserves_structured_checks_and_artifacts(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-replay-schema", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    session.replay_attempts = [
+        ReplayVerificationResult(
+            attempt_id="attempt-schema",
+            status="failed",
+            image=session.image,
+            image_id=VALID_IMAGE_ID,
+            commit_sha="a" * 40,
+            recipe_sha256="b" * 64,
+            timeout_seconds=45,
+            cleanup_succeeded=True,
+            failure_classification="sha256_mismatch",
+            checks=[
+                VerificationCheck(
+                    name="artifact_1_sha256",
+                    target="hello",
+                    command="clean_replay",
+                    passed=False,
+                    expected="c" * 64,
+                    actual="d" * 64,
+                )
+            ],
+            artifacts=[
+                ReplayArtifactComparison(
+                    path="hello",
+                    expected_type="executable",
+                    actual_type="executable",
+                    expected_size_bytes=120,
+                    actual_size_bytes=120,
+                    expected_sha256="c" * 64,
+                    actual_sha256="d" * 64,
+                    expected_smoke_output_sha256="e" * 64,
+                    actual_smoke_output_sha256="f" * 64,
+                    type_matches=True,
+                    size_matches=True,
+                    smoke_matches=True,
+                    mismatches=["sha256"],
+                )
+            ],
+        )
+    ]
+    manager.save_session(session)
+
+    loaded = manager.load_session(session.session_id, session.thread_id)
+
+    assert isinstance(loaded.replay_attempts[0], ReplayVerificationResult)
+    assert isinstance(loaded.replay_attempts[0].checks[0], VerificationCheck)
+    assert isinstance(loaded.replay_attempts[0].artifacts[0], ReplayArtifactComparison)
+    assert loaded.replay_attempts[0].checks[0].expected == "c" * 64
+    assert loaded.replay_attempts[0].artifacts[0].mismatches == ["sha256"]
+    assert loaded.replay_attempts[0].timeout_seconds == 45
+    assert loaded.replay_attempts[0].artifacts[0].expected_smoke_output_sha256 == "e" * 64
+
+
+def test_compile_session_loads_legacy_metadata_without_replay_fields(tmp_path: Path):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-legacy-schema", repo_url="https://example.com/repo.git")
+    payload = session.to_dict()
+    payload.pop("image_id")
+    payload.pop("replay_attempts")
+    Path(session.metadata_path).write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = manager.load_session(session.session_id, session.thread_id)
+
+    assert loaded.image_id is None
+    assert loaded.replay_attempts == []
+
+
+def test_replay_docker_command_uses_immutable_image_isolated_mounts_read_only_recipe_and_timeout(tmp_path: Path, monkeypatch):
+    paths = make_test_paths(tmp_path)
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-replay-runtime", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    attempt_id = "attempt123"
+    recipe_dir = get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)
+    workspace_dir = get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths)
+    artifacts_dir = get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths)
+    logs_dir = get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths)
+    for directory in (recipe_dir, workspace_dir, artifacts_dir, logs_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    (recipe_dir / "build.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[:3] == ["docker", "network", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout="network\n", stderr="")
+        if command[:3] == ["docker", "inspect", "--format"]:
+            return SimpleNamespace(returncode=0, stdout=f"{VALID_IMAGE_ID}\n", stderr="")
+        if command[:2] == ["docker", "run"]:
+            return SimpleNamespace(returncode=0, stdout="replay-container-id\n", stderr="")
+        if command[:2] == ["docker", "exec"]:
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(config=RuntimeConfig(network=DEFAULT_NETWORK, replay_timeout_seconds=30), manager=manager)
+
+    handle = runtime.create_replay_container(session, attempt_id=attempt_id, timeout_seconds=17)
+    result = runtime.exec_replay_container(session, handle, timeout_seconds=11)
+
+    assert result.exit_code == 0
+    docker_run, run_kwargs = next((command, kwargs) for command, kwargs in calls if command[:2] == ["docker", "run"])
+    assert docker_run[-4:] == [VALID_IMAGE_ID, "tail", "-f", "/dev/null"]
+    assert session.image not in docker_run
+    assert f"{get_host_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)}:/repro:ro" in docker_run
+    assert f"{get_host_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths)}:/workspace" in docker_run
+    assert f"{get_host_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths)}:/artifacts" in docker_run
+    assert f"{get_host_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths)}:/logs" in docker_run
+    assert all(f"{get_host_workspace_dir(session.session_id, session.thread_id, paths)}:" not in item for item in docker_run)
+    assert run_kwargs["timeout"] == 17
+    docker_exec, exec_kwargs = next((command, kwargs) for command, kwargs in calls if command[:2] == ["docker", "exec"])
+    assert docker_exec[-7:] == ["timeout", "--signal=TERM", "--kill-after=5s", "11s", "bash", "-lc", "bash /repro/build.sh"]
+    assert exec_kwargs["timeout"] == 21
+
+
+def test_clean_replay_create_timeout_is_persisted_as_timed_out(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    class CreateTimeoutRuntime(FakeReplayRuntime):
+        def create_replay_container(self, session: CompileSession, *, attempt_id: str, timeout_seconds: int):
+            self.attempt_id = attempt_id
+            raise subprocess.TimeoutExpired(["docker", "network", "inspect"], timeout_seconds)
+
+    runtime = CreateTimeoutRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session, timeout_seconds=7)
+
+    assert attempt.status == "timed_out"
+    assert attempt.failure_classification == "timeout"
+    assert attempt.timeout_seconds == 7
+    assert attempt.completed_at is not None
+    assert attempt.duration_seconds is not None
+    reloaded = manager.load_session(session.session_id, session.thread_id).replay_attempts[-1]
+    assert reloaded.status == "timed_out"
+    assert reloaded.timeout_seconds == 7
+
+
+def test_parent_recorded_replay_cancellation_wins_over_worker_save(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    class ParentCancellingRuntime(FakeReplayRuntime):
+        def exec_replay_container(self, session: CompileSession, handle: ReplayContainerHandle, **kwargs):
+            if kwargs.get("command", "bash /repro/build.sh") == "bash /repro/build.sh":
+                current = self.manager.load_session(session.session_id, session.thread_id)
+                authoritative = current.replay_attempts[-1]
+                authoritative.status = "cancelled"
+                authoritative.failure_classification = "cancelled"
+                authoritative.cleanup_succeeded = True
+                authoritative.completed_at = authoritative.completed_at or operations.utc_now_iso()
+                authoritative.notes.append("Parent cancellation is authoritative.")
+                self.manager.save_session(current)
+            return super().exec_replay_container(session, handle, **kwargs)
+
+    runtime = ParentCancellingRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "cancelled"
+    assert attempt.failure_classification == "cancelled"
+    assert attempt.cleanup_succeeded is True
+    assert "Parent cancellation is authoritative." in attempt.notes
+    reloaded = manager.load_session(session.session_id, session.thread_id).replay_attempts[-1]
+    assert reloaded.status == "cancelled"
+    assert reloaded.failure_classification == "cancelled"
+
+
+def test_parent_cancellation_before_docker_run_prevents_replay_creation(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+
+    class CancelBeforeCreateRuntime(FakeReplayRuntime):
+        def replay_container_name(self, session: CompileSession, attempt_id: str) -> str:
+            current = self.manager.load_session(session.session_id, session.thread_id)
+            operations.cleanup_compile_session_container_impl(session=current)
+            return super().replay_container_name(session, attempt_id)
+
+        def stop_and_remove_container(self, _session: CompileSession):
+            return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+        def create_replay_container(self, *args, **kwargs):
+            self.events.append(("create", args, kwargs))
+            raise AssertionError("Cancellation before docker run must prevent replay container creation")
+
+    runtime = CancelBeforeCreateRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "cancelled"
+    assert attempt.failure_classification == "cancelled"
+    assert not any(event[0] == "create" for event in runtime.events)
+    assert attempt.cleanup_succeeded is True
+
+
+def test_parent_cleanup_waits_for_replay_create_checkpoint_and_removes_by_container_id(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    create_entered = threading.Event()
+    release_create = threading.Event()
+    cleanup_started = threading.Event()
+    parent_removed_container = threading.Event()
+    cleanup_calls: list[tuple[bool, str | None]] = []
+
+    class GatedCreateRuntime(FakeReplayRuntime):
+        def create_replay_container(self, session: CompileSession, *, attempt_id: str, timeout_seconds: int) -> ReplayContainerHandle:
+            create_entered.set()
+            assert release_create.wait(10)
+            return super().create_replay_container(
+                session,
+                attempt_id=attempt_id,
+                timeout_seconds=timeout_seconds,
+            )
+
+        def exec_replay_container(self, session: CompileSession, handle: ReplayContainerHandle, **kwargs) -> CommandResult:
+            if kwargs.get("command", "bash /repro/build.sh") == "bash /repro/build.sh":
+                assert parent_removed_container.wait(10)
+            return super().exec_replay_container(session, handle, **kwargs)
+
+        def stop_and_remove_replay_container(
+            self,
+            session: CompileSession,
+            handle: ReplayContainerHandle | None = None,
+            *,
+            container_id: str | None = None,
+            container_name: str | None = None,
+        ) -> ContainerCleanupResult:
+            resolved_id = handle.container_id if handle is not None else container_id
+            cleanup_calls.append((handle is None, resolved_id))
+            if handle is None:
+                parent_removed_container.set()
+            return super().stop_and_remove_replay_container(
+                session,
+                handle,
+                container_id=container_id,
+                container_name=container_name,
+            )
+
+        def stop_and_remove_container(self, _session: CompileSession) -> ContainerCleanupResult:
+            return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    runtime = GatedCreateRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    def parent_cleanup():
+        cleanup_started.set()
+        current = manager.load_session(session.session_id, session.thread_id)
+        return operations.cleanup_compile_session_container_impl(
+            session=current,
+            interrupted_status="cancelled",
+            error="Parent run was cancelled.",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        replay_future = pool.submit(verify_clean_replay_impl, session=session)
+        assert create_entered.wait(5)
+        cleanup_future = pool.submit(parent_cleanup)
+        assert cleanup_started.wait(5)
+        assert not parent_removed_container.is_set()
+        release_create.set()
+        _updated, cleanup_result = cleanup_future.result(timeout=10)
+        attempt = replay_future.result(timeout=10)
+
+    assert cleanup_result.succeeded is True
+    assert cleanup_calls[0] == (True, "replay-container-id")
+    assert attempt.status == "cancelled"
+    authoritative = manager.load_session(session.session_id, session.thread_id)
+    assert authoritative.termination_status == "cancelled"
+    assert authoritative.replay_attempts[-1].container_id == "replay-container-id"
+
+
+def test_clean_replay_compares_full_smoke_output_hash_beyond_preview(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    shared_preview = "x" * 4000
+    expected_output = shared_preview + "expected suffix\n"
+    actual_output = shared_preview + "different suffix\n"
+    session.artifacts[0].smoke_output = shared_preview
+    session.artifacts[0].smoke_output_sha256 = hashlib.sha256(expected_output.encode()).hexdigest()
+    manager.save_session(session)
+    runtime = FakeReplayRuntime(manager, smoke_output=actual_output)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "smoke_mismatch"
+    comparison = attempt.artifacts[0]
+    assert comparison.expected_smoke_output == comparison.actual_smoke_output == shared_preview
+    assert comparison.expected_smoke_output_sha256 != comparison.actual_smoke_output_sha256
+    assert comparison.smoke_matches is False
+
+
+def test_replay_network_inspect_timeout_is_bounded(tmp_path: Path, monkeypatch):
+    paths = make_test_paths(tmp_path)
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-network-timeout", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    attempt_id = "network-timeout"
+    recipe_dir = get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)
+    for directory in (
+        recipe_dir,
+        get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths),
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (recipe_dir / "build.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        assert command[:3] == ["docker", "network", "inspect"]
+        assert 1 <= kwargs["timeout"] <= 4
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(config=RuntimeConfig(network=DEFAULT_NETWORK), manager=manager)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runtime.create_replay_container(session, attempt_id=attempt_id, timeout_seconds=4)
+
+
+def test_replay_run_timeout_retries_cleanup_until_late_container_is_removed(tmp_path: Path, monkeypatch):
+    paths = make_test_paths(tmp_path)
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-run-timeout-late-create", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    attempt_id = "run-timeout-late-create"
+    recipe_dir = get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)
+    for directory in (
+        recipe_dir,
+        get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths),
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (recipe_dir / "build.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    run_timeout = subprocess.TimeoutExpired(["docker", "run"], 5)
+    remove_calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        if command[:3] == ["docker", "network", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout="network\n", stderr="")
+        if command[:2] == ["docker", "run"]:
+            raise run_timeout
+        if command[:3] == ["docker", "rm", "-f"]:
+            remove_calls.append(command)
+            if len(remove_calls) == 1:
+                return SimpleNamespace(returncode=1, stdout="", stderr="Error: No such container")
+            return SimpleNamespace(returncode=0, stdout=f"{command[-1]}\n", stderr="")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(
+        config=RuntimeConfig(network=DEFAULT_NETWORK, cleanup_timeout_seconds=3),
+        manager=manager,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        runtime.create_replay_container(session, attempt_id=attempt_id, timeout_seconds=5)
+
+    assert exc_info.value is run_timeout
+    assert len(remove_calls) == 2
+    assert all(command[-1] == runtime.replay_container_name(session, attempt_id) for command in remove_calls)
+
+
+def test_replay_run_timeout_reconciliation_is_bounded_when_container_never_appears(tmp_path: Path, monkeypatch):
+    paths = make_test_paths(tmp_path)
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-run-timeout-missing", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    attempt_id = "run-timeout-missing"
+    recipe_dir = get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)
+    for directory in (
+        recipe_dir,
+        get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths),
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (recipe_dir / "build.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    clock = [0.0]
+    remove_timeouts: list[float] = []
+    run_timeout = subprocess.TimeoutExpired(["docker", "run"], 5)
+
+    def fake_monotonic() -> float:
+        return clock[0]
+
+    def fake_sleep(seconds: float) -> None:
+        clock[0] += seconds
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["docker", "network", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout="network\n", stderr="")
+        if command[:2] == ["docker", "run"]:
+            raise run_timeout
+        if command[:3] == ["docker", "rm", "-f"]:
+            remove_timeouts.append(kwargs["timeout"])
+            return SimpleNamespace(returncode=1, stdout="", stderr="Error: No such container")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.time.monotonic", fake_monotonic)
+    monkeypatch.setattr("deerflow.compile.docker_runtime.time.sleep", fake_sleep)
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(
+        config=RuntimeConfig(network=DEFAULT_NETWORK, cleanup_timeout_seconds=2),
+        manager=manager,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        runtime.create_replay_container(session, attempt_id=attempt_id, timeout_seconds=5)
+
+    assert exc_info.value is run_timeout
+    assert clock[0] == 2.0
+    assert len(remove_timeouts) == 4
+    assert all(0 < timeout <= 2.0 for timeout in remove_timeouts)
+
+
+def test_replay_image_inspect_timeout_cleans_by_precomputed_name(tmp_path: Path, monkeypatch):
+    paths = make_test_paths(tmp_path)
+    manager = CompileSessionManager(paths=paths)
+    session = manager.create_session(thread_id="thread-image-timeout", repo_url="https://example.com/repo.git")
+    session.image_id = VALID_IMAGE_ID
+    attempt_id = "image-timeout"
+    recipe_dir = get_replay_recipe_dir(session.session_id, session.thread_id, attempt_id, paths)
+    for directory in (
+        recipe_dir,
+        get_replay_workspace_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_artifacts_dir(session.session_id, session.thread_id, attempt_id, paths),
+        get_replay_logs_dir(session.session_id, session.thread_id, attempt_id, paths),
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (recipe_dir / "build.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        assert kwargs.get("timeout") is not None
+        if command[:3] == ["docker", "network", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout="network\n", stderr="")
+        if command[:2] == ["docker", "run"]:
+            return SimpleNamespace(returncode=0, stdout="late-container-id\n", stderr="")
+        if command[:3] == ["docker", "inspect", "--format"]:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        if command[:2] == ["docker", "stop"] or command[:3] == ["docker", "rm", "-f"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="Error: No such container")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(config=RuntimeConfig(network=DEFAULT_NETWORK), manager=manager)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runtime.create_replay_container(session, attempt_id=attempt_id, timeout_seconds=5)
+
+    assert any(command[:3] == ["docker", "rm", "-f"] for command in calls)
+
+
+def test_cleanup_stop_timeout_falls_back_to_bounded_force_remove(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-cleanup-timeout", repo_url="https://example.com/repo.git")
+    session.container_id = "container-timeout"
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        assert kwargs["timeout"] <= 4
+        if command[:2] == ["docker", "stop"]:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        if command[:3] == ["docker", "rm", "-f"]:
+            return SimpleNamespace(returncode=0, stdout="container-timeout\n", stderr="")
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(
+        config=RuntimeConfig(remove_on_cleanup=True, cleanup_timeout_seconds=4),
+        manager=manager,
+    )
+
+    result = runtime.stop_and_remove_container(session)
+
+    assert result.succeeded is True
+    assert result.stopped is False
+    assert result.removed is True
+    assert [command[:2] for command in calls] == [["docker", "stop"], ["docker", "rm"]]
+
+
+def test_cleanup_remove_timeout_is_reported_without_hanging(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(thread_id="thread-remove-timeout", repo_url="https://example.com/repo.git")
+    session.container_id = "container-timeout"
+
+    def fake_run(command, **kwargs):
+        assert kwargs["timeout"] <= 4
+        if command[:2] == ["docker", "stop"]:
+            return SimpleNamespace(returncode=0, stdout="container-timeout\n", stderr="")
+        if command[:3] == ["docker", "rm", "-f"]:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        raise AssertionError(f"Unexpected Docker command: {command}")
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    runtime = CompileDockerRuntime(
+        config=RuntimeConfig(remove_on_cleanup=True, cleanup_timeout_seconds=4),
+        manager=manager,
+    )
+
+    result = runtime.stop_and_remove_container(session)
+
+    assert result.succeeded is False
+    assert result.stopped is True
+    assert result.removed is False
+
+
+def test_finalize_rejects_original_artifact_mutated_after_replay(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    replay_runtime = FakeReplayRuntime(manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=replay_runtime))
+    attempt = verify_clean_replay_impl(session=session)
+    assert attempt.status == "passed"
+    session.verification = VerificationResult(status="passed", artifact_count=1)
+    manager.mark_session_status(session, "verified")
+
+    artifact_path = Path(session.leadagent_artifacts_dir) / "hello"
+    artifact_path.write_bytes(artifact_path.read_bytes() + b"changed-after-replay")
+
+    def cleanup(_session: CompileSession):
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(stop_and_remove_container=cleanup)),
+    )
+
+    updated, cleanup_result = operations.cleanup_and_finalize_compile_session_impl(session=session)
+
+    assert cleanup_result.succeeded is True
+    assert updated.status == "failed"
+    assert updated.finalized_at is not None
+    assert "changed after clean replay" in (updated.error or "")
+    final_check = next(check for check in updated.verification.checks if check.name == "accepted_artifacts_unchanged_after_cleanup")
+    assert final_check.passed is False
+    assert "sha256:hello" in final_check.actual["mismatches"]


### PR DESCRIPTION
## 变更内容

- 在全新容器中执行 commit-pinned candidate recipe，使用原始不可变镜像 ID、空 workspace/artifacts 和只读 recipe。
- 对原始与重放产物的完整集合、类型、大小、SHA-256 及 executable smoke 输出进行严格比较。
- 持久化结构化 replay 证据，并为 Docker create/exec/stop/remove、总超时、取消、对账和清理设置有界控制。
- 增加 first-reason-wins termination fence，防止迟到的同步 submit/replay worker 覆盖已取消或已终结的 Session。
- 增加单元测试、真实线程竞态测试和 opt-in Docker 集成测试。

## 根因

只保留成功命令的候选配方仍可能依赖此前失败命令留下的文件系统副作用，因此“脚本生成成功”不能证明产物可独立重建。Docker 客户端超时和 stale Session copy 还可能造成迟到创建的 replay 容器逃逸清理，或迟到 submit 覆盖权威终态。

## 影响

Compile Session 只有在候选配方于隔离的干净容器中执行成功，且 replay 产物与原始接受产物严格一致后才进入 `verified`。Replay 容器不接收模型凭据，也不挂载原 Session 的 workspace 或 artifacts；成功、失败、超时和取消路径都保留有界证据并执行幂等清理。

当前支持的基线仍是单后端进程；跨进程锁或 revision/CAS 不在本 PR 范围内。

## 验证

- compile runtime、terminal tools、cancellation：`108 passed`
- 后端全量：`1395 passed, 17 skipped`
- opt-in 真实 Docker integration：`2 passed in 74.50s`
- Docker 场景覆盖干净 CMake replay 成功，以及依赖失败 configure 副作用的配方被拒绝
- Ruff check 与 format check 通过
- 开发和部署 Docker Compose 配置解析通过
- 测试后 replay/compile 容器计数均为 0
- `git diff --check`、敏感信息与冻结资产检查通过
- `range-diff` 仅包含主干已有测试 workspace 隔离夹具的预期适配

Closes #7