### PR TITLE
功能：记录有界的 agent 失败证据

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -2,16 +2,15 @@
 
 跨 Claude Code session 的项目状态流水。按 CLAUDE.md §7 维护。
 
-## 进行中 (In Progress)
-<!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
-
-- 2026-07-21 — 将 Issue #25 / PR #28 的 build-system identity 增量重排到 `main@6f8cab4f`
-  - 范围: 将 manifest `cases[].build_system` 写入 physical-attempt policy 和首条 ledger，约束 compiler 路径，并在 identify 与 submit 两处执行 expected/observed identity gate；不调用模型，不重跑 pilot
-  - 历史边界: 保留 PR #27 的异步 runner；v3 current-tree gate继续拒绝运行时漂移，history audit 继续从 `c4b817f3` 读取冻结 protocol blobs；v1-v5 manifest、Schema、validator、runner hash 与 ledger 不改写
-  - 状态: 单提交增量、实现审查和本地完整验证均已完成；聚焦组 `150 passed`，兼容/历史组 `242 passed, 6 skipped`，后端全量 `1532 passed, 26 skipped`，真实 Docker mismatch `1 passed in 16.83s`，等待推送、PR CI 与合并
-
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-25 — 记录有界的 agent 工具失败与无编译动作终态证据
+  - 文件: `backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py`、`backend/packages/harness/deerflow/compile/evidence.py`、`scripts/forge_benchmark_runner.py` 及对应测试
+  - 动机: Issue #26；区分 endpoint、agent/tool、build、submit/replay 与 completion 失败域，避免 tool exception 仅留在 stderr、模型完成却没有编译动作只表现为 `submit_missing`
+  - 安全与语义: `agent.tool_failed` 仅白名单记录角色、工具名、tool-call ID、异常类、sync/async 与 `terminal=false`；仅在模型请求已完成、流显式结束、零编译工具调用时记录终态 `agent.no_compile_progress`。不读取或写入 prompt、模型内容、工具参数、stdout/stderr、异常文本、headers、密钥或宿主路径。
+  - 边界: 专用 Schema 同时保护 append/verify 并覆盖 digest-valid 篡改、终态后拒写和敏感内容；保留 PR #27 异步 runner、PR #28 identity gate、v3 history/current-tree 审计；v1-v5 manifest、Schema、validator、runner hash 与 ledger 未改写，也没有模型调用或 pilot replacement。
+  - 证据: 聚焦 `50 passed`，兼容/历史/异步/compile lifecycle `261 passed, 6 skipped`，后端全量 `1543 passed, 26 skipped`，真实 Docker mismatch `1 passed in 17.82s`；Ruff check、`py_compile`、Compose config、`git diff --check`、冻结资产与无遗留 compile/replay 容器通过。前端没有差异；lint 为 7 个既有 warning，format、typecheck/build 分别被既有格式与 i18n 类型问题阻塞。
 
 - 2026-07-21 — 冻结并校验 benchmark case 的构建系统身份
   - 文件: `backend/packages/harness/deerflow/compile/evidence.py`, `backend/packages/harness/deerflow/compile/operations.py`, `backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py`, `backend/packages/harness/deerflow/tools/builtins/task_tool.py`, `scripts/forge_benchmark_runner.py` 及对应测试
@@ -104,9 +103,12 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 完成 Issue #25 / PR #28 的 build-system identity 重排、审查、完整 CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- PR #28 合并后继续处理 Issue #26 / PR #29；不得删除仍被上层 PR 引用的远端 head 分支。
-- Issue #26 有界 agent/tool failure evidence 完成并冻结新协议后，才能创建下一批 physical attempts。
+- 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
+- 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
+- 评审 stacked Draft PR #9，并在 CI 与基线 manifest 冻结后再转为 ready。
+- 按堆叠顺序评审并合并 Issue #16/#17/#18 与 pilot v3 的 Draft PR；五个 v3 physical attempts 必须使用新 ledger，不能 replacement 或覆盖 v2 的五条原始 ledger。
+- 完成 Issue #26 / PR #29 的推送、完整 CI 与主干合并；保留旧 remote head 供 PR #31 引用，保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- Issue #26 合并后，按堆叠顺序继续处理 Issue #30 / PR #31；只有全部 instrumentation 修复合入并冻结新协议后，才能创建下一批 physical attempts。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -147,3 +149,5 @@
 - Ledger 事件名的首段不允许下划线；`build_system.checked` 不符合 `^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$`，应使用 `build.system_checked`。新增事件必须先用 recorder 的真实 append/verify 路径测试，不能只断言 mock 调用。
 - 开发容器的完整仓库位于只读 `/repo`，`/app/backend` 只是可写后端挂载；benchmark 测试会从工作目录推断仓库根，因此必须从 `/repo/backend` 启动并复用 `/app/backend/.venv`。从 `/app/backend` 运行会因缺少根目录 manifest、Schema 和 Dockerfile 产生大量伪失败。
 - Ruff 必须从 `/repo/backend` 启动以加载 `backend/pyproject.toml`；从 `/repo` 启动会退回默认格式规则，把原本符合仓库配置的 runner 误报为需要大范围格式化。只读挂载下同时使用 `--no-cache`。
+- Tool error middleware 为继续 Agent 推理会生成包含异常详情的 `ToolMessage`，但该内容只能面向当前模型，绝不能进入实验账本。`agent.tool_failed` 必须在异常捕获点从原始异常对象提取类型名，并用专用白名单 Schema 拒绝详情、prompt、参数、stdout/stderr、secret 和宿主路径。
+- `test_create_deerflow_agent.py` 仍有 17 个与当前 factory 不一致的既有 feature/sandbox/anchor 期望，例如要求已删除的 `SandboxMiddleware`；本次扩展执行得到 27 passed/17 failed，而与本次变更直接相关的 `test_always_on_error_handling` 单独通过。不要把这些旧测试失败归因于 agent evidence import，也不要在 #26 中顺手改动。

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -12,6 +12,8 @@ from langgraph.errors import GraphBubbleUp
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
+from deerflow.compile.evidence import record_agent_tool_failure
+
 logger = logging.getLogger(__name__)
 
 _MISSING_TOOL_CALL_ID = "missing_tool_call_id"
@@ -47,6 +49,7 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
             raise
         except Exception as exc:
             logger.exception("Tool execution failed (sync): name=%s id=%s", request.tool_call.get("name"), request.tool_call.get("id"))
+            record_agent_tool_failure(request, exc, execution_mode="sync")
             return self._build_error_message(request, exc)
 
     @override
@@ -61,6 +64,7 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
             raise
         except Exception as exc:
             logger.exception("Tool execution failed (async): name=%s id=%s", request.tool_call.get("name"), request.tool_call.get("id"))
+            record_agent_tool_failure(request, exc, execution_mode="async")
             return self._build_error_message(request, exc)
 
 

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -23,6 +23,7 @@ LEDGER_CANONICALIZATION = "json-sort-keys-compact-utf8"
 _EVENT_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$")
 _EVIDENCE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*_[0-9a-f]{32}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_BOUNDED_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 _WINDOWS_PATH_RE = re.compile(r"(?i)(?:^|[^A-Za-z0-9_])(?:[A-Z]:[\\/]|\\\\)")
 _WSL_PATH_RE = re.compile(r"(?i)(?:^|[^A-Za-z0-9_])/mnt/[a-z](?:/|$)")
 _HOME_PATH_RE = re.compile(r"(?:^|[^A-Za-z0-9_])/(?:home|Users)/[^/\s]+/")
@@ -53,6 +54,7 @@ _FORBIDDEN_KEYS = {
 }
 _ALLOWED_MODEL_ROLES = {"lead", "compiler", "system"}
 _ALLOWED_BUILD_SYSTEMS = {"cmake", "make", "autotools"}
+_ALLOWED_TOOL_EXECUTION_MODES = {"sync", "async"}
 _ALLOWED_COMMAND_ROLES = {
     "clone",
     "inspect",
@@ -137,6 +139,68 @@ def _validate_safe_value(value: Any, path: str = "payload") -> None:
             _validate_safe_value(item, f"{path}.{key}")
         return
     raise EvidenceError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str = "payload") -> None:
+    if event == "agent.tool_failed":
+        required = {
+            "failure_id",
+            "role",
+            "tool_name",
+            "tool_call_id",
+            "exception_class",
+            "execution_mode",
+            "terminal",
+        }
+        if set(payload) != required:
+            raise EvidenceError(f"{path} has an invalid agent.tool_failed schema")
+        _validate_id(payload["failure_id"], f"{path}.failure_id")
+        if payload["role"] not in _ALLOWED_MODEL_ROLES:
+            raise EvidenceError(f"{path}.role is invalid")
+        for key in ("tool_name", "tool_call_id", "exception_class"):
+            if not isinstance(payload[key], str) or not _BOUNDED_IDENTIFIER_RE.fullmatch(payload[key]):
+                raise EvidenceError(f"{path}.{key} must be a bounded identifier")
+        if payload["execution_mode"] not in _ALLOWED_TOOL_EXECUTION_MODES:
+            raise EvidenceError(f"{path}.execution_mode is invalid")
+        if payload["terminal"] is not False:
+            raise EvidenceError(f"{path}.terminal must be false for a recoverable tool error")
+        return
+
+    if event == "agent.no_compile_progress":
+        required = {
+            "failure_id",
+            "classification",
+            "completed_model_request_count",
+            "tool_call_count",
+            "compile_tool_call_count",
+            "stream_completed",
+            "terminal",
+        }
+        if set(payload) != required:
+            raise EvidenceError(f"{path} has an invalid agent.no_compile_progress schema")
+        _validate_id(payload["failure_id"], f"{path}.failure_id")
+        if payload["classification"] != "no_compile_tool_call":
+            raise EvidenceError(f"{path}.classification is invalid")
+        for key in (
+            "completed_model_request_count",
+            "tool_call_count",
+            "compile_tool_call_count",
+        ):
+            if type(payload[key]) is not int or payload[key] < 0:
+                raise EvidenceError(f"{path}.{key} must be a non-negative integer")
+        if payload["completed_model_request_count"] < 1:
+            raise EvidenceError(f"{path}.completed_model_request_count must be positive")
+        if payload["compile_tool_call_count"] != 0:
+            raise EvidenceError(f"{path}.compile_tool_call_count must be zero")
+        if payload["stream_completed"] is not True or payload["terminal"] is not True:
+            raise EvidenceError(f"{path} must describe a completed terminal stream")
+
+
+def _bounded_identifier(value: Any, fallback: str) -> str:
+    candidate = str(value or "")
+    if _BOUNDED_IDENTIFIER_RE.fullmatch(candidate):
+        return candidate
+    return fallback
 
 
 def _validate_endpoint(value: str) -> str:
@@ -339,6 +403,11 @@ class ExperimentLedger:
             if not isinstance(event["payload"], dict):
                 raise EvidenceError(f"Ledger line {line_number}.payload must be an object")
             _validate_safe_value(event["payload"], f"line {line_number}.payload")
+            _validate_agent_event_payload(
+                event["event"],
+                event["payload"],
+                f"line {line_number}.payload",
+            )
             actual_digest = event["event_sha256"]
             _validate_sha256(actual_digest, f"line {line_number}.event_sha256")
             unsigned = {key: value for key, value in event.items() if key != "event_sha256"}
@@ -364,6 +433,7 @@ class ExperimentLedger:
         if not isinstance(payload, dict):
             raise EvidenceError("Evidence payload must be an object")
         _validate_safe_value(payload)
+        _validate_agent_event_payload(event, payload)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with _path_lock(self.path), _exclusive_sibling_lock(self.path):
             existing = self.verify_path(self.path) if self.path.exists() else []
@@ -484,6 +554,36 @@ def request_model_role(request: Any) -> str:
         if isinstance(role, str) and role in _ALLOWED_MODEL_ROLES:
             return role
     return "lead"
+
+
+def record_agent_tool_failure(
+    request: Any,
+    exc: Exception,
+    *,
+    execution_mode: str,
+) -> dict[str, Any] | None:
+    if execution_mode not in _ALLOWED_TOOL_EXECUTION_MODES:
+        raise EvidenceError("execution_mode must be sync or async")
+    tool_call = getattr(request, "tool_call", None)
+    if not isinstance(tool_call, dict):
+        tool_call = {}
+    return record_experiment_event(
+        request_thread_id(request),
+        "agent.tool_failed",
+        failure_id=new_evidence_id("failure"),
+        role=request_model_role(request),
+        tool_name=_bounded_identifier(tool_call.get("name"), "unknown_tool"),
+        tool_call_id=_bounded_identifier(
+            tool_call.get("id"),
+            "missing_tool_call_id",
+        ),
+        exception_class=_bounded_identifier(
+            type(exc).__name__,
+            "UnknownException",
+        ),
+        execution_mode=execution_mode,
+        terminal=False,
+    )
 
 
 def request_model_name(request: Any, fallback: str) -> str:

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import replace
 from pathlib import Path
@@ -12,10 +13,12 @@ from deerflow.compile.evidence import (
     ExperimentLedger,
     ExperimentPolicy,
     activate_experiment,
+    canonical_json_bytes,
     deactivate_experiment,
     get_active_experiment,
     model_response_metadata,
     new_evidence_id,
+    record_agent_tool_failure,
     record_experiment_event,
 )
 
@@ -127,6 +130,130 @@ def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) 
     events = ledger.read()
     assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
     assert get_active_experiment(thread_id) is None
+
+
+def test_agent_tool_failure_records_only_bounded_identity_and_exception_class(
+    tmp_path: Path,
+) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = new_evidence_id("thread")
+    request = SimpleNamespace(
+        tool_call={"name": "task", "id": "call-safe-123"},
+        runtime=SimpleNamespace(
+            context={"thread_id": thread_id, "agent_name": "compiler"},
+            config={"configurable": {}},
+        ),
+    )
+    exception_detail = "sk-this-must-not-enter-ledger C:\\Users\\YiWei\\private"
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+    )
+    try:
+        record_agent_tool_failure(
+            request,
+            RuntimeError(exception_detail),
+            execution_mode="async",
+        )
+    finally:
+        deactivate_experiment(thread_id)
+
+    payload = ledger.read()[-1]["payload"]
+    assert payload == {
+        "failure_id": payload["failure_id"],
+        "role": "compiler",
+        "tool_name": "task",
+        "tool_call_id": "call-safe-123",
+        "exception_class": "RuntimeError",
+        "execution_mode": "async",
+        "terminal": False,
+    }
+    assert exception_detail not in ledger.path.read_text(encoding="utf-8")
+
+
+def test_agent_event_schema_rejects_raw_or_inconsistent_payloads(
+    tmp_path: Path,
+) -> None:
+    ledger = create_ledger(tmp_path)
+    with pytest.raises(EvidenceError, match="agent.tool_failed schema"):
+        ledger.append(
+            "agent.tool_failed",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "role": "lead",
+                "tool_name": "task",
+                "tool_call_id": "call-1",
+                "exception_class": "RuntimeError",
+                "execution_mode": "async",
+                "terminal": False,
+                "detail": "raw exception detail is forbidden by schema",
+            },
+        )
+    with pytest.raises(EvidenceError, match="compile_tool_call_count must be zero"):
+        ledger.append(
+            "agent.no_compile_progress",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "classification": "no_compile_tool_call",
+                "completed_model_request_count": 1,
+                "tool_call_count": 1,
+                "compile_tool_call_count": 1,
+                "stream_completed": True,
+                "terminal": True,
+            },
+        )
+
+
+def test_agent_event_schema_rejects_digest_valid_tampering(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    ledger.append(
+        "agent.no_compile_progress",
+        {
+            "failure_id": new_evidence_id("failure"),
+            "classification": "no_compile_tool_call",
+            "completed_model_request_count": 1,
+            "tool_call_count": 0,
+            "compile_tool_call_count": 0,
+            "stream_completed": True,
+            "terminal": True,
+        },
+    )
+    records = [json.loads(line) for line in ledger.path.read_text(encoding="utf-8").splitlines()]
+    records[-1]["payload"]["completed_model_request_count"] = -1
+    unsigned = {key: value for key, value in records[-1].items() if key != "event_sha256"}
+    records[-1]["event_sha256"] = hashlib.sha256(canonical_json_bytes(unsigned)).hexdigest()
+    ledger.path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True, separators=(",", ":")) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        EvidenceError,
+        match="completed_model_request_count must be a non-negative integer",
+    ):
+        ExperimentLedger.verify_path(ledger.path)
+
+
+def test_completed_ledger_rejects_late_agent_evidence(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    ledger.append("experiment.completed", {"status": "failed"})
+
+    with pytest.raises(EvidenceError, match="immutable"):
+        ledger.append(
+            "agent.no_compile_progress",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "classification": "no_compile_tool_call",
+                "completed_model_request_count": 1,
+                "tool_call_count": 0,
+                "compile_tool_call_count": 0,
+                "stream_completed": True,
+                "terminal": True,
+            },
+        )
 
 
 @pytest.mark.parametrize("build_system", ["cmake", "make", "autotools"])

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -8,7 +8,7 @@ import pytest
 
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import ContainerCleanupResult
-from deerflow.compile.evidence import ExperimentLedger
+from deerflow.compile.evidence import ExperimentLedger, new_evidence_id, record_experiment_event
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.operations import CompileOperationsServices
 from deerflow.config.paths import Paths
@@ -524,6 +524,274 @@ def test_run_retries_session_finalization_after_orphan_cleanup(
     completed = ledger.read()[-1]
     assert completed["event"] == "experiment.completed"
     assert completed["payload"]["session_finalization_succeeded"] is True
+
+
+def test_run_records_no_compile_progress_without_raw_stream_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: ready_preflight(manifest),
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+    raw_content = "sk-stream-content-must-not-enter-ledger C:\\Users\\private"
+
+    class NoActionClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        async def astream(self, message: str, *, thread_id: str):
+            del message
+            record_experiment_event(
+                thread_id,
+                "model.request_completed",
+                model_request_id=new_evidence_id("model_request"),
+                actual_model="provider-confirmed-model",
+            )
+            yield SimpleNamespace(
+                type="messages-tuple",
+                data={"type": "ai", "content": raw_content},
+            )
+            yield SimpleNamespace(type="end", data={"usage": {}})
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", NoActionClient)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "reconcile_orphans",
+        lambda _attempt_id: {
+            "scan_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    result = forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    assert result["status"] == "failed"
+    events = ledger.read()
+    no_progress = next(event for event in events if event["event"] == "agent.no_compile_progress")
+    assert no_progress["payload"]["completed_model_request_count"] == 1
+    assert no_progress["payload"]["tool_call_count"] == 0
+    assert no_progress["payload"]["compile_tool_call_count"] == 0
+    assert no_progress["payload"]["stream_completed"] is True
+    assert no_progress["payload"]["terminal"] is True
+    assert raw_content not in ledger.path.read_text(encoding="utf-8")
+
+
+def test_run_does_not_mark_progress_missing_after_compile_tool_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: ready_preflight(manifest),
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+    raw_arguments = {"prompt": "must not enter evidence"}
+
+    class CompileActionClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        async def astream(self, message: str, *, thread_id: str):
+            del message
+            record_experiment_event(
+                thread_id,
+                "model.request_completed",
+                model_request_id=new_evidence_id("model_request"),
+                actual_model="provider-confirmed-model",
+            )
+            yield SimpleNamespace(
+                type="messages-tuple",
+                data={
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "task",
+                            "id": "call-compile",
+                            "args": raw_arguments,
+                        }
+                    ],
+                },
+            )
+            yield SimpleNamespace(type="end", data={"usage": {}})
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", CompileActionClient)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "reconcile_orphans",
+        lambda _attempt_id: {
+            "scan_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    events = ledger.read()
+    assert not any(event["event"] == "agent.no_compile_progress" for event in events)
+    assert "must not enter evidence" not in ledger.path.read_text(encoding="utf-8")
+
+
+def test_run_does_not_mark_progress_missing_when_stream_does_not_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: ready_preflight(manifest),
+    )
+    ledger, _ = forge_benchmark_runner.create_attempt(
+        manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        output_dir=tmp_path,
+    )
+
+    class IncompleteStreamClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        async def astream(self, message: str, *, thread_id: str):
+            del message
+            record_experiment_event(
+                thread_id,
+                "model.request_completed",
+                model_request_id=new_evidence_id("model_request"),
+                actual_model="provider-confirmed-model",
+            )
+            yield SimpleNamespace(type="messages-tuple", data={"type": "ai"})
+
+    import deerflow.client
+
+    monkeypatch.setattr(deerflow.client, "DeerFlowClient", IncompleteStreamClient)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "reconcile_orphans",
+        lambda _attempt_id: {
+            "scan_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    forge_benchmark_runner.run_attempt(manifest, ledger.path)
+
+    assert not any(event["event"] == "agent.no_compile_progress" for event in ledger.read())
+
+
+def test_offline_failure_domains_keep_missing_evidence_null() -> None:
+    assert forge_benchmark_runner.recompute_failure_domains([]) == {
+        "model_endpoint": None,
+        "agent_tool": None,
+        "build": None,
+        "submit_replay": None,
+        "completion": None,
+    }
+
+
+def test_offline_failure_domains_separate_agent_and_runtime_failures() -> None:
+    events = [
+        {
+            "event": "failure.recorded",
+            "payload": {
+                "domain": "model_endpoint",
+                "classification": "timeout",
+            },
+        },
+        {
+            "event": "agent.tool_failed",
+            "payload": {
+                "exception_class": "RuntimeError",
+                "tool_name": "task",
+                "terminal": False,
+            },
+        },
+        {
+            "event": "agent.no_compile_progress",
+            "payload": {
+                "classification": "no_compile_tool_call",
+                "terminal": True,
+            },
+        },
+        {
+            "event": "failure.recorded",
+            "payload": {
+                "domain": "build",
+                "classification": "dependency_setup_failed",
+            },
+        },
+        {
+            "event": "failure.recorded",
+            "payload": {
+                "domain": "verification",
+                "classification": "artifact_hash_mismatch",
+            },
+        },
+        {
+            "event": "run.failed",
+            "payload": {"classification": "KeyboardInterrupt"},
+        },
+    ]
+
+    domains = forge_benchmark_runner.recompute_failure_domains(events)
+
+    assert domains["model_endpoint"] == [{"event": "failure.recorded", "classification": "timeout"}]
+    assert domains["agent_tool"] == [
+        {
+            "event": "agent.tool_failed",
+            "classification": "RuntimeError",
+            "tool_name": "task",
+            "terminal": False,
+        },
+        {
+            "event": "agent.no_compile_progress",
+            "classification": "no_compile_tool_call",
+            "terminal": True,
+        },
+    ]
+    assert domains["build"] == [
+        {
+            "event": "failure.recorded",
+            "classification": "dependency_setup_failed",
+        }
+    ]
+    assert domains["submit_replay"] == [
+        {
+            "event": "failure.recorded",
+            "classification": "artifact_hash_mismatch",
+        }
+    ]
+    assert domains["completion"] == [{"event": "run.failed", "classification": "KeyboardInterrupt"}]
 
 
 def test_gate_recomputation_detects_tampering_and_oracle_is_independent() -> None:

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.messages import ToolMessage
 from langgraph.errors import GraphInterrupt
 
+from deerflow.agents.middlewares import tool_error_handling_middleware
 from deerflow.agents.middlewares.tool_error_handling_middleware import ToolErrorHandlingMiddleware
 
 
@@ -39,6 +40,28 @@ def test_wrap_tool_call_returns_error_tool_message_on_exception():
     assert result.status == "error"
     assert "Tool 'web_search' failed" in result.text
     assert "network down" in result.text
+
+
+def test_wrap_tool_call_records_bounded_failure_identity(monkeypatch):
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="task", tool_call_id="tc-evidence")
+    recorded: list[tuple[object, Exception, str]] = []
+
+    monkeypatch.setattr(
+        tool_error_handling_middleware,
+        "record_agent_tool_failure",
+        lambda request, exc, *, execution_mode: recorded.append((request, exc, execution_mode)),
+    )
+
+    def _boom(_req):
+        raise RuntimeError("must not be passed as evidence payload")
+
+    middleware.wrap_tool_call(req, _boom)
+
+    assert len(recorded) == 1
+    assert recorded[0][0] is req
+    assert type(recorded[0][1]) is RuntimeError
+    assert recorded[0][2] == "sync"
 
 
 def test_wrap_tool_call_uses_fallback_tool_call_id_when_missing():
@@ -82,6 +105,29 @@ async def test_awrap_tool_call_returns_error_tool_message_on_exception():
     assert result.name == "mcp_tool"
     assert result.status == "error"
     assert "request timed out" in result.text
+
+
+@pytest.mark.anyio
+async def test_awrap_tool_call_records_async_failure_identity(monkeypatch):
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="task", tool_call_id="tc-async-evidence")
+    recorded: list[tuple[object, Exception, str]] = []
+
+    monkeypatch.setattr(
+        tool_error_handling_middleware,
+        "record_agent_tool_failure",
+        lambda request, exc, *, execution_mode: recorded.append((request, exc, execution_mode)),
+    )
+
+    async def _boom(_req):
+        raise TimeoutError("must not be passed as evidence payload")
+
+    await middleware.awrap_tool_call(req, _boom)
+
+    assert len(recorded) == 1
+    assert recorded[0][0] is req
+    assert type(recorded[0][1]) is TimeoutError
+    assert recorded[0][2] == "async"
 
 
 @pytest.mark.anyio

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -44,6 +44,26 @@ class RunnerError(ValueError):
     pass
 
 
+_COMPILE_ACTION_TOOL_NAMES = frozenset(
+    {
+        "prepare_compile_session",
+        "clone_repository",
+        "identify_build_system",
+        "task",
+        "run_container_bash",
+        "submit_build_result",
+        "finalize_session",
+    }
+)
+_FAILURE_DOMAIN_NAMES = (
+    "model_endpoint",
+    "agent_tool",
+    "build",
+    "submit_replay",
+    "completion",
+)
+
+
 def _sha256_file(path: Path) -> str | None:
     if not path.is_file():
         return None
@@ -520,6 +540,61 @@ def create_attempt(
     return ledger, preflight
 
 
+def recompute_failure_domains(events: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]] | None]:
+    domains: dict[str, list[dict[str, Any]]] = {name: [] for name in _FAILURE_DOMAIN_NAMES}
+    recorded_domain_map = {
+        "model_endpoint": "model_endpoint",
+        "build": "build",
+        "verification": "submit_replay",
+        "submit": "submit_replay",
+        "replay": "submit_replay",
+    }
+    for event in events:
+        event_name = event["event"]
+        payload = event["payload"]
+        if event_name == "failure.recorded":
+            domain = recorded_domain_map.get(payload.get("domain"))
+            if domain is not None:
+                domains[domain].append(
+                    {
+                        "event": event_name,
+                        "classification": payload.get("classification"),
+                    }
+                )
+        elif event_name == "agent.tool_failed":
+            domains["agent_tool"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("exception_class"),
+                    "tool_name": payload.get("tool_name"),
+                    "terminal": payload.get("terminal"),
+                }
+            )
+        elif event_name == "agent.no_compile_progress":
+            domains["agent_tool"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("classification"),
+                    "terminal": payload.get("terminal"),
+                }
+            )
+        elif event_name == "run.failed":
+            domains["completion"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("classification"),
+                }
+            )
+        elif event_name == "experiment.completed" and payload.get("status") != "passed":
+            domains["completion"].append(
+                {
+                    "event": event_name,
+                    "classification": "experiment_failed",
+                }
+            )
+    return {name: values or None for name, values in domains.items()}
+
+
 def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
     commands: dict[str, dict[str, Any]] = {}
     replays: dict[str, dict[str, Any]] = {}
@@ -579,7 +654,12 @@ def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
                 "gates": recomputed,
             }
         )
-    return {"valid": not mismatches, "submits": results, "mismatches": mismatches}
+    return {
+        "valid": not mismatches,
+        "submits": results,
+        "mismatches": mismatches,
+        "failure_domains": recompute_failure_domains(events),
+    }
 
 
 def run_oracle(
@@ -657,9 +737,40 @@ def _finalize_attempt_sessions(
     return all(session.finalized_at is not None for session in sessions)
 
 
-async def _consume_client_stream(client: Any, message: str, *, thread_id: str) -> None:
-    async for _event in client.astream(message, thread_id=thread_id):
-        pass
+async def _consume_client_stream(
+    client: Any,
+    message: str,
+    *,
+    thread_id: str,
+) -> dict[str, int | bool]:
+    tool_call_count = 0
+    compile_tool_call_count = 0
+    stream_completed = False
+    async for event in client.astream(message, thread_id=thread_id):
+        if event.type == "end":
+            stream_completed = True
+            continue
+        if event.type != "messages-tuple" or not isinstance(event.data, dict):
+            continue
+        if event.data.get("type") != "ai":
+            continue
+        tool_calls = event.data.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            tool_name = tool_call.get("name")
+            if not isinstance(tool_name, str):
+                continue
+            tool_call_count += 1
+            if tool_name in _COMPILE_ACTION_TOOL_NAMES:
+                compile_tool_call_count += 1
+    return {
+        "tool_call_count": tool_call_count,
+        "compile_tool_call_count": compile_tool_call_count,
+        "stream_completed": stream_completed,
+    }
 
 
 def run_attempt(
@@ -718,7 +829,25 @@ def run_attempt(
             available_skills=set(),
         )
         message = f"Compile the C/C++ repository at {policy.expected_repo_url} using exact commit {policy.expected_commit_sha}. Use the compiler subagent and finish only after deterministic artifact submission and session finalization."
-        asyncio.run(_consume_client_stream(client, message, thread_id=thread_id))
+        stream_summary = asyncio.run(_consume_client_stream(client, message, thread_id=thread_id))
+        completed_model_request_count = sum(event["event"] == "model.request_completed" for event in ledger.read())
+        if (
+            completed_model_request_count > 0
+            and stream_summary["stream_completed"]
+            and stream_summary["compile_tool_call_count"] == 0
+        ):
+            ledger.append(
+                "agent.no_compile_progress",
+                {
+                    "failure_id": new_evidence_id("failure"),
+                    "classification": "no_compile_tool_call",
+                    "completed_model_request_count": completed_model_request_count,
+                    "tool_call_count": stream_summary["tool_call_count"],
+                    "compile_tool_call_count": 0,
+                    "stream_completed": stream_summary["stream_completed"],
+                    "terminal": True,
+                },
+            )
         run_status = "completed"
     except BaseException as exc:
         ledger.append(


### PR DESCRIPTION
## 变更内容

- 在同步与异步工具异常捕获点记录有界的 `agent.tool_failed`。
- 仅记录角色、工具名、tool-call ID、异常类、执行模式与终态标记；不记录异常文本、prompt、模型内容、工具参数、stdout/stderr、headers、密钥或宿主路径。
- 仅在模型请求已完成、流显式结束且零编译工具调用时记录终态 `agent.no_compile_progress`。
- 离线 gate 将失败证据分为 `model_endpoint`、`agent_tool`、`build`、`submit_replay`、`completion` 五个可空域。

## 边界

保留异步 runner、build-system identity gate 和 v3 history/current-tree 审计语义；未改写 v1-v5 manifest、Schema、validator、runner hash 或既有 ledger。本阶段未调用模型，也未执行或替换 pilot。

## 验证

- 聚焦 evidence / middleware / runner：`50 passed`
- 兼容、历史、异步 client 与 compile lifecycle：`261 passed, 6 skipped`
- 后端全量：`1543 passed, 26 skipped`
- 真实 Docker build-system mismatch gate：`1 passed in 17.82s`
- Ruff check、`py_compile`、Compose config、`git diff --check`、冻结资产与无遗留 compile/replay 容器通过
- 前端无差异；lint 只有 7 个既有 warning，format、typecheck/build 被既有格式与 i18n 类型错误阻塞，未扩大本 PR 范围修复

Closes #26