### PR TITLE
功能：增加 C/C++ pilot 物理尝试证据账本

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,10 +8,20 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-20 — 将 physical-attempt evidence ledger 重排到最新主干并修复模型工厂测试契约
+  - 文件: `backend/tests/test_lead_agent_model_resolution.py`, `.claude/memory/project.md`
+  - 动机: PR #13 在 `main` 已包含 Issue #10 后改为单提交增量；模型工厂新增实验 thread/role 参数后，同步测试替身并断言普通会话不会携带实验 thread ID
+  - 证据: benchmark/ledger/runner `87 passed`，compile runtime/terminal/cancellation `114 passed`，模型 middleware/factory `30 passed`，后端全量 `1489 passed, 17 skipped`，真实 Docker replay `2 passed in 75.55s`；Ruff、Compose、前端 lint/typecheck/build、冻结资产、diff 与敏感信息检查通过
+
 - 2026-07-20 — 将 C/C++ benchmark 协议重排到最新主干并完成发布前验证
   - 文件: `scripts/forge_benchmark.py`, `backend/tests/test_forge_benchmark.py`, `benchmarks/README.md`, `benchmarks/manifests/cpp-pilot-v1.json`, `benchmarks/schemas/forge-cpp-benchmark-v1.schema.json`, `.github/workflows/backend-unit-tests.yml`
   - 动机: 在不改写 v1-v5 冻结 manifest、Schema、记录器或账本的前提下，把 Issue #10 的协议增量从旧 clean-replay 分支重放到 `main`；Forge 组件按 manifest 声明的历史 Git revision 校验，当前 recorder 与 Schema 仍按工作树字节校验，CI checkout 获取完整历史以执行同一严格检查
   - 证据: 聚焦回归 `183 passed`，后端全量 `1470 passed, 17 skipped`，后端 Ruff、前端 lint/typecheck/build、Draft 2020-12 meta-schema、冻结资产、diff 与敏感信息检查通过
+
+- 2026-07-18 — 实现 C/C++ pilot runner 与 physical-attempt evidence ledger
+  - 文件: `scripts/forge_benchmark_runner.py`, `backend/packages/harness/deerflow/compile/evidence.py`, `backend/packages/harness/deerflow/compile/operations.py`, `backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py`, `backend/tests/test_experiment_evidence.py`, `backend/tests/test_forge_benchmark_runner.py`
+  - 动机: 在首个模型请求前持久化实验尝试，以 hash chain 记录物理模型请求、命令、submit/replay/delivery gate、actual model/endpoint 和 orphan reconciliation；runner 强制 exact commit、镜像、依赖、环境、有序构建参数、replay delay、模型重试/超时与 compiler 预算，且拒绝重复 slot、fallback、密钥/宿主路径和终态后写入
+  - 证据: benchmark/ledger/runner `87 passed`，compile runtime/terminal/cancellation `114 passed`，模型 middleware/factory `30 passed`，真实 Docker replay `2 passed in 63.14s`；定向 Ruff/format、`py_compile`、Compose config、`git diff --check` 与 WSL preflight 通过
 
 - 2026-07-18 — 冻结 C/C++ pilot 协议、manifest、证据 Schema 与原子 JSONL 记录器
   - 文件: `scripts/forge_benchmark.py`, `backend/tests/test_forge_benchmark.py`, `benchmarks/README.md`, `benchmarks/manifests/cpp-pilot-v1.json`, `benchmarks/schemas/forge-cpp-benchmark-v1.schema.json`
@@ -35,13 +45,15 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #11 的实际 pilot runner 与 experiment/physical-attempt 账本：在首个模型请求前持久化物理尝试，逐 submit 记录稳定 request/replay ID、实际模型/端点结果/重试、Memory/Skill 状态、Forge revision/dirty state 和镜像身份；只有 gate 通过后才运行 5-case pilot。
-- PR #12 合并后继续自底向上处理 PR #13；处理堆叠链期间不启动 v6 pilot，也不删除仍被上层 PR 引用的 base 分支。
+- 完成 Issue #11 / PR #13 的审阅、完整 CI 与主干合并；处理堆叠链期间不启动 v6 pilot，也不删除仍被上层 PR 引用的 base 分支。
+- Issue #11 交付后创建新版 manifest，重新冻结包含 evidence middleware、runner、prompt constraint injection 与新工具契约的 Forge revision/component hashes，并解除 `instrumentation_blocker`；v1 manifest 保持不可变。
+- 新版 manifest preflight 全绿后，按 `gpt-5.6-sol` 串行执行五个 case 的首次 pilot；任何 DeepSeek 或其他模型对照必须使用单独版本化 condition/manifest，不能混入冻结 baseline。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 协作语言约定：后续 GitHub Issue、Pull Request、评论、评审说明和提交说明默认使用中文；分支名、代码标识、命令和必要技术术语继续遵循仓库的 ASCII/既有命名规范。若外部协作明确要求英文，先向用户确认。
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。
 - WSL 的 `127.0.0.1` 代理不能直接传入 Docker build；编译镜像代理必须使用容器可达地址。
 - 后端全量 Ruff 当前有 9 个本次改动之外的既有错误；相关改动文件的定向 Ruff 已通过。
@@ -53,6 +65,10 @@
 - Manifest 中声明的模型、端点、镜像和运行参数只是实验意图，不是实际运行证明；observed 字段必须由 runner 从真实请求、Forge 状态和 Docker 结果写入。
 - Benchmark run record 必须固定 recorder 与 Schema 的 SHA-256；只固定 manifest 不足以证明不同批次使用了相同采集语义。
 - 没有观测到的实际模型、镜像 ID、submit/replay 结果等字段必须保持 `null`，不能用 manifest 声明值、预期结果或事后推断补齐证据。
-- 历史 manifest 的 Forge 组件哈希必须按其声明的 Git revision 读取 blob 校验；把它永久对照最新工作树，会在 stacked PR squash 合并后产生伪漂移。协议记录器与 Schema 仍应按当前字节校验。
+- 历史 manifest 的 Forge 组件哈希必须按其声明的 Git revision 读取 blob 校验；把它永久对照最新工作树，会在 stacked PR squash 合并或后续 instrumentation 后产生伪漂移。协议记录器与 Schema 仍应按当前字节校验；最小后端镜像没有 Git 时，由运行时 preflight 校验当前工作树。
 - 一次性前端测试容器的镜像内置源码可能落后于主干；应只读挂载当前 `frontend/src`、`public` 和 `next.config.js`，并让容器使用独立 `.next`，不能在运行 `next dev` 的容器内并发构建。
 - Actions checkout 默认 `fetch-depth: 1`；需要读取 manifest 固定历史 revision 的 benchmark 测试必须显式获取完整 Git 历史，否则本地完整 clone 通过而 CI 会因找不到历史路径失败。
+- Compose 中只读挂载的 `/repo` 适合 runner/preflight，但 Ruff/pytest 必须关闭仓库内缓存；需要格式化时使用一次性可写 bind mount。WSL 宿主当前没有 `uv`，标准库 runner 可直接运行，依赖完整的回归测试继续在 LangGraph 开发容器中执行。
+- Manifest 的 CMake/configure 参数必须确定性注入 compiler prompt，并按有序 token 子序列验证；只检查参数集合会掩盖顺序敏感的配置偏差。
+- 在仓库根直接启动 Compose 会改变 project name，并可能因网络网段重叠创建失败；开发服务必须继续使用既定 `deer-flow-dev` project/启动脚本。
+- Compose 开发容器只把完整仓库只读挂载到 `/repo`，而 `/app/backend` 仅是后端源码挂载；依赖仓库根资产的 pytest/Ruff 必须从 `/repo/backend` 运行，并使用 `/app/backend/.venv` 解释器、关闭仓库内缓存。

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -288,7 +288,12 @@ def make_lead_agent(config: RunnableConfig):
 
     if is_bootstrap:
         return create_agent(
-            model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
+            model=create_chat_model(
+                name=model_name,
+                thinking_enabled=thinking_enabled,
+                experiment_thread_id=cfg.get("thread_id"),
+                experiment_role="lead",
+            ),
             tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled) + [setup_agent],
             middleware=_build_middlewares(config, model_name=model_name),
             system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"])),
@@ -296,7 +301,13 @@ def make_lead_agent(config: RunnableConfig):
         )
 
     return create_agent(
-        model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort),
+        model=create_chat_model(
+            name=model_name,
+            thinking_enabled=thinking_enabled,
+            reasoning_effort=reasoning_effort,
+            experiment_thread_id=cfg.get("thread_id"),
+            experiment_role="lead",
+        ),
         tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled),
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
         system_prompt=apply_prompt_template(

--- a/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
@@ -19,6 +19,17 @@ from langchain.agents.middleware.types import (
 from langchain_core.messages import AIMessage
 from langgraph.errors import GraphBubbleUp
 
+from deerflow.compile.evidence import (
+    get_active_experiment,
+    model_response_metadata,
+    new_evidence_id,
+    record_experiment_event,
+    request_model_endpoint,
+    request_model_name,
+    request_model_role,
+    request_thread_id,
+)
+
 logger = logging.getLogger(__name__)
 
 _RETRIABLE_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
@@ -114,6 +125,132 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
             return "The configured LLM provider is temporarily unavailable after multiple retries. Please wait a moment and continue the conversation."
         return f"LLM request failed: {detail}"
 
+    def _effective_max_attempts(self, request: ModelRequest) -> int:
+        active = get_active_experiment(request_thread_id(request))
+        if active is not None:
+            return active.policy.model_max_retries + 1
+        return self.retry_max_attempts
+
+    def _failure_classification(
+        self,
+        exc: BaseException,
+        reason: str,
+    ) -> str:
+        status_code = _extract_status_code(exc)
+        exception_name = type(exc).__name__.lower()
+        if reason == "quota":
+            return "quota"
+        if reason == "auth":
+            return "authentication"
+        if status_code == 429:
+            return "rate_limited"
+        if "timeout" in exception_name:
+            return "timeout"
+        if "connection" in exception_name:
+            return "connection_error"
+        if status_code is not None:
+            return f"http_{status_code}"
+        if reason == "busy":
+            return "provider_busy"
+        if reason == "transient":
+            return "transient_provider_error"
+        return "provider_error"
+
+    def _request_started(
+        self,
+        request: ModelRequest,
+        *,
+        model_call_id: str,
+        model_request_id: str,
+        attempt: int,
+        max_attempts: int,
+    ) -> str | None:
+        thread_id = request_thread_id(request)
+        active = get_active_experiment(thread_id)
+        configured_model = request_model_name(
+            request,
+            active.policy.model_name if active is not None else "unknown",
+        )
+        record_experiment_event(
+            thread_id,
+            "model.request_started",
+            model_call_id=model_call_id,
+            model_request_id=model_request_id,
+            role=request_model_role(request),
+            attempt=attempt,
+            max_attempts=max_attempts,
+            configured_model=configured_model,
+            observed_endpoint=request_model_endpoint(request),
+            request_timeout_seconds=(active.policy.request_timeout_seconds if active is not None else None),
+            provider_max_retries=0 if active is not None else None,
+        )
+        return thread_id
+
+    def _request_completed(
+        self,
+        thread_id: str | None,
+        response: ModelCallResult,
+        *,
+        model_call_id: str,
+        model_request_id: str,
+        attempt: int,
+        latency_seconds: float,
+    ) -> None:
+        actual_model, token_usage = model_response_metadata(response)
+        record_experiment_event(
+            thread_id,
+            "model.request_completed",
+            model_call_id=model_call_id,
+            model_request_id=model_request_id,
+            attempt=attempt,
+            latency_seconds=round(latency_seconds, 6),
+            status_code=None,
+            actual_model=actual_model,
+            token_usage=token_usage,
+        )
+
+    def _request_failed(
+        self,
+        thread_id: str | None,
+        exc: BaseException,
+        reason: str,
+        *,
+        model_call_id: str,
+        model_request_id: str,
+        attempt: int,
+        max_attempts: int,
+        latency_seconds: float,
+        retriable: bool,
+    ) -> str:
+        classification = self._failure_classification(exc, reason)
+        exhausted = retriable and attempt >= max_attempts
+        record_experiment_event(
+            thread_id,
+            "model.request_failed",
+            model_call_id=model_call_id,
+            model_request_id=model_request_id,
+            attempt=attempt,
+            max_attempts=max_attempts,
+            latency_seconds=round(latency_seconds, 6),
+            status_code=_extract_status_code(exc),
+            classification=classification,
+            retriable=retriable,
+            retry_exhausted=exhausted,
+        )
+        if not retriable or exhausted:
+            record_experiment_event(
+                thread_id,
+                "failure.recorded",
+                failure_id=new_evidence_id("failure"),
+                model_call_id=model_call_id,
+                model_request_id=model_request_id,
+                domain="model_endpoint",
+                classification=classification,
+                primary=True,
+                secondary_classifications=(["retry_exhausted"] if exhausted else []),
+            )
+        return classification
+
     def _emit_retry_event(self, attempt: int, wait_ms: int, reason: str) -> None:
         try:
             from langgraph.config import get_stream_writer
@@ -138,16 +275,59 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelCallResult:
+        model_call_id = new_evidence_id("model_call")
+        max_attempts = self._effective_max_attempts(request)
         attempt = 1
         while True:
+            model_request_id = new_evidence_id("model_request")
+            thread_id = self._request_started(
+                request,
+                model_call_id=model_call_id,
+                model_request_id=model_request_id,
+                attempt=attempt,
+                max_attempts=max_attempts,
+            )
+            started_monotonic = time.monotonic()
             try:
-                return handler(request)
+                response = handler(request)
+                self._request_completed(
+                    thread_id,
+                    response,
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    latency_seconds=time.monotonic() - started_monotonic,
+                )
+                return response
             except GraphBubbleUp:
+                record_experiment_event(
+                    thread_id,
+                    "model.request_cancelled",
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    classification="graph_control_flow",
+                    latency_seconds=round(
+                        time.monotonic() - started_monotonic,
+                        6,
+                    ),
+                )
                 # Preserve LangGraph control-flow signals (interrupt/pause/resume).
                 raise
             except Exception as exc:
                 retriable, reason = self._classify_error(exc)
-                if retriable and attempt < self.retry_max_attempts:
+                self._request_failed(
+                    thread_id,
+                    exc,
+                    reason,
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    latency_seconds=time.monotonic() - started_monotonic,
+                    retriable=retriable,
+                )
+                if retriable and attempt < max_attempts:
                     wait_ms = self._build_retry_delay_ms(attempt, exc)
                     logger.warning(
                         "Transient LLM error on attempt %d/%d; retrying in %dms: %s",
@@ -157,6 +337,16 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                         _extract_error_detail(exc),
                     )
                     self._emit_retry_event(attempt, wait_ms, reason)
+                    record_experiment_event(
+                        thread_id,
+                        "model.retry_scheduled",
+                        model_call_id=model_call_id,
+                        failed_model_request_id=model_request_id,
+                        attempt=attempt,
+                        next_attempt=attempt + 1,
+                        wait_ms=wait_ms,
+                        classification=self._failure_classification(exc, reason),
+                    )
                     time.sleep(wait_ms / 1000)
                     attempt += 1
                     continue
@@ -174,16 +364,73 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
+        model_call_id = new_evidence_id("model_call")
+        max_attempts = self._effective_max_attempts(request)
         attempt = 1
         while True:
+            model_request_id = new_evidence_id("model_request")
+            thread_id = self._request_started(
+                request,
+                model_call_id=model_call_id,
+                model_request_id=model_request_id,
+                attempt=attempt,
+                max_attempts=max_attempts,
+            )
+            started_monotonic = time.monotonic()
             try:
-                return await handler(request)
+                response = await handler(request)
+                self._request_completed(
+                    thread_id,
+                    response,
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    latency_seconds=time.monotonic() - started_monotonic,
+                )
+                return response
             except GraphBubbleUp:
+                record_experiment_event(
+                    thread_id,
+                    "model.request_cancelled",
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    classification="graph_control_flow",
+                    latency_seconds=round(
+                        time.monotonic() - started_monotonic,
+                        6,
+                    ),
+                )
                 # Preserve LangGraph control-flow signals (interrupt/pause/resume).
+                raise
+            except asyncio.CancelledError:
+                record_experiment_event(
+                    thread_id,
+                    "model.request_cancelled",
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    classification="cancelled",
+                    latency_seconds=round(
+                        time.monotonic() - started_monotonic,
+                        6,
+                    ),
+                )
                 raise
             except Exception as exc:
                 retriable, reason = self._classify_error(exc)
-                if retriable and attempt < self.retry_max_attempts:
+                self._request_failed(
+                    thread_id,
+                    exc,
+                    reason,
+                    model_call_id=model_call_id,
+                    model_request_id=model_request_id,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    latency_seconds=time.monotonic() - started_monotonic,
+                    retriable=retriable,
+                )
+                if retriable and attempt < max_attempts:
                     wait_ms = self._build_retry_delay_ms(attempt, exc)
                     logger.warning(
                         "Transient LLM error on attempt %d/%d; retrying in %dms: %s",
@@ -193,6 +440,16 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                         _extract_error_detail(exc),
                     )
                     self._emit_retry_event(attempt, wait_ms, reason)
+                    record_experiment_event(
+                        thread_id,
+                        "model.retry_scheduled",
+                        model_call_id=model_call_id,
+                        failed_model_request_id=model_request_id,
+                        attempt=attempt,
+                        next_attempt=attempt + 1,
+                        wait_ms=wait_ms,
+                        classification=self._failure_classification(exc, reason),
+                    )
                     await asyncio.sleep(wait_ms / 1000)
                     attempt += 1
                     continue

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -224,7 +224,12 @@ class DeerFlowClient:
         max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
 
         kwargs: dict[str, Any] = {
-            "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
+            "model": create_chat_model(
+                name=model_name,
+                thinking_enabled=thinking_enabled,
+                experiment_thread_id=cfg.get("thread_id"),
+                experiment_role=self._agent_name or "lead",
+            ),
             "tools": self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled),
             "middleware": _build_middlewares(config, model_name=model_name, agent_name=self._agent_name, custom_middlewares=self._middlewares),
             "system_prompt": apply_prompt_template(

--- a/backend/packages/harness/deerflow/compile/__init__.py
+++ b/backend/packages/harness/deerflow/compile/__init__.py
@@ -1,30 +1,62 @@
-from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import (
-    clone_repository_impl,
-    finalize_compile_session_impl,
-    finalize_compile_session_json,
-    get_bound_session,
-    get_compile_services,
-    inspect_build_system_impl,
-    prepare_compile_session_impl,
-    relative_or_original,
-    submit_build_result_impl,
-)
-from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession
+"""Public compile API with lazy imports for standalone evidence tooling."""
 
-__all__ = [
-    "BuildArtifact",
-    "BuildCommandRecord",
-    "CommandResult",
-    "CompileSession",
-    "CompileSessionManager",
-    "get_compile_services",
-    "get_bound_session",
-    "relative_or_original",
-    "prepare_compile_session_impl",
-    "clone_repository_impl",
-    "inspect_build_system_impl",
-    "submit_build_result_impl",
-    "finalize_compile_session_impl",
-    "finalize_compile_session_json",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_EXPORTS = {
+    "BuildArtifact": ("deerflow.compile.schemas", "BuildArtifact"),
+    "BuildCommandRecord": ("deerflow.compile.schemas", "BuildCommandRecord"),
+    "CommandResult": ("deerflow.compile.schemas", "CommandResult"),
+    "CompileSession": ("deerflow.compile.schemas", "CompileSession"),
+    "CompileSessionManager": (
+        "deerflow.compile.manager",
+        "CompileSessionManager",
+    ),
+    "get_compile_services": (
+        "deerflow.compile.operations",
+        "get_compile_services",
+    ),
+    "get_bound_session": ("deerflow.compile.operations", "get_bound_session"),
+    "relative_or_original": (
+        "deerflow.compile.operations",
+        "relative_or_original",
+    ),
+    "prepare_compile_session_impl": (
+        "deerflow.compile.operations",
+        "prepare_compile_session_impl",
+    ),
+    "clone_repository_impl": (
+        "deerflow.compile.operations",
+        "clone_repository_impl",
+    ),
+    "inspect_build_system_impl": (
+        "deerflow.compile.operations",
+        "inspect_build_system_impl",
+    ),
+    "submit_build_result_impl": (
+        "deerflow.compile.operations",
+        "submit_build_result_impl",
+    ),
+    "finalize_compile_session_impl": (
+        "deerflow.compile.operations",
+        "finalize_compile_session_impl",
+    ),
+    "finalize_compile_session_json": (
+        "deerflow.compile.operations",
+        "finalize_compile_session_json",
+    ),
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    target = _EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(name)
+    module_name, attribute_name = target
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value

--- a/backend/packages/harness/deerflow/compile/docker_runtime.py
+++ b/backend/packages/harness/deerflow/compile/docker_runtime.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from deerflow.compile.evidence import get_active_experiment
 from deerflow.compile.paths import (
     get_host_artifacts_dir,
     get_host_logs_dir,
@@ -114,6 +115,29 @@ class CompileDockerRuntime:
             environment[lower_name] = value
             docker_flags.extend(["-e", upper_name, "-e", lower_name])
         return docker_flags, environment
+
+    @staticmethod
+    def _experiment_environment_flags(session: CompileSession) -> list[str]:
+        active = get_active_experiment(session.thread_id)
+        if active is None:
+            return []
+        flags: list[str] = []
+        for name, value in active.policy.environment:
+            if value is not None:
+                flags.extend(["--env", f"{name}={value}"])
+        return flags
+
+    @staticmethod
+    def _experiment_label_flags(session: CompileSession) -> list[str]:
+        active = get_active_experiment(session.thread_id)
+        if active is None:
+            return []
+        return [
+            "--label",
+            f"deerflow.compile.experiment_id={active.experiment_id}",
+            "--label",
+            (f"deerflow.compile.physical_attempt_id={active.physical_attempt_id}"),
+        ]
 
     def _paths(self) -> Paths:
         manager_paths = getattr(self.manager, "paths", None)
@@ -323,6 +347,8 @@ class CompileDockerRuntime:
         host_logs_dir = self._host_logs_dir(session)
         host_repro_dir = self._host_repro_dir(session)
         proxy_flags, run_environment = self._runtime_proxy_environment()
+        experiment_environment_flags = self._experiment_environment_flags(session)
+        experiment_label_flags = self._experiment_label_flags(session)
         container_name = f"deerflow-compile-{session.thread_id[:8]}-{session.session_id[:8]}"
         command = [
             "docker",
@@ -330,11 +356,19 @@ class CompileDockerRuntime:
             "-d",
             "--name",
             container_name,
+            "--label",
+            "deerflow.compile.role=compile",
+            "--label",
+            f"deerflow.compile.session_id={session.session_id}",
+            "--label",
+            f"deerflow.compile.thread_id={session.thread_id}",
+            *experiment_label_flags,
             "--network",
             self.config.network,
             "--add-host",
             "host.docker.internal:host-gateway",
             *proxy_flags,
+            *experiment_environment_flags,
             "-v",
             f"{host_workspace_dir}:{CONTAINER_WORKSPACE_DIR}",
             "-v",
@@ -451,6 +485,8 @@ class CompileDockerRuntime:
         host_artifacts_dir = self._host_replay_artifacts_dir(session, attempt_id)
         host_logs_dir = self._host_replay_logs_dir(session, attempt_id)
         proxy_flags, run_environment = self._runtime_proxy_environment()
+        experiment_environment_flags = self._experiment_environment_flags(session)
+        experiment_label_flags = self._experiment_label_flags(session)
         container_name = self.replay_container_name(session, attempt_id)
         command = [
             "docker",
@@ -466,11 +502,13 @@ class CompileDockerRuntime:
             f"deerflow.compile.thread_id={session.thread_id}",
             "--label",
             f"deerflow.compile.attempt_id={attempt_id}",
+            *experiment_label_flags,
             "--network",
             self.config.network,
             "--add-host",
             "host.docker.internal:host-gateway",
             *proxy_flags,
+            *experiment_environment_flags,
             "-v",
             f"{host_recipe_dir}:{CONTAINER_REPRO_DIR}:ro",
             "-v",

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import tempfile
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from deerflow.compile.schemas import utc_now_iso
+
+LEDGER_VERSION = "1.0.0"
+LEDGER_CANONICALIZATION = "json-sort-keys-compact-utf8"
+
+_EVENT_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$")
+_EVIDENCE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*_[0-9a-f]{32}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_WINDOWS_PATH_RE = re.compile(r"(?i)(?:^|[^A-Za-z0-9_])(?:[A-Z]:[\\/]|\\\\)")
+_WSL_PATH_RE = re.compile(r"(?i)(?:^|[^A-Za-z0-9_])/mnt/[a-z](?:/|$)")
+_HOME_PATH_RE = re.compile(r"(?:^|[^A-Za-z0-9_])/(?:home|Users)/[^/\s]+/")
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._-]{12,}"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+_FORBIDDEN_KEYS = {
+    "api_key",
+    "authorization",
+    "command",
+    "command_text",
+    "content",
+    "credential_value",
+    "error_message",
+    "log_content",
+    "prompt",
+    "request_body",
+    "response",
+    "response_body",
+    "secret",
+    "secret_hash",
+    "stderr",
+    "stdout",
+}
+_ALLOWED_MODEL_ROLES = {"lead", "compiler", "system"}
+_ALLOWED_COMMAND_ROLES = {
+    "clone",
+    "inspect",
+    "dependency_setup",
+    "configure",
+    "build",
+    "artifact_stage",
+    "smoke",
+    "replay_delay",
+    "other",
+}
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+def new_evidence_id(prefix: str) -> str:
+    normalized = prefix.strip().lower()
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", normalized):
+        raise EvidenceError(f"Invalid evidence ID prefix: {prefix!r}")
+    return f"{normalized}_{uuid.uuid4().hex}"
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise EvidenceError(f"Evidence is not canonical JSON: {exc}") from exc
+    return encoded.encode("utf-8")
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _validate_id(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not _EVIDENCE_ID_RE.fullmatch(value):
+        raise EvidenceError(f"{path} must be a stable evidence ID")
+    return value
+
+
+def _validate_sha256(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not _SHA256_RE.fullmatch(value):
+        raise EvidenceError(f"{path} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _validate_safe_value(value: Any, path: str = "payload") -> None:
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, int):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise EvidenceError(f"{path} must be finite")
+        return
+    if isinstance(value, str):
+        if any(character in value for character in ("\0", "\r", "\n")):
+            raise EvidenceError(f"{path} contains a control character")
+        if ".compile-sessions" in value or _WINDOWS_PATH_RE.search(value) or _WSL_PATH_RE.search(value) or _HOME_PATH_RE.search(value):
+            raise EvidenceError(f"{path} contains a host path")
+        if any(pattern.search(value) for pattern in _SECRET_VALUE_PATTERNS):
+            raise EvidenceError(f"{path} contains a credential-like value")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_safe_value(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str) or not key:
+                raise EvidenceError(f"{path} contains an invalid key")
+            if key.lower() in _FORBIDDEN_KEYS:
+                raise EvidenceError(f"{path}.{key} is forbidden in experiment evidence")
+            _validate_safe_value(item, f"{path}.{key}")
+        return
+    raise EvidenceError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _validate_endpoint(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise EvidenceError("The experiment endpoint must be a credential-free HTTPS URL")
+    return value.rstrip("/")
+
+
+@dataclass(frozen=True)
+class ExperimentPolicy:
+    benchmark_id: str
+    manifest_sha256: str
+    case_id: str
+    condition: str
+    repetition: int
+    expected_repo_url: str
+    expected_commit_sha: str
+    compile_image: str
+    image_id: str
+    model_name: str
+    endpoint: str
+    credential_env: str
+    request_timeout_seconds: int
+    model_max_retries: int
+    compiler_max_turns: int
+    subagent_timeout_seconds: int
+    memory_enabled: bool
+    skills_enabled: bool
+    required_system_packages: tuple[str, ...]
+    cmake_arguments: tuple[str, ...]
+    configure_arguments: tuple[str, ...]
+    environment: tuple[tuple[str, str | None], ...]
+    minimum_replay_delay_seconds: int
+
+    def __post_init__(self) -> None:
+        _validate_sha256(self.manifest_sha256, "manifest_sha256")
+        if self.repetition < 1:
+            raise EvidenceError("repetition must be positive")
+        if self.request_timeout_seconds < 1 or self.model_max_retries < 0:
+            raise EvidenceError("invalid model timeout/retry policy")
+        if self.memory_enabled or self.skills_enabled:
+            raise EvidenceError("The C/C++ baseline requires Memory and Skills to be disabled")
+        if self.minimum_replay_delay_seconds < 0:
+            raise EvidenceError("minimum replay delay cannot be negative")
+        _validate_endpoint(self.endpoint)
+        _validate_safe_value(self.to_payload())
+
+    @property
+    def process_environment(self) -> dict[str, str | None]:
+        return dict(self.environment)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "benchmark_id": self.benchmark_id,
+            "manifest_sha256": self.manifest_sha256,
+            "case_id": self.case_id,
+            "condition": self.condition,
+            "repetition": self.repetition,
+            "expected_repo_url": self.expected_repo_url,
+            "expected_commit_sha": self.expected_commit_sha,
+            "compile_image": self.compile_image,
+            "image_id": self.image_id,
+            "model_name": self.model_name,
+            "endpoint": self.endpoint,
+            "credential_env": self.credential_env,
+            "request_timeout_seconds": self.request_timeout_seconds,
+            "model_max_retries": self.model_max_retries,
+            "compiler_max_turns": self.compiler_max_turns,
+            "subagent_timeout_seconds": self.subagent_timeout_seconds,
+            "memory_enabled": self.memory_enabled,
+            "skills_enabled": self.skills_enabled,
+            "required_system_packages": list(self.required_system_packages),
+            "cmake_arguments": list(self.cmake_arguments),
+            "configure_arguments": list(self.configure_arguments),
+            "environment": dict(self.environment),
+            "minimum_replay_delay_seconds": self.minimum_replay_delay_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class ActiveExperiment:
+    thread_id: str
+    experiment_id: str
+    physical_attempt_id: str
+    ledger: ExperimentLedger
+    policy: ExperimentPolicy
+
+
+_PATH_LOCKS: dict[Path, threading.RLock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+_ACTIVE_EXPERIMENTS: dict[str, ActiveExperiment] = {}
+_ACTIVE_EXPERIMENTS_GUARD = threading.RLock()
+
+
+def _path_lock(path: Path) -> threading.RLock:
+    resolved = path.resolve()
+    with _PATH_LOCKS_GUARD:
+        return _PATH_LOCKS.setdefault(resolved, threading.RLock())
+
+
+@contextmanager
+def _exclusive_sibling_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(f".{path.name}.lock")
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.write(descriptor, f"pid={os.getpid()}\n".encode("ascii"))
+        os.fsync(descriptor)
+        yield
+    except FileExistsError as exc:
+        raise EvidenceError(f"Experiment ledger lock already exists: {lock_path.name}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+class ExperimentLedger:
+    def __init__(self, path: Path, experiment_id: str, physical_attempt_id: str):
+        self.path = path
+        self.experiment_id = _validate_id(experiment_id, "experiment_id")
+        self.physical_attempt_id = _validate_id(physical_attempt_id, "physical_attempt_id")
+
+    @classmethod
+    def create(
+        cls,
+        path: Path,
+        *,
+        experiment_id: str,
+        physical_attempt_id: str,
+        context: dict[str, Any],
+    ) -> ExperimentLedger:
+        ledger = cls(path, experiment_id, physical_attempt_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _path_lock(path):
+            if path.exists():
+                raise EvidenceError("A physical attempt ledger already exists and cannot be overwritten")
+            ledger.append("experiment.started", context)
+        return ledger
+
+    @classmethod
+    def open(cls, path: Path) -> ExperimentLedger:
+        events = cls.verify_path(path)
+        if not events:
+            raise EvidenceError("Experiment ledger is empty")
+        first = events[0]
+        return cls(path, first["experiment_id"], first["physical_attempt_id"])
+
+    @staticmethod
+    def verify_path(path: Path) -> list[dict[str, Any]]:
+        if not path.is_file():
+            raise EvidenceError("Experiment ledger does not exist")
+        events: list[dict[str, Any]] = []
+        previous_digest: str | None = None
+        for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not raw_line.strip():
+                raise EvidenceError(f"Ledger line {line_number} is blank")
+            try:
+                event = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                raise EvidenceError(f"Ledger line {line_number} is not valid JSON") from exc
+            if not isinstance(event, dict):
+                raise EvidenceError(f"Ledger line {line_number} is not an object")
+            required = {
+                "ledger_version",
+                "canonicalization",
+                "sequence",
+                "occurred_at",
+                "event",
+                "experiment_id",
+                "physical_attempt_id",
+                "previous_event_sha256",
+                "payload",
+                "event_sha256",
+            }
+            if set(event) != required:
+                raise EvidenceError(f"Ledger line {line_number} has unexpected fields")
+            if event["ledger_version"] != LEDGER_VERSION or event["canonicalization"] != LEDGER_CANONICALIZATION:
+                raise EvidenceError(f"Ledger line {line_number} has an unsupported protocol identity")
+            if event["sequence"] != line_number:
+                raise EvidenceError(f"Ledger line {line_number} has a non-contiguous sequence")
+            if event["previous_event_sha256"] != previous_digest:
+                raise EvidenceError(f"Ledger line {line_number} breaks the hash chain")
+            _validate_id(event["experiment_id"], f"line {line_number}.experiment_id")
+            _validate_id(event["physical_attempt_id"], f"line {line_number}.physical_attempt_id")
+            if not isinstance(event["event"], str) or not _EVENT_TYPE_RE.fullmatch(event["event"]):
+                raise EvidenceError(f"Ledger line {line_number} has an invalid event type")
+            if not isinstance(event["payload"], dict):
+                raise EvidenceError(f"Ledger line {line_number}.payload must be an object")
+            _validate_safe_value(event["payload"], f"line {line_number}.payload")
+            actual_digest = event["event_sha256"]
+            _validate_sha256(actual_digest, f"line {line_number}.event_sha256")
+            unsigned = {key: value for key, value in event.items() if key != "event_sha256"}
+            if _sha256(unsigned) != actual_digest:
+                raise EvidenceError(f"Ledger line {line_number} has an invalid event digest")
+            previous_digest = actual_digest
+            events.append(event)
+        if events:
+            experiment_ids = {event["experiment_id"] for event in events}
+            attempt_ids = {event["physical_attempt_id"] for event in events}
+            if len(experiment_ids) != 1 or len(attempt_ids) != 1:
+                raise EvidenceError("One ledger may describe only one physical attempt")
+            if events[0]["event"] != "experiment.started":
+                raise EvidenceError("The first ledger event must be experiment.started")
+        return events
+
+    def read(self) -> list[dict[str, Any]]:
+        return self.verify_path(self.path)
+
+    def append(self, event: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if not _EVENT_TYPE_RE.fullmatch(event):
+            raise EvidenceError(f"Invalid evidence event type: {event!r}")
+        if not isinstance(payload, dict):
+            raise EvidenceError("Evidence payload must be an object")
+        _validate_safe_value(payload)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with _path_lock(self.path), _exclusive_sibling_lock(self.path):
+            existing = self.verify_path(self.path) if self.path.exists() else []
+            if not existing and event != "experiment.started":
+                raise EvidenceError("The first ledger event must be experiment.started")
+            if existing:
+                if existing[0]["experiment_id"] != self.experiment_id or existing[0]["physical_attempt_id"] != self.physical_attempt_id:
+                    raise EvidenceError("Ledger identity does not match the active physical attempt")
+                if any(item["event"] == "experiment.completed" for item in existing):
+                    raise EvidenceError("A completed experiment ledger is immutable")
+            unsigned = {
+                "ledger_version": LEDGER_VERSION,
+                "canonicalization": LEDGER_CANONICALIZATION,
+                "sequence": len(existing) + 1,
+                "occurred_at": utc_now_iso(),
+                "event": event,
+                "experiment_id": self.experiment_id,
+                "physical_attempt_id": self.physical_attempt_id,
+                "previous_event_sha256": existing[-1]["event_sha256"] if existing else None,
+                "payload": payload,
+            }
+            record = {**unsigned, "event_sha256": _sha256(unsigned)}
+            lines = [canonical_json_bytes(item).decode("utf-8") for item in existing]
+            lines.append(canonical_json_bytes(record).decode("utf-8"))
+            temporary_path: str | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    encoding="utf-8",
+                    dir=self.path.parent,
+                    prefix=f".{self.path.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                    newline="\n",
+                ) as fp:
+                    temporary_path = fp.name
+                    fp.write("\n".join(lines) + "\n")
+                    fp.flush()
+                    os.fsync(fp.fileno())
+                os.replace(temporary_path, self.path)
+                if os.name == "posix":
+                    directory_fd = os.open(self.path.parent, os.O_RDONLY)
+                    try:
+                        os.fsync(directory_fd)
+                    finally:
+                        os.close(directory_fd)
+            finally:
+                if temporary_path and os.path.exists(temporary_path):
+                    os.unlink(temporary_path)
+            return record
+
+
+def activate_experiment(
+    *,
+    thread_id: str,
+    experiment_id: str,
+    physical_attempt_id: str,
+    ledger: ExperimentLedger,
+    policy: ExperimentPolicy,
+) -> ActiveExperiment:
+    if not thread_id or any(character in thread_id for character in ("\0", "\r", "\n")):
+        raise EvidenceError("A safe thread_id is required to activate experiment evidence")
+    active = ActiveExperiment(
+        thread_id=thread_id,
+        experiment_id=_validate_id(experiment_id, "experiment_id"),
+        physical_attempt_id=_validate_id(physical_attempt_id, "physical_attempt_id"),
+        ledger=ledger,
+        policy=policy,
+    )
+    if ledger.experiment_id != active.experiment_id or ledger.physical_attempt_id != active.physical_attempt_id:
+        raise EvidenceError("Active experiment identity does not match its ledger")
+    with _ACTIVE_EXPERIMENTS_GUARD:
+        if thread_id in _ACTIVE_EXPERIMENTS:
+            raise EvidenceError("An experiment is already active for this thread")
+        _ACTIVE_EXPERIMENTS[thread_id] = active
+    return active
+
+
+def deactivate_experiment(thread_id: str) -> ActiveExperiment | None:
+    with _ACTIVE_EXPERIMENTS_GUARD:
+        return _ACTIVE_EXPERIMENTS.pop(thread_id, None)
+
+
+def get_active_experiment(thread_id: str | None) -> ActiveExperiment | None:
+    if not thread_id:
+        return None
+    with _ACTIVE_EXPERIMENTS_GUARD:
+        return _ACTIVE_EXPERIMENTS.get(thread_id)
+
+
+def record_experiment_event(thread_id: str | None, event: str, **payload: Any) -> dict[str, Any] | None:
+    active = get_active_experiment(thread_id)
+    if active is None:
+        return None
+    return active.ledger.append(event, payload)
+
+
+def request_thread_id(request: Any) -> str | None:
+    runtime = getattr(request, "runtime", None)
+    context = getattr(runtime, "context", None)
+    if isinstance(context, dict) and isinstance(context.get("thread_id"), str):
+        return context["thread_id"]
+    config = getattr(runtime, "config", None)
+    if isinstance(config, dict):
+        configurable = config.get("configurable")
+        if isinstance(configurable, dict) and isinstance(configurable.get("thread_id"), str):
+            return configurable["thread_id"]
+    return None
+
+
+def request_model_role(request: Any) -> str:
+    runtime = getattr(request, "runtime", None)
+    context = getattr(runtime, "context", None)
+    if isinstance(context, dict):
+        role = context.get("agent_name")
+        if role == "compiler":
+            return "compiler"
+        if isinstance(role, str) and role in _ALLOWED_MODEL_ROLES:
+            return role
+    return "lead"
+
+
+def request_model_name(request: Any, fallback: str) -> str:
+    model = getattr(request, "model", None)
+    for attribute in ("model_name", "model"):
+        value = getattr(model, attribute, None)
+        if isinstance(value, str) and value and len(value) <= 128:
+            _validate_safe_value(value, "model_name")
+            return value
+    return fallback
+
+
+def request_model_endpoint(request: Any) -> str | None:
+    model = getattr(request, "model", None)
+    candidates = [
+        getattr(model, "openai_api_base", None),
+        getattr(model, "base_url", None),
+    ]
+    for client_attribute in ("root_client", "client"):
+        client = getattr(model, client_attribute, None)
+        candidates.append(getattr(client, "base_url", None))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        value = str(candidate).rstrip("/")
+        try:
+            return _validate_endpoint(value)
+        except EvidenceError:
+            continue
+    return None
+
+
+def model_response_metadata(response: Any) -> tuple[str | None, dict[str, int | None]]:
+    candidates: list[Any] = []
+    if hasattr(response, "result"):
+        candidates.append(getattr(response, "result"))
+    candidates.append(response)
+    actual_model: str | None = None
+    usage = {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+    for candidate in candidates:
+        metadata = getattr(candidate, "response_metadata", None)
+        if isinstance(metadata, dict):
+            for key in ("model_name", "model"):
+                value = metadata.get(key)
+                if isinstance(value, str) and value and len(value) <= 128:
+                    actual_model = value
+                    break
+        usage_metadata = getattr(candidate, "usage_metadata", None)
+        if isinstance(usage_metadata, dict):
+            for key in usage:
+                value = usage_metadata.get(key)
+                if isinstance(value, int) and value >= 0:
+                    usage[key] = value
+        if actual_model is not None or any(value is not None for value in usage.values()):
+            break
+    return actual_model, usage
+
+
+def allowed_command_role(role: str | None) -> str:
+    if role is None:
+        return "other"
+    if role not in _ALLOWED_COMMAND_ROLES:
+        raise EvidenceError(f"Unsupported compile command role: {role!r}")
+    return role

--- a/backend/packages/harness/deerflow/compile/manager.py
+++ b/backend/packages/harness/deerflow/compile/manager.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from deerflow.compile.evidence import record_experiment_event
 from deerflow.compile.paths import (
     get_artifacts_dir,
     get_logs_dir,
@@ -242,6 +243,25 @@ class CompileSessionManager:
                 completed_at=command.completed_at,
                 exit_code=command.exit_code,
                 log_path=command.log_path,
+                command_id=command.command_id,
+                role=command.role,
+                timeout_seconds=command.timeout_seconds,
+                duration_seconds=command.duration_seconds,
+                timed_out=command.timed_out,
+                termination=command.termination,
+            )
+            record_experiment_event(
+                session.thread_id,
+                "command.completed",
+                command_id=command.command_id,
+                session_id=session.session_id,
+                role=command.role,
+                stage=command.stage,
+                exit_code=command.exit_code,
+                timeout_seconds=command.timeout_seconds,
+                duration_seconds=command.duration_seconds,
+                timed_out=command.timed_out,
+                termination=command.termination,
             )
         return session
 

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -12,11 +12,18 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path, PurePosixPath
-from shlex import quote
+from shlex import quote, split
 from typing import BinaryIO
 from urllib.parse import urlsplit
 
 from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSPACE_DIR, CompileDockerRuntime, ContainerCleanupResult, ReplayContainerHandle
+from deerflow.compile.evidence import (
+    EvidenceError,
+    allowed_command_role,
+    get_active_experiment,
+    new_evidence_id,
+    record_experiment_event,
+)
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.paths import get_replay_artifacts_dir, get_replay_logs_dir, get_replay_recipe_dir, get_replay_workspace_dir
 from deerflow.compile.schemas import (
@@ -105,7 +112,13 @@ def _session_lifecycle_fenced(session: CompileSession) -> bool:
     return session.finalized_at is not None or session.termination_requested_at is not None or session.status in _TERMINAL_SESSION_STATUSES
 
 
-def _abort_submit_for_lifecycle(session: CompileSession, *, stage: str) -> str:
+def _abort_submit_for_lifecycle(
+    session: CompileSession,
+    *,
+    stage: str,
+    submit_attempt_id: str | None = None,
+    supporting_command_id: str | None = None,
+) -> str:
     services = get_compile_services()
     status = session.termination_status or session.status
     if status not in _TERMINAL_SESSION_STATUSES:
@@ -118,6 +131,17 @@ def _abort_submit_for_lifecycle(session: CompileSession, *, stage: str) -> str:
         status=status,
         finalized_at=session.finalized_at,
         termination_requested_at=session.termination_requested_at,
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
+    )
+    record_experiment_event(
+        session.thread_id,
+        "submit.aborted",
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
+        session_id=session.session_id,
+        stage=stage,
+        status=status,
     )
     return json.dumps(
         {
@@ -126,6 +150,8 @@ def _abort_submit_for_lifecycle(session: CompileSession, *, stage: str) -> str:
             "candidate_status": "not_committed",
             "replay_status": "not_run",
             "replay_attempt_id": None,
+            "submit_attempt_id": submit_attempt_id,
+            "supporting_command_id": supporting_command_id,
             "image_id": session.image_id,
             "artifact_count": 0,
             "artifacts": [],
@@ -167,11 +193,24 @@ def append_command_record(
     exit_code: int,
     started_at: str,
     completed_at: str,
+    *,
+    role: str | None = None,
+    timeout_seconds: int | None = None,
+    duration_seconds: float | None = None,
+    timed_out: bool = False,
+    termination: str | None = None,
+    command_id: str | None = None,
 ) -> BuildCommandRecord:
     record = BuildCommandRecord(
         stage=stage,
         command=command,
         workdir=workdir,
+        command_id=command_id or new_evidence_id("command"),
+        role=allowed_command_role(role or stage if stage in {"clone", "inspect"} else role),
+        timeout_seconds=timeout_seconds,
+        duration_seconds=duration_seconds,
+        timed_out=timed_out,
+        termination=termination,
         started_at=started_at,
         completed_at=completed_at,
         exit_code=exit_code,
@@ -179,6 +218,53 @@ def append_command_record(
     )
     get_compile_services().manager.record_command(session, record)
     return record
+
+
+def _apply_experiment_dependencies(session: CompileSession) -> None:
+    active = get_active_experiment(session.thread_id)
+    if active is None or not active.policy.required_system_packages:
+        return
+    services = get_compile_services()
+    packages = " ".join(shell_quote(package) for package in active.policy.required_system_packages)
+    command = f"apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends {packages}"
+    timeout_seconds = 1200
+    started_at = utc_now_iso()
+    started_monotonic = time.monotonic()
+    result = services.runtime.exec(
+        session,
+        command,
+        workdir=CONTAINER_WORKSPACE_DIR,
+        timeout_seconds=timeout_seconds,
+        log_path=local_log_path(session, "000_benchmark_dependency_setup.log"),
+    )
+    completed_at = utc_now_iso()
+    append_command_record(
+        session,
+        "bash",
+        command,
+        CONTAINER_WORKSPACE_DIR,
+        result.log_path or local_log_path(session, "000_benchmark_dependency_setup.log"),
+        result.exit_code,
+        started_at,
+        completed_at,
+        role="dependency_setup",
+        timeout_seconds=timeout_seconds,
+        duration_seconds=round(time.monotonic() - started_monotonic, 6),
+        timed_out=result.exit_code == 124,
+        termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
+    )
+    if result.exit_code != 0:
+        services.manager.mark_session_status(session, "failed", error="Benchmark dependency setup failed.")
+        record_experiment_event(
+            session.thread_id,
+            "failure.recorded",
+            failure_id=new_evidence_id("failure"),
+            session_id=session.session_id,
+            domain="build",
+            classification="dependency_setup_failed",
+            primary=True,
+        )
+        raise RuntimeError("Benchmark dependency setup failed before compilation")
 
 
 def prepare_compile_session_impl(
@@ -191,6 +277,10 @@ def prepare_compile_session_impl(
     run_id: str | None = None,
 ) -> CompileSession:
     services = get_compile_services()
+    active = get_active_experiment(thread_id)
+    if active is not None:
+        if repo_url.rstrip("/") != active.policy.expected_repo_url.rstrip("/"):
+            raise EvidenceError("Compile repository does not match the active benchmark case")
     session_id = uuid.uuid4().hex[:12]
     with services.manager.session_lock(thread_id, session_id):
         session = services.manager.create_session(
@@ -211,6 +301,19 @@ def prepare_compile_session_impl(
             task_description=task_description,
         )
         services.runtime.create_container(session)
+        if active is not None:
+            if session.image != active.policy.compile_image or session.image_id != active.policy.image_id:
+                services.runtime.stop_and_remove_container(session)
+                raise EvidenceError("Compile container identity does not match the active benchmark policy")
+            record_experiment_event(
+                thread_id,
+                "session.bound",
+                session_id=session.session_id,
+                repo_url=session.repo_url,
+                image=session.image,
+                image_id=session.image_id,
+            )
+            _apply_experiment_dependencies(session)
         services.manager.save_session(session)
         services.manager.mark_session_status(session, "ready")
         services.manager.log_event(
@@ -253,16 +356,33 @@ def clone_repository_impl(
 
     repo_dir = Path(session.leadagent_repo_dir)
     effective_branch = branch if branch is not None else session.branch
+    active = get_active_experiment(session.thread_id)
+    expected_commit_sha = active.policy.expected_commit_sha if active is not None else None
+    if active is not None and repo_url.rstrip("/") != active.policy.expected_repo_url.rstrip("/"):
+        raise EvidenceError("Clone repository does not match the active benchmark case")
     session.repo_url = repo_url
     session.branch = effective_branch
     services.manager.save_session(session)
 
-    clone_command_parts = ["git clone", f"--depth {depth}"]
-    if effective_branch:
-        clone_command_parts.append(f"--branch {shell_quote(effective_branch)}")
-    clone_command_parts.append(f"{shell_quote(repo_url)} {shell_quote(CONTAINER_REPO_DIR)}")
-    clone_command = " ".join(clone_command_parts)
-    attempt_command = f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)} && {clone_command}"
+    if expected_commit_sha:
+        object_format = "sha256" if len(expected_commit_sha) == 64 else "sha1"
+        attempt_command = " && ".join(
+            (
+                f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)}",
+                f"git init --object-format={object_format} {shell_quote(CONTAINER_REPO_DIR)}",
+                f"git -C {shell_quote(CONTAINER_REPO_DIR)} remote add origin {shell_quote(repo_url)}",
+                f"git -C {shell_quote(CONTAINER_REPO_DIR)} fetch --depth {max(1, depth)} origin {shell_quote(expected_commit_sha)}",
+                f"git -C {shell_quote(CONTAINER_REPO_DIR)} checkout --detach FETCH_HEAD",
+                f'test "$(git -C {shell_quote(CONTAINER_REPO_DIR)} rev-parse HEAD)" = {shell_quote(expected_commit_sha)}',
+            )
+        )
+    else:
+        clone_command_parts = ["git clone", f"--depth {depth}"]
+        if effective_branch:
+            clone_command_parts.append(f"--branch {shell_quote(effective_branch)}")
+        clone_command_parts.append(f"{shell_quote(repo_url)} {shell_quote(CONTAINER_REPO_DIR)}")
+        clone_command = " ".join(clone_command_parts)
+        attempt_command = f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)} && {clone_command}"
 
     retries = max(1, max_retries)
     last_result: CommandResult | None = None
@@ -282,6 +402,7 @@ def clone_repository_impl(
             target_dir=str(repo_dir),
         )
         started_at = utc_now_iso()
+        started_monotonic = time.monotonic()
 
         result = services.runtime.exec(
             session,
@@ -299,6 +420,11 @@ def clone_repository_impl(
             result.exit_code,
             started_at,
             completed_at,
+            role="clone",
+            timeout_seconds=600,
+            duration_seconds=round(time.monotonic() - started_monotonic, 6),
+            timed_out=result.exit_code == 124,
+            termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
         )
         last_result = result
 
@@ -311,6 +437,9 @@ def clone_repository_impl(
             if sha.exit_code == 0:
                 session.commit_sha = (sha.stdout or "").strip()
                 services.manager.save_session(session)
+            if expected_commit_sha and session.commit_sha != expected_commit_sha:
+                services.manager.mark_session_status(session, "failed", error="Cloned commit does not match the benchmark case.")
+                raise EvidenceError("Cloned commit does not match the active benchmark policy")
 
             services.manager.log_event(
                 session,
@@ -760,6 +889,71 @@ def _record_submit_check(
     )
 
 
+def _artifact_evidence_snapshot(artifacts: list[BuildArtifact]) -> list[dict]:
+    snapshots: list[dict] = []
+    for artifact in artifacts:
+        try:
+            relative_path = _artifact_relative_path(artifact)
+        except ValueError:
+            relative_path = None
+        snapshots.append(
+            {
+                "path": relative_path,
+                "artifact_type": artifact.artifact_type,
+                "size_bytes": artifact.size_bytes,
+                "sha256": artifact.sha256,
+                "smoke_exit_code": artifact.smoke_exit_code,
+                "smoke_output_sha256": artifact.smoke_output_sha256,
+            }
+        )
+    return snapshots
+
+
+def _check_evidence_snapshot(checks: list[VerificationCheck]) -> list[dict]:
+    return [
+        {
+            "name": check.name,
+            "passed": check.passed,
+            "exit_code": check.exit_code,
+        }
+        for check in checks
+    ]
+
+
+def _replay_artifact_evidence_snapshot(
+    artifacts: list[ReplayArtifactComparison],
+) -> list[dict]:
+    return [
+        {
+            "path": artifact.path,
+            "expected_type": artifact.expected_type,
+            "actual_type": artifact.actual_type,
+            "expected_size_bytes": artifact.expected_size_bytes,
+            "actual_size_bytes": artifact.actual_size_bytes,
+            "expected_sha256": artifact.expected_sha256,
+            "actual_sha256": artifact.actual_sha256,
+            "expected_smoke_exit_code": artifact.expected_smoke_exit_code,
+            "actual_smoke_exit_code": artifact.actual_smoke_exit_code,
+            "expected_smoke_output_sha256": artifact.expected_smoke_output_sha256,
+            "actual_smoke_output_sha256": artifact.actual_smoke_output_sha256,
+            "passed": artifact.passed,
+            "mismatches": list(artifact.mismatches),
+        }
+        for artifact in artifacts
+    ]
+
+
+def _record_replay_failure(
+    attempt: ReplayVerificationResult,
+    classification: str,
+) -> None:
+    if attempt.primary_failure_classification is None:
+        attempt.primary_failure_classification = classification
+    elif classification != attempt.primary_failure_classification and classification not in attempt.secondary_failure_classifications:
+        attempt.secondary_failure_classifications.append(classification)
+    attempt.failure_classification = attempt.primary_failure_classification
+
+
 def _commit_submit_verification(
     *,
     session: CompileSession,
@@ -781,14 +975,98 @@ def _commit_submit_verification(
         return True
 
 
-def submit_build_result_impl(*, session: CompileSession) -> str:
+def _command_contains_arguments(command: str, expected: tuple[str, ...]) -> bool:
+    if not expected:
+        return True
+    try:
+        tokens = split(command, posix=True)
+    except ValueError:
+        return False
+    token_iterator = iter(tokens)
+    return all(any(token == argument for token in token_iterator) for argument in expected)
+
+
+def _experiment_submit_constraints(
+    session: CompileSession,
+    supporting_command_id: str | None,
+) -> tuple[bool, list[str]]:
+    active = get_active_experiment(session.thread_id)
+    if active is None:
+        return True, []
+    failures: list[str] = []
+    supporting = next((command for command in session.commands if command.command_id == supporting_command_id), None)
+    if supporting is None:
+        failures.append("supporting_command_missing")
+    elif supporting.role != "build":
+        failures.append("supporting_command_role_invalid")
+    elif supporting.exit_code != 0 or supporting.timed_out:
+        failures.append("supporting_command_not_successful")
+
+    successful_commands = [command for command in session.commands if command.exit_code == 0 and not command.timed_out]
+    if active.policy.required_system_packages and not any(command.role == "dependency_setup" for command in successful_commands):
+        failures.append("dependency_setup_not_observed")
+    if active.policy.cmake_arguments and not any(command.role == "configure" and _command_contains_arguments(command.command, active.policy.cmake_arguments) for command in successful_commands):
+        failures.append("cmake_arguments_not_observed")
+    if active.policy.configure_arguments and not any(command.role == "configure" and _command_contains_arguments(command.command, active.policy.configure_arguments) for command in successful_commands):
+        failures.append("configure_arguments_not_observed")
+    return not failures, failures
+
+
+def _apply_experiment_replay_delay(session: CompileSession) -> None:
+    active = get_active_experiment(session.thread_id)
+    if active is None or active.policy.minimum_replay_delay_seconds <= 0:
+        return
     services = get_compile_services()
+    seconds = active.policy.minimum_replay_delay_seconds
+    command = f"sleep {seconds}"
+    timeout_seconds = seconds + 10
+    started_at = utc_now_iso()
+    started_monotonic = time.monotonic()
+    result = services.runtime.exec(
+        session,
+        command,
+        workdir=CONTAINER_WORKSPACE_DIR,
+        timeout_seconds=timeout_seconds,
+        log_path=local_log_path(session, f"{len(session.commands) + 1:03d}_benchmark_replay_delay.log"),
+    )
+    append_command_record(
+        session,
+        "bash",
+        command,
+        CONTAINER_WORKSPACE_DIR,
+        result.log_path or local_log_path(session, f"{len(session.commands) + 1:03d}_benchmark_replay_delay.log"),
+        result.exit_code,
+        started_at,
+        utc_now_iso(),
+        role="replay_delay",
+        timeout_seconds=timeout_seconds,
+        duration_seconds=round(time.monotonic() - started_monotonic, 6),
+        timed_out=result.exit_code == 124,
+        termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
+    )
+    if result.exit_code != 0:
+        raise RuntimeError("Benchmark replay delay could not be established")
+
+
+def submit_build_result_impl(
+    *,
+    session: CompileSession,
+    supporting_command_id: str | None = None,
+) -> str:
+    services = get_compile_services()
+    submit_attempt_id = new_evidence_id("submit")
     with services.manager.session_lock(session.thread_id, session.session_id):
         current = _load_authoritative_session(session)
         if _session_lifecycle_fenced(current):
             session.__dict__.update(current.__dict__)
-            return _abort_submit_for_lifecycle(session, stage="entry")
+            return _abort_submit_for_lifecycle(
+                session,
+                stage="entry",
+                submit_attempt_id=submit_attempt_id,
+                supporting_command_id=supporting_command_id,
+            )
         session.__dict__.update(current.__dict__)
+    constraints_passed, constraint_failures = _experiment_submit_constraints(session, supporting_command_id)
     submit_index = len(session.commands) + 1
     summary_log_path = local_log_path(session, f"{submit_index:03d}_submit.log")
     while Path(summary_log_path).exists():
@@ -800,11 +1078,39 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         leadagent_artifacts_dir=session.leadagent_artifacts_dir,
         container_artifacts_dir="/artifacts",
         log_path=summary_log_path,
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
     )
+    record_experiment_event(
+        session.thread_id,
+        "submit.started",
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
+        session_id=session.session_id,
+        command_cutoff_before_delay=len(session.commands),
+    )
+    try:
+        _apply_experiment_replay_delay(session)
+    except RuntimeError:
+        constraints_passed = False
+        constraint_failures.append("minimum_replay_delay_not_observed")
     discovered_files = sorted(_list_leadagent_artifact_files(session), key=lambda p: p.as_posix())
     checks: list[VerificationCheck] = []
     artifacts: list[BuildArtifact] = []
     notes: list[str] = []
+
+    if not constraints_passed:
+        message = "Error: Verification failed. Benchmark launch constraints were not completely observed."
+        notes.append(message)
+        _record_submit_check(
+            checks=checks,
+            name="benchmark_constraints",
+            target="experiment-policy",
+            passed=False,
+            summary=message,
+            expected="applied",
+            actual=list(constraint_failures),
+        )
 
     if not discovered_files:
         notes.append("Error: Verification failed. No files were found in /artifacts. Copy your final build outputs into /artifacts and submit again.")
@@ -938,11 +1244,22 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
                     session.__dict__.update(current.__dict__)
 
     if candidate_lifecycle_fenced:
-        return _abort_submit_for_lifecycle(session, stage="candidate_checkpoint")
+        return _abort_submit_for_lifecycle(
+            session,
+            stage="candidate_checkpoint",
+            submit_attempt_id=submit_attempt_id,
+            supporting_command_id=supporting_command_id,
+        )
 
     candidate_failed_checks = sum(1 for check in checks if not check.passed)
     if candidate_status == "passed" and artifacts and candidate_failed_checks == 0:
-        replay_attempt = verify_clean_replay_impl(session=session)
+        if get_active_experiment(session.thread_id) is None:
+            replay_attempt = verify_clean_replay_impl(session=session)
+        else:
+            replay_attempt = verify_clean_replay_impl(
+                session=session,
+                submit_attempt_id=submit_attempt_id,
+            )
         replay_passed = replay_attempt.status == "passed" and replay_attempt.cleanup_succeeded is True
         replay_summary = (
             "Candidate recipe rebuilt matching artifacts in a clean container and cleanup succeeded."
@@ -983,7 +1300,12 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         status=target_status,
         error=target_error,
     ):
-        return _abort_submit_for_lifecycle(session, stage="final_checkpoint")
+        return _abort_submit_for_lifecycle(
+            session,
+            stage="final_checkpoint",
+            submit_attempt_id=submit_attempt_id,
+            supporting_command_id=supporting_command_id,
+        )
 
     payload = {
         "exit_code": 0 if status == "passed" else 1,
@@ -991,6 +1313,8 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         "candidate_status": candidate_status,
         "replay_status": replay_attempt.status if replay_attempt else "not_run",
         "replay_attempt_id": replay_attempt.attempt_id if replay_attempt else None,
+        "submit_attempt_id": submit_attempt_id,
+        "supporting_command_id": supporting_command_id,
         "image_id": session.image_id,
         "artifact_count": len(artifacts),
         "artifacts": [
@@ -1017,7 +1341,61 @@ def submit_build_result_impl(*, session: CompileSession) -> str:
         candidate_status=candidate_status,
         replay_status=replay_attempt.status if replay_attempt else "not_run",
         replay_attempt_id=replay_attempt.attempt_id if replay_attempt else None,
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
     )
+    supporting_command = next(
+        (command for command in session.commands if command.command_id == supporting_command_id),
+        None,
+    )
+    supporting_command_passed = supporting_command is not None and supporting_command.role == "build" and supporting_command.exit_code == 0 and not supporting_command.timed_out
+    replay_passed = replay_attempt is not None and replay_attempt.status == "passed" and replay_attempt.cleanup_succeeded is True
+    record_experiment_event(
+        session.thread_id,
+        "submit.completed",
+        submit_attempt_id=submit_attempt_id,
+        supporting_command_id=supporting_command_id,
+        session_id=session.session_id,
+        status=status,
+        candidate_status=candidate_status,
+        command_cutoff=len(session.commands),
+        command_ids=[command.command_id for command in session.commands],
+        artifacts=_artifact_evidence_snapshot(artifacts),
+        checks=_check_evidence_snapshot(checks),
+        recipe_sha256=(replay_attempt.recipe_sha256 if replay_attempt else None),
+        replay=(
+            {
+                "replay_attempt_id": replay_attempt.attempt_id,
+                "status": replay_attempt.status,
+                "primary_failure_classification": replay_attempt.primary_failure_classification,
+                "secondary_failure_classifications": list(replay_attempt.secondary_failure_classifications),
+                "cleanup_succeeded": replay_attempt.cleanup_succeeded,
+            }
+            if replay_attempt
+            else None
+        ),
+        gates={
+            "exit_code": supporting_command_passed,
+            "candidate_only": candidate_status == "passed",
+            "replay_ready": replay_attempt is not None and bool(replay_attempt.recipe_sha256),
+            "clean_replay": replay_passed,
+            "delivered": None,
+        },
+    )
+    if status != "passed":
+        primary_classification = replay_attempt.primary_failure_classification if replay_attempt is not None else (constraint_failures[0] if constraint_failures else "candidate_verification_failed")
+        record_experiment_event(
+            session.thread_id,
+            "failure.recorded",
+            failure_id=new_evidence_id("failure"),
+            submit_attempt_id=submit_attempt_id,
+            replay_attempt_id=(replay_attempt.attempt_id if replay_attempt else None),
+            session_id=session.session_id,
+            domain="verification",
+            classification=primary_classification,
+            primary=True,
+            secondary_classifications=(list(replay_attempt.secondary_failure_classifications) if replay_attempt else []),
+        )
 
     if status == "passed":
         services.manager.log_event(
@@ -1425,7 +1803,10 @@ def _merge_authoritative_replay_cancellation(
         if note not in attempt.notes:
             attempt.notes.append(note)
     attempt.status = "cancelled"
-    attempt.failure_classification = authoritative.failure_classification or "cancelled"
+    authoritative_primary = authoritative.primary_failure_classification or authoritative.failure_classification or "cancelled"
+    _record_replay_failure(attempt, authoritative_primary)
+    for classification in authoritative.secondary_failure_classifications:
+        _record_replay_failure(attempt, classification)
 
 
 def _persist_replay_attempt(
@@ -1447,7 +1828,7 @@ def _persist_replay_attempt(
         else:
             if _session_lifecycle_fenced(current):
                 attempt.status = "cancelled"
-                attempt.failure_classification = attempt.failure_classification or "session_terminated"
+                _record_replay_failure(attempt, "session_terminated")
                 attempt.cleanup_succeeded = attempt.cleanup_succeeded if attempt.cleanup_succeeded is not None else True
                 session.__dict__.update(current.__dict__)
                 return attempt
@@ -1455,7 +1836,7 @@ def _persist_replay_attempt(
         if _session_lifecycle_fenced(current):
             if existing_attempt is not None and existing_attempt.status != "cancelled":
                 attempt.status = "cancelled"
-                attempt.failure_classification = "session_terminated"
+                _record_replay_failure(attempt, "session_terminated")
             if current.finalized_at is not None:
                 session.__dict__.update(current.__dict__)
                 return attempt
@@ -1467,6 +1848,7 @@ def _persist_replay_attempt(
 def verify_clean_replay_impl(
     *,
     session: CompileSession,
+    submit_attempt_id: str | None = None,
     timeout_seconds: int | None = None,
 ) -> ReplayVerificationResult:
     services = get_compile_services()
@@ -1474,7 +1856,7 @@ def verify_clean_replay_impl(
     effective_timeout = max(1, timeout_seconds or configured_timeout)
     started_monotonic = time.monotonic()
     deadline = started_monotonic + effective_timeout
-    attempt_id = uuid.uuid4().hex[:12]
+    attempt_id = new_evidence_id("replay")
     with services.manager.session_lock(session.thread_id, session.session_id):
         current = _load_authoritative_session(session)
         session.__dict__.update(current.__dict__)
@@ -1485,11 +1867,12 @@ def verify_clean_replay_impl(
             image_id=session.image_id or "",
             commit_sha=session.commit_sha or "",
             recipe_sha256="",
+            submit_attempt_id=submit_attempt_id,
             timeout_seconds=effective_timeout,
         )
         if _session_lifecycle_fenced(session):
             attempt.status = "cancelled"
-            attempt.failure_classification = "session_terminated"
+            _record_replay_failure(attempt, "session_terminated")
             attempt.cleanup_succeeded = True
             attempt.completed_at = utc_now_iso()
             attempt.duration_seconds = round(time.monotonic() - started_monotonic, 6)
@@ -1502,6 +1885,17 @@ def verify_clean_replay_impl(
         "replay.started",
         attempt_id=attempt_id,
         image=session.image,
+        image_id=session.image_id,
+        commit_sha=session.commit_sha,
+        timeout_seconds=effective_timeout,
+        submit_attempt_id=submit_attempt_id,
+    )
+    record_experiment_event(
+        session.thread_id,
+        "replay.started",
+        replay_attempt_id=attempt_id,
+        submit_attempt_id=submit_attempt_id,
+        session_id=session.session_id,
         image_id=session.image_id,
         commit_sha=session.commit_sha,
         timeout_seconds=effective_timeout,
@@ -1585,7 +1979,7 @@ def verify_clean_replay_impl(
                     _merge_authoritative_replay_cancellation(attempt, authoritative)
                 if attempt.status != "cancelled":
                     attempt.status = "cancelled"
-                    attempt.failure_classification = "session_terminated"
+                    _record_replay_failure(attempt, "session_terminated")
                 current.replay_attempts = [attempt if item.attempt_id == attempt.attempt_id else item for item in current.replay_attempts]
                 if current.finalized_at is None:
                     services.manager.save_session(current, allow_lifecycle_fenced=True)
@@ -1649,16 +2043,16 @@ def verify_clean_replay_impl(
                 "Replay artifacts did not match the accepted build.",
             )
     except _ReplayVerificationFailure as exc:
-        attempt.failure_classification = exc.classification
+        _record_replay_failure(attempt, exc.classification)
         attempt.notes.append(str(exc))
     except subprocess.TimeoutExpired as exc:
-        attempt.failure_classification = "timeout"
+        _record_replay_failure(attempt, "timeout")
         attempt.notes.append(f"Docker replay operation timed out: {exc}")
     except Exception as exc:
-        attempt.failure_classification = "internal_error"
+        _record_replay_failure(attempt, "internal_error")
         attempt.notes.append(f"Clean replay verification failed: {exc}")
     except BaseException as exc:
-        attempt.failure_classification = "cancelled"
+        _record_replay_failure(attempt, "cancelled")
         attempt.notes.append(f"Clean replay was cancelled by {type(exc).__name__}.")
         pending_base_exception = exc
     finally:
@@ -1686,14 +2080,14 @@ def verify_clean_replay_impl(
             actual={"stopped": cleanup_result.stopped, "removed": cleanup_result.removed},
         )
         if not attempt.cleanup_succeeded:
-            attempt.failure_classification = "cleanup_failed"
+            _record_replay_failure(attempt, "cleanup_failed")
         if pending_base_exception is not None:
             attempt.status = "cancelled"
-        elif attempt.failure_classification == "timeout":
+        elif attempt.primary_failure_classification == "timeout":
             attempt.status = "timed_out"
-        elif attempt.failure_classification == "cancelled":
+        elif attempt.primary_failure_classification == "cancelled":
             attempt.status = "cancelled"
-        elif attempt.failure_classification is None and attempt.cleanup_succeeded:
+        elif attempt.primary_failure_classification is None and attempt.cleanup_succeeded:
             attempt.status = "passed"
         else:
             attempt.status = "failed"
@@ -1713,6 +2107,28 @@ def verify_clean_replay_impl(
             image_id=attempt.image_id,
             recipe_sha256=attempt.recipe_sha256,
             completed_by="replay_worker",
+            submit_attempt_id=submit_attempt_id,
+            primary_failure_classification=attempt.primary_failure_classification,
+            secondary_failure_classifications=attempt.secondary_failure_classifications,
+        )
+        record_experiment_event(
+            session.thread_id,
+            "replay.completed",
+            replay_attempt_id=attempt.attempt_id,
+            submit_attempt_id=submit_attempt_id,
+            session_id=session.session_id,
+            status=attempt.status,
+            exit_code=attempt.exit_code,
+            cleanup_succeeded=attempt.cleanup_succeeded,
+            duration_seconds=attempt.duration_seconds,
+            timeout_seconds=attempt.timeout_seconds,
+            image_id=attempt.image_id,
+            commit_sha=attempt.commit_sha,
+            recipe_sha256=attempt.recipe_sha256 or None,
+            primary_failure_classification=attempt.primary_failure_classification,
+            secondary_failure_classifications=list(attempt.secondary_failure_classifications),
+            checks=_check_evidence_snapshot(attempt.checks),
+            artifacts=_replay_artifact_evidence_snapshot(attempt.artifacts),
         )
     if pending_base_exception is not None:
         raise pending_base_exception
@@ -1840,6 +2256,22 @@ def finalize_compile_session_impl(
                 generate_repro_bundle_requested=generate_repro_bundle,
                 replay_verified=replay_verified,
             )
+            latest_replay = current.replay_attempts[-1] if current.replay_attempts else None
+            delivered = status == "completed" and replay_verified
+            record_experiment_event(
+                current.thread_id,
+                "delivery.completed",
+                session_id=current.session_id,
+                submit_attempt_id=(latest_replay.submit_attempt_id if latest_replay else None),
+                replay_attempt_id=(latest_replay.attempt_id if latest_replay else None),
+                status=status,
+                delivered=delivered,
+                replay_verified=replay_verified,
+                artifact_count=len(current.artifacts),
+                artifacts=_artifact_evidence_snapshot(current.artifacts),
+                primary_failure_classification=(latest_replay.primary_failure_classification if latest_replay else (None if delivered else "delivery_rejected")),
+                secondary_failure_classifications=(list(latest_replay.secondary_failure_classifications) if latest_replay else []),
+            )
 
         session.__dict__.update(current.__dict__)
         return session
@@ -1871,7 +2303,7 @@ def _cleanup_pending_replay_containers(session: CompileSession) -> ContainerClea
         attempt.cleanup_succeeded = cleanup_result.succeeded and cleanup_result.removed
         if was_active:
             attempt.status = "cancelled"
-            attempt.failure_classification = attempt.failure_classification or "cancelled"
+            _record_replay_failure(attempt, "cancelled")
             attempt.completed_at = attempt.completed_at or utc_now_iso()
             if attempt.duration_seconds is None:
                 try:
@@ -1883,6 +2315,8 @@ def _cleanup_pending_replay_containers(session: CompileSession) -> ContainerClea
             completed_attempts.append((attempt, "parent_cleanup"))
         elif previous_cleanup_succeeded is not True and attempt.cleanup_succeeded:
             completed_attempts.append((attempt, "parent_cleanup_retry"))
+        if not attempt.cleanup_succeeded:
+            _record_replay_failure(attempt, "cleanup_failed")
         _record_replay_check(
             attempt,
             name="parent_container_cleanup",
@@ -1912,6 +2346,21 @@ def _cleanup_pending_replay_containers(session: CompileSession) -> ContainerClea
             image_id=attempt.image_id,
             recipe_sha256=attempt.recipe_sha256,
             completed_by=completed_by,
+            submit_attempt_id=attempt.submit_attempt_id,
+            primary_failure_classification=attempt.primary_failure_classification,
+            secondary_failure_classifications=attempt.secondary_failure_classifications,
+        )
+        record_experiment_event(
+            session.thread_id,
+            "replay.reconciled",
+            replay_attempt_id=attempt.attempt_id,
+            submit_attempt_id=attempt.submit_attempt_id,
+            session_id=session.session_id,
+            status=attempt.status,
+            cleanup_succeeded=attempt.cleanup_succeeded,
+            completed_by=completed_by,
+            primary_failure_classification=attempt.primary_failure_classification,
+            secondary_failure_classifications=list(attempt.secondary_failure_classifications),
         )
     return ContainerCleanupResult(
         succeeded=all(result.succeeded for result in cleanup_results),

--- a/backend/packages/harness/deerflow/compile/schemas.py
+++ b/backend/packages/harness/deerflow/compile/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,6 +16,12 @@ class BuildCommandRecord:
     stage: str
     command: str
     workdir: str
+    command_id: str = field(default_factory=lambda: f"command_{uuid.uuid4().hex}")
+    role: str = "other"
+    timeout_seconds: int | None = None
+    duration_seconds: float | None = None
+    timed_out: bool = False
+    termination: str | None = None
     started_at: str = field(default_factory=utc_now_iso)
     completed_at: str | None = None
     exit_code: int | None = None
@@ -89,6 +96,9 @@ class ReplayVerificationResult:
     image_id: str
     commit_sha: str
     recipe_sha256: str
+    submit_attempt_id: str | None = None
+    primary_failure_classification: str | None = None
+    secondary_failure_classifications: list[str] = field(default_factory=list)
     timeout_seconds: int | None = None
     started_at: str = field(default_factory=utc_now_iso)
     completed_at: str | None = None

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -2,6 +2,7 @@ import logging
 
 from langchain.chat_models import BaseChatModel
 
+from deerflow.compile.evidence import EvidenceError, get_active_experiment
 from deerflow.config import get_app_config
 from deerflow.reflection import resolve_class
 from deerflow.tracing import build_tracing_callbacks
@@ -39,9 +40,14 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
     Returns:
         A chat model instance.
     """
+    experiment_thread_id = kwargs.pop("experiment_thread_id", None)
+    experiment_role = kwargs.pop("experiment_role", None)
+    active = get_active_experiment(experiment_thread_id)
     config = get_app_config()
     if name is None:
         name = config.models[0].name
+    if active is not None and name != active.policy.model_name:
+        raise EvidenceError("Model fallback is forbidden while a benchmark experiment is active")
     model_config = config.get_model_config(name)
     if model_config is None:
         raise ValueError(f"Model {name} not found in config") from None
@@ -60,6 +66,25 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
             "supports_vision",
         },
     )
+    if active is not None:
+        configured_model = model_settings_from_config.get("model")
+        configured_endpoint = model_settings_from_config.get(
+            "base_url",
+            model_settings_from_config.get("openai_api_base"),
+        )
+        if configured_model != active.policy.model_name:
+            raise EvidenceError("Configured provider model does not match the benchmark policy")
+        if configured_endpoint is None or str(configured_endpoint).rstrip("/") != active.policy.endpoint:
+            raise EvidenceError("Configured provider endpoint does not match the benchmark policy")
+        model_settings_from_config["request_timeout"] = float(active.policy.request_timeout_seconds)
+        # Provider retries are opaque. The evidence middleware owns all
+        # physical retry attempts for an active experiment.
+        model_settings_from_config["max_retries"] = 0
+        logger.info(
+            "Applied frozen benchmark model policy: role=%s timeout=%ss retries=0",
+            experiment_role or "unknown",
+            active.policy.request_timeout_seconds,
+        )
     # Compute effective when_thinking_enabled by merging in the `thinking` shortcut field.
     # The `thinking` shortcut is equivalent to setting when_thinking_enabled["thinking"].
     has_thinking_settings = (model_config.when_thinking_enabled is not None) or (model_config.thinking is not None)

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -203,7 +203,12 @@ class SubagentExecutor:
         from deerflow.agents.thread_state import ThreadState
 
         model_name = _get_model_name(self.config, self.parent_model)
-        model = create_chat_model(name=model_name, thinking_enabled=False)
+        model = create_chat_model(
+            name=model_name,
+            thinking_enabled=False,
+            experiment_thread_id=self.thread_id,
+            experiment_role=self.config.name,
+        )
 
         from deerflow.agents.middlewares.tool_error_handling_middleware import build_subagent_runtime_middlewares
 
@@ -254,6 +259,7 @@ class SubagentExecutor:
             if self.thread_id:
                 run_config["configurable"] = {"thread_id": self.thread_id}
                 context["thread_id"] = self.thread_id
+            context["agent_name"] = self.config.name
 
             final_state = None
 

--- a/backend/packages/harness/deerflow/tools/bound_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/bound_compile_tools.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import subprocess
+import time
 from collections import deque
 
 from langchain.tools import tool
 
+from deerflow.compile.evidence import allowed_command_role, new_evidence_id
 from deerflow.compile.operations import get_bound_session, get_compile_services, submit_build_result_impl
 from deerflow.compile.schemas import BuildCommandRecord, CommandResult, CompileSession, utc_now_iso
 
@@ -31,20 +33,30 @@ def _record_bash_command(
     completed_at: str,
     exit_code: int,
     log_path: str,
-) -> None:
+    command_id: str,
+    command_role: str,
+    timeout_seconds: int,
+    duration_seconds: float,
+    timed_out: bool,
+) -> BuildCommandRecord:
     services = get_compile_services()
-    services.manager.record_command(
-        session,
-        BuildCommandRecord(
-            stage="bash",
-            command=command,
-            workdir=workdir,
-            started_at=started_at,
-            completed_at=completed_at,
-            exit_code=exit_code,
-            log_path=log_path,
-        ),
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir=workdir,
+        command_id=command_id,
+        role=command_role,
+        timeout_seconds=timeout_seconds,
+        duration_seconds=duration_seconds,
+        timed_out=timed_out,
+        termination="timeout" if timed_out else ("failed" if exit_code != 0 else "completed"),
+        started_at=started_at,
+        completed_at=completed_at,
+        exit_code=exit_code,
+        log_path=log_path,
     )
+    services.manager.record_command(session, record)
+    return record
 
 
 def _run_container_bash_impl(
@@ -53,9 +65,12 @@ def _run_container_bash_impl(
     command: str,
     timeout_seconds: int = 1200,
     workdir: str | None = None,
+    command_role: str = "other",
 ) -> tuple[CommandResult, str]:
     services = get_compile_services()
     effective_workdir = workdir or "/workspace/repo"
+    effective_role = allowed_command_role(command_role)
+    command_id = new_evidence_id("command")
     log_path = str(services.manager.local_logs_dir(session) / f"{len(session.commands) + 1:03d}_bash.log")
 
     services.manager.log_event(
@@ -65,8 +80,11 @@ def _run_container_bash_impl(
         workdir=effective_workdir,
         timeout_seconds=timeout_seconds,
         log_path=log_path,
+        command_id=command_id,
+        command_role=effective_role,
     )
     started_at = utc_now_iso()
+    started_monotonic = time.monotonic()
 
     try:
         result = services.runtime.exec(
@@ -87,6 +105,11 @@ def _run_container_bash_impl(
             completed_at=completed_at,
             exit_code=124,
             log_path=log_path,
+            command_id=command_id,
+            command_role=effective_role,
+            timeout_seconds=timeout_seconds,
+            duration_seconds=round(time.monotonic() - started_monotonic, 6),
+            timed_out=True,
         )
         services.manager.log_event(
             session,
@@ -95,12 +118,14 @@ def _run_container_bash_impl(
             workdir=effective_workdir,
             timeout_seconds=timeout_seconds,
             log_path=log_path,
+            command_id=command_id,
+            command_role=effective_role,
         )
         stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
         stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
         combined_output = stdout + stderr
         # Return a structured timeout to the agent instead of raising.
-        message = f"exit_code=124 (Timeout)\nworkdir={effective_workdir}\nerror: {timeout_message}\noutput_tail:\n{_truncate_output_tail(combined_output)}"
+        message = f"command_id={command_id}\ncommand_role={effective_role}\nexit_code=124 (Timeout)\nworkdir={effective_workdir}\nerror: {timeout_message}\noutput_tail:\n{_truncate_output_tail(combined_output)}"
         result = CommandResult(
             exit_code=124,
             stdout=stdout,
@@ -119,6 +144,11 @@ def _run_container_bash_impl(
         completed_at=completed_at,
         exit_code=result.exit_code,
         log_path=log_path,
+        command_id=command_id,
+        command_role=effective_role,
+        timeout_seconds=timeout_seconds,
+        duration_seconds=round(time.monotonic() - started_monotonic, 6),
+        timed_out=False,
     )
     truncated_output = _truncate_output_tail(result.combined_output)
     services.manager.log_event(
@@ -130,8 +160,10 @@ def _run_container_bash_impl(
         log_path=log_path,
         exit_code=result.exit_code,
         truncated_output=truncated_output,
+        command_id=command_id,
+        command_role=effective_role,
     )
-    message = f"exit_code={result.exit_code}\nworkdir={effective_workdir}\nlog_path={log_path}\noutput_tail:\n{truncated_output}"
+    message = f"command_id={command_id}\ncommand_role={effective_role}\nexit_code={result.exit_code}\nworkdir={effective_workdir}\nlog_path={log_path}\noutput_tail:\n{truncated_output}"
     return result, message
 
 
@@ -142,6 +174,7 @@ def run_container_bash(
     command: str,
     timeout_seconds: int = 1200,
     workdir: str | None = None,
+    command_role: str = "other",
 ) -> str:
     """Run a bash command inside a compile session container.
 
@@ -155,6 +188,7 @@ def run_container_bash(
         command: Bash command to execute inside the compile container.
         timeout_seconds: Command timeout in seconds.
         workdir: Optional absolute working directory inside the compile container.
+        command_role: Evidence role: configure, build, artifact_stage, smoke, or other.
     """
     session = get_bound_session(session_id=session_id, thread_id=thread_id)
     _, message = _run_container_bash_impl(
@@ -162,6 +196,7 @@ def run_container_bash(
         command=command,
         timeout_seconds=timeout_seconds,
         workdir=workdir,
+        command_role=command_role,
     )
     return message
 
@@ -170,15 +205,22 @@ def run_container_bash(
 def submit_build_result(
     session_id: str,
     thread_id: str,
+    supporting_command_id: str | None = None,
 ) -> str:
     """Submit final build artifacts from `/artifacts` for deterministic acceptance.
 
     Args:
         session_id: Compile session identifier.
         thread_id: Parent workflow thread identifier.
+        supporting_command_id: Stable ID of the successful build command supporting this submission.
     """
     session = get_bound_session(session_id=session_id, thread_id=thread_id)
-    return submit_build_result_impl(session=session)
+    if supporting_command_id is None:
+        return submit_build_result_impl(session=session)
+    return submit_build_result_impl(
+        session=session,
+        supporting_command_id=supporting_command_id,
+    )
 
 
 def get_bound_compile_tools(session: CompileSession):
@@ -187,6 +229,7 @@ def get_bound_compile_tools(session: CompileSession):
         command: str,
         timeout_seconds: int = 1200,
         workdir: str | None = None,
+        command_role: str = "other",
     ) -> str:
         """Run a bash command inside the bound compile session container.
 
@@ -194,18 +237,29 @@ def get_bound_compile_tools(session: CompileSession):
             command: Bash command to execute inside the compile container.
             timeout_seconds: Command timeout in seconds.
             workdir: Optional absolute working directory inside the compile container.
+            command_role: Evidence role: configure, build, artifact_stage, smoke, or other.
         """
         _, message = _run_container_bash_impl(
             session=session,
             command=command,
             timeout_seconds=timeout_seconds,
             workdir=workdir,
+            command_role=command_role,
         )
         return message
 
     @tool("submit_build_result", parse_docstring=True)
-    def bound_submit_build_result() -> str:
-        """Submit final build artifacts from `/artifacts` for deterministic acceptance."""
-        return submit_build_result_impl(session=session)
+    def bound_submit_build_result(supporting_command_id: str | None = None) -> str:
+        """Submit final build artifacts from `/artifacts` for deterministic acceptance.
+
+        Args:
+            supporting_command_id: Stable ID of the successful build command supporting this submission.
+        """
+        if supporting_command_id is None:
+            return submit_build_result_impl(session=session)
+        return submit_build_result_impl(
+            session=session,
+            supporting_command_id=supporting_command_id,
+        )
 
     return [bound_run_container_bash, bound_submit_build_result]

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import inspect
+import json
 import logging
 import uuid
 from dataclasses import replace
@@ -13,6 +14,7 @@ from langgraph.typing import ContextT
 
 from deerflow.agents.lead_agent.prompt import get_skills_prompt_section
 from deerflow.agents.thread_state import ThreadState
+from deerflow.compile.evidence import ExperimentPolicy
 from deerflow.subagents import SubagentExecutor, get_available_subagent_names, get_subagent_config
 from deerflow.subagents.executor import (
     SubagentStatus,
@@ -34,6 +36,25 @@ def _apply_max_turns_override(config, *, subagent_type: str, requested_max_turns
     if requested_max_turns is None or subagent_type == "compiler":
         return config
     return replace(config, max_turns=requested_max_turns)
+
+
+def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
+    requirements = [
+        "Active C/C++ benchmark constraints:",
+        f"- Build exact commit {policy.expected_commit_sha} from {policy.expected_repo_url}.",
+        "- The runner already applies the declared system packages, container environment, and replay delay.",
+    ]
+    if policy.cmake_arguments:
+        requirements.append(f"- Every relevant CMake configure command must include these exact argument tokens in this order: {json.dumps(list(policy.cmake_arguments), ensure_ascii=True)}.")
+    if policy.configure_arguments:
+        requirements.append(f"- Every relevant Autotools configure command must include these exact argument tokens in this order: {json.dumps(list(policy.configure_arguments), ensure_ascii=True)}.")
+    requirements.extend(
+        [
+            "- Set command_role on every run_container_bash call; use configure for configuration and build for the successful command that supports final acceptance.",
+            "- Pass that successful build command's returned command_id as supporting_command_id to submit_build_result.",
+        ]
+    )
+    return f"{prompt.rstrip()}\n\n" + "\n".join(requirements)
 
 
 def _get_compile_state(runtime: ToolRuntime[ContextT, ThreadState]) -> dict[str, str]:
@@ -212,6 +233,7 @@ async def task_tool(
 
     if subagent_type == "compiler":
         from deerflow.agents.middlewares.tool_error_handling_middleware import load_bound_session_async
+        from deerflow.compile.evidence import get_active_experiment
         from deerflow.tools.bound_compile_tools import get_bound_compile_tools
 
         session_id = compile_state.get(COMPILE_SESSION_STATE_KEY)
@@ -222,6 +244,13 @@ async def task_tool(
 
         session = await load_bound_session_async(session_id=session_id, thread_id=thread_id)
         tools = get_bound_compile_tools(session)
+        active = get_active_experiment(thread_id)
+        if active is not None:
+            config = config.with_overrides(
+                max_turns=active.policy.compiler_max_turns,
+                timeout_seconds=active.policy.subagent_timeout_seconds,
+            )
+            prompt = _with_benchmark_constraints(prompt, active.policy)
     else:
         tools = get_subagent_tools(subagent_type=subagent_type, model_name=parent_model)
 

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -11,6 +11,7 @@ import pytest
 
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import DEFAULT_NETWORK, CompileDockerRuntime, ContainerCleanupResult, ReplayContainerHandle, RuntimeConfig
+from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, submit_build_result_impl, verify_clean_replay_impl
 from deerflow.compile.paths import (
@@ -58,6 +59,23 @@ def add_replayable_build_command(session: CompileSession, command: str = "cmake 
             exit_code=0,
         )
     )
+
+
+@pytest.mark.parametrize(
+    ("command", "expected", "matches"),
+    [
+        ("cmake -S . -B build -DA=1 -DB=2", ("-DA=1", "-DB=2"), True),
+        ("cmake -S . -B build -DB=2 -DA=1", ("-DA=1", "-DB=2"), False),
+        ("./configure --prefix=/usr --disable-shared", ("--prefix=/usr",), True),
+        ("cmake -S . -B build", ("-DA=1",), False),
+    ],
+)
+def test_benchmark_arguments_must_be_observed_in_declared_order(
+    command: str,
+    expected: tuple[str, ...],
+    matches: bool,
+) -> None:
+    assert operations._command_contains_arguments(command, expected) is matches
 
 
 def install_passed_replay_stub(monkeypatch) -> None:
@@ -931,6 +949,71 @@ def test_docker_runtime_uses_paths_host_workspace_root(tmp_path: Path, monkeypat
     assert ["docker", "network", "inspect", DEFAULT_NETWORK] in commands
     assert f"{host_root / '.compile-sessions' / session.thread_id / session.session_id / 'workspace'}:/workspace" in docker_command
     assert "HOST_PROJECT_ROOT" not in docker_command
+
+
+def test_docker_runtime_applies_experiment_labels_and_public_environment_only(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    thread_id = "thread-experiment-runtime"
+    session = manager.create_session(thread_id=thread_id, repo_url="https://example.com/repo.git")
+    ledger = ExperimentLedger.create(
+        tmp_path / "evidence.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v1",
+        manifest_sha256="1" * 64,
+        case_id="fixture",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url=session.repo_url,
+        expected_commit_sha="2" * 40,
+        compile_image=session.image,
+        image_id=VALID_IMAGE_ID,
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(("CFLAGS", "-O2"), ("SOURCE_DATE_EPOCH", None)),
+        minimum_replay_delay_seconds=0,
+    )
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        if command[:3] == ["docker", "inspect", "--format"]:
+            return SimpleNamespace(stdout=f"{VALID_IMAGE_ID}\n", stderr="", returncode=0)
+        return SimpleNamespace(stdout="container-id\n", stderr="", returncode=0)
+
+    monkeypatch.setattr("deerflow.compile.docker_runtime.subprocess.run", fake_run)
+    try:
+        CompileDockerRuntime(manager=manager).create_container(session)
+    finally:
+        deactivate_experiment(thread_id)
+
+    docker_command = next(command for command in commands if command[:2] == ["docker", "run"])
+    assert f"deerflow.compile.experiment_id={active.experiment_id}" in docker_command
+    assert f"deerflow.compile.physical_attempt_id={active.physical_attempt_id}" in docker_command
+    assert "CFLAGS=-O2" in docker_command
+    assert not any(argument.startswith("SOURCE_DATE_EPOCH=") for argument in docker_command)
+    assert policy.credential_env not in docker_command
 
 
 def test_docker_runtime_creates_missing_network(tmp_path: Path, monkeypatch):
@@ -1930,6 +2013,24 @@ def test_clean_replay_cleanup_failure_blocks_an_otherwise_matching_result(tmp_pa
     cleanup_check = next(check for check in attempt.checks if check.name == "container_cleanup")
     assert cleanup_check.passed is False
     assert cleanup_check.actual == {"stopped": True, "removed": False}
+
+
+def test_clean_replay_preserves_execution_failure_as_primary_when_cleanup_also_fails(tmp_path: Path, monkeypatch):
+    manager, session = make_replay_ready_session(tmp_path)
+    runtime = FakeReplayRuntime(
+        manager,
+        build_exit_code=2,
+        cleanup_result=ContainerCleanupResult(succeeded=False, stopped=True, removed=False),
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+
+    attempt = verify_clean_replay_impl(session=session)
+
+    assert attempt.status == "failed"
+    assert attempt.failure_classification == "recipe_execution_failed"
+    assert attempt.primary_failure_classification == "recipe_execution_failed"
+    assert attempt.secondary_failure_classifications == ["cleanup_failed"]
+    assert attempt.cleanup_succeeded is False
 
 
 def test_replay_schema_roundtrip_preserves_structured_checks_and_artifacts(tmp_path: Path):

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile.evidence import (
+    EvidenceError,
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    get_active_experiment,
+    new_evidence_id,
+    record_experiment_event,
+)
+
+
+def make_policy() -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v1",
+        manifest_sha256="1" * 64,
+        case_id="fmt",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url="https://github.com/fmtlib/fmt.git",
+        expected_commit_sha="2" * 40,
+        compile_image="autocompiler:gcc13",
+        image_id=f"sha256:{'3' * 64}",
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=("ninja-build",),
+        cmake_arguments=("-DBUILD_TESTING=OFF",),
+        configure_arguments=(),
+        environment=(("CFLAGS", "-O2"),),
+        minimum_replay_delay_seconds=0,
+    )
+
+
+def create_ledger(tmp_path: Path) -> ExperimentLedger:
+    return ExperimentLedger.create(
+        tmp_path / "attempt.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": new_evidence_id("thread"), "policy": make_policy().to_payload()},
+    )
+
+
+def test_ledger_builds_contiguous_hash_chain_and_becomes_immutable(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    ledger.append("preflight.completed", {"ready": True})
+    ledger.append("experiment.completed", {"status": "passed"})
+
+    events = ExperimentLedger.verify_path(ledger.path)
+
+    assert [event["sequence"] for event in events] == [1, 2, 3]
+    assert events[0]["previous_event_sha256"] is None
+    assert events[1]["previous_event_sha256"] == events[0]["event_sha256"]
+    assert events[2]["previous_event_sha256"] == events[1]["event_sha256"]
+    with pytest.raises(EvidenceError, match="immutable"):
+        ledger.append("oracle.completed", {"passed": True})
+
+
+def test_ledger_detects_tampering(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    ledger.append("preflight.completed", {"ready": False})
+    records = [json.loads(line) for line in ledger.path.read_text(encoding="utf-8").splitlines()]
+    records[1]["payload"]["ready"] = True
+    ledger.path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True, separators=(",", ":")) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvidenceError, match="invalid event digest"):
+        ExperimentLedger.verify_path(ledger.path)
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({"credential": "sk-example-secret-value-123456789"}, "credential-like"),
+        ({"artifact_path": r"C:\\Users\\YiWei\\private\\artifact"}, "host path"),
+        ({"command": "cmake --build build"}, "forbidden"),
+    ],
+)
+def test_ledger_rejects_sensitive_or_raw_evidence(
+    tmp_path: Path,
+    payload: dict[str, str],
+    message: str,
+) -> None:
+    ledger = create_ledger(tmp_path)
+
+    with pytest.raises(EvidenceError, match=message):
+        ledger.append("unsafe.observed", payload)
+
+
+def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    policy = make_policy()
+    thread_id = new_evidence_id("thread")
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        assert get_active_experiment(thread_id) is active
+        assert record_experiment_event(thread_id, "model.request_started", attempt=1) is not None
+        assert record_experiment_event("unrelated-thread", "model.request_started", attempt=1) is None
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+    events = ledger.read()
+    assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
+    assert get_active_experiment(thread_id) is None

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile.evidence import ExperimentLedger
+from deerflow.tools.builtins.task_tool import _with_benchmark_constraints
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_benchmark_runner.py"
+SPEC = importlib.util.spec_from_file_location("forge_benchmark_runner", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+forge_benchmark_runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(forge_benchmark_runner)
+
+
+def load_manifest() -> dict:
+    path = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v1.json"
+    return forge_benchmark_runner._load_manifest(path)
+
+
+def ready_preflight(manifest: dict, *, ready: bool = True) -> dict:
+    return {
+        "ready": ready,
+        "manifest_sha256": forge_benchmark_runner.protocol.manifest_sha256(manifest),
+        "manifest_file_sha256": "1" * 64,
+        "forge": {
+            "revision": manifest["forge"]["commit_sha"],
+            "dirty": False,
+            "expected_revision": manifest["forge"]["commit_sha"],
+            "components": {},
+        },
+        "protocol": {},
+        "runtime": {
+            "image_id": manifest["runtime"]["image_id"],
+            "docker_server_version": manifest["runtime"]["host"]["docker_server_version"],
+            "platform_system": "Linux",
+            "platform_machine": "x86_64",
+        },
+        "checks": {"fixture_ready": ready},
+    }
+
+
+def test_build_policy_applies_frozen_case_and_model_constraints() -> None:
+    manifest = load_manifest()
+
+    policy = forge_benchmark_runner.build_policy(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+    )
+
+    assert policy.model_name == "gpt-5.6-sol"
+    assert policy.model_max_retries == 0
+    assert policy.memory_enabled is False
+    assert policy.skills_enabled is False
+    assert policy.expected_commit_sha == manifest["cases"][0]["commit_sha"]
+    assert policy.process_environment == manifest["cases"][0]["constraints"]["environment"]
+
+
+def test_compiler_prompt_receives_ordered_manifest_constraints() -> None:
+    manifest = load_manifest()
+    policy = forge_benchmark_runner.build_policy(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+    )
+
+    prompt = _with_benchmark_constraints("Compile this repository.", policy)
+
+    positions = [prompt.index(argument) for argument in policy.cmake_arguments]
+    assert positions == sorted(positions)
+    assert "command_role" in prompt
+    assert "supporting_command_id" in prompt
+    assert policy.credential_env not in prompt
+
+
+def test_create_attempt_rejects_duplicate_slot_and_links_explicit_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    preflight = ready_preflight(manifest)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: preflight,
+    )
+
+    original, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+    with pytest.raises(forge_benchmark_runner.RunnerError, match="already has physical evidence"):
+        forge_benchmark_runner.create_attempt(
+            manifest,
+            case_id="fmt",
+            condition_id="baseline",
+            repetition=1,
+            output_dir=tmp_path,
+        )
+
+    replacement, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+        replacement_for=original.physical_attempt_id,
+    )
+
+    assert replacement.experiment_id == original.experiment_id
+    assert replacement.physical_attempt_id != original.physical_attempt_id
+    assert replacement.read()[0]["payload"]["replacement_for_physical_attempt_id"] == original.physical_attempt_id
+
+
+def test_run_refuses_failed_preflight_before_importing_model_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    preflight = ready_preflight(manifest, ready=False)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: preflight,
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+
+    with pytest.raises(forge_benchmark_runner.RunnerError, match="did not pass preflight"):
+        forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    assert not any(event["event"].startswith("model.") for event in ledger.read())
+
+
+def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    preflight = ready_preflight(manifest)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: preflight,
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+
+    class InterruptingClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        def stream(self, message: str, *, thread_id: str):
+            del message, thread_id
+            raise KeyboardInterrupt
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", InterruptingClient)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "reconcile_orphans",
+        lambda _attempt_id: {
+            "scan_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    events = ExperimentLedger.verify_path(ledger.path)
+    assert "run.failed" in [event["event"] for event in events]
+    assert events[-1]["event"] == "orphan.reconciled"
+    assert not any(event["event"] == "experiment.completed" for event in events)
+    ExperimentLedger.open(ledger.path).append("recovery.recorded", {"status": "interrupted"})
+
+
+def test_gate_recomputation_detects_tampering_and_oracle_is_independent() -> None:
+    manifest = load_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == "fmt")
+    expected_artifact = case["oracle"]["required_artifacts"][0]
+    events = [
+        {"event": "experiment.started", "payload": {"policy": {"case_id": "fmt"}}},
+        {
+            "event": "command.completed",
+            "payload": {
+                "command_id": "command-1",
+                "role": "build",
+                "exit_code": 0,
+                "timed_out": False,
+            },
+        },
+        {
+            "event": "replay.completed",
+            "payload": {
+                "replay_attempt_id": "replay-1",
+                "status": "passed",
+                "cleanup_succeeded": True,
+                "primary_failure_classification": None,
+            },
+        },
+        {
+            "event": "submit.completed",
+            "payload": {
+                "submit_attempt_id": "submit-1",
+                "supporting_command_id": "command-1",
+                "candidate_status": "passed",
+                "artifacts": [
+                    {
+                        "path": expected_artifact["relative_path"],
+                        "artifact_type": expected_artifact["artifact_type"],
+                    }
+                ],
+                "checks": [{"passed": True}],
+                "recipe_sha256": "2" * 64,
+                "replay": {
+                    "replay_attempt_id": "replay-1",
+                    "status": "passed",
+                    "primary_failure_classification": None,
+                },
+                "gates": {
+                    "exit_code": True,
+                    "candidate_only": True,
+                    "replay_ready": True,
+                    "clean_replay": False,
+                    "delivered": None,
+                },
+            },
+        },
+        {
+            "event": "delivery.completed",
+            "payload": {"submit_attempt_id": "submit-1", "delivered": True},
+        },
+    ]
+
+    gates = forge_benchmark_runner.recompute_gates(events)
+    oracle = forge_benchmark_runner.run_oracle(manifest, events)
+
+    assert gates["valid"] is False
+    assert gates["mismatches"] == [
+        {
+            "submit_attempt_id": "submit-1",
+            "gate": "clean_replay",
+            "recorded": False,
+            "recomputed": True,
+        }
+    ]
+    assert oracle["passed"] is True

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -87,10 +87,19 @@ def test_make_lead_agent_disables_thinking_when_model_does_not_support_it(monkey
 
     captured: dict[str, object] = {}
 
-    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None):
+    def _fake_create_chat_model(
+        *,
+        name,
+        thinking_enabled,
+        reasoning_effort=None,
+        experiment_thread_id=None,
+        experiment_role=None,
+    ):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort
+        captured["experiment_thread_id"] = experiment_thread_id
+        captured["experiment_role"] = experiment_role
         return object()
 
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
@@ -109,6 +118,8 @@ def test_make_lead_agent_disables_thinking_when_model_does_not_support_it(monkey
 
     assert captured["name"] == "safe-model"
     assert captured["thinking_enabled"] is False
+    assert captured["experiment_thread_id"] is None
+    assert captured["experiment_role"] == "lead"
     assert result["model"] is not None
 
 

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,13 @@ from langgraph.errors import GraphBubbleUp
 
 from deerflow.agents.middlewares.llm_error_handling_middleware import (
     LLMErrorHandlingMiddleware,
+)
+from deerflow.compile.evidence import (
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
 )
 
 
@@ -134,3 +142,75 @@ def test_async_model_call_propagates_graph_bubble_up() -> None:
 
     with pytest.raises(GraphBubbleUp):
         asyncio.run(middleware.awrap_model_call(SimpleNamespace(), handler))
+
+
+def test_active_experiment_records_one_429_attempt_without_exception_text(
+    tmp_path: Path,
+) -> None:
+    thread_id = new_evidence_id("thread")
+    ledger = ExperimentLedger.create(
+        tmp_path / "attempt.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v1",
+        manifest_sha256="1" * 64,
+        case_id="fmt",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url="https://github.com/fmtlib/fmt.git",
+        expected_commit_sha="2" * 40,
+        compile_image="autocompiler:gcc13",
+        image_id=f"sha256:{'3' * 64}",
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    request = SimpleNamespace(
+        runtime=SimpleNamespace(context={"thread_id": thread_id, "agent_name": "compiler"}),
+        model=SimpleNamespace(model_name=policy.model_name, base_url=policy.endpoint),
+    )
+    sentinel = "provider-secret-sentinel-that-must-not-be-persisted"
+
+    def handler(_request) -> AIMessage:
+        raise FakeError(f"rate limited: {sentinel}", status_code=429)
+
+    try:
+        result = LLMErrorHandlingMiddleware().wrap_model_call(request, handler)
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert isinstance(result, AIMessage)
+    events = ledger.read()
+    assert [event["event"] for event in events] == [
+        "experiment.started",
+        "model.request_started",
+        "model.request_failed",
+        "failure.recorded",
+    ]
+    assert events[1]["payload"]["role"] == "compiler"
+    assert events[1]["payload"]["max_attempts"] == 1
+    assert events[2]["payload"]["classification"] == "rate_limited"
+    assert events[2]["payload"]["retry_exhausted"] is True
+    assert events[3]["payload"]["domain"] == "model_endpoint"
+    assert sentinel not in ledger.path.read_text(encoding="utf-8")

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -127,6 +127,7 @@ services:
     command: sh -c "{ cd backend && (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && PYTHONPATH=. uv run --frozen uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env'; } > /app/logs/gateway.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
+      - ../:/repo:ro
       # CompileSessionManager writes through /workspace while compile containers
       # bind the same directory using the host-visible DEER_FLOW_ROOT path.
       - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
@@ -160,6 +161,7 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - FORGE_REPO_ROOT=/repo
       - DEER_FLOW_WORKSPACE_ROOT=/workspace
       - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
       - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}
@@ -195,6 +197,7 @@ services:
     command: sh -c "cd backend && { (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && allow_blocking='' && if [ \"$${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run --frozen langgraph dev --no-browser $${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker $${LANGGRAPH_JOBS_PER_WORKER:-10}; } > /app/logs/langgraph.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
+      - ../:/repo:ro
       # Keep service-side session state and host Docker bind mounts aligned.
       - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
       # Preserve the .venv built during Docker image build — mounting the full backend/
@@ -227,6 +230,7 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - FORGE_REPO_ROOT=/repo
       - DEER_FLOW_WORKSPACE_ROOT=/workspace
       - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
       - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""Evidence-first runner for the Forge C/C++ benchmark protocol.
+
+The runner deliberately separates attempt creation from model execution. A
+physical-attempt ledger must exist before ``run`` can issue a provider call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+for import_root in (str(HARNESS_ROOT), str(Path(__file__).resolve().parent)):
+    if import_root not in sys.path:
+        sys.path.insert(0, import_root)
+
+import forge_benchmark as protocol  # noqa: E402
+
+from deerflow.compile.evidence import (  # noqa: E402
+    EvidenceError,
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+
+
+class RunnerError(ValueError):
+    pass
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _run_command(arguments: list[str], *, cwd: Path = REPO_ROOT) -> tuple[int, str]:
+    try:
+        result = subprocess.run(
+            arguments,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 1, ""
+    return result.returncode, result.stdout.strip()
+
+
+def _git_state(repo_root: Path) -> dict[str, Any]:
+    revision_code, revision = _run_command(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+    )
+    dirty_code, dirty_output = _run_command(
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
+        cwd=repo_root,
+    )
+    return {
+        "revision": revision if revision_code == 0 else None,
+        "dirty": bool(dirty_output) if dirty_code == 0 else None,
+    }
+
+
+def _manifest_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
+    for case in manifest["cases"]:
+        if case["id"] == case_id:
+            return case
+    raise RunnerError(f"Unknown benchmark case: {case_id}")
+
+
+def _manifest_condition(
+    manifest: dict[str, Any],
+    condition_id: str,
+) -> dict[str, Any]:
+    for condition in manifest["conditions"]:
+        if condition["id"] == condition_id:
+            return condition
+    raise RunnerError(f"Unknown benchmark condition: {condition_id}")
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+) -> ExperimentPolicy:
+    case = _manifest_case(manifest, case_id)
+    condition = _manifest_condition(manifest, condition_id)
+    model = manifest["model"]
+    runtime = manifest["runtime"]
+    constraints = case["constraints"]
+    build_arguments = constraints["build_arguments"]
+    lead_model = model["roles"]["lead"]
+    compiler_model = model["roles"]["compiler"]
+    if lead_model != compiler_model:
+        raise RunnerError("The v1 runner requires one frozen model for both roles")
+    if repetition > condition["repetitions"]:
+        raise RunnerError("Repetition exceeds the manifest condition")
+    return ExperimentPolicy(
+        benchmark_id=manifest["benchmark"]["id"],
+        manifest_sha256=protocol.manifest_sha256(manifest),
+        case_id=case_id,
+        condition=condition_id,
+        repetition=repetition,
+        expected_repo_url=case["repository_url"],
+        expected_commit_sha=case["commit_sha"],
+        compile_image=runtime["compile_image"],
+        image_id=runtime["image_id"],
+        model_name=lead_model,
+        endpoint=model["endpoint"].rstrip("/"),
+        credential_env=model["credential_env"],
+        request_timeout_seconds=model["request_timeout_seconds"],
+        model_max_retries=model["max_retries"],
+        compiler_max_turns=runtime["compiler_max_turns"],
+        subagent_timeout_seconds=runtime["subagent_timeout_seconds"],
+        memory_enabled=condition["memory_enabled"],
+        skills_enabled=condition["skills_enabled"],
+        required_system_packages=tuple(constraints["required_system_packages"]),
+        cmake_arguments=tuple(build_arguments["cmake"]),
+        configure_arguments=tuple(build_arguments["configure"]),
+        environment=tuple(constraints["environment"].items()),
+        minimum_replay_delay_seconds=constraints["minimum_replay_delay_seconds"],
+    )
+
+
+def _endpoint_reachable(endpoint: str) -> bool:
+    request = urllib.request.Request(
+        f"{endpoint.rstrip('/')}/models",
+        method="GET",
+        headers={"User-Agent": "forge-benchmark-preflight/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except urllib.error.HTTPError as exc:
+        return 100 <= exc.code <= 599
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def _credential_present(variable_name: str) -> bool:
+    if variable_name in os.environ:
+        return True
+    code, container_ids = _run_command(
+        [
+            "docker",
+            "ps",
+            "-q",
+            "--filter",
+            "label=com.docker.compose.service=langgraph",
+        ]
+    )
+    if code != 0:
+        return False
+    for container_id in container_ids.splitlines():
+        exists_code, _ = _run_command(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "sh",
+                "-c",
+                f'test "${{{variable_name}+x}}" = x',
+            ]
+        )
+        if exists_code == 0:
+            return True
+    return False
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path = REPO_ROOT,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    forge_state = _git_state(repo_root)
+    component_results: dict[str, dict[str, Any]] = {}
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        actual_digest = _sha256_file(repo_root / relative_path)
+        component_results[relative_path] = {
+            "expected": expected_digest,
+            "actual": actual_digest,
+            "matches": actual_digest == expected_digest,
+        }
+
+    protocol_results: dict[str, dict[str, Any]] = {}
+    for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
+        actual_digest = _sha256_file(repo_root / relative_path)
+        protocol_results[relative_path] = {
+            "expected": expected_digest,
+            "actual": actual_digest,
+            "matches": actual_digest == expected_digest,
+        }
+
+    runtime = manifest["runtime"]
+    image_code, image_id = _run_command(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}",
+            runtime["compile_image"],
+        ],
+        cwd=repo_root,
+    )
+    network_code, _ = _run_command(
+        ["docker", "network", "inspect", runtime["network_policy"]["network_name"]],
+        cwd=repo_root,
+    )
+    docker_version_code, docker_version = _run_command(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        cwd=repo_root,
+    )
+    model = manifest["model"]
+    condition_baseline = all(not condition["memory_enabled"] and not condition["skills_enabled"] for condition in manifest["conditions"])
+    endpoint_reachable = _endpoint_reachable(model["endpoint"]) if check_endpoint else None
+    checks = {
+        "credential_present": _credential_present(model["credential_env"]),
+        "endpoint_reachable": endpoint_reachable,
+        "forge_revision_matches": forge_state["revision"] == manifest["forge"]["commit_sha"],
+        "forge_clean": forge_state["dirty"] is False,
+        "forge_components_match": all(result["matches"] for result in component_results.values()),
+        "protocol_artifacts_match": all(result["matches"] for result in protocol_results.values()),
+        "image_present": image_code == 0,
+        "image_id_matches": image_code == 0 and image_id == runtime["image_id"],
+        "network_present": network_code == 0,
+        "docker_server_matches": (docker_version_code == 0 and docker_version == runtime["host"]["docker_server_version"]),
+        "single_process_serial": runtime["backend_processes"] == 1 and runtime["max_parallel_runs"] == 1,
+        "fallback_forbidden": model["fallback_policy"] == "forbidden",
+        "memory_skills_disabled": condition_baseline,
+        "instrumentation_unblocked": not manifest["scope"]["instrumentation_blocker"],
+    }
+    required_checks = [
+        checks["credential_present"],
+        checks["forge_revision_matches"],
+        checks["forge_clean"],
+        checks["forge_components_match"],
+        checks["protocol_artifacts_match"],
+        checks["image_id_matches"],
+        checks["network_present"],
+        checks["single_process_serial"],
+        checks["fallback_forbidden"],
+        checks["memory_skills_disabled"],
+        checks["instrumentation_unblocked"],
+    ]
+    if check_endpoint:
+        required_checks.append(checks["endpoint_reachable"] is True)
+    return {
+        "ready": all(required_checks),
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "manifest_file_sha256": _sha256_file(repo_root / "benchmarks" / "manifests" / "cpp-pilot-v1.json"),
+        "forge": {
+            **forge_state,
+            "expected_revision": manifest["forge"]["commit_sha"],
+            "components": component_results,
+        },
+        "protocol": protocol_results,
+        "runtime": {
+            "image_id": image_id if image_code == 0 else None,
+            "docker_server_version": (docker_version if docker_version_code == 0 else None),
+            "platform_system": platform.system(),
+            "platform_machine": platform.machine(),
+        },
+        "checks": checks,
+    }
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    return protocol.validate_manifest(protocol.load_json_document(path))
+
+
+def _slot_matches(
+    events: list[dict[str, Any]],
+    policy: ExperimentPolicy,
+) -> bool:
+    if not events:
+        return False
+    recorded = events[0]["payload"].get("policy")
+    if not isinstance(recorded, dict):
+        return False
+    return all(
+        recorded.get(key) == value
+        for key, value in {
+            "benchmark_id": policy.benchmark_id,
+            "case_id": policy.case_id,
+            "condition": policy.condition,
+            "repetition": policy.repetition,
+        }.items()
+    )
+
+
+def find_slot_ledgers(
+    output_dir: Path,
+    policy: ExperimentPolicy,
+) -> list[tuple[Path, list[dict[str, Any]]]]:
+    matches: list[tuple[Path, list[dict[str, Any]]]] = []
+    if not output_dir.exists():
+        return matches
+    for ledger_path in sorted(output_dir.rglob("*.jsonl")):
+        try:
+            events = ExperimentLedger.verify_path(ledger_path)
+        except EvidenceError:
+            continue
+        if _slot_matches(events, policy):
+            matches.append((ledger_path, events))
+    return matches
+
+
+def create_attempt(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+    replacement_for: str | None = None,
+    check_endpoint: bool = True,
+    repo_root: Path = REPO_ROOT,
+) -> tuple[ExperimentLedger, dict[str, Any]]:
+    policy = build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+    existing = find_slot_ledgers(output_dir, policy)
+    if existing and replacement_for is None:
+        raise RunnerError("This benchmark slot already has physical evidence; create an explicit replacement attempt")
+    replacement_event: dict[str, Any] | None = None
+    if replacement_for is not None:
+        replacement_event = next(
+            (events[0] for _path, events in existing if events[0]["physical_attempt_id"] == replacement_for),
+            None,
+        )
+        if replacement_event is None:
+            raise RunnerError("The replacement attempt does not belong to this slot")
+
+    preflight = collect_preflight(
+        manifest,
+        repo_root=repo_root,
+        check_endpoint=check_endpoint,
+    )
+    experiment_id = replacement_event["experiment_id"] if replacement_event is not None else new_evidence_id("experiment")
+    physical_attempt_id = new_evidence_id("physical_attempt")
+    thread_id = new_evidence_id("thread")
+    ledger_path = output_dir / policy.case_id / policy.condition / f"rep-{policy.repetition:03d}" / f"{physical_attempt_id}.jsonl"
+    context = {
+        "thread_id": thread_id,
+        "replacement_for_physical_attempt_id": replacement_for,
+        "policy": policy.to_payload(),
+        "forge": preflight["forge"],
+        "protocol": {
+            "manifest_sha256": preflight["manifest_sha256"],
+            "manifest_file_sha256": preflight["manifest_file_sha256"],
+            "artifacts": preflight["protocol"],
+        },
+        "runtime": preflight["runtime"],
+        "preflight_checks": preflight["checks"],
+        "preflight_ready": preflight["ready"],
+    }
+    ledger = ExperimentLedger.create(
+        ledger_path,
+        experiment_id=experiment_id,
+        physical_attempt_id=physical_attempt_id,
+        context=context,
+    )
+    ledger.append(
+        "preflight.completed",
+        {
+            "ready": preflight["ready"],
+            "checks": preflight["checks"],
+        },
+    )
+    return ledger, preflight
+
+
+def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
+    commands: dict[str, dict[str, Any]] = {}
+    replays: dict[str, dict[str, Any]] = {}
+    deliveries: dict[str, dict[str, Any]] = {}
+    submits: list[dict[str, Any]] = []
+    for event in events:
+        payload = event["payload"]
+        if event["event"] == "command.completed":
+            commands[payload["command_id"]] = payload
+        elif event["event"] == "replay.completed":
+            replays[payload["replay_attempt_id"]] = payload
+        elif event["event"] == "delivery.completed":
+            submit_id = payload.get("submit_attempt_id")
+            if submit_id:
+                deliveries[submit_id] = payload
+        elif event["event"] == "submit.completed":
+            submits.append(payload)
+
+    results: list[dict[str, Any]] = []
+    mismatches: list[dict[str, Any]] = []
+    for submit in submits:
+        supporting = commands.get(submit.get("supporting_command_id"))
+        replay_snapshot = submit.get("replay") or {}
+        replay = replays.get(replay_snapshot.get("replay_attempt_id"))
+        checks = submit.get("checks") or []
+        recomputed = {
+            "exit_code": supporting is not None and supporting.get("role") == "build" and supporting.get("exit_code") == 0 and supporting.get("timed_out") is False,
+            "candidate_only": submit.get("candidate_status") == "passed" and bool(submit.get("artifacts")) and all(check.get("passed") is True for check in checks),
+            "replay_ready": bool(submit.get("recipe_sha256")) and bool(replay_snapshot.get("replay_attempt_id")),
+            "clean_replay": replay is not None and replay.get("status") == "passed" and replay.get("cleanup_succeeded") is True and replay.get("primary_failure_classification") is None,
+            "delivered": bool(deliveries.get(submit["submit_attempt_id"], {}).get("delivered")),
+        }
+        recorded = submit.get("gates") or {}
+        for gate in ("exit_code", "candidate_only", "replay_ready", "clean_replay"):
+            if recorded.get(gate) != recomputed[gate]:
+                mismatches.append(
+                    {
+                        "submit_attempt_id": submit["submit_attempt_id"],
+                        "gate": gate,
+                        "recorded": recorded.get(gate),
+                        "recomputed": recomputed[gate],
+                    }
+                )
+        delivery = deliveries.get(submit["submit_attempt_id"])
+        if delivery is not None and delivery.get("delivered") != recomputed["delivered"]:
+            mismatches.append(
+                {
+                    "submit_attempt_id": submit["submit_attempt_id"],
+                    "gate": "delivered",
+                    "recorded": delivery.get("delivered"),
+                    "recomputed": recomputed["delivered"],
+                }
+            )
+        results.append(
+            {
+                "submit_attempt_id": submit["submit_attempt_id"],
+                "gates": recomputed,
+            }
+        )
+    return {"valid": not mismatches, "submits": results, "mismatches": mismatches}
+
+
+def run_oracle(
+    manifest: dict[str, Any],
+    events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    started = events[0]["payload"]
+    case = _manifest_case(manifest, started["policy"]["case_id"])
+    submits = [event["payload"] for event in events if event["event"] == "submit.completed"]
+    if not submits:
+        return {"passed": False, "classification": "submit_missing"}
+    submit = submits[-1]
+    expected_artifacts = {(artifact["relative_path"], artifact["artifact_type"]) for artifact in case["oracle"]["required_artifacts"]}
+    actual_artifacts = {(artifact.get("path"), artifact.get("artifact_type")) for artifact in submit.get("artifacts", [])}
+    replay = submit.get("replay") or {}
+    expected_candidate_pass = case["oracle"]["expected_candidate_status"] == "pass"
+    expected_replay_pass = case["oracle"]["expected_clean_replay_status"] == "pass"
+    candidate_pass = submit.get("candidate_status") == "passed"
+    replay_pass = replay.get("status") == "passed"
+    expected_failure = case["oracle"].get("expected_replay_failure_classification")
+    actual_failure = replay.get("primary_failure_classification")
+    failure_matches = expected_failure is None or actual_failure == expected_failure
+    passed = expected_artifacts.issubset(actual_artifacts) and candidate_pass == expected_candidate_pass and replay_pass == expected_replay_pass and failure_matches
+    return {
+        "passed": passed,
+        "classification": None if passed else "oracle_mismatch",
+        "submit_attempt_id": submit["submit_attempt_id"],
+        "artifact_oracle_passed": expected_artifacts.issubset(actual_artifacts),
+        "candidate_expectation_passed": candidate_pass == expected_candidate_pass,
+        "replay_expectation_passed": replay_pass == expected_replay_pass,
+        "failure_classification_expectation_passed": failure_matches,
+    }
+
+
+def reconcile_orphans(physical_attempt_id: str) -> dict[str, Any]:
+    code, output = _run_command(
+        [
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+            (f"label=deerflow.compile.physical_attempt_id={physical_attempt_id}"),
+        ]
+    )
+    identifiers = output.splitlines() if code == 0 and output else []
+    removed = 0
+    for identifier in identifiers:
+        remove_code, _ = _run_command(["docker", "rm", "-f", identifier])
+        if remove_code == 0:
+            removed += 1
+    return {
+        "scan_succeeded": code == 0,
+        "orphan_count": len(identifiers),
+        "removed_count": removed,
+        "cleanup_succeeded": code == 0 and removed == len(identifiers),
+    }
+
+
+def run_attempt(
+    manifest: dict[str, Any],
+    ledger_path: Path,
+) -> dict[str, Any]:
+    ledger = ExperimentLedger.open(ledger_path)
+    events = ledger.read()
+    context = events[0]["payload"]
+    if context.get("preflight_ready") is not True:
+        raise RunnerError("The physical attempt did not pass preflight")
+    if any(event["event"].startswith("model.") for event in events):
+        raise RunnerError("A physical attempt cannot issue model calls twice")
+    policy_data = context["policy"]
+    policy = build_policy(
+        manifest,
+        case_id=policy_data["case_id"],
+        condition_id=policy_data["condition"],
+        repetition=policy_data["repetition"],
+    )
+    if policy.to_payload() != policy_data:
+        raise RunnerError("The ledger policy no longer matches the manifest")
+    thread_id = context["thread_id"]
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    run_status = "failed"
+    try:
+        from deerflow.client import DeerFlowClient
+
+        client = DeerFlowClient(
+            model_name=policy.model_name,
+            thinking_enabled=False,
+            subagent_enabled=True,
+            plan_mode=False,
+            available_skills=set(),
+        )
+        message = f"Compile the C/C++ repository at {policy.expected_repo_url} using exact commit {policy.expected_commit_sha}. Use the compiler subagent and finish only after deterministic artifact submission and session finalization."
+        for _event in client.stream(message, thread_id=thread_id):
+            pass
+        run_status = "completed"
+    except BaseException as exc:
+        ledger.append(
+            "run.failed",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "classification": type(exc).__name__,
+            },
+        )
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
+    finally:
+        deactivate_experiment(thread_id)
+        reconciliation = reconcile_orphans(ledger.physical_attempt_id)
+        ledger.append("orphan.reconciled", reconciliation)
+
+    events = ledger.read()
+    gates = recompute_gates(events)
+    oracle = run_oracle(manifest, events)
+    ledger.append("oracle.completed", oracle)
+    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] else "failed"
+    ledger.append(
+        "experiment.completed",
+        {
+            "status": final_status,
+            "gate_recomputation_valid": gates["valid"],
+            "oracle_passed": oracle["passed"],
+            "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
+        },
+    )
+    return {
+        "status": final_status,
+        "gate_recomputation": gates,
+        "oracle": oracle,
+        "orphan_reconciliation": reconciliation,
+    }
+
+
+def _json_print(value: Any) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--manifest",
+        type=Path,
+        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v1.json",
+    )
+    common.add_argument("--skip-endpoint-check", action="store_true")
+
+    subparsers.add_parser("preflight", parents=[common])
+    create = subparsers.add_parser("create-attempt", parents=[common])
+    create.add_argument("--case", required=True)
+    create.add_argument("--condition", default="baseline")
+    create.add_argument("--repetition", type=int, default=1)
+    create.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "benchmarks" / "evidence",
+    )
+    create.add_argument("--replacement-for")
+
+    verify = subparsers.add_parser("verify-ledger", parents=[common])
+    verify.add_argument("--ledger", type=Path, required=True)
+    run = subparsers.add_parser("run", parents=[common])
+    run.add_argument("--ledger", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = _load_manifest(args.manifest)
+        if args.command == "preflight":
+            result = collect_preflight(
+                manifest,
+                check_endpoint=not args.skip_endpoint_check,
+            )
+            _json_print(result)
+            return 0 if result["ready"] else 2
+        if args.command == "create-attempt":
+            ledger, preflight = create_attempt(
+                manifest,
+                case_id=args.case,
+                condition_id=args.condition,
+                repetition=args.repetition,
+                output_dir=args.output_dir,
+                replacement_for=args.replacement_for,
+                check_endpoint=not args.skip_endpoint_check,
+            )
+            _json_print(
+                {
+                    "created": True,
+                    "ledger": str(ledger.path),
+                    "physical_attempt_id": ledger.physical_attempt_id,
+                    "preflight_ready": preflight["ready"],
+                }
+            )
+            return 0
+        if args.command == "verify-ledger":
+            events = ExperimentLedger.verify_path(args.ledger)
+            gates = recompute_gates(events)
+            oracle = run_oracle(manifest, events)
+            result = {
+                "ledger_valid": True,
+                "gate_recomputation": gates,
+                "oracle": oracle,
+            }
+            _json_print(result)
+            return 0 if gates["valid"] else 2
+        if args.command == "run":
+            result = run_attempt(manifest, args.ledger)
+            _json_print(result)
+            return 0 if result["status"] == "passed" else 2
+    except (EvidenceError, RunnerError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 evidence-first benchmark runner，提供 preflight、physical-attempt 创建/替换、ledger 校验、显式运行、离线 gate recomputation、独立 artifact oracle 与 orphan reconciliation。
- 新增连续序号和 SHA-256 前向 hash chain 的 JSONL evidence ledger，并拒绝密钥、prompt/response、异常文本、原始命令输出和宿主路径。
- 接入模型物理请求、编译命令、submit、replay、delivery/finalize 观测；稳定关联 model request、command、submit 和 replay ID。
- 区分 replay 主失败与 cleanup 次生失败，避免次生清理问题覆盖真实因果。
- Active experiment 强制 exact commit/image、冻结模型与端点、0 provider retries、超时/turn budget、依赖、环境、有序构建参数和 replay delay；禁止 fallback、Memory/Skills 和重复 slot。
- 为 Gateway/LangGraph 只读挂载 /repo，使 Compose/DooD 控制面可以从完整仓库根执行 runner preflight。

## 不变量

- v1-v5 manifest、Schema、validator、runner hash 与 ledger 均未修改。
- 首个模型请求前必须已经存在可校验的 physical-attempt ledger。
- 未观测值保持 null，不用 manifest 预期值或事后推断补证据。
- 本 PR 未启动 v6 或任何真实模型 pilot；新版协议与五 case 实跑由 #14 / PR #15 承接。
- Compose/DooD、Compile Session 与 clean replay 机制保持不变。

## 验证

- benchmark / ledger / runner：87 passed
- compile runtime / terminal / cancellation：114 passed
- model middleware / factory：30 passed
- 后端全量：1489 passed, 17 skipped
- opt-in 真实 Docker clean replay：2 passed in 75.55s
- Ruff check/format、Compose config、前端 lint/typecheck/build、git diff --check：通过
- 冻结协议资产：无改动
- 敏感信息检查：唯一 sk-* 命中为拒绝凭据的测试伪值，无真实凭据
- orphan 对账：无遗留 compile/replay 容器

## 后续

PR #15 当前仍以本分支为 base。合并后保留远端分支，下一阶段再将 PR #15 重排到最新 main 并更新其冻结 revision/component hashes。

Closes #11