### PR TITLE
修复：校验 benchmark 构建系统身份

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,13 +5,19 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-20 — 将 Issue #24 / PR #27 的 async runner 增量重排到 `main@c4b817f3`
-  - 范围: 保留 `DeerFlowClient.stream()` 同步兼容 API，新增原生 `astream()` 并让 benchmark runner 通过异步路径执行 coroutine-only compiler 子代理；不调用模型，不重跑 pilot
-  - 历史边界: v3 current-tree gate 继续拒绝 client/runner 漂移；历史审计改从 PR #23 的冻结协议提交 `c4b817f3` 读取 protocol blobs，并要求 HEAD 后继于该提交；v1-v5 manifest、Schema、validator、runner hash 与 ledger 不改写
-  - 状态: 单提交重排已完成；聚焦 `157 passed, 3 skipped`、后端全量 `1523 passed, 25 skipped`、真实 Docker `4 passed`、v3 历史审计、Ruff/format、Compose、前端串行 format/lint/typecheck/build、冻结资产与 0 orphan 对账均通过，等待推送、PR CI 与合并
+- 2026-07-21 — 将 Issue #25 / PR #28 的 build-system identity 增量重排到 `main@6f8cab4f`
+  - 范围: 将 manifest `cases[].build_system` 写入 physical-attempt policy 和首条 ledger，约束 compiler 路径，并在 identify 与 submit 两处执行 expected/observed identity gate；不调用模型，不重跑 pilot
+  - 历史边界: 保留 PR #27 的异步 runner；v3 current-tree gate继续拒绝运行时漂移，history audit 继续从 `c4b817f3` 读取冻结 protocol blobs；v1-v5 manifest、Schema、validator、runner hash 与 ledger 不改写
+  - 状态: 单提交增量、实现审查和本地完整验证均已完成；聚焦组 `150 passed`，兼容/历史组 `242 passed, 6 skipped`，后端全量 `1532 passed, 26 skipped`，真实 Docker mismatch `1 passed in 16.83s`，等待推送、PR CI 与合并
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-21 — 冻结并校验 benchmark case 的构建系统身份
+  - 文件: `backend/packages/harness/deerflow/compile/evidence.py`, `backend/packages/harness/deerflow/compile/operations.py`, `backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py`, `backend/packages/harness/deerflow/tools/builtins/task_tool.py`, `scripts/forge_benchmark_runner.py` 及对应测试
+  - 动机: Issue #25；把 manifest `cases[].build_system` 写入 `ExperimentPolicy` 和首条 ledger policy，compiler prompt 固定 CMake/Make/Autotools 路径，避免声明的实验条件与实际构建路径漂移
+  - 行为: `identify_build_system` 后记录 expected/observed identity；不匹配时在 compiler 子代理启动前失败终结并清理 Session，submit gate 再独立复核，不修改 v1/v2/v3 manifest、Schema 或既有 ledger
+  - 证据: policy/runner/prompt/terminalization/submit gate 聚焦组 `150 passed`，异步 client、v2/v3 历史 gate、取消与 task 兼容组 `242 passed, 6 skipped`，后端全量 `1532 passed, 26 skipped`；真实 Docker mismatch `1 passed in 16.83s`，确认 CMake fixture 在预期 Autotools 时不会进入 compiler 且无遗留 compile/replay 容器；Ruff、format、Compose、冻结资产、前端串行 format/lint/typecheck/build 与 `git diff --check` 通过
 
 - 2026-07-19 — 让 benchmark runner 通过原生异步事件流执行 compiler 子代理
   - 文件: `backend/packages/harness/deerflow/client.py`, `scripts/forge_benchmark_runner.py`, `backend/tests/test_client.py`, `backend/tests/test_forge_benchmark_runner.py`, `backend/tests/test_forge_benchmark_v3.py`, `backend/CLAUDE.md`
@@ -98,9 +104,9 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #24 / PR #27 的 async runner 重排、历史审计、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- PR #27 合并后继续处理 Issue #25 / PR #28；不得删除仍被上层 PR 引用的远端 head 分支。
-- Issue #25 build-system identity gate 与 Issue #26 有界 agent/tool failure evidence 完成并冻结新协议后，才能创建下一批 physical attempts。
+- 完成 Issue #25 / PR #28 的 build-system identity 重排、审查、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- PR #28 合并后继续处理 Issue #26 / PR #29；不得删除仍被上层 PR 引用的远端 head 分支。
+- Issue #26 有界 agent/tool failure evidence 完成并冻结新协议后，才能创建下一批 physical attempts。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -136,5 +142,8 @@
 - JSON Schema 内部若使用 `#/$defs/...` 根引用，实例校验必须把完整 schema 交给 validator；直接抽出 `$defs.manifest` 会失去根定义并产生 `PointerToNowhere`，这属于校验命令错误，不是 schema 失效。
 - `DeerFlowClient.stream()` 仍是同步兼容 API；任何可能调用 coroutine-only 工具的 embedded consumer 必须使用 `DeerFlowClient.astream()`，不能用阻塞包装破坏取消/终止语义。
 - 冻结协议的 current-tree gate 与历史 provenance audit 目的不同；合法修改 runner 后，前者应继续拒绝漂移，后者必须从已审阅的协议提交读取冻结 blob，不能永久依赖当前工作树。
-- Physical-attempt policy 当前未冻结 `cases[].build_system`，且 ledger 不记录有界的 agent tool failure/no-action completion；修复前即使 exact clone 成功，也不能把 0 submit 解释为 compiler 能力结果。
+- Physical-attempt policy 已由 Issue #25 冻结 `cases[].build_system` 并校验 expected/observed identity；ledger 仍未记录有界的 agent tool failure/no-action completion，在 Issue #26 完成前仍不能把 0 submit 解释为 compiler 能力结果。
 - Codex/PowerShell 对 `wsl docker exec` 的外层命令超时不保证容器内 Python 已停止；本次真实委派在外层 10 秒超时后仍继续到 clean replay。必须先检查 `docker top`、Session 终态和 label 容器，再决定是否重跑或清理，避免重复任务。
+- Ledger 事件名的首段不允许下划线；`build_system.checked` 不符合 `^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$`，应使用 `build.system_checked`。新增事件必须先用 recorder 的真实 append/verify 路径测试，不能只断言 mock 调用。
+- 开发容器的完整仓库位于只读 `/repo`，`/app/backend` 只是可写后端挂载；benchmark 测试会从工作目录推断仓库根，因此必须从 `/repo/backend` 启动并复用 `/app/backend/.venv`。从 `/app/backend` 运行会因缺少根目录 manifest、Schema 和 Dockerfile 产生大量伪失败。
+- Ruff 必须从 `/repo/backend` 启动以加载 `backend/pyproject.toml`；从 `/repo` 启动会退回默认格式规则，把原本符合仓库配置的 runner 误报为需要大范围格式化。只读挂载下同时使用 `--no-cache`。

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -52,6 +52,7 @@ _FORBIDDEN_KEYS = {
     "stdout",
 }
 _ALLOWED_MODEL_ROLES = {"lead", "compiler", "system"}
+_ALLOWED_BUILD_SYSTEMS = {"cmake", "make", "autotools"}
 _ALLOWED_COMMAND_ROLES = {
     "clone",
     "inspect",
@@ -154,6 +155,7 @@ class ExperimentPolicy:
     repetition: int
     expected_repo_url: str
     expected_commit_sha: str
+    expected_build_system: str
     compile_image: str
     image_id: str
     model_name: str
@@ -181,6 +183,12 @@ class ExperimentPolicy:
             raise EvidenceError("The C/C++ baseline requires Memory and Skills to be disabled")
         if self.minimum_replay_delay_seconds < 0:
             raise EvidenceError("minimum replay delay cannot be negative")
+        if self.expected_build_system not in _ALLOWED_BUILD_SYSTEMS:
+            raise EvidenceError("expected_build_system must be cmake, make, or autotools")
+        if self.expected_build_system != "cmake" and self.cmake_arguments:
+            raise EvidenceError("cmake_arguments require expected_build_system=cmake")
+        if self.expected_build_system != "autotools" and self.configure_arguments:
+            raise EvidenceError("configure_arguments require expected_build_system=autotools")
         _validate_endpoint(self.endpoint)
         _validate_safe_value(self.to_payload())
 
@@ -197,6 +205,7 @@ class ExperimentPolicy:
             "repetition": self.repetition,
             "expected_repo_url": self.expected_repo_url,
             "expected_commit_sha": self.expected_commit_sha,
+            "expected_build_system": self.expected_build_system,
             "compile_image": self.compile_image,
             "image_id": self.image_id,
             "model_name": self.model_name,

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -995,6 +995,18 @@ def _experiment_submit_constraints(
     if active is None:
         return True, []
     failures: list[str] = []
+    if session.build_system != active.policy.expected_build_system:
+        failures.append("build_system_mismatch")
+        record_experiment_event(
+            session.thread_id,
+            "protocol.deviation",
+            phase="submit",
+            classification="build_system_mismatch",
+            session_id=session.session_id,
+            expected_build_system=active.policy.expected_build_system,
+            observed_build_system=session.build_system,
+            submit_allowed=False,
+        )
     supporting = next((command for command in session.commands if command.command_id == supporting_command_id), None)
     if supporting is None:
         failures.append("supporting_command_missing")

--- a/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
@@ -8,7 +8,9 @@ from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 from langgraph.typing import ContextT
 
+from deerflow.compile.evidence import get_active_experiment, record_experiment_event
 from deerflow.compile.operations import cleanup_and_finalize_compile_session_impl, clone_repository_impl, get_bound_session, inspect_build_system_impl, prepare_compile_session_impl
+from deerflow.compile.schemas import CompileSession
 
 if TYPE_CHECKING:
     from deerflow.agents.thread_state import ThreadState
@@ -55,6 +57,50 @@ def _build_compile_state_update(
     if build_system:
         update[COMPILE_BUILD_SYSTEM_STATE_KEY] = build_system
     return update
+
+
+def _enforce_experiment_build_system(
+    *,
+    session: CompileSession,
+    observed_build_system: str,
+) -> tuple[bool, str | None]:
+    active = get_active_experiment(session.thread_id)
+    if active is None:
+        return True, None
+
+    expected_build_system = active.policy.expected_build_system
+    matches = observed_build_system == expected_build_system
+    record_experiment_event(
+        session.thread_id,
+        "build.system_checked",
+        session_id=session.session_id,
+        expected_build_system=expected_build_system,
+        observed_build_system=observed_build_system,
+        matches=matches,
+        compiler_allowed=matches,
+    )
+    if matches:
+        return True, None
+
+    error = f"Benchmark protocol deviation: expected build system {expected_build_system}, observed {observed_build_system}."
+    updated, cleanup_result = cleanup_and_finalize_compile_session_impl(
+        session=session,
+        interrupted_status="failed",
+        error=error,
+    )
+    record_experiment_event(
+        session.thread_id,
+        "protocol.deviation",
+        phase="identify_build_system",
+        classification="build_system_mismatch",
+        session_id=session.session_id,
+        expected_build_system=expected_build_system,
+        observed_build_system=observed_build_system,
+        compiler_allowed=False,
+        cleanup_succeeded=cleanup_result.succeeded and cleanup_result.removed,
+        session_finalized=updated.finalized_at is not None,
+    )
+    return False, error
 
 
 @tool("prepare_compile_session", parse_docstring=True)
@@ -171,12 +217,20 @@ def identify_build_system(
     session = get_bound_session(session_id=effective_session_id, thread_id=_get_thread_id(runtime))
     primary_system, detected, suggested_commands = inspect_build_system_impl(session=session)
     root_file = detected[0][1] if detected else None
+    build_system_matches, deviation_error = _enforce_experiment_build_system(
+        session=session,
+        observed_build_system=primary_system,
+    )
     message = f'Build system identified: system={primary_system}, root_file={root_file or "none"}. Next call task(..., subagent_type="compiler") directly.'
     update = _build_compile_state_update(
         session_id=effective_session_id,
         container_id=session.container_id,
         build_system=primary_system,
     )
+    if not build_system_matches:
+        update["compile_terminal"] = True
+        update["messages"] = [ToolMessage(deviation_error or "Benchmark build-system identity mismatch.", tool_call_id=tool_call_id)]
+        return Command(update=update)
     update["messages"] = [ToolMessage(message, tool_call_id=tool_call_id)]
     return Command(update=update)
 

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -42,6 +42,7 @@ def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
     requirements = [
         "Active C/C++ benchmark constraints:",
         f"- Build exact commit {policy.expected_commit_sha} from {policy.expected_repo_url}.",
+        f"- Use the frozen {policy.expected_build_system} build-system path; do not switch to another detected build system.",
         "- The runner already applies the declared system packages, container environment, and replay delay.",
     ]
     if policy.cmake_arguments:

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -18,10 +18,12 @@ import pytest
 
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, finalize_unfinished_thread_sessions_impl, verify_clean_replay_impl
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
+from deerflow.tools.builtins import agent_compile_tools
 
 REPO_URL = "https://github.com/MattClarkson/CMakeHelloWorld.git"
 COMMIT_SHA = "6fda0b169299b1241ed883c8d4af8519da30ce52"
@@ -302,6 +304,106 @@ def test_unfinished_session_finalization_removes_real_compile_container(monkeypa
         )
         assert inspect.returncode != 0
     finally:
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
+def test_build_system_mismatch_stops_before_real_compiler_delegation(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-build-system-gate-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    ledger = ExperimentLedger.create(
+        Path(session.metadata_path).parent / "build-system-gate.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v4",
+        manifest_sha256="1" * 64,
+        case_id="cmake-mismatch-fixture",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url=REPO_URL,
+        expected_commit_sha=COMMIT_SHA,
+        expected_build_system="autotools",
+        compile_image=COMPILE_IMAGE,
+        image_id="sha256:" + "1" * 64,
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=("--disable-subunit",),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        clone_result, _message = clone_repository_impl(
+            session=session,
+            repo_url=REPO_URL,
+            max_retries=1,
+        )
+        assert clone_result.exit_code == 0, clone_result.combined_output
+
+        result = agent_compile_tools.identify_build_system.func(
+            runtime=SimpleNamespace(
+                state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+                context={"thread_id": thread_id},
+                config={"configurable": {}},
+            ),
+            tool_call_id="tool-real-build-system-mismatch",
+        )
+
+        reloaded = manager.load_session(session.session_id, thread_id)
+        assert result.update["compile_terminal"] is True
+        assert reloaded.build_system == "cmake"
+        assert reloaded.status == "failed"
+        assert reloaded.finalized_at is not None
+        assert not reloaded.commands or all(command.role != "build" for command in reloaded.commands)
+        inspect = subprocess.run(
+            ["docker", "inspect", session.container_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert inspect.returncode != 0
+        events = ledger.read()
+        assert [event["event"] for event in events if event["event"] in {"build.system_checked", "protocol.deviation"}] == [
+            "build.system_checked",
+            "protocol.deviation",
+        ]
+        deviation = next(event for event in events if event["event"] == "protocol.deviation")
+        assert deviation["payload"]["expected_build_system"] == "autotools"
+        assert deviation["payload"]["observed_build_system"] == "cmake"
+        assert deviation["payload"]["compiler_allowed"] is False
+        assert deviation["payload"]["cleanup_succeeded"] is True
+        assert deviation["payload"]["session_finalized"] is True
+    finally:
+        deactivate_experiment(thread_id)
         runtime.stop_and_remove_container(session)
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
 

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -78,6 +78,87 @@ def test_benchmark_arguments_must_be_observed_in_declared_order(
     assert operations._command_contains_arguments(command, expected) is matches
 
 
+def test_submit_gate_rejects_observed_build_system_mismatch(tmp_path: Path) -> None:
+    thread_id = "thread-build-system-submit-gate"
+    session = CompileSession(
+        session_id="session-build-system-submit-gate",
+        thread_id=thread_id,
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="inspected",
+        build_system="make",
+        metadata_path="session.json",
+        leadagent_repo_dir="workspace/repo",
+        leadagent_artifacts_dir="artifacts",
+        leadagent_logs_dir="logs",
+        leadagent_repro_dir="repro",
+        commands=[
+            BuildCommandRecord(
+                stage="bash",
+                command="make -j2",
+                workdir="/workspace/repo",
+                command_id="command-build",
+                role="build",
+                exit_code=0,
+            )
+        ],
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "build-system-submit-gate.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v4",
+        manifest_sha256="1" * 64,
+        case_id="fixture",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url=session.repo_url,
+        expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
+        compile_image=session.image,
+        image_id=VALID_IMAGE_ID,
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        passed, failures = operations._experiment_submit_constraints(
+            session,
+            "command-build",
+        )
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert passed is False
+    assert failures == ["build_system_mismatch"]
+    deviation = ledger.read()[-1]
+    assert deviation["event"] == "protocol.deviation"
+    assert deviation["payload"]["phase"] == "submit"
+    assert deviation["payload"]["submit_allowed"] is False
+
+
 def install_passed_replay_stub(monkeypatch) -> None:
     def fake_verify_clean_replay(*, session: CompileSession, timeout_seconds: int | None = None) -> ReplayVerificationResult:
         del timeout_seconds
@@ -969,6 +1050,7 @@ def test_docker_runtime_applies_experiment_labels_and_public_environment_only(tm
         repetition=1,
         expected_repo_url=session.repo_url,
         expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
         compile_image=session.image,
         image_id=VALID_IMAGE_ID,
         model_name="gpt-5.6-sol",

--- a/backend/tests/test_compile_terminal_tools.py
+++ b/backend/tests/test_compile_terminal_tools.py
@@ -207,6 +207,63 @@ def test_finalize_cleans_container_then_ends_lead_with_deterministic_summary(mon
     assert jump == {"compile_terminal": False, "jump_to": "end"}
 
 
+def test_build_system_mismatch_cleans_session_and_stops_before_compiler(monkeypatch):
+    session = make_session()
+    session.status = "source_ready"
+    session.build_system = None
+    session.finalized_at = None
+    recorded_events: list[tuple[str, dict]] = []
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+
+    def inspect_build_system(*, session: CompileSession):
+        session.build_system = "cmake"
+        return "cmake", [("cmake", "CMakeLists.txt")], ["cmake -S . -B build"]
+
+    def cleanup_and_finalize(*, session: CompileSession, interrupted_status: str, error: str):
+        cleanup_calls.append(session.session_id)
+        assert interrupted_status == "failed"
+        assert "expected build system autotools" in error
+        session.status = "failed"
+        session.finalized_at = "2026-07-19T00:00:00+00:00"
+        return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
+
+    monkeypatch.setattr(agent_compile_tools, "inspect_build_system_impl", inspect_build_system)
+    monkeypatch.setattr(agent_compile_tools, "cleanup_and_finalize_compile_session_impl", cleanup_and_finalize)
+    monkeypatch.setattr(
+        agent_compile_tools,
+        "get_active_experiment",
+        lambda _thread_id: SimpleNamespace(policy=SimpleNamespace(expected_build_system="autotools")),
+    )
+    monkeypatch.setattr(
+        agent_compile_tools,
+        "record_experiment_event",
+        lambda _thread_id, event, **payload: recorded_events.append((event, payload)),
+    )
+    runtime = SimpleNamespace(
+        state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+        context={"thread_id": session.thread_id},
+        config={"configurable": {}},
+    )
+
+    result = agent_compile_tools.identify_build_system.func(
+        runtime=runtime,
+        tool_call_id="tool-build-system-mismatch",
+    )
+
+    assert cleanup_calls == [session.session_id]
+    assert result.update["compile_terminal"] is True
+    assert result.update[agent_compile_tools.COMPILE_BUILD_SYSTEM_STATE_KEY] == "cmake"
+    assert "expected build system autotools" in result.update["messages"][0].content
+    assert [event for event, _payload in recorded_events] == [
+        "build.system_checked",
+        "protocol.deviation",
+    ]
+    assert recorded_events[-1][1]["compiler_allowed"] is False
+    assert recorded_events[-1][1]["session_finalized"] is True
+
+
 def test_finalize_ends_lead_graph_after_one_model_call(monkeypatch):
     session = make_session()
     events: list[str] = []

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -28,6 +29,7 @@ def make_policy() -> ExperimentPolicy:
         repetition=1,
         expected_repo_url="https://github.com/fmtlib/fmt.git",
         expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
         compile_image="autocompiler:gcc13",
         image_id=f"sha256:{'3' * 64}",
         model_name="gpt-5.6-sol",
@@ -125,6 +127,25 @@ def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) 
     events = ledger.read()
     assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
     assert get_active_experiment(thread_id) is None
+
+
+@pytest.mark.parametrize("build_system", ["cmake", "make", "autotools"])
+def test_experiment_policy_persists_supported_build_system_identity(build_system: str) -> None:
+    policy = replace(
+        make_policy(),
+        expected_build_system=build_system,
+        cmake_arguments=() if build_system != "cmake" else ("-DBUILD_TESTING=OFF",),
+        configure_arguments=("--disable-subunit",) if build_system == "autotools" else (),
+    )
+
+    assert policy.to_payload()["expected_build_system"] == build_system
+
+
+def test_experiment_policy_rejects_build_system_argument_drift() -> None:
+    with pytest.raises(EvidenceError, match="expected_build_system"):
+        replace(make_policy(), expected_build_system="meson")
+    with pytest.raises(EvidenceError, match="cmake_arguments"):
+        replace(make_policy(), expected_build_system="make")
 
 
 def test_model_response_metadata_reads_bounded_model_response_messages() -> None:

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -75,7 +75,24 @@ def test_build_policy_applies_frozen_case_and_model_constraints() -> None:
     assert policy.memory_enabled is False
     assert policy.skills_enabled is False
     assert policy.expected_commit_sha == manifest["cases"][0]["commit_sha"]
+    assert policy.expected_build_system == manifest["cases"][0]["build_system"]
     assert policy.process_environment == manifest["cases"][0]["constraints"]["environment"]
+
+
+@pytest.mark.parametrize("case_id", ["fmt", "hiredis", "libcheck"])
+def test_build_policy_freezes_each_supported_build_system(case_id: str) -> None:
+    manifest = load_v3_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == case_id)
+
+    policy = forge_benchmark_runner.build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id="baseline",
+        repetition=1,
+    )
+
+    assert policy.expected_build_system == case["build_system"]
+    assert policy.to_payload()["expected_build_system"] == case["build_system"]
 
 
 @pytest.mark.parametrize(
@@ -187,6 +204,7 @@ def test_compiler_prompt_receives_ordered_manifest_constraints() -> None:
     assert positions == sorted(positions)
     assert "command_role" in prompt
     assert "supporting_command_id" in prompt
+    assert policy.expected_build_system in prompt
     assert policy.credential_env not in prompt
 
 
@@ -209,6 +227,7 @@ def test_create_attempt_rejects_duplicate_slot_and_links_explicit_replacement(
         repetition=1,
         output_dir=tmp_path,
     )
+    assert original.read()[0]["payload"]["policy"]["expected_build_system"] == "cmake"
     with pytest.raises(forge_benchmark_runner.RunnerError, match="already has physical evidence"):
         forge_benchmark_runner.create_attempt(
             manifest,

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -162,6 +162,7 @@ def test_active_experiment_records_one_429_attempt_without_exception_text(
         repetition=1,
         expected_repo_url="https://github.com/fmtlib/fmt.git",
         expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
         compile_image="autocompiler:gcc13",
         image_id=f"sha256:{'3' * 64}",
         model_name="gpt-5.6-sol",

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -211,6 +211,7 @@ def build_policy(
         repetition=repetition,
         expected_repo_url=case["repository_url"],
         expected_commit_sha=case["commit_sha"],
+        expected_build_system=case["build_system"],
         compile_image=runtime["compile_image"],
         image_id=runtime["image_id"],
         model_name=lead_model,


### PR DESCRIPTION
## 变更内容

- 将 manifest 中每个 case 的 `build_system` 写入 `ExperimentPolicy` 和 physical-attempt 首条 ledger policy。
- compiler prompt 明确绑定 CMake、Make 或 Autotools 构建路径。
- 在 `identify_build_system` 后记录 expected/observed identity；不匹配时在 compiler 子代理启动前失败终结并清理 Compile Session。
- 在 submit gate 再次从权威 Session 复核构建系统身份，避免绕过前置 gate。
- 增加 policy、runner、prompt、terminalization、submit gate 和真实 Docker 回归。

## 根因与影响

pilot v3 的 `libcheck` 在 manifest 中声明 Autotools，但运行时识别为 CMake。此前 manifest 声明没有进入运行 policy，也没有硬性 identity gate，因此不同构建路径可能被混入同一实验条件，影响成功率、耗时和失败归因的可比性。

本变更让声明的构建系统成为可审计、可执行的实验约束。v1-v5 manifest、Schema、validator、冻结 runner hash 与既有 ledger 均保持不变；没有模型请求、replacement 或新 physical attempt。

## 验证

- policy/runner/prompt/terminalization/submit gate 聚焦组：`150 passed`
- 异步 client、v2/v3 历史 gate、取消与 task 兼容组：`242 passed, 6 skipped`
- 后端全量：`1532 passed, 26 skipped`
- 真实 Docker mismatch：`1 passed in 16.83s`
- Ruff check/format、Compose config、冻结 manifest/Schema、`git diff --check` 通过
- 前端 format、lint、typecheck、build 串行通过
- 无遗留 `deerflow-compile-*`、`deerflow-replay-*` 或测试容器

Closes #25
