### PR TITLE
修复：在 runner 退出后同步终结编译会话

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -11,8 +11,8 @@
 - 2026-07-20 — 将 Issue #17 / PR #20 的 runner Session 终结修复重排到最新主干并完成本地验证
   - 文件: `scripts/forge_benchmark_runner.py`, `backend/tests/test_forge_benchmark_runner.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
   - 动机: runner 在嵌入式 client 正常返回、异常或提前退出后，先同步终结该 physical attempt thread 的未完成 Compile Session，再清理 orphan；首次终结未闭合但 orphan 清理成功时幂等重试，endpoint failure、Session lifecycle 与 orphan cleanup 保持独立证据域
-  - 证据: runner 单测 `12 passed`，benchmark/evidence `100 passed, 3 skipped`，compile runtime/terminal/cancellation `115 passed`，后端全量 `1503 passed, 22 skipped`，真实 Docker exact clone/session finalization/clean replay `4 passed in 94.88s`；改动文件 Ruff/format、Compose config、前端 lint/typecheck/build、冻结资产和 diff 检查通过且无遗留容器
-  - 边界: 全量 Ruff 的 4 个错误均位于未改动且与 `origin/main` 相同的 `scripts/check.py`、`scripts/forge_benchmark.py`；v1-v5 manifest、Schema、runner hash 与 ledger 未修改或重跑，未启动 v6 pilot；PR retarget、CI 与合并待完成
+  - 证据: runner 单测 `12 passed`，benchmark/evidence `100 passed, 3 skipped`，带 Git 的 v2 历史测试 `10 passed`，compile runtime/terminal/cancellation `115 passed`，后端全量 `1503 passed, 22 skipped`，真实 Docker exact clone/session finalization/clean replay `4 passed in 94.88s`；改动文件 Ruff/format、Compose config、前端 lint/typecheck/build、冻结资产和 diff 检查通过且无遗留容器
+  - 边界: 全量 Ruff 的 4 个错误均位于未改动且与 `origin/main` 相同的 `scripts/check.py`、`scripts/forge_benchmark.py`；Issue #22 计划中的 v2 current-tree drift 测试语义提前并入本 PR，继续要求旧 runner 漂移被明确拒绝；v1-v5 manifest、Schema、runner hash 与 ledger 未修改或重跑，未启动 v6 pilot；CI 与合并待完成
 
 - 2026-07-20 — 将 Issue #16 / PR #19 的 exact-commit clone ownership 修复重排到最新主干并完成本地验证
   - 文件: `backend/packages/harness/deerflow/compile/operations.py`, `backend/tests/test_compile_runtime.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-20 — 将 Issue #17 / PR #20 的 runner Session 终结修复重排到最新主干并完成本地验证
+  - 文件: `scripts/forge_benchmark_runner.py`, `backend/tests/test_forge_benchmark_runner.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
+  - 动机: runner 在嵌入式 client 正常返回、异常或提前退出后，先同步终结该 physical attempt thread 的未完成 Compile Session，再清理 orphan；首次终结未闭合但 orphan 清理成功时幂等重试，endpoint failure、Session lifecycle 与 orphan cleanup 保持独立证据域
+  - 证据: runner 单测 `12 passed`，benchmark/evidence `100 passed, 3 skipped`，compile runtime/terminal/cancellation `115 passed`，后端全量 `1503 passed, 22 skipped`，真实 Docker exact clone/session finalization/clean replay `4 passed in 94.88s`；改动文件 Ruff/format、Compose config、前端 lint/typecheck/build、冻结资产和 diff 检查通过且无遗留容器
+  - 边界: 全量 Ruff 的 4 个错误均位于未改动且与 `origin/main` 相同的 `scripts/check.py`、`scripts/forge_benchmark.py`；v1-v5 manifest、Schema、runner hash 与 ledger 未修改或重跑，未启动 v6 pilot；PR retarget、CI 与合并待完成
+
 - 2026-07-20 — 将 Issue #16 / PR #19 的 exact-commit clone ownership 修复重排到最新主干并完成本地验证
   - 文件: `backend/packages/harness/deerflow/compile/operations.py`, `backend/tests/test_compile_runtime.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
   - 动机: 从旧堆叠基线提取单一修复，在 `git init` 后、首次 `git -C`/fetch 前配置容器内 `/workspace/repo` 为 `safe.directory`；保持 remote URL、完整 commit、普通 clone、clean replay、artifact gate、v1-v5 协议和 ledger 不变
@@ -27,7 +33,6 @@
   - 文件: `scripts/forge_benchmark.py`, `backend/tests/test_forge_benchmark.py`, `benchmarks/README.md`, `benchmarks/manifests/cpp-pilot-v1.json`, `benchmarks/schemas/forge-cpp-benchmark-v1.schema.json`, `.github/workflows/backend-unit-tests.yml`
   - 动机: 在不改写 v1-v5 冻结 manifest、Schema、记录器或账本的前提下，把 Issue #10 的协议增量从旧 clean-replay 分支重放到 `main`；Forge 组件按 manifest 声明的历史 Git revision 校验，当前 recorder 与 Schema 仍按工作树字节校验，CI checkout 获取完整历史以执行同一严格检查
   - 证据: 聚焦回归 `183 passed`，后端全量 `1470 passed, 17 skipped`，后端 Ruff、前端 lint/typecheck/build、Draft 2020-12 meta-schema、冻结资产、diff 与敏感信息检查通过
-
 - 2026-07-18 — 完成 v2 五 case 首次 physical pilot 并保留失败证据
   - 文件: `.compile-sessions/benchmark-evidence/`（本地 Git 忽略的 append-only ledger），`.claude/memory/project.md`
   - 动机: 在 clean-tree preflight `ready=true` 后，以 `gpt-5.6-sol`、0 provider retries、无 fallback、Memory/Skills 关闭和 `compose-dood` 严格串行执行 `fmt`、`hiredis`、`libcheck`、`libgit2`、`sysstat-nondeterministic`；每个 slot 在首个模型请求前已有独立 ledger，未 replacement
@@ -66,8 +71,8 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #16 / PR #19 的重排、审阅、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- PR #19 合并后按 #20 -> #21 -> #23 顺序继续处理堆叠 PR；不得删除仍被上层 PR 引用的远端 base 分支。
+- 完成 Issue #17 / PR #20 的审阅、完整验证、CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- PR #20 合并后继续处理 Issue #18 / PR #21；不得删除仍被上层 PR 引用的远端 base 分支。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -77,7 +82,7 @@
 - PowerShell -> WSL -> `bash -lc` 的多层命令可能提前展开临时 `$repo` 变量，使 Docker bind mount 退化为 `/frontend/...`；一次性容器优先传完整 WSL 绝对路径，启动失败后先按固定名称清理并确认无残留。
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。
 - WSL 的 `127.0.0.1` 代理不能直接传入 Docker build；编译镜像代理必须使用容器可达地址。
-- 后端全量 Ruff 当前有 9 个本次改动之外的既有错误；相关改动文件的定向 Ruff 已通过。
+- 后端全量 Ruff 当前有 4 个本次改动之外且与 `origin/main` 相同的既有错误：`scripts/check.py` 的 3 个 UP045 与 `scripts/forge_benchmark.py` 的 1 个 I001；本次改动文件的 Ruff check/format 已通过。
 - 成功 bash 记录只是候选 recipe；失败命令可能留下持久副作用。进入研究基线前必须在新容器与空 `/workspace`、`/artifacts` 中实际 replay，不能把 `repro_bundle` 生成成功等同于独立复现成功。
 - Windows 挂载目录在编译镜像中可能触发 Git `dubious ownership`；replay 初始化仓库后必须把 `/workspace/repo` 加入 `safe.directory`。
 - 不要把含 `$()`、重定向和多层引号的后验校验直接嵌进 PowerShell → WSL → `docker run ... bash -lc`；参数可能被中间层重解释。应先单独运行 `bash /repro/build.sh` 获取退出码，再用独立命令检查类型、输出与哈希。

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -19,7 +19,7 @@ import pytest
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import CompileDockerRuntime
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, verify_clean_replay_impl
+from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, finalize_unfinished_thread_sessions_impl, verify_clean_replay_impl
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
 
@@ -269,6 +269,41 @@ def test_exact_commit_clone_accepts_bind_mounted_workspace_ownership(monkeypatch
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
         assert compile_cleanup.succeeded is True
         assert compile_cleanup.removed is True
+
+
+def test_unfinished_session_finalization_removes_real_compile_container(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-finalize-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        manager.mark_session_status(session, "ready")
+
+        finalized = finalize_unfinished_thread_sessions_impl(thread_id=thread_id)
+
+        assert len(finalized) == 1
+        reloaded = manager.load_session(session.session_id, thread_id)
+        assert reloaded.status == "failed"
+        assert reloaded.finalized_at is not None
+        inspect = subprocess.run(
+            ["docker", "inspect", session.container_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert inspect.returncode != 0
+    finally:
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
 
 
 def test_clean_replay_rebuilds_pinned_cmake_fixture_in_fresh_container(monkeypatch):

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import ContainerCleanupResult
 from deerflow.compile.evidence import ExperimentLedger
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
 from deerflow.tools.builtins.task_tool import _with_benchmark_constraints
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -316,6 +322,162 @@ def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(
     assert events[-1]["event"] == "orphan.reconciled"
     assert not any(event["event"] == "experiment.completed" for event in events)
     ExperimentLedger.open(ledger.path).append("recovery.recorded", {"status": "interrupted"})
+
+
+@pytest.mark.parametrize("raise_error", [False, True])
+def test_run_terminalizes_unfinished_session_after_client_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raise_error: bool,
+) -> None:
+    manifest = load_manifest()
+    preflight = ready_preflight(manifest)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: preflight,
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path / "evidence",
+    )
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    manager = CompileSessionManager(
+        paths=Paths(
+            base_dir=tmp_path / "state",
+            workspace_root=tmp_path / "workspace",
+            host_workspace_root=str(tmp_path / "workspace"),
+        )
+    )
+    cleanup_calls: list[str] = []
+
+    def stop_and_remove_container(session):
+        cleanup_calls.append(session.session_id)
+        return ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(
+            manager=manager,
+            runtime=SimpleNamespace(stop_and_remove_container=stop_and_remove_container),
+        ),
+    )
+
+    class ReturningClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        def stream(self, message: str, *, thread_id: str):
+            del message
+            session = manager.create_session(thread_id=thread_id, repo_url="https://example.com/repo.git")
+            session.container_id = "container-123"
+            manager.save_session(session)
+            manager.mark_session_status(session, "ready")
+            if raise_error:
+                raise TimeoutError
+            return iter(())
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", ReturningClient)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "reconcile_orphans",
+        lambda _attempt_id: {
+            "scan_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    result = forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    sessions = manager.list_sessions(thread_id)
+    assert len(sessions) == 1
+    finalized = manager.load_session(sessions[0].session_id, thread_id)
+    assert finalized.status == "failed"
+    assert finalized.finalized_at is not None
+    assert (finalized.termination_status == "failed") is raise_error
+    assert cleanup_calls == [finalized.session_id]
+    assert result["session_finalization_succeeded"] is True
+    completed = ledger.read()[-1]
+    assert completed["event"] == "experiment.completed"
+    assert completed["payload"]["session_finalization_succeeded"] is True
+
+
+def test_run_retries_session_finalization_after_orphan_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    preflight = ready_preflight(manifest)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: preflight,
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path / "evidence",
+    )
+    call_order: list[str] = []
+    finalization_results = iter([False, True])
+
+    class ReturningClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        def stream(self, message: str, *, thread_id: str):
+            del message, thread_id
+            return iter(())
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", ReturningClient)
+
+    def finalize_sessions(
+        thread_id: str,
+        *,
+        interrupted_status: str | None,
+        error: str | None,
+    ) -> bool:
+        del thread_id
+        assert interrupted_status is None
+        assert error is None
+        call_order.append("finalize")
+        return next(finalization_results)
+
+    def reconcile(_attempt_id: str) -> dict[str, object]:
+        call_order.append("reconcile")
+        return {
+            "scan_succeeded": True,
+            "orphan_count": 1,
+            "removed_count": 1,
+            "cleanup_succeeded": True,
+        }
+
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "_finalize_attempt_sessions",
+        finalize_sessions,
+    )
+    monkeypatch.setattr(forge_benchmark_runner, "reconcile_orphans", reconcile)
+
+    result = forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    assert call_order == ["finalize", "reconcile", "finalize"]
+    assert result["session_finalization_succeeded"] is True
+    completed = ledger.read()[-1]
+    assert completed["event"] == "experiment.completed"
+    assert completed["payload"]["session_finalization_succeeded"] is True
 
 
 def test_gate_recomputation_detects_tampering_and_oracle_is_independent() -> None:

--- a/backend/tests/test_forge_benchmark_v2.py
+++ b/backend/tests/test_forge_benchmark_v2.py
@@ -74,16 +74,18 @@ def test_v2_manifest_rejects_protocol_drift(mutation, message: str) -> None:
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")
-def test_v2_manifest_digest_is_canonical_and_historical_files_match() -> None:
+def test_v2_manifest_digest_is_canonical_and_current_runner_drift_is_rejected() -> None:
     manifest = load_v2_manifest()
     digest = forge_benchmark_v2.manifest_sha256(manifest)
     reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
 
     assert forge_benchmark_v2.manifest_sha256(reparsed) == digest
     assert digest == "6f29c0f06b5c6e72f9cf0d38afb35be3a61d304ad2ed4f2556a29b5cd7a1422b"
-    audit = forge_benchmark_history.audit_v2_history(manifest, REPO_ROOT)
-    assert audit["lineage_mode"] == "audited_squash_successor"
-    assert audit["successor_commit"] == "9e002f4568a77de07fdce65b49373afb7e5cc74e"
+    with pytest.raises(
+        forge_benchmark_history.HistoryAuditError,
+        match=r"frozen protocol artifact mismatch: scripts/forge_benchmark_runner\.py",
+    ):
+        forge_benchmark_history.audit_v2_history(manifest, REPO_ROOT)
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -615,6 +615,25 @@ def reconcile_orphans(physical_attempt_id: str) -> dict[str, Any]:
     }
 
 
+def _finalize_attempt_sessions(
+    thread_id: str,
+    *,
+    interrupted_status: str | None,
+    error: str | None,
+) -> bool:
+    try:
+        from deerflow.compile.operations import finalize_unfinished_thread_sessions_impl
+
+        sessions = finalize_unfinished_thread_sessions_impl(
+            thread_id=thread_id,
+            interrupted_status=interrupted_status,
+            error=error,
+        )
+    except Exception:
+        return False
+    return all(session.finalized_at is not None for session in sessions)
+
+
 def run_attempt(
     manifest: dict[str, Any],
     ledger_path: Path,
@@ -656,6 +675,7 @@ def run_attempt(
         policy=policy,
     )
     run_status = "failed"
+    session_finalization_succeeded = False
     try:
         from deerflow.client import DeerFlowClient
 
@@ -681,15 +701,28 @@ def run_attempt(
         if isinstance(exc, (KeyboardInterrupt, SystemExit)):
             raise
     finally:
+        interrupted_status = "failed" if run_status == "failed" else None
+        termination_error = "Benchmark run ended before compile session finalization." if interrupted_status is not None else None
+        session_finalization_succeeded = _finalize_attempt_sessions(
+            thread_id,
+            interrupted_status=interrupted_status,
+            error=termination_error,
+        )
         deactivate_experiment(thread_id)
         reconciliation = reconcile_orphans(ledger.physical_attempt_id)
+        if not session_finalization_succeeded and reconciliation["cleanup_succeeded"]:
+            session_finalization_succeeded = _finalize_attempt_sessions(
+                thread_id,
+                interrupted_status=interrupted_status,
+                error=termination_error,
+            )
         ledger.append("orphan.reconciled", reconciliation)
 
     events = ledger.read()
     gates = recompute_gates(events)
     oracle = run_oracle(manifest, events)
     ledger.append("oracle.completed", oracle)
-    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] else "failed"
+    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] and session_finalization_succeeded else "failed"
     ledger.append(
         "experiment.completed",
         {
@@ -697,6 +730,7 @@ def run_attempt(
             "gate_recomputation_valid": gates["valid"],
             "oracle_passed": oracle["passed"],
             "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
+            "session_finalization_succeeded": session_finalization_succeeded,
         },
     )
     return {
@@ -704,6 +738,7 @@ def run_attempt(
         "gate_recomputation": gates,
         "oracle": oracle,
         "orphan_reconciliation": reconciliation,
+        "session_finalization_succeeded": session_finalization_succeeded,
     }
 
 


### PR DESCRIPTION
## 改动

- benchmark client 正常返回、异常或提前退出后，先同步终结该 physical attempt 唯一 thread 下的未完成 Compile Session
- Session 收口后再执行 orphan reconciliation；若首次收口因容器清理未完成而失败，在 orphan 删除成功后幂等重试
- `experiment.completed` 独立记录 `session_finalization_succeeded`，不覆盖 endpoint/build failure attribution
- 增加正常返回、超时异常、重试顺序和真实 Docker `ready -> failed/finalized` 覆盖
- 将 Issue #22 计划中的 v2 current-tree drift 测试语义提前落地：旧协议资产保持冻结，当前 runner 漂移必须被 v2 gate 明确拒绝

## 根因

runner 直接使用嵌入式 `DeerFlowClient.stream`，没有经过 Gateway run worker 的 `finally`。模型错误中间件还可能把 endpoint timeout 转成正常 agent 返回，因此 runner 即使按 label 删除了 orphan 容器，对应 `session.json` 仍可能停在 `ready`。

## 影响

endpoint failure、Session lifecycle 与 orphan cleanup 继续作为三个独立证据域。已有 termination reason 保持 first-reason-wins；迟到 submit 仍受持久 termination fence 约束。runner 只有在 Session 终结、gate、oracle 和 orphan 清理全部成功时才可把 experiment 标为通过。

## 验证

- runner 单测：`12 passed`
- benchmark/evidence：`100 passed, 3 skipped`
- 带 Git 的 v2 历史测试：`10 passed`
- compile runtime/terminal/cancellation：`115 passed`
- 本地 Compose 后端全量：`1503 passed, 22 skipped`
- GitHub 后端全量：`1506 passed, 19 skipped`
- 真实 Docker exact clone、Session finalization 与 clean replay：`4 passed in 94.88s`
- 本次改动文件 Ruff check/format、Compose config、前端 lint/typecheck/build、冻结资产与 diff 检查通过
- GitHub `backend-unit-tests`、后端 lint、前端 lint/build 全绿
- 无遗留 compile/replay 容器

## 已知基线

额外扫描 `/repo/scripts` 时的 4 个 Ruff 错误均位于本次未修改且与 `origin/main` 相同的 `scripts/check.py` 与 `scripts/forge_benchmark.py`；GitHub 仓库定义的后端 lint 门禁已通过。

## 协议边界

本 PR 不修改或重跑 v1-v5 manifest、Schema、runner hash 与 ledger，不启动 v6 pilot。v2 的历史 manifest/digest 与声明基线 Git blob 校验继续保留，只有当前 runner 工作树漂移被改为预期拒绝。

Closes #17