### PR TITLE
修复：提取模型响应中的实际模型证据

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-20 — 将 Issue #18 / PR #21 的 actual-model evidence 修复重排到 `main@796cf05a` 并完成本地验证
+  - 文件: `backend/packages/harness/deerflow/compile/evidence.py`, `backend/tests/test_experiment_evidence.py`, `.claude/memory/project.md`
+  - 动机: LangChain `ModelResponse.result` 是结构化 message 列表，旧 helper 把整个列表当成单个候选，因而漏读 `AIMessage.response_metadata`；新实现最多遍历 8 个 message，允许模型身份与 usage 来自不同 message
+  - 安全边界: 只读取 `response_metadata.model_name/model` 和三项非负整数 token usage；unsafe model 与布尔 token 被拒绝但不改变模型调用结果；不读取或保存 content、prompt、response body、headers、异常文本、密钥或宿主路径，provider 未提供身份时保持 `actual_model=null`
+  - 证据: 模型/evidence `46 passed`，benchmark/runner/evidence `104 passed, 3 skipped`，带 Git 的 v2 历史测试 `10 passed`，后端全量 `1507 passed, 22 skipped`；后端 Ruff/format、Compose config、前端串行 format/lint/typecheck/build、diff 和无遗留容器检查通过
+  - 边界: v1-v5 manifest、Schema、validator、协议哈希和 ledger 未修改或重跑；本阶段没有模型请求，等待 PR 完整 CI 与合并
+
 - 2026-07-20 — 将 Issue #17 / PR #20 的 runner Session 终结修复重排到最新主干并完成本地验证
   - 文件: `scripts/forge_benchmark_runner.py`, `backend/tests/test_forge_benchmark_runner.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
   - 动机: runner 在嵌入式 client 正常返回、异常或提前退出后，先同步终结该 physical attempt thread 的未完成 Compile Session，再清理 orphan；首次终结未闭合但 orphan 清理成功时幂等重试，endpoint failure、Session lifecycle 与 orphan cleanup 保持独立证据域
@@ -71,8 +78,8 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #17 / PR #20 的审阅、完整验证、CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- PR #20 合并后继续处理 Issue #18 / PR #21；不得删除仍被上层 PR 引用的远端 base 分支。
+- 完成 Issue #18 / PR #21 的回归、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- PR #21 合并后继续处理 Issue #22 / PR #23；不得删除仍被上层 PR 引用的远端 head 分支。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -510,7 +510,11 @@ def request_model_endpoint(request: Any) -> str | None:
 def model_response_metadata(response: Any) -> tuple[str | None, dict[str, int | None]]:
     candidates: list[Any] = []
     if hasattr(response, "result"):
-        candidates.append(getattr(response, "result"))
+        result = getattr(response, "result")
+        if isinstance(result, (list, tuple)):
+            candidates.extend(result[:8])
+        else:
+            candidates.append(result)
     candidates.append(response)
     actual_model: str | None = None
     usage = {"input_tokens": None, "output_tokens": None, "total_tokens": None}
@@ -520,15 +524,19 @@ def model_response_metadata(response: Any) -> tuple[str | None, dict[str, int | 
             for key in ("model_name", "model"):
                 value = metadata.get(key)
                 if isinstance(value, str) and value and len(value) <= 128:
+                    try:
+                        _validate_safe_value(value, "actual_model")
+                    except EvidenceError:
+                        continue
                     actual_model = value
                     break
         usage_metadata = getattr(candidate, "usage_metadata", None)
         if isinstance(usage_metadata, dict):
             for key in usage:
                 value = usage_metadata.get(key)
-                if isinstance(value, int) and value >= 0:
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
                     usage[key] = value
-        if actual_model is not None or any(value is not None for value in usage.values()):
+        if actual_model is not None and any(value is not None for value in usage.values()):
             break
     return actual_model, usage
 

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +13,7 @@ from deerflow.compile.evidence import (
     activate_experiment,
     deactivate_experiment,
     get_active_experiment,
+    model_response_metadata,
     new_evidence_id,
     record_experiment_event,
 )
@@ -123,3 +125,71 @@ def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) 
     events = ledger.read()
     assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
     assert get_active_experiment(thread_id) is None
+
+
+def test_model_response_metadata_reads_bounded_model_response_messages() -> None:
+    response = SimpleNamespace(
+        result=[
+            SimpleNamespace(
+                response_metadata={},
+                usage_metadata={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+            ),
+            SimpleNamespace(
+                response_metadata={"model_name": "provider-confirmed-model"},
+                usage_metadata=None,
+            ),
+        ]
+    )
+
+    actual_model, usage = model_response_metadata(response)
+
+    assert actual_model == "provider-confirmed-model"
+    assert usage == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+
+
+def test_model_response_metadata_keeps_unobserved_model_null() -> None:
+    response = SimpleNamespace(
+        result=[
+            SimpleNamespace(
+                response_metadata={"finish_reason": "stop"},
+                usage_metadata=None,
+                content="must not be inspected",
+            )
+        ]
+    )
+
+    actual_model, usage = model_response_metadata(response)
+
+    assert actual_model is None
+    assert usage == {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+
+
+def test_model_response_metadata_rejects_unsafe_model_and_boolean_usage() -> None:
+    response = SimpleNamespace(
+        result=[
+            SimpleNamespace(
+                response_metadata={"model_name": "unsafe\nmodel"},
+                usage_metadata={"input_tokens": True},
+            )
+        ]
+    )
+
+    actual_model, usage = model_response_metadata(response)
+
+    assert actual_model is None
+    assert usage == {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+
+
+def test_model_response_metadata_reads_at_most_eight_messages() -> None:
+    messages = [SimpleNamespace(response_metadata={}, usage_metadata=None) for _ in range(8)]
+    messages.append(
+        SimpleNamespace(
+            response_metadata={"model_name": "out-of-bounds-model"},
+            usage_metadata={"total_tokens": 99},
+        )
+    )
+
+    actual_model, usage = model_response_metadata(SimpleNamespace(result=messages))
+
+    assert actual_model is None
+    assert usage == {"input_tokens": None, "output_tokens": None, "total_tokens": None}


### PR DESCRIPTION
## 改动

- 展开 LangChain `ModelResponse.result` 中最多 8 个结构化 message 候选
- 只读取 `response_metadata.model_name/model` 和 `usage_metadata` 的 input/output/total token 非负整数
- 支持模型身份与 token usage 分散在不同 message 的情况
- 拒绝 unsafe model 值和布尔 token，但不让观测失败改变已成功的模型调用结果
- provider 没有身份字段时继续保存 `actual_model=null`，不从 configured model 回填

## 根因

当前 LangChain 的 `ModelResponse.result` 是 `list[BaseMessage]`。旧 helper 把整个 list 当作单个候选，无法访问其中 `AIMessage.response_metadata`，因此即使 provider 返回了结构化模型身份也会漏记。

## 安全边界

不读取或保存 message content、additional kwargs、response body、原始 headers、prompt、异常文本、密钥或宿主路径。模型名继续经过长度和安全值校验；未观测字段保持 `null`。

v1-v5 manifest、Schema、validator、协议哈希和 ledger 均未修改或重跑，本阶段没有发起模型请求。

## 验证

- 模型/evidence：`46 passed`
- benchmark/runner/evidence：`104 passed, 3 skipped`
- 带 Git 的 v2 历史审计：`10 passed`
- 后端全量：`1507 passed, 22 skipped`
- 后端 Ruff 与格式检查通过
- Compose 配置检查通过
- 前端 format、lint、typecheck、build 串行通过
- diff、敏感信息和遗留容器检查通过

Closes #18
