### PR TITLE
功能：冻结并审计 C/C++ pilot v3 协议

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,11 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-07-20 — 将 Issue #22 / PR #23 的 pilot v3 协议与既有五 case 审计重排到 `main@17e09f58`
+  - 范围: 保留 v3 manifest、Schema、validator、runner 与 digest 的冻结字节，移植 `73d28a16`/`88283298` 的真实增量，删除 PR #20 已提前落地的重复 v2 drift 测试
+  - 历史边界: v3 五份 ledger 已绑定 `371f678e` 与 digest `d67ab40e...`，不得改写、replacement 或重跑；当前主干漂移必须被旧 v3 gate 拒绝，并另行验证历史 baseline blob 与审阅后继
+  - 状态: 已备份旧 head `88283298` 并开始冲突解析；等待历史审计、完整回归、PR CI 与合并
+
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
@@ -14,7 +19,6 @@
   - 安全边界: 只读取 `response_metadata.model_name/model` 和三项非负整数 token usage；unsafe model 与布尔 token 被拒绝但不改变模型调用结果；不读取或保存 content、prompt、response body、headers、异常文本、密钥或宿主路径，provider 未提供身份时保持 `actual_model=null`
   - 证据: 模型/evidence `46 passed`，benchmark/runner/evidence `104 passed, 3 skipped`，带 Git 的 v2 历史测试 `10 passed`，后端全量 `1507 passed, 22 skipped`；后端 Ruff/format、Compose config、前端串行 format/lint/typecheck/build、diff 和无遗留容器检查通过
   - 边界: v1-v5 manifest、Schema、validator、协议哈希和 ledger 未修改或重跑；本阶段没有模型请求，等待 PR 完整 CI 与合并
-
 - 2026-07-20 — 将 Issue #17 / PR #20 的 runner Session 终结修复重排到最新主干并完成本地验证
   - 文件: `scripts/forge_benchmark_runner.py`, `backend/tests/test_forge_benchmark_runner.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
   - 动机: runner 在嵌入式 client 正常返回、异常或提前退出后，先同步终结该 physical attempt thread 的未完成 Compile Session，再清理 orphan；首次终结未闭合但 orphan 清理成功时幂等重试，endpoint failure、Session lifecycle 与 orphan cleanup 保持独立证据域
@@ -78,8 +82,8 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #18 / PR #21 的回归、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- PR #21 合并后继续处理 Issue #22 / PR #23；不得删除仍被上层 PR 引用的远端 head 分支。
+- 完成 Issue #22 / PR #23 的历史审计、回归、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- PR #23 合并后继续处理 Issue #24 / PR #27；不得删除仍被上层 PR 引用的远端 head 分支。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -111,3 +115,4 @@
 - Manifest 的 CMake/configure 参数必须确定性注入 compiler prompt，并按有序 token 子序列验证；只检查参数集合会掩盖顺序敏感的配置偏差。
 - 在仓库根直接启动 Compose 会改变 project name，并可能因网络网段重叠创建失败；开发服务必须继续使用既定 `deer-flow-dev` project/启动脚本。
 - Compose 开发容器只把完整仓库只读挂载到 `/repo`，而 `/app/backend` 仅是后端源码挂载；依赖仓库根资产的 pytest/Ruff 必须从 `/repo/backend` 运行，并使用 `/app/backend/.venv` 解释器、关闭仓库内缓存。
+- 从大型冻结协议文件派生新版本时，单次命令输出可能被工具上限静默截断；必须分块读取并在冻结哈希前校验 JSON 解析、行数和机械替换后的完整字节相等性。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,7 +8,7 @@
 - 2026-07-20 — 将 Issue #22 / PR #23 的 pilot v3 协议与既有五 case 审计重排到 `main@17e09f58`
   - 范围: 保留 v3 manifest、Schema、validator、runner 与 digest 的冻结字节，移植 `73d28a16`/`88283298` 的真实增量，删除 PR #20 已提前落地的重复 v2 drift 测试
   - 历史边界: v3 五份 ledger 已绑定 `371f678e` 与 digest `d67ab40e...`，不得改写、replacement 或重跑；当前主干漂移必须被旧 v3 gate 拒绝，并另行验证历史 baseline blob 与审阅后继
-  - 状态: 已备份旧 head `88283298` 并开始冲突解析；等待历史审计、完整回归、PR CI 与合并
+  - 状态: 两笔真实增量已重排为中文提交，v3 历史审计已固定 baseline tree/blob 与审阅后主干 successor，并拒绝旧分叉；后端全量 `1519 passed, 25 skipped`，聚焦测试、Schema、Compose、改动文件 Ruff/format、前端串行 format/lint/typecheck/build、冻结哈希、diff 与无遗留容器检查通过，等待推送、PR 完整 CI 与合并
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
@@ -120,12 +120,13 @@
 - 历史 manifest 的 Forge 组件哈希必须按其声明的 Git revision 读取 blob 校验；把它永久对照最新工作树，会在 stacked PR squash 合并或后续 instrumentation 后产生伪漂移。协议记录器与 Schema 仍应按当前字节校验；最小后端镜像没有 Git 时，由运行时 preflight 校验当前工作树。
 - Rebase 等价不能伪装成 Git ancestry：`d845b735` 不会因为其重排版本最终 squash 到主干就成为 `9e002f45` 的祖先。历史审计必须固定原 baseline tree、审阅后的 rebased head、squash successor 和相同 successor tree，并拒绝不在该 successor ancestry 上的 head。
 - 7.4 GiB WSL2 中不要并行启动前端 lint、typecheck 和 Next.js build；三个一次性 Node 容器会耗尽内存并让 WSL 服务超时。应串行执行，给每个容器设置内存/CPU 上限和独立匿名 `.next` 卷；无真实认证密钥的 CI build 使用仓库支持的 `SKIP_ENV_VALIDATION=1`。
-- 一次性前端测试容器的镜像内置源码可能落后于主干；应只读挂载当前 `frontend/src`、`public` 和 `next.config.js`，并让容器使用独立 `.next`，不能在运行 `next dev` 的容器内并发构建。
+- 一次性前端测试容器的镜像内置源码可能落后于主干；lint/typecheck/build 应只读挂载当前 `frontend/src`、`public` 和 `next.config.js`，format 还要挂载其扫描到的根级 Markdown/配置文件；使用独立 `.next`，不能在运行 `next dev` 的容器内并发构建。
 - Actions checkout 默认 `fetch-depth: 1`；需要读取 manifest 固定历史 revision 的 benchmark 测试必须显式获取完整 Git 历史，否则本地完整 clone 通过而 CI 会因找不到历史路径失败。
 - Compose 中只读挂载的 `/repo` 适合 runner/preflight，但 Ruff/pytest 必须关闭仓库内缓存；需要格式化时使用一次性可写 bind mount。WSL 宿主当前没有 `uv`，标准库 runner 可直接运行，依赖完整的回归测试继续在 LangGraph 开发容器中执行。
 - Manifest 的 CMake/configure 参数必须确定性注入 compiler prompt，并按有序 token 子序列验证；只检查参数集合会掩盖顺序敏感的配置偏差。
 - 在仓库根直接启动 Compose 会改变 project name，并可能因网络网段重叠创建失败；开发服务必须继续使用既定 `deer-flow-dev` project/启动脚本。
 - Compose 开发容器只把完整仓库只读挂载到 `/repo`，而 `/app/backend` 仅是后端源码挂载；依赖仓库根资产的 pytest/Ruff 必须从 `/repo/backend` 运行，并使用 `/app/backend/.venv` 解释器、关闭仓库内缓存。
 - 从大型冻结协议文件派生新版本时，单次命令输出可能被工具上限静默截断；必须分块读取并在冻结哈希前校验 JSON 解析、行数和机械替换后的完整字节相等性。
+- JSON Schema 内部若使用 `#/$defs/...` 根引用，实例校验必须把完整 schema 交给 validator；直接抽出 `$defs.manifest` 会失去根定义并产生 `PointerToNowhere`，这属于校验命令错误，不是 schema 失效。
 - `DeerFlowClient.stream()` 使用同步 LangGraph 执行路径，不能调用只有 coroutine 的 `task_tool`；benchmark runner 进入 compiler 子代理前必须改用 async streaming，不能用阻塞包装破坏取消/终止语义。
 - Physical-attempt policy 当前未冻结 `cases[].build_system`，且 ledger 不记录有界的 agent tool failure/no-action completion；修复前即使 exact clone 成功，也不能把 0 submit 解释为 compiler 能力结果。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -13,6 +13,17 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-19 — 完成 pilot v3 五个 physical attempt 并审计三类新阻塞
+  - 文件: `.compile-sessions/benchmark-evidence-v3/`（本地 Git 忽略的 append-only ledger）, `.claude/memory/project.md`
+  - 结果: `fmt`、`hiredis`、`libcheck`、`libgit2`、`sysstat-nondeterministic` 五份 ledger 的 hash chain 与离线 gate 全部有效，全部为 `submit_missing`，0 submit、0 clean replay、0 replacement、0 遗留 compile/replay 容器；`fmt`/`hiredis` 首个 lead 请求超时，`libcheck`/`sysstat` 在 exact clone 后的后续 lead 请求超时，`libgit2` 模型成功返回但没有编译工具调用
+  - 修复证据: `libcheck` 与 `sysstat` exact commit 匹配，证明 Issue #16 clone ownership 修复生效；两个 session 都为 `failed`、已 finalized 且容器删除，证明 Issue #17 兜底生效；`libcheck`、`libgit2`、`sysstat` 的成功响应均记录 `actual_model=gpt-5.6-sol`，证明 Issue #18 提取生效
+  - 新发现: embedded runner 的同步 `DeerFlowClient.stream()` 不能调用 async-only `task_tool`；manifest `build_system` 未进入 `ExperimentPolicy`，`libcheck` 声明 Autotools 但 observed 为 CMake；tool failure 与模型成功但 0 编译动作都缺少有界 ledger 事件。已创建 Issue #24、#25、#26；v3 不做 replacement，修复后必须冻结新协议版本
+
+- 2026-07-18 — 冻结包含 Issue #16/#17/#18 修复的 C/C++ pilot v3 协议
+  - 文件: `scripts/forge_benchmark_v3.py`, `scripts/forge_benchmark_runner.py`, `benchmarks/manifests/cpp-pilot-v3.json`, `benchmarks/schemas/forge-cpp-benchmark-v3.schema.json`, `benchmarks/README.md`, `backend/tests/test_forge_benchmark_v2.py`, `backend/tests/test_forge_benchmark_v3.py`, `backend/tests/test_forge_benchmark_runner.py`
+  - 动机: 在不修改 v1/v2 协议和五份 v2 ledger 的前提下，以 `371f678e` 冻结 ownership、session terminalization 与 actual-model 提取修复；runner 默认路由 v3，同时继续接受历史 v1/v2，并保持 `compose-dood`、`gpt-5.6-sol`、120 秒、0 provider retries、无 fallback 和 Memory/Skills 关闭
+  - 证据: v3 canonical digest `d67ab40eb75db7edd01dbf760ec3b01ca495c08a3bdb05f4f33f07ce90e1b92f` 在 Windows/WSL 一致；Schema meta/instance validation、benchmark/runner/evidence `114 passed, 2 skipped`、compile `115 passed`、model/evidence `38 passed`、真实 Docker `4 passed in 90.68s`、定向 Ruff/format、`py_compile` 与 `git diff --check` 通过；提交前 preflight 除预期 `forge_clean=false` 外全部匹配
+
 - 2026-07-20 — 将 Issue #18 / PR #21 的 actual-model evidence 修复重排到 `main@796cf05a` 并完成本地验证
   - 文件: `backend/packages/harness/deerflow/compile/evidence.py`, `backend/tests/test_experiment_evidence.py`, `.claude/memory/project.md`
   - 动机: LangChain `ModelResponse.result` 是结构化 message 列表，旧 helper 把整个列表当成单个候选，因而漏读 `AIMessage.response_metadata`；新实现最多遍历 8 个 message，允许模型身份与 usage 来自不同 message
@@ -24,7 +35,6 @@
   - 动机: runner 在嵌入式 client 正常返回、异常或提前退出后，先同步终结该 physical attempt thread 的未完成 Compile Session，再清理 orphan；首次终结未闭合但 orphan 清理成功时幂等重试，endpoint failure、Session lifecycle 与 orphan cleanup 保持独立证据域
   - 证据: runner 单测 `12 passed`，benchmark/evidence `100 passed, 3 skipped`，带 Git 的 v2 历史测试 `10 passed`，compile runtime/terminal/cancellation `115 passed`，后端全量 `1503 passed, 22 skipped`，真实 Docker exact clone/session finalization/clean replay `4 passed in 94.88s`；改动文件 Ruff/format、Compose config、前端 lint/typecheck/build、冻结资产和 diff 检查通过且无遗留容器
   - 边界: 全量 Ruff 的 4 个错误均位于未改动且与 `origin/main` 相同的 `scripts/check.py`、`scripts/forge_benchmark.py`；Issue #22 计划中的 v2 current-tree drift 测试语义提前并入本 PR，继续要求旧 runner 漂移被明确拒绝；v1-v5 manifest、Schema、runner hash 与 ledger 未修改或重跑，未启动 v6 pilot；CI 与合并待完成
-
 - 2026-07-20 — 将 Issue #16 / PR #19 的 exact-commit clone ownership 修复重排到最新主干并完成本地验证
   - 文件: `backend/packages/harness/deerflow/compile/operations.py`, `backend/tests/test_compile_runtime.py`, `backend/tests/test_compile_replay_docker.py`, `.claude/memory/project.md`
   - 动机: 从旧堆叠基线提取单一修复，在 `git init` 后、首次 `git -C`/fetch 前配置容器内 `/workspace/repo` 为 `safe.directory`；保持 remote URL、完整 commit、普通 clone、clean replay、artifact gate、v1-v5 协议和 ledger 不变
@@ -84,6 +94,7 @@
 
 - 完成 Issue #22 / PR #23 的历史审计、回归、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
 - PR #23 合并后继续处理 Issue #24 / PR #27；不得删除仍被上层 PR 引用的远端 head 分支。
+- 优先修复 Issue #24 的 benchmark async runner，再实现 Issue #25 build-system identity gate 与 Issue #26 有界 agent/tool failure evidence；三项完成并冻结新协议后才能创建下一批 physical attempts。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -116,3 +127,5 @@
 - 在仓库根直接启动 Compose 会改变 project name，并可能因网络网段重叠创建失败；开发服务必须继续使用既定 `deer-flow-dev` project/启动脚本。
 - Compose 开发容器只把完整仓库只读挂载到 `/repo`，而 `/app/backend` 仅是后端源码挂载；依赖仓库根资产的 pytest/Ruff 必须从 `/repo/backend` 运行，并使用 `/app/backend/.venv` 解释器、关闭仓库内缓存。
 - 从大型冻结协议文件派生新版本时，单次命令输出可能被工具上限静默截断；必须分块读取并在冻结哈希前校验 JSON 解析、行数和机械替换后的完整字节相等性。
+- `DeerFlowClient.stream()` 使用同步 LangGraph 执行路径，不能调用只有 coroutine 的 `task_tool`；benchmark runner 进入 compiler 子代理前必须改用 async streaming，不能用阻塞包装破坏取消/终止语义。
+- Physical-attempt policy 当前未冻结 `cases[].build_system`，且 ledger 不记录有界的 agent tool failure/no-action completion；修复前即使 exact clone 成功，也不能把 0 submit 解释为 compiler 能力结果。

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -33,6 +33,11 @@ def load_v2_manifest() -> dict:
     return forge_benchmark_runner._load_manifest(path)
 
 
+def load_v3_manifest() -> dict:
+    path = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v3.json"
+    return forge_benchmark_runner._load_manifest(path)
+
+
 def ready_preflight(manifest: dict, *, ready: bool = True) -> dict:
     return {
         "ready": ready,
@@ -73,10 +78,19 @@ def test_build_policy_applies_frozen_case_and_model_constraints() -> None:
     assert policy.process_environment == manifest["cases"][0]["constraints"]["environment"]
 
 
-def test_v2_preflight_accepts_clean_descendant_with_frozen_components(
+@pytest.mark.parametrize(
+    ("manifest_loader", "manifest_name"),
+    [
+        (load_v2_manifest, "cpp-pilot-v2.json"),
+        (load_v3_manifest, "cpp-pilot-v3.json"),
+    ],
+)
+def test_runnable_preflight_accepts_clean_descendant_with_frozen_components(
     monkeypatch: pytest.MonkeyPatch,
+    manifest_loader,
+    manifest_name: str,
 ) -> None:
-    manifest = load_v2_manifest()
+    manifest = manifest_loader()
     expected_hashes = {
         **manifest["forge"]["component_sha256"],
         **manifest["protocol_artifact_sha256"],
@@ -120,7 +134,7 @@ def test_v2_preflight_accepts_clean_descendant_with_frozen_components(
     preflight = forge_benchmark_runner.collect_preflight(
         manifest,
         repo_root=REPO_ROOT,
-        manifest_path=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v2.json",
+        manifest_path=REPO_ROOT / "benchmarks" / "manifests" / manifest_name,
     )
 
     assert preflight["ready"] is True
@@ -132,10 +146,12 @@ def test_v2_preflight_accepts_clean_descendant_with_frozen_components(
     assert preflight["runtime"]["control_plane_topology"] == "compose-dood"
 
 
-def test_v2_preflight_rejects_missing_baseline_or_compose_dood(
+@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest])
+def test_runnable_preflight_rejects_missing_baseline_or_compose_dood(
     monkeypatch: pytest.MonkeyPatch,
+    manifest_loader,
 ) -> None:
-    manifest = load_v2_manifest()
+    manifest = manifest_loader()
     monkeypatch.setattr(
         forge_benchmark_runner,
         "_git_state",
@@ -241,11 +257,13 @@ def test_run_refuses_failed_preflight_before_importing_model_client(
     assert not any(event["event"].startswith("model.") for event in ledger.read())
 
 
-def test_v2_run_refuses_non_compose_process_before_model_request(
+@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest])
+def test_runnable_run_refuses_non_compose_process_before_model_request(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    manifest_loader,
 ) -> None:
-    manifest = load_v2_manifest()
+    manifest = manifest_loader()
     preflight = ready_preflight(manifest)
     monkeypatch.setattr(
         forge_benchmark_runner,
@@ -271,6 +289,12 @@ def test_v2_run_refuses_non_compose_process_before_model_request(
     events = ledger.read()
     assert events[-1]["event"] == "runtime.topology_rejected"
     assert not any(event["event"].startswith("model.") for event in events)
+
+
+def test_runner_defaults_to_v3_manifest() -> None:
+    args = forge_benchmark_runner._build_parser().parse_args(["preflight"])
+
+    assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v3.json"
 
 
 def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(

--- a/backend/tests/test_forge_benchmark_v3.py
+++ b/backend/tests/test_forge_benchmark_v3.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -17,12 +18,20 @@ V1_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark.py"
 V3_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v3.json"
 V3_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v3.schema.json"
 V3_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v3.py"
+HISTORY_AUDITOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_history.py"
 
 SPEC = importlib.util.spec_from_file_location("forge_benchmark_v3", V3_VALIDATOR_PATH)
 assert SPEC is not None
 assert SPEC.loader is not None
 forge_benchmark_v3 = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(forge_benchmark_v3)
+
+HISTORY_SPEC = importlib.util.spec_from_file_location("forge_benchmark_history_v3", HISTORY_AUDITOR_PATH)
+assert HISTORY_SPEC is not None
+assert HISTORY_SPEC.loader is not None
+forge_benchmark_history = importlib.util.module_from_spec(HISTORY_SPEC)
+sys.modules[HISTORY_SPEC.name] = forge_benchmark_history
+HISTORY_SPEC.loader.exec_module(forge_benchmark_history)
 
 
 def load_v3_manifest() -> dict:
@@ -64,13 +73,41 @@ def test_v3_manifest_rejects_protocol_drift(mutation, message: str) -> None:
         forge_benchmark_v3.validate_manifest(manifest)
 
 
-def test_v3_manifest_digest_is_canonical_and_frozen_files_match() -> None:
+def test_v3_manifest_digest_is_canonical_and_current_runtime_drift_is_rejected() -> None:
     manifest = load_v3_manifest()
     digest = forge_benchmark_v3.manifest_sha256(manifest)
     reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
 
     assert forge_benchmark_v3.manifest_sha256(reparsed) == digest
-    forge_benchmark_v3.verify_frozen_components(manifest, REPO_ROOT)
+    assert digest == "d67ab40eb75db7edd01dbf760ec3b01ca495c08a3bdb05f4f33f07ce90e1b92f"
+    with pytest.raises(
+        forge_benchmark_v3.BenchmarkError,
+        match=r"manifest\.forge\.component_sha256\..*: does not match the current repository file",
+    ):
+        forge_benchmark_v3.verify_frozen_components(manifest, REPO_ROOT)
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")
+def test_v3_history_accepts_the_reviewed_main_successor() -> None:
+    result = forge_benchmark_history.audit_v3_history(load_v3_manifest(), REPO_ROOT)
+
+    assert result["lineage_mode"] == "audited_reviewed_successor"
+    assert result["baseline_commit"] == "371f678e07acc6ae87f80d7544f573332d74fa88"
+    assert result["baseline_tree_sha"] == "a7ab45a93ea763adadcad15cbce31f4c4c36849e"
+    assert result["successor_commit"] == "17e09f5896ca8bf5739cec413c16402cb441209d"
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")
+def test_v3_history_rejects_the_unreviewed_old_fork() -> None:
+    with pytest.raises(
+        forge_benchmark_history.HistoryAuditError,
+        match="does not descend from the v3 audited reviewed successor",
+    ):
+        forge_benchmark_history.audit_v3_history(
+            load_v3_manifest(),
+            REPO_ROOT,
+            head_revision="8828329896d92e8550eb1d0b3cf59bed58441987",
+        )
 
 
 def test_v3_runtime_components_match_the_declared_baseline() -> None:

--- a/backend/tests/test_forge_benchmark_v3.py
+++ b/backend/tests/test_forge_benchmark_v3.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+V1_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v1.json"
+V1_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v1.schema.json"
+V1_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark.py"
+V3_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v3.json"
+V3_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v3.schema.json"
+V3_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v3.py"
+
+SPEC = importlib.util.spec_from_file_location("forge_benchmark_v3", V3_VALIDATOR_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+forge_benchmark_v3 = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(forge_benchmark_v3)
+
+
+def load_v3_manifest() -> dict:
+    return json.loads(V3_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_v1_protocol_files_remain_byte_for_byte_immutable() -> None:
+    assert hashlib.sha256(V1_MANIFEST_PATH.read_bytes()).hexdigest() == "6d73afaa476eef172fc810a63daf7ad22f0f84434bdb6300de7eb4c34269bbee"
+    assert hashlib.sha256(V1_SCHEMA_PATH.read_bytes()).hexdigest() == "ad4d39978cc06ee5c4d5641f4630908a53dc8c8898be49e98632c52f80b28adb"
+    assert hashlib.sha256(V1_VALIDATOR_PATH.read_bytes()).hexdigest() == "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278"
+
+
+def test_v3_manifest_unblocks_only_the_new_compose_dood_protocol() -> None:
+    v1_manifest = json.loads(V1_MANIFEST_PATH.read_text(encoding="utf-8"))
+    v3_manifest = load_v3_manifest()
+
+    assert v1_manifest["scope"]["instrumentation_blocker"] is True
+    assert v3_manifest["scope"]["instrumentation_blocker"] is False
+    assert v3_manifest["runtime"]["control_plane_topology"] == "compose-dood"
+    assert v3_manifest["forge"]["commit_sha"] == forge_benchmark_v3.BASELINE_COMMIT
+    assert v3_manifest["forge"]["revision_policy"] == forge_benchmark_v3.REVISION_POLICY
+    assert forge_benchmark_v3.validate_manifest(v3_manifest) is v3_manifest
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda manifest: manifest["scope"].update(instrumentation_blocker=True), "runnable v3 pilot"),
+        (lambda manifest: manifest["runtime"].update(control_plane_topology="wsl-native"), "compose-dood"),
+        (lambda manifest: manifest["forge"].update(commit_sha="f" * 40), "Issue #16/#17/#18"),
+        (lambda manifest: manifest["model"]["roles"].update(compiler="gpt-5.4"), "gpt-5.6-sol"),
+    ],
+)
+def test_v3_manifest_rejects_protocol_drift(mutation, message: str) -> None:
+    manifest = copy.deepcopy(load_v3_manifest())
+    mutation(manifest)
+
+    with pytest.raises(forge_benchmark_v3.BenchmarkError, match=message):
+        forge_benchmark_v3.validate_manifest(manifest)
+
+
+def test_v3_manifest_digest_is_canonical_and_frozen_files_match() -> None:
+    manifest = load_v3_manifest()
+    digest = forge_benchmark_v3.manifest_sha256(manifest)
+    reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
+
+    assert forge_benchmark_v3.manifest_sha256(reparsed) == digest
+    forge_benchmark_v3.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v3_runtime_components_match_the_declared_baseline() -> None:
+    manifest = load_v3_manifest()
+    baseline = manifest["forge"]["commit_sha"]
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        result = subprocess.run(
+            [git, "show", f"{baseline}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
+
+
+def test_v3_schema_tracks_the_validator_topology_and_identity_contract() -> None:
+    schema = json.loads(V3_SCHEMA_PATH.read_text(encoding="utf-8"))
+    manifest_schema = schema["$defs"]["manifest"]
+    forge_schema = manifest_schema["properties"]["forge"]
+    runtime_schema = manifest_schema["properties"]["runtime"]
+
+    assert manifest_schema["properties"]["schema_version"]["const"] == "3.0.0"
+    assert manifest_schema["properties"]["scope"]["properties"]["instrumentation_blocker"]["const"] is False
+    assert forge_schema["properties"]["commit_sha"]["const"] == forge_benchmark_v3.BASELINE_COMMIT
+    assert forge_schema["properties"]["revision_policy"]["const"] == forge_benchmark_v3.REVISION_POLICY
+    assert set(forge_schema["properties"]["component_sha256"]["required"]) == forge_benchmark_v3.COMPONENT_PATHS
+    assert runtime_schema["properties"]["control_plane_topology"]["const"] == "compose-dood"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,25 @@
 # Forge C/C++ benchmark protocols
 
-## Runnable pilot v2
+## Runnable pilot v3
+
+`cpp-pilot-v3.json` is the five-case calibration protocol for the runtime that includes the Issue #16 exact-clone ownership fix, Issue #17 runner/session terminalization fix, and Issue #18 provider-reported model identity extraction. It preserves every v1/v2 protocol artifact and existing physical-attempt ledger, keeps `control_plane_topology: "compose-dood"`, and creates a separate v3 evidence stratum.
+
+The runtime implementation baseline is `371f678e07acc6ae87f80d7544f573332d74fa88`. A clean runtime HEAD must contain that commit as an ancestor and its 20 frozen runtime components must match the baseline. The model and execution controls remain unchanged from v2: `gpt-5.6-sol` for both roles, the RichLab `/v1` endpoint, `OpenAI_AK`, a 120-second request timeout, zero provider retries, no fallback, one serial backend run, and disabled Memory/Skills.
+
+Validate the manifest on Windows and WSL, then run preflight in the frozen Compose/DooD environment:
+
+```powershell
+python scripts/forge_benchmark_v3.py validate-manifest benchmarks/manifests/cpp-pilot-v3.json
+```
+
+```bash
+python3 scripts/forge_benchmark_runner.py preflight \
+  --manifest benchmarks/manifests/cpp-pilot-v3.json
+```
+
+Only `ready: true` on a clean committed tree authorizes collection. Create and run one new v3 physical attempt for each of the five cases, strictly serially. Do not pass `--replacement-for`, edit or delete a v2 ledger, or pool v2 and v3 outcomes. Once the first v3 ledger is created, the v3 manifest and protocol artifacts are frozen for that collection stratum.
+
+## Historical pilot v2
 
 `cpp-pilot-v2.json` is the runnable five-case calibration protocol created after the Issue #11 evidence ledger landed. It keeps the v1 manifest, validator, and Schema byte-for-byte unchanged, freezes the expanded runtime/evidence component set, and records `control_plane_topology: "compose-dood"`. The v2 baseline uses `gpt-5.6-sol` for both roles, 120-second provider timeouts, zero provider retries, no fallback, and disabled Memory/Skills.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,23 +1,19 @@
 # Forge C/C++ benchmark protocols
 
-## Runnable pilot v3
+## Historical pilot v3
 
-`cpp-pilot-v3.json` is the five-case calibration protocol for the runtime that includes the Issue #16 exact-clone ownership fix, Issue #17 runner/session terminalization fix, and Issue #18 provider-reported model identity extraction. It preserves every v1/v2 protocol artifact and existing physical-attempt ledger, keeps `control_plane_topology: "compose-dood"`, and creates a separate v3 evidence stratum.
+`cpp-pilot-v3.json` is the completed five-case calibration protocol for the runtime that includes the Issue #16 exact-clone ownership fix, Issue #17 runner/session terminalization fix, and Issue #18 provider-reported model identity extraction. It preserves every v1/v2 protocol artifact and existing physical-attempt ledger, keeps `control_plane_topology: "compose-dood"`, and creates a separate v3 evidence stratum. Its five physical attempts are immutable historical evidence and must not be rerun, replaced, or pooled with another protocol version.
 
-The runtime implementation baseline is `371f678e07acc6ae87f80d7544f573332d74fa88`. A clean runtime HEAD must contain that commit as an ancestor and its 20 frozen runtime components must match the baseline. The model and execution controls remain unchanged from v2: `gpt-5.6-sol` for both roles, the RichLab `/v1` endpoint, `OpenAI_AK`, a 120-second request timeout, zero provider retries, no fallback, one serial backend run, and disabled Memory/Skills.
+The runtime implementation baseline is `371f678e07acc6ae87f80d7544f573332d74fa88`. The reviewed fixes were later restacked and squash-merged, so current main no longer has that old branch commit as an ancestor and is not tree-equivalent to it. Historical audit instead verifies every frozen runtime blob at the original baseline and requires the inspected HEAD to descend from reviewed main successor `17e09f5896ca8bf5739cec413c16402cb441209d`. The model and execution controls remain unchanged from v2: `gpt-5.6-sol` for both roles, the RichLab `/v1` endpoint, `OpenAI_AK`, a 120-second request timeout, zero provider retries, no fallback, one serial backend run, and disabled Memory/Skills.
 
-Validate the manifest on Windows and WSL, then run preflight in the frozen Compose/DooD environment:
+Validate the frozen manifest and audit its Git provenance with:
 
 ```powershell
 python scripts/forge_benchmark_v3.py validate-manifest benchmarks/manifests/cpp-pilot-v3.json
+python scripts/forge_benchmark_history.py benchmarks/manifests/cpp-pilot-v3.json
 ```
 
-```bash
-python3 scripts/forge_benchmark_runner.py preflight \
-  --manifest benchmarks/manifests/cpp-pilot-v3.json
-```
-
-Only `ready: true` on a clean committed tree authorizes collection. Create and run one new v3 physical attempt for each of the five cases, strictly serially. Do not pass `--replacement-for`, edit or delete a v2 ledger, or pool v2 and v3 outcomes. Once the first v3 ledger is created, the v3 manifest and protocol artifacts are frozen for that collection stratum.
+The old v3 current-tree preflight is expected to reject later reviewed runtime drift. That rejection preserves the frozen collection boundary; it is not permission to rewrite the manifest or create replacement attempts.
 
 ## Historical pilot v2
 

--- a/benchmarks/manifests/cpp-pilot-v3.json
+++ b/benchmarks/manifests/cpp-pilot-v3.json
@@ -1,0 +1,291 @@
+{
+  "schema_version": "3.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "json-sort-keys-compact-utf8",
+  "benchmark": {
+    "id": "forge-cpp-clean-replay-pilot-v3",
+    "name": "Forge C/C++ Clean Replay Pilot v3",
+    "purpose": "clean_replay_collection_calibration",
+    "dataset_provenance": "self_selected_calibration_set"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "pilot",
+    "formal_comparison_enabled": false,
+    "instrumentation_blocker": false
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "371f678e07acc6ae87f80d7544f573332d74fa88",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "532f674e7cd43c099a3b171421a01a44bf3c00c9494d86f65b5c9cf5672c63b8",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/client.py": "a6fb7e2dd69b91d65e4d68b7faf02e10eb18d2883fd2e259b95daf6b3673aeb6",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "86daabd359f774b14a4b333e2eebf049ae24376cd0625eff1bbb4f026491cff6",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "f5037107f48b0da941039106d186318c2eed86f9e4ea5f132ac982b08fd84e42",
+      "backend/packages/harness/deerflow/compile/schemas.py": "b4ec61ecaed0bf1bcdd52075c057e305924d110ab4326258677e192068a0d086",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "5d30e7231d2f254b3c504e455a6d1b445c9b854e65025142656479204fe1227f",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6e44a497e1e8239dd93f219cc61f5c94c4a02ed9252a8ea9bc00ca8afc233757",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "79c59f2c7127d80d2639027ef48975002447181ba2a2a65678a3dba8fbbbe6b2",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "a4b0f15d02afa3adce671755d898a20f4e08052f290c0c12952412f2186b392b",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "ecb7889be3e3ec94abc58b080a792c8e33d5860a1ddd9934095a1aa7ed199679",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "c1d7bbd83e5fc5b4616c9758eee4e3b9ff00eef69935787d13a52b5277c81af5"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_v3.py": "d18dbd22b2ef7df2063c2b6ed656d089e1c8fc1418d4c1196b73ad84a532bec6",
+    "scripts/forge_benchmark_runner.py": "8386b50a2bc43570dedbdde623d6db2d584b1387e5a6dadbbfeb9b1269114ee8",
+    "benchmarks/schemas/forge-cpp-benchmark-v3.schema.json": "33748caa620f8d4c2aedb5b829992a470d5c3c68d5d40e42994d76e8df7087c2"
+  },
+  "model": {
+    "endpoint": "https://richlab-api-x.choosefire.com/v1",
+    "credential_env": "OpenAI_AK",
+    "roles": {
+      "lead": "gpt-5.6-sol",
+      "compiler": "gpt-5.6-sol"
+    },
+    "fallback_policy": "forbidden",
+    "request_timeout_seconds": 120,
+    "max_retries": 0
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "compiler_max_turns": 36,
+    "subagent_timeout_seconds": 180,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "conditions": [
+    {
+      "id": "baseline",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "cases": [
+    {
+      "id": "fmt",
+      "repository_url": "https://github.com/fmtlib/fmt",
+      "commit_sha": "123913715afeb8a437e6388b4473fcc4753e1c9a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfmt.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFMT_TEST=OFF",
+            "-DFMT_DOC=OFF",
+            "-DFMT_INSTALL=OFF",
+            "-DBUILD_SHARED_LIBS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hiredis",
+      "repository_url": "https://github.com/redis/hiredis",
+      "commit_sha": "60e5075d4ac77424809f855ba3e398df7aacefe8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "BSD-3-Clause",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhiredis.a",
+            "artifact_type": "static_library"
+          },
+          {
+            "relative_path": "libhiredis.so",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "make"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libcheck",
+      "repository_url": "https://github.com/libcheck/check",
+      "commit_sha": "11970a7e112dfe243a2e68773f014687df2900e8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcheck.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "autoconf",
+          "automake",
+          "libtool",
+          "pkg-config",
+          "texinfo"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-subunit"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libgit2",
+      "repository_url": "https://github.com/libgit2/libgit2",
+      "commit_sha": "338e6fb681369ff0537719095e22ce9dc602dbf0",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "GPL-2.0-only WITH libgit2-linking-exception",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgit2.so.1.9.0",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "pkg-config",
+          "libssl-dev",
+          "libhttp-parser-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DBUILD_TESTS=OFF",
+            "-DBUILD_CLI=OFF",
+            "-DUSE_HTTPS=OpenSSL",
+            "-DUSE_HTTP_PARSER=system",
+            "-DREGEX_BACKEND=builtin",
+            "-DUSE_SSH=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sysstat-nondeterministic",
+      "repository_url": "https://github.com/sysstat/sysstat",
+      "commit_sha": "b8f987807e7c7ba5c1b2ca8b7b1e9d80e61bce6c",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "reject",
+        "expected_replay_failure_classification": "sha256_mismatch",
+        "required_artifacts": [
+          {
+            "relative_path": "sar",
+            "artifact_type": "executable"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-nls"
+          ]
+        },
+        "environment": {
+          "CFLAGS": "-O2 -DUSE_SCCSID",
+          "SOURCE_DATE_EPOCH": null
+        },
+        "minimum_replay_delay_seconds": 2
+      }
+    }
+  ]
+}

--- a/benchmarks/schemas/forge-cpp-benchmark-v3.schema.json
+++ b/benchmarks/schemas/forge-cpp-benchmark-v3.schema.json
@@ -1,0 +1,3450 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-benchmark-v3.schema.json",
+  "title": "Forge-AutoCompiler C/C++ benchmark pilot manifest v3",
+  "description": "The runnable five-case pilot manifest with frozen evidence instrumentation and control-plane topology.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/manifest"
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_commit_sha": {
+      "type": "string",
+      "description": "A complete SHA-1 or SHA-256 Git object ID; symbolic or abbreviated refs are invalid.",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+/@-]*$"
+    },
+    "safe_repository_url": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS repository URL without userinfo, query parameters, or a fragment.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9._~!$&'()*+,;=:@%/-]+$"
+    },
+    "model_endpoint": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS OpenAI-compatible base URL ending in /v1, without credentials or URL parameters.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/v1/?$"
+    },
+    "environment_variable_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "relative_artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "A POSIX path relative to /artifacts. Absolute, parent-traversal, and backslash paths are invalid.",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "language": {
+      "enum": [
+        "C",
+        "C++"
+      ]
+    },
+    "languages": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/language"
+      }
+    },
+    "build_system": {
+      "enum": [
+        "cmake",
+        "make",
+        "autotools"
+      ]
+    },
+    "gate_status": {
+      "enum": [
+        "pass",
+        "reject"
+      ]
+    },
+    "nullable_gate_status": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/gate_status"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "run_record_lifecycle_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "image_identity_unavailable"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "cancelled"
+                        ]
+                      },
+                      "failure_classification": {
+                        "const": "image_identity_unavailable"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      },
+                      "passed": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.deferred"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "failed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "cancelled"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "cancelled"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "timed_out"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "timed_out"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verified",
+                      "verification_failed",
+                      "completed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verification_failed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "verification_failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "run_record_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  }
+                }
+              },
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "enum": [
+                      "pass",
+                      "reject"
+                    ]
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "maxItems": 1000
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "not_observed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "started"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.started"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "aborted"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.aborted"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "candidate_generation": {
+                    "const": true
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  },
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "failed"
+                      },
+                      "replay_attempt_id": {
+                        "type": "null"
+                      },
+                      "replay_status": {
+                        "const": "not_run"
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "replay_attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "replay_status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "cleanup_failed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "clean_replay": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "passed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          },
+                          "reason": {
+                            "type": "null"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "artifact_type": {
+      "enum": [
+        "executable",
+        "shared_library",
+        "static_library",
+        "object"
+      ]
+    },
+    "nullable_nonnegative_integer": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_nonnegative_number": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_boolean": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullable_sha256": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sha256"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "required_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type"
+      ],
+      "properties": {
+        "relative_path": {
+          "$ref": "#/$defs/relative_artifact_path"
+        },
+        "artifact_type": {
+          "$ref": "#/$defs/artifact_type"
+        }
+      }
+    },
+    "build_argument_vector": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[^\\u0000\\r\\n]+$"
+      }
+    },
+    "case_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required_system_packages",
+        "build_arguments",
+        "environment",
+        "minimum_replay_delay_seconds"
+      ],
+      "properties": {
+        "required_system_packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+-]*$"
+          }
+        },
+        "build_arguments": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cmake",
+            "configure"
+          ],
+          "properties": {
+            "cmake": {
+              "$ref": "#/$defs/build_argument_vector"
+            },
+            "configure": {
+              "$ref": "#/$defs/build_argument_vector"
+            }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "description": "Only reviewed, non-secret process environment controls are permitted.",
+          "additionalProperties": false,
+          "properties": {
+            "CFLAGS": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[^\\u0000\\r\\n]+$"
+            },
+            "SOURCE_DATE_EPOCH": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128,
+                  "pattern": "^[^\\u0000\\r\\n]+$"
+                }
+              ]
+            }
+          }
+        },
+        "minimum_replay_delay_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3600
+        }
+      }
+    },
+    "benchmark_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repository_url",
+        "commit_sha",
+        "languages",
+        "build_system",
+        "license",
+        "oracle",
+        "constraints"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repository_url": {
+          "$ref": "#/$defs/safe_repository_url"
+        },
+        "commit_sha": {
+          "$ref": "#/$defs/git_commit_sha"
+        },
+        "languages": {
+          "$ref": "#/$defs/languages"
+        },
+        "build_system": {
+          "$ref": "#/$defs/build_system"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9 .()+-]*$"
+        },
+        "oracle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "expected_candidate_status",
+            "expected_clean_replay_status",
+            "required_artifacts"
+          ],
+          "properties": {
+            "expected_candidate_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_clean_replay_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required_artifacts": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/required_artifact"
+              }
+            }
+          }
+        },
+        "constraints": {
+          "$ref": "#/$defs/case_constraints"
+        }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark",
+        "scope",
+        "forge",
+        "protocol_artifact_sha256",
+        "model",
+        "runtime",
+        "conditions",
+        "cases"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "3.0.0"
+        },
+        "document_type": {
+          "const": "manifest"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "purpose",
+            "dataset_provenance"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/identifier"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 160
+            },
+            "purpose": {
+              "const": "clean_replay_collection_calibration"
+            },
+            "dataset_provenance": {
+              "const": "self_selected_calibration_set"
+            }
+          }
+        },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "languages",
+            "phase",
+            "formal_comparison_enabled",
+            "instrumentation_blocker"
+          ],
+          "properties": {
+            "languages": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/language"
+              }
+            },
+            "phase": {
+              "const": "pilot"
+            },
+            "formal_comparison_enabled": {
+              "const": false
+            },
+            "instrumentation_blocker": {
+              "const": false
+            }
+          }
+        },
+        "forge": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository_url",
+            "commit_sha",
+            "revision_policy",
+            "component_sha256"
+          ],
+          "properties": {
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "const": "371f678e07acc6ae87f80d7544f573332d74fa88"
+            },
+            "revision_policy": {
+              "const": "baseline_ancestor_with_frozen_components"
+            },
+            "component_sha256": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+                "backend/packages/harness/deerflow/client.py",
+                "backend/packages/harness/deerflow/compile/__init__.py",
+                "backend/packages/harness/deerflow/compile/docker_runtime.py",
+                "backend/packages/harness/deerflow/compile/evidence.py",
+                "backend/packages/harness/deerflow/compile/manager.py",
+                "backend/packages/harness/deerflow/compile/operations.py",
+                "backend/packages/harness/deerflow/compile/schemas.py",
+                "backend/packages/harness/deerflow/models/factory.py",
+                "backend/packages/harness/deerflow/subagents/executor.py",
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+                "docker/compile/Dockerfile",
+                "docker/docker-compose-dev.yaml",
+                "config.example.yaml",
+                "backend/uv.lock"
+              ],
+              "properties": {
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/client.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/__init__.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/evidence.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/manager.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/operations.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/schemas.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/models/factory.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/subagents/executor.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/compile/Dockerfile": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/docker-compose-dev.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "config.example.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/uv.lock": {
+                  "$ref": "#/$defs/sha256"
+                }
+              }
+            }
+          }
+        },
+        "protocol_artifact_sha256": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scripts/forge_benchmark.py",
+            "scripts/forge_benchmark_v3.py",
+            "scripts/forge_benchmark_runner.py",
+            "benchmarks/schemas/forge-cpp-benchmark-v3.schema.json"
+          ],
+          "properties": {
+            "scripts/forge_benchmark.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_v3.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_runner.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "benchmarks/schemas/forge-cpp-benchmark-v3.schema.json": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        },
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "endpoint",
+            "credential_env",
+            "roles",
+            "fallback_policy",
+            "request_timeout_seconds",
+            "max_retries"
+          ],
+          "properties": {
+            "endpoint": {
+              "$ref": "#/$defs/model_endpoint"
+            },
+            "credential_env": {
+              "const": "OpenAI_AK"
+            },
+            "roles": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "lead",
+                "compiler"
+              ],
+              "properties": {
+                "lead": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "compiler": {
+                  "$ref": "#/$defs/safe_token"
+                }
+              }
+            },
+            "fallback_policy": {
+              "const": "forbidden"
+            },
+            "request_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_retries": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "compile_image",
+            "image_id",
+            "control_plane_topology",
+            "replay_timeout_seconds",
+            "cleanup_timeout_seconds",
+            "docker_control_timeout_seconds",
+            "compiler_max_turns",
+            "subagent_timeout_seconds",
+            "max_parallel_runs",
+            "backend_processes",
+            "network_policy",
+            "host"
+          ],
+          "properties": {
+            "compile_image": {
+              "$ref": "#/$defs/safe_token"
+            },
+            "image_id": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "control_plane_topology": {
+              "const": "compose-dood"
+            },
+            "replay_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "cleanup_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "docker_control_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "compiler_max_turns": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "subagent_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_parallel_runs": {
+              "const": 1
+            },
+            "backend_processes": {
+              "const": 1
+            },
+            "network_policy": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "network_name",
+                "egress"
+              ],
+              "properties": {
+                "network_name": {
+                  "const": "compile_network_wwf_v1"
+                },
+                "egress": {
+                  "const": "enabled_for_clone_and_dependencies"
+                }
+              }
+            },
+            "host": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "wsl_distribution",
+                "cpu_count",
+                "memory_kib",
+                "kernel",
+                "architecture",
+                "docker_server_version"
+              ],
+              "properties": {
+                "wsl_distribution": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "cpu_count": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "memory_kib": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "kernel": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "architecture": {
+                  "enum": [
+                    "x86_64",
+                    "aarch64"
+                  ]
+                },
+                "docker_server_version": {
+                  "type": "string",
+                  "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$"
+                }
+              }
+            }
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "memory_enabled",
+              "skills_enabled",
+              "repetitions",
+              "acceptance_gate"
+            ],
+            "properties": {
+              "id": {
+                "const": "baseline"
+              },
+              "memory_enabled": {
+                "const": false
+              },
+              "skills_enabled": {
+                "const": false
+              },
+              "repetitions": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              },
+              "acceptance_gate": {
+                "const": "clean_replay"
+              }
+            }
+          }
+        },
+        "cases": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/benchmark_case"
+          }
+        }
+      }
+    },
+    "normalized_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type",
+        "size_bytes",
+        "sha256",
+        "smoke_exit_code",
+        "smoke_output_sha256"
+      ],
+      "properties": {
+        "relative_path": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/relative_artifact_path"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "artifact_type": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/artifact_type"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "size_bytes": {
+          "$ref": "#/$defs/nullable_nonnegative_integer"
+        },
+        "sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        },
+        "smoke_exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "smoke_output_sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "artifact_type"
+            ],
+            "properties": {
+              "artifact_type": {
+                "const": "executable"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "smoke_exit_code": {
+                "const": 0
+              },
+              "smoke_output_sha256": {
+                "$ref": "#/$defs/sha256"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "failure_classification": {
+      "enum": [
+        "artifact_set_mismatch",
+        "type_mismatch",
+        "size_mismatch",
+        "sha256_mismatch",
+        "smoke_mismatch",
+        "recipe_snapshot_mismatch",
+        "image_identity_unavailable",
+        "recipe_execution_failed",
+        "timeout",
+        "internal_error",
+        "cancelled",
+        "cleanup_failed",
+        "session_terminated"
+      ]
+    },
+    "submit_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "stage",
+            "status",
+            "failed_checks",
+            "replay_attempt_id",
+            "artifact_count",
+            "candidate_status",
+            "replay_status"
+          ],
+          "properties": {
+            "event": {
+              "enum": [
+                "submit.started",
+                "submit.completed",
+                "submit.aborted"
+              ]
+            },
+            "stage": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "entry",
+                "candidate_checkpoint",
+                "final_checkpoint",
+                null
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                "completed",
+                null
+              ]
+            },
+            "failed_checks": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "replay_attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "candidate_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "replay_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                "not_run",
+                null
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.started"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "type": "null"
+                  },
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.aborted"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "candidate_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled",
+                      "not_run"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "const": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  },
+                  "replay_status": {
+                    "const": "passed"
+                  },
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "replay_status": {
+                    "not": {
+                      "const": "passed"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "status": {
+                    "const": "failed"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "const": "not_run"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "completion_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "artifact.finalization_recheck"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.deferred"
+            },
+            "reason": {
+              "const": "container_cleanup_failed"
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "const": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "enum": [
+                "failed",
+                "cancelled",
+                "timed_out"
+              ]
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        }
+      ]
+    },
+    "replay_attempt": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "attempt_id",
+            "image",
+            "image_id",
+            "commit_sha",
+            "status",
+            "failure_classification",
+            "exit_code",
+            "cleanup_succeeded",
+            "duration_seconds",
+            "timeout_seconds",
+            "recipe_sha256"
+          ],
+          "properties": {
+            "attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "pending",
+                "running",
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                null
+              ]
+            },
+            "failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "exit_code": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "timeout_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "recipe_sha256": {
+              "$ref": "#/$defs/nullable_sha256"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "image": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  },
+                  "cleanup_succeeded": {
+                    "type": "boolean"
+                  },
+                  "duration_seconds": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  },
+                  "failure_classification": {
+                    "type": "null"
+                  },
+                  "exit_code": {
+                    "const": 0
+                  },
+                  "cleanup_succeeded": {
+                    "const": true
+                  },
+                  "recipe_sha256": {
+                    "$ref": "#/$defs/sha256"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "$ref": "#/$defs/failure_classification"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  },
+                  "failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "timed_out"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "const": "timeout"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "run_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark_id",
+        "manifest_sha256",
+        "recorded_at",
+        "case_id",
+        "condition",
+        "repetition",
+        "source",
+        "outcome",
+        "failure_attribution",
+        "evidence"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "1.0.0"
+        },
+        "document_type": {
+          "const": "run_record"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "case_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "condition": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repetition": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_id",
+            "run_id",
+            "repository_url",
+            "commit_sha",
+            "build_system",
+            "image_id"
+          ],
+          "properties": {
+            "session_id": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{12}$"
+            },
+            "run_id": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 160,
+                  "pattern": "^(?:[0-9a-f]{12,64}|[0-9a-fA-F]{8}-[0-9a-fA-F-]{27,})$"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        },
+        "outcome": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_status",
+            "submit_status",
+            "candidate_status",
+            "clean_replay_status",
+            "replay_failure_classification",
+            "replay_cleanup_succeeded",
+            "verification_status",
+            "artifact_count",
+            "finalized",
+            "oracle_match"
+          ],
+          "properties": {
+            "session_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "created",
+                "ready",
+                "source_ready",
+                "inspected",
+                "replay_verifying",
+                "verified",
+                "verification_failed",
+                "completed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                null
+              ]
+            },
+            "submit_status": {
+              "enum": [
+                "not_observed",
+                "started",
+                "aborted",
+                "completed"
+              ]
+            },
+            "candidate_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "clean_replay_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "verification_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "candidate_ready",
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "finalized": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "oracle_match": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "failure_attribution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "model_endpoint",
+            "agent",
+            "build",
+            "candidate_generation",
+            "clean_replay",
+            "cleanup",
+            "completion"
+          ],
+          "properties": {
+            "model_endpoint": {
+              "type": "null"
+            },
+            "agent": {
+              "type": "null"
+            },
+            "build": {
+              "type": "null"
+            },
+            "candidate_generation": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "clean_replay": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "cleanup": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "completion": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "command_summary",
+            "session_duration_seconds",
+            "artifacts",
+            "submit_event",
+            "replay_attempt",
+            "completion_event"
+          ],
+          "properties": {
+            "command_summary": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "total",
+                    "successful_bash",
+                    "failed_bash"
+                  ],
+                  "properties": {
+                    "total": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "successful_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "failed_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    }
+                  }
+                }
+              ]
+            },
+            "session_duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "artifacts": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array",
+                  "maxItems": 1000,
+                  "uniqueItems": true,
+                  "items": {
+                    "$ref": "#/$defs/normalized_artifact"
+                  }
+                }
+              ]
+            },
+            "submit_event": {
+              "$ref": "#/$defs/submit_event"
+            },
+            "replay_attempt": {
+              "$ref": "#/$defs/replay_attempt"
+            },
+            "completion_event": {
+              "$ref": "#/$defs/completion_event"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "submit_event",
+                  "artifacts"
+                ],
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "required": [
+                      "event",
+                      "candidate_status",
+                      "artifact_count"
+                    ],
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "artifact_count": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "allOf": [
+                        {
+                          "$ref": "#/$defs/normalized_artifact"
+                        },
+                        {
+                          "properties": {
+                            "relative_path": {
+                              "$ref": "#/$defs/relative_artifact_path"
+                            },
+                            "artifact_type": {
+                              "$ref": "#/$defs/artifact_type"
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "sha256": {
+                              "$ref": "#/$defs/sha256"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "candidate_status",
+                  "replay_cleanup_succeeded",
+                  "replay_failure_classification",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "const": false
+                  },
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "attempt_id",
+                      "image",
+                      "image_id",
+                      "commit_sha",
+                      "status",
+                      "failure_classification",
+                      "exit_code",
+                      "cleanup_succeeded",
+                      "duration_seconds",
+                      "timeout_seconds",
+                      "recipe_sha256"
+                    ],
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image_id": {
+                        "type": "string",
+                        "pattern": "^sha256:[0-9a-f]{64}$"
+                      },
+                      "commit_sha": {
+                        "$ref": "#/$defs/git_commit_sha"
+                      },
+                      "status": {
+                        "const": "passed"
+                      },
+                      "failure_classification": {
+                        "type": "null"
+                      },
+                      "exit_code": {
+                        "const": 0
+                      },
+                      "cleanup_succeeded": {
+                        "const": true
+                      },
+                      "duration_seconds": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "recipe_sha256": {
+                        "$ref": "#/$defs/sha256"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "replay_failure_classification"
+                ],
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "cleanup_failed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status",
+                  "replay_cleanup_succeeded"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "failure_classification",
+                      "cleanup_succeeded"
+                    ],
+                    "properties": {
+                      "failure_classification": {
+                        "const": "cleanup_failed"
+                      },
+                      "cleanup_succeeded": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status",
+                  "clean_replay_status",
+                  "replay_failure_classification",
+                  "replay_cleanup_succeeded",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation",
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "type": "null"
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "null"
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/run_record_conditions"
+        },
+        {
+          "$ref": "#/$defs/run_record_lifecycle_conditions"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/forge_benchmark_history.py
+++ b/scripts/forge_benchmark_history.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import forge_benchmark_v2 as protocol_v2
+import forge_benchmark_v3 as protocol_v3
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -31,12 +32,27 @@ class AuditedSquashLineage:
     successor_tree_sha: str
 
 
+@dataclass(frozen=True)
+class AuditedReviewedSuccessorLineage:
+    baseline_commit: str
+    baseline_tree_sha: str
+    successor_commit: str
+    successor_tree_sha: str
+
+
 V2_LINEAGE = AuditedSquashLineage(
     baseline_commit="d845b735576be706f79fcf0666f66c14929a52cc",
     baseline_tree_sha="67c604af71df09376f17a881828a465cdebe879a",
     source_head="561b38cee9f027b0dfb01ff765b44a28dbf2de8f",
     successor_commit="9e002f4568a77de07fdce65b49373afb7e5cc74e",
     successor_tree_sha="29aa07d5bb4bb5e9482b1f0e5146237757adf695",
+)
+
+V3_LINEAGE = AuditedReviewedSuccessorLineage(
+    baseline_commit="371f678e07acc6ae87f80d7544f573332d74fa88",
+    baseline_tree_sha="a7ab45a93ea763adadcad15cbce31f4c4c36849e",
+    successor_commit="17e09f5896ca8bf5739cec413c16402cb441209d",
+    successor_tree_sha="64f0bbd6ee7d8ae5190da36eb560df121732794c",
 )
 
 
@@ -140,6 +156,49 @@ def audit_v2_history(
     }
 
 
+def audit_v3_history(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    head_revision: str = "HEAD",
+) -> dict[str, Any]:
+    """Verify v3 blobs and prove that HEAD follows the reviewed main successor."""
+    protocol_v3.validate_manifest(manifest)
+    baseline = manifest["forge"]["commit_sha"]
+    if baseline != V3_LINEAGE.baseline_commit:
+        raise HistoryAuditError("the v3 baseline is not covered by the audited lineage")
+
+    baseline_tree = _git_text(repo_root, ["rev-parse", f"{baseline}^{{tree}}"])
+    if baseline_tree != V3_LINEAGE.baseline_tree_sha:
+        raise HistoryAuditError("the v3 baseline has an unexpected tree")
+    successor_tree = _git_text(repo_root, ["rev-parse", f"{V3_LINEAGE.successor_commit}^{{tree}}"])
+    if successor_tree != V3_LINEAGE.successor_tree_sha:
+        raise HistoryAuditError("the v3 reviewed successor has an unexpected tree")
+
+    resolved_head = _git_text(repo_root, ["rev-parse", head_revision])
+    if not _is_ancestor(repo_root, V3_LINEAGE.successor_commit, resolved_head):
+        raise HistoryAuditError("HEAD does not descend from the v3 audited reviewed successor")
+
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        blob = _git(repo_root, ["show", f"{baseline}:{relative_path}"])
+        if hashlib.sha256(blob).hexdigest() != expected_digest:
+            raise HistoryAuditError(f"frozen baseline blob mismatch: {relative_path}")
+
+    for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
+        artifact = _safe_repository_file(repo_root, relative_path)
+        if hashlib.sha256(artifact.read_bytes()).hexdigest() != expected_digest:
+            raise HistoryAuditError(f"frozen protocol artifact mismatch: {relative_path}")
+
+    return {
+        "baseline_commit": baseline,
+        "head_revision": resolved_head,
+        "lineage_mode": "audited_reviewed_successor",
+        "successor_commit": V3_LINEAGE.successor_commit,
+        "baseline_tree_sha": V3_LINEAGE.baseline_tree_sha,
+        "successor_tree_sha": V3_LINEAGE.successor_tree_sha,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -152,7 +211,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         manifest = protocol_v2.load_json_document(args.manifest)
-        result = audit_v2_history(manifest, head_revision=args.head)
+        schema_version = manifest.get("schema_version") if isinstance(manifest, dict) else None
+        if schema_version == protocol_v2.SCHEMA_VERSION:
+            result = audit_v2_history(manifest, head_revision=args.head)
+        elif schema_version == protocol_v3.SCHEMA_VERSION:
+            result = audit_v3_history(manifest, head_revision=args.head)
+        else:
+            raise HistoryAuditError("only frozen benchmark v2 and v3 history can be audited")
     except (HistoryAuditError, protocol_v2.BenchmarkError, OSError, UnicodeError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -27,6 +27,7 @@ for import_root in (str(HARNESS_ROOT), str(Path(__file__).resolve().parent)):
 
 import forge_benchmark as protocol  # noqa: E402
 import forge_benchmark_v2 as protocol_v2  # noqa: E402
+import forge_benchmark_v3 as protocol_v3  # noqa: E402
 
 from deerflow.compile.evidence import (  # noqa: E402
     EvidenceError,
@@ -88,6 +89,8 @@ def _manifest_protocol(manifest: dict[str, Any]):
         return protocol
     if schema_version == protocol_v2.SCHEMA_VERSION:
         return protocol_v2
+    if schema_version == protocol_v3.SCHEMA_VERSION:
+        return protocol_v3
     raise RunnerError(f"Unsupported benchmark schema version: {schema_version}")
 
 
@@ -282,7 +285,11 @@ def collect_preflight(
     forge_baseline = manifest["forge"]["commit_sha"]
     revision_policy = manifest["forge"].get("revision_policy", "exact")
     baseline_is_ancestor = _baseline_is_ancestor(repo_root, forge_baseline)
-    baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy == protocol_v2.REVISION_POLICY else False
+    runnable_revision_policies = {
+        protocol_v2.REVISION_POLICY,
+        protocol_v3.REVISION_POLICY,
+    }
+    baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy in runnable_revision_policies else False
     component_results: dict[str, dict[str, Any]] = {}
     for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
         actual_digest = _sha256_file(repo_root / relative_path)
@@ -326,7 +333,11 @@ def collect_preflight(
     endpoint_reachable = _endpoint_reachable(model["endpoint"]) if check_endpoint else None
     expected_topology = runtime.get("control_plane_topology")
     compose_dood_present = _compose_dood_present(repo_root)
-    topology_matches = expected_topology is None or (expected_topology == protocol_v2.CONTROL_PLANE_TOPOLOGY and compose_dood_present)
+    compose_dood_topologies = {
+        protocol_v2.CONTROL_PLANE_TOPOLOGY,
+        protocol_v3.CONTROL_PLANE_TOPOLOGY,
+    }
+    topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
     checks = {
         "credential_present": _credential_present(model["credential_env"]),
         "endpoint_reachable": endpoint_reachable,
@@ -366,7 +377,17 @@ def collect_preflight(
     return {
         "ready": all(required_checks),
         "manifest_sha256": _manifest_sha256(manifest),
-        "manifest_file_sha256": _sha256_file(manifest_path or repo_root / "benchmarks" / "manifests" / ("cpp-pilot-v2.json" if manifest["schema_version"] == protocol_v2.SCHEMA_VERSION else "cpp-pilot-v1.json")),
+        "manifest_file_sha256": _sha256_file(
+            manifest_path
+            or repo_root
+            / "benchmarks"
+            / "manifests"
+            / {
+                protocol.SCHEMA_VERSION: "cpp-pilot-v1.json",
+                protocol_v2.SCHEMA_VERSION: "cpp-pilot-v2.json",
+                protocol_v3.SCHEMA_VERSION: "cpp-pilot-v3.json",
+            }[manifest["schema_version"]]
+        ),
         "forge": {
             **forge_state,
             "expected_revision": manifest["forge"]["commit_sha"],
@@ -379,7 +400,7 @@ def collect_preflight(
             "docker_server_version": (docker_version if docker_version_code == 0 else None),
             "platform_system": platform.system(),
             "platform_machine": platform.machine(),
-            "control_plane_topology": (protocol_v2.CONTROL_PLANE_TOPOLOGY if compose_dood_present else None),
+            "control_plane_topology": (protocol_v3.CONTROL_PLANE_TOPOLOGY if compose_dood_present else None),
         },
         "checks": checks,
     }
@@ -646,7 +667,10 @@ def run_attempt(
     if any(event["event"].startswith("model.") for event in events):
         raise RunnerError("A physical attempt cannot issue model calls twice")
     expected_topology = manifest["runtime"].get("control_plane_topology")
-    if expected_topology == protocol_v2.CONTROL_PLANE_TOPOLOGY:
+    if expected_topology in {
+        protocol_v2.CONTROL_PLANE_TOPOLOGY,
+        protocol_v3.CONTROL_PLANE_TOPOLOGY,
+    }:
         if not _running_inside_compose_dood(REPO_ROOT):
             ledger.append(
                 "runtime.topology_rejected",
@@ -753,7 +777,7 @@ def _build_parser() -> argparse.ArgumentParser:
     common.add_argument(
         "--manifest",
         type=Path,
-        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v2.json",
+        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v3.json",
     )
     common.add_argument("--skip-endpoint-check", action="store_true")
 

--- a/scripts/forge_benchmark_v3.py
+++ b/scripts/forge_benchmark_v3.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Validate the runnable Forge C/C++ pilot v3 manifest."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+
+SCHEMA_VERSION = "3.0.0"
+BASELINE_COMMIT = "371f678e07acc6ae87f80d7544f573332d74fa88"
+REVISION_POLICY = "baseline_ancestor_with_frozen_components"
+CONTROL_PLANE_TOPOLOGY = "compose-dood"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+COMPONENT_PATHS = {
+    "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+    "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+    "backend/packages/harness/deerflow/client.py",
+    "backend/packages/harness/deerflow/compile/__init__.py",
+    "backend/packages/harness/deerflow/compile/docker_runtime.py",
+    "backend/packages/harness/deerflow/compile/evidence.py",
+    "backend/packages/harness/deerflow/compile/manager.py",
+    "backend/packages/harness/deerflow/compile/operations.py",
+    "backend/packages/harness/deerflow/compile/schemas.py",
+    "backend/packages/harness/deerflow/models/factory.py",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+    "backend/packages/harness/deerflow/subagents/executor.py",
+    "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+    "backend/uv.lock",
+    "config.example.yaml",
+    "docker/compile/Dockerfile",
+    "docker/docker-compose-dev.yaml",
+}
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_benchmark.py",
+    "scripts/forge_benchmark_v3.py",
+    "scripts/forge_benchmark_runner.py",
+    "benchmarks/schemas/forge-cpp-benchmark-v3.schema.json",
+}
+
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+
+
+def _validate_hash_map(
+    value: Any,
+    *,
+    expected_paths: set[str],
+    path: str,
+) -> dict[str, Any]:
+    hashes = v1._as_object(value, path)
+    if set(hashes) != expected_paths:
+        v1._fail(path, "must contain exactly the required v3 frozen artifact hashes")
+    for relative_path, digest in hashes.items():
+        pure_path = PurePosixPath(relative_path)
+        if pure_path.is_absolute() or ".." in pure_path.parts or "\\" in relative_path:
+            v1._fail(f"{path}.{relative_path}", "must stay inside the repository")
+        v1._validate_sha256(digest, f"{path}.{relative_path}")
+    return hashes
+
+
+def _validate_manifest_impl(document: Any) -> dict[str, Any]:
+    manifest = v1._as_object(document, "manifest")
+    v1._require_exact_keys(
+        manifest,
+        {
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "forge",
+            "protocol_artifact_sha256",
+            "model",
+            "runtime",
+            "conditions",
+            "cases",
+        },
+        "manifest",
+        optional={"$schema"},
+    )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        v1._fail("manifest.schema_version", f"unsupported version; expected {SCHEMA_VERSION}")
+    v1._scan_for_unsafe_values(manifest)
+
+    scope = v1._as_object(v1._required(manifest, "scope", "manifest"), "manifest.scope")
+    if scope.get("instrumentation_blocker") is not False:
+        v1._fail(
+            "manifest.scope.instrumentation_blocker",
+            "must be false for the runnable v3 pilot",
+        )
+
+    forge = v1._as_object(v1._required(manifest, "forge", "manifest"), "manifest.forge")
+    v1._require_exact_keys(
+        forge,
+        {"repository_url", "commit_sha", "revision_policy", "component_sha256"},
+        "manifest.forge",
+    )
+    if forge.get("commit_sha") != BASELINE_COMMIT:
+        v1._fail(
+            "manifest.forge.commit_sha",
+            "must bind the Issue #16/#17/#18 fixed implementation baseline",
+        )
+    if forge.get("revision_policy") != REVISION_POLICY:
+        v1._fail(
+            "manifest.forge.revision_policy",
+            f"must be {REVISION_POLICY!r}",
+        )
+    _validate_hash_map(
+        v1._required(forge, "component_sha256", "manifest.forge"),
+        expected_paths=COMPONENT_PATHS,
+        path="manifest.forge.component_sha256",
+    )
+    _validate_hash_map(
+        v1._required(manifest, "protocol_artifact_sha256", "manifest"),
+        expected_paths=PROTOCOL_ARTIFACT_PATHS,
+        path="manifest.protocol_artifact_sha256",
+    )
+
+    runtime = v1._as_object(v1._required(manifest, "runtime", "manifest"), "manifest.runtime")
+    if runtime.get("control_plane_topology") != CONTROL_PLANE_TOPOLOGY:
+        v1._fail(
+            "manifest.runtime.control_plane_topology",
+            f"must be {CONTROL_PLANE_TOPOLOGY!r}",
+        )
+
+    model = v1._as_object(v1._required(manifest, "model", "manifest"), "manifest.model")
+    if model.get("endpoint") != "https://richlab-api-x.choosefire.com/v1":
+        v1._fail("manifest.model.endpoint", "must use the frozen pilot endpoint")
+    if model.get("roles") != {"lead": "gpt-5.6-sol", "compiler": "gpt-5.6-sol"}:
+        v1._fail("manifest.model.roles", "must use gpt-5.6-sol for both roles")
+    if model.get("request_timeout_seconds") != 120 or model.get("max_retries") != 0:
+        v1._fail("manifest.model", "must freeze a 120-second timeout and zero retries")
+
+    compatibility_manifest = copy.deepcopy(manifest)
+    compatibility_manifest["schema_version"] = v1.SCHEMA_VERSION
+    compatibility_manifest["scope"]["instrumentation_blocker"] = True
+    compatibility_manifest["forge"].pop("revision_policy")
+    compatibility_manifest["forge"]["component_sha256"] = {path: forge["component_sha256"][path] for path in v1._COMPONENT_PATHS}
+    compatibility_manifest["runtime"].pop("control_plane_topology")
+    compatibility_manifest["protocol_artifact_sha256"] = {
+        "scripts/forge_benchmark.py": manifest["protocol_artifact_sha256"]["scripts/forge_benchmark.py"],
+        "benchmarks/schemas/forge-cpp-benchmark-v1.schema.json": manifest["protocol_artifact_sha256"]["benchmarks/schemas/forge-cpp-benchmark-v3.schema.json"],
+    }
+    v1.validate_manifest(compatibility_manifest)
+    if manifest["benchmark"]["id"] != "forge-cpp-clean-replay-pilot-v3":
+        v1._fail("manifest.benchmark.id", "must identify the v3 clean-replay pilot")
+    if manifest["conditions"][0]["repetitions"] != 1:
+        v1._fail("manifest.conditions[0].repetitions", "must be 1 for the five-case pilot")
+    return manifest
+
+
+def validate_manifest(document: Any) -> dict[str, Any]:
+    """Validate a v3 manifest without reading repository files."""
+    try:
+        return _validate_manifest_impl(document)
+    except BenchmarkError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: contains a malformed value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    validate_manifest(manifest)
+    try:
+        return json.dumps(
+            manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: cannot be represented as canonical JSON") from exc
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path) -> None:
+    """Verify the v3 runtime and protocol files against the current clean tree."""
+    validate_manifest(manifest)
+    try:
+        resolved_root = repo_root.resolve(strict=True)
+    except OSError as exc:
+        raise BenchmarkError("frozen_components: repository root is unavailable") from exc
+    if not resolved_root.is_dir():
+        raise BenchmarkError("frozen_components: repository root must be a directory")
+
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+    ):
+        for relative_path, expected_sha256 in hashes.items():
+            candidate = resolved_root
+            for part in PurePosixPath(relative_path).parts:
+                candidate /= part
+                if candidate.is_symlink():
+                    v1._fail(f"{path_prefix}.{relative_path}", "must reference an ordinary file, not a symlink")
+            if not candidate.is_file():
+                v1._fail(f"{path_prefix}.{relative_path}", "references a missing ordinary file")
+            try:
+                resolved_candidate = candidate.resolve(strict=True)
+                resolved_candidate.relative_to(resolved_root)
+                actual_sha256 = hashlib.sha256(resolved_candidate.read_bytes()).hexdigest()
+            except (OSError, ValueError) as exc:
+                raise BenchmarkError(f"{path_prefix}.{relative_path}: could not be read safely") from exc
+            if actual_sha256 != expected_sha256:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match the current repository file")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser(
+        "validate-manifest",
+        help="validate and hash a runnable v3 benchmark manifest",
+    )
+    validate_parser.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = validate_manifest(load_json_document(args.manifest))
+        verify_frozen_components(manifest, REPOSITORY_ROOT)
+        print(
+            json.dumps(
+                {
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 将 pilot v3 的真实增量重排到最新 `main`，保留 v3 manifest、Schema、validator、runner 和 canonical digest 的冻结字节。
- 冻结包含 Issue #16/#17/#18 修复的五 case C/C++ pilot v3 协议，并保留既有五份 append-only ledger。
- 新增 v3 历史来源审计：逐项校验 `371f678e` baseline blob，并要求当前 HEAD 后继于已审阅的主干 successor `17e09f58`。
- 明确旧 v3 current-tree gate 应拒绝后续合法 runtime 漂移，且旧分叉不能冒充已审阅主干后继。
- 记录五个 physical attempt 的审计结论，并将后续工作拆分到 Issue #24、#25、#26。

## 实验结果

v3 五个 case 均完成一次不可替换的 physical attempt：

- 5/5 ledger hash chain 与离线 gate 有效
- 5/5 `submit_missing`
- 0 submit、0 clean replay、0 replacement
- 0 遗留 compile/replay 容器

这些结果属于 instrumentation calibration，不解释为 compiler 能力结论，也不会重跑或改写。

## 验证

- 后端全量：`1519 passed, 25 skipped`
- benchmark v1/v2/v3/runner 聚焦：`31 passed, 6 skipped`
- Windows Git 历史审计：审阅后 successor 正向通过，旧 head `88283298` 按预期拒绝
- v3 Draft 2020-12 Schema meta-validation 与 manifest instance validation 通过
- Compose config 通过
- 本次改动文件 Ruff check/format 通过
- 前端 format、lint、typecheck、build 串行通过
- 冻结哈希、diff、敏感信息与容器残留检查通过

## 边界

- 未调用模型，未启动 v6 pilot。
- 未修改或重跑 v1-v5 ledger。
- v3 manifest、Schema、validator、runner 与 digest 保持原始冻结字节。
- 继续使用 WSL2 Compose/DooD 控制面。

Closes #22
