### PR TITLE
修复：解决 WSL 挂载下精确提交克隆的所有权校验

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,11 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-20 — 将 Issue #16 / PR #19 的 exact-commit clone ownership 修复重排到最新主干并完成本地验证
+  - 文件: `backend/packages/harness/deerflow/compile/operations.py`, `backend/tests/test_compile_runtime.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
+  - 动机: 从旧堆叠基线提取单一修复，在 `git init` 后、首次 `git -C`/fetch 前配置容器内 `/workspace/repo` 为 `safe.directory`；保持 remote URL、完整 commit、普通 clone、clean replay、artifact gate、v1-v5 协议和 ledger 不变
+  - 证据: compile runtime/terminal/cancellation `115 passed`，后端全量 `1500 passed, 21 skipped`，真实 Docker exact clone 与两条 clean replay `3 passed in 89.62s`；全量 Ruff、Compose、前端 lint/typecheck/build、diff 和无遗留 compile/replay 容器检查通过
+
 - 2026-07-20 — 将 v2 pilot 协议与既有五 case 审计重排到主干，并增加 squash provenance 校验
   - 文件: `scripts/forge_benchmark_history.py`, `backend/tests/test_forge_benchmark_v2.py`, `benchmarks/README.md`, `.claude/memory/project.md`
   - 动机: v2 历史实验绑定 `d845b735`，而 Issue #11 重排后 head `561b38ce` 被 squash 为 `9e002f45`，Git ancestry 不再连续；在不改写 v2 manifest、Schema、validator、runner、canonical digest 或 ledger 的前提下，显式验证 baseline blob、两端 tree 身份和 successor ancestry
@@ -61,14 +66,15 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #14 / PR #15 的重排、审阅、完整 CI 与主干合并；保持 v2 协议和五份历史 physical-attempt ledger 不变，不启动 v6 pilot。
-- PR #15 合并后继续自底向上处理剩余堆叠 PR；不得删除仍被上层 PR 引用的远端 base 分支。
+- 完成 Issue #16 / PR #19 的重排、审阅、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- PR #19 合并后按 #20 -> #21 -> #23 顺序继续处理堆叠 PR；不得删除仍被上层 PR 引用的远端 base 分支。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
 - 协作语言约定：后续 GitHub Issue、Pull Request、评论、评审说明和提交说明默认使用中文；分支名、代码标识、命令和必要技术术语继续遵循仓库的 ASCII/既有命名规范。若外部协作明确要求英文，先向用户确认。
+- PowerShell -> WSL -> `bash -lc` 的多层命令可能提前展开临时 `$repo` 变量，使 Docker bind mount 退化为 `/frontend/...`；一次性容器优先传完整 WSL 绝对路径，启动失败后先按固定名称清理并确认无残留。
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。
 - WSL 的 `127.0.0.1` 代理不能直接传入 Docker build；编译镜像代理必须使用容器可达地址。
 - 后端全量 Ruff 当前有 9 个本次改动之外的既有错误；相关改动文件的定向 Ruff 已通过。

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -370,6 +370,7 @@ def clone_repository_impl(
             (
                 f"rm -rf -- {shell_quote(CONTAINER_REPO_DIR)}",
                 f"git init --object-format={object_format} {shell_quote(CONTAINER_REPO_DIR)}",
+                f"git config --global --replace-all safe.directory {shell_quote(CONTAINER_REPO_DIR)}",
                 f"git -C {shell_quote(CONTAINER_REPO_DIR)} remote add origin {shell_quote(repo_url)}",
                 f"git -C {shell_quote(CONTAINER_REPO_DIR)} fetch --depth {max(1, depth)} origin {shell_quote(expected_commit_sha)}",
                 f"git -C {shell_quote(CONTAINER_REPO_DIR)} checkout --detach FETCH_HEAD",

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -12,13 +12,14 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import CompileDockerRuntime
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, verify_clean_replay_impl
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, verify_clean_replay_impl
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
 
@@ -230,6 +231,39 @@ def _run_replay_scenario(monkeypatch, *, failed_configure_side_effect: bool):
         assert attempt.cleanup_succeeded is True
         _assert_no_replay_container(session)
         return attempt
+    finally:
+        compile_cleanup = runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+        assert compile_cleanup.succeeded is True
+        assert compile_cleanup.removed is True
+
+
+def test_exact_commit_clone_accepts_bind_mounted_workspace_ownership(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-clone-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    policy = SimpleNamespace(expected_repo_url=REPO_URL, expected_commit_sha=COMMIT_SHA)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    monkeypatch.setattr(operations, "get_active_experiment", lambda active_thread_id: SimpleNamespace(policy=policy) if active_thread_id == thread_id else None)
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+
+        result, _message = clone_repository_impl(
+            session=session,
+            repo_url=REPO_URL,
+            max_retries=1,
+        )
+
+        assert result.exit_code == 0, result.combined_output
+        assert session.commit_sha == COMMIT_SHA
+        assert session.status == "source_ready"
     finally:
         compile_cleanup = runtime.stop_and_remove_container(session)
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -1154,6 +1154,38 @@ def test_clone_repository_runs_git_inside_compile_container(tmp_path: Path, monk
     assert "Repository cloned successfully" in message
 
 
+def test_exact_commit_clone_marks_repository_safe_before_git_c_operations(tmp_path: Path, monkeypatch):
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    repo_url = "https://example.com/repo.git"
+    commit_sha = "0123456789abcdef0123456789abcdef01234567"
+    session = manager.create_session(thread_id="thread-exact-clone", repo_url=repo_url)
+    session.container_id = "container-123"
+    calls: list[str] = []
+
+    def fake_exec(session_arg, command, **_kwargs):
+        assert session_arg is session
+        calls.append(command)
+        if command.endswith("rev-parse HEAD"):
+            return CommandResult(exit_code=0, stdout=f"{commit_sha}\n", stderr="", combined_output=f"{commit_sha}\n")
+        return CommandResult(exit_code=0, stdout="", stderr="", combined_output="")
+
+    active = SimpleNamespace(policy=SimpleNamespace(expected_repo_url=repo_url, expected_commit_sha=commit_sha))
+    monkeypatch.setattr(operations, "get_active_experiment", lambda _thread_id: active)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)))
+
+    result, message = clone_repository_impl(session=session, repo_url=repo_url, max_retries=1)
+
+    assert result.exit_code == 0
+    exact_clone_command = calls[0]
+    safe_directory = "git config --global --replace-all safe.directory /workspace/repo"
+    first_git_c = "git -C /workspace/repo remote add origin"
+    assert safe_directory in exact_clone_command
+    assert exact_clone_command.index(safe_directory) < exact_clone_command.index(first_git_c)
+    assert session.commit_sha == commit_sha
+    assert session.status == "source_ready"
+    assert "Repository cloned successfully" in message
+
+
 def test_clone_repository_retries_with_container_side_cleanup(tmp_path: Path, monkeypatch):
     manager = CompileSessionManager(paths=make_test_paths(tmp_path))
     session = manager.create_session(thread_id="thread-clone-retry", repo_url="https://example.com/repo.git")


### PR DESCRIPTION
## 改动

- 在 exact-commit clone 的空仓库初始化后、首次 `git -C` / fetch 前，将容器内 `/workspace/repo` 配置为 Git `safe.directory`
- 保持仓库 URL、完整 commit、凭据与宿主路径校验不变
- 增加命令顺序单测和 Windows/WSL bind mount 上的真实 Docker exact clone 验证
- 将修复从旧堆叠基线重排到 `main@2220054f`，PR 只保留 Issue #16 的真实增量

## 根因

v2 pilot 的 `hiredis` 与 `sysstat-nondeterministic` 在 `git init` 后立即执行 `git -C`。Windows/WSL bind mount 的宿主 ownership 与编译容器用户不一致，Git 在 safe-directory 配置之前便以 `dubious ownership` 退出 128。原实现只在 clone 全部成功后、读取 HEAD 时配置，时机过晚。

## 边界

修复仅作用于 active experiment 的 exact-commit clone 路径；普通 clone、clean replay、镜像身份和 artifact gate 不变。v1-v5 manifest、Schema、runner 与既有 ledger 均未修改；Issue #14 已消费的 v2 ledger 不会修改、replacement 或重跑。

## 验证

- compile runtime / terminal / cancellation：`115 passed`
- 后端全量：`1500 passed, 21 skipped`
- 真实 Docker exact clone 与两条 clean replay：`3 passed in 89.62s`
- 全量 Ruff check / format 通过
- Docker Compose config 通过
- 前端 lint、typecheck、build 通过
- `git diff --check` 通过
- 无遗留 compile/replay 容器

Closes #16
