### PR TITLE
修复：复用运行级异步事件循环

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-25 — 重排并验证 Issue #32 的运行级异步 event-loop ownership 修复
+  - 范围: 将旧堆叠中的单提交增量重放到 `main@2cfbf795`；已有运行 loop 时直接创建 compiler 后台 task，无运行 loop 的同步兼容调用仍使用隔离线程。
+  - 兼容: v4 runtime current-tree gate 仍拒绝随后合法的 `executor.py` 漂移；历史 component blob 审计与冻结 manifest/Schema/validator/ledger 保持不变。executor 测试 fixture 不再 reload 模块，避免 enum class identity 伪失败。
+  - 证据: v4/executor 聚焦 `48 passed, 1 skipped`，后端全量 `1565 passed, 27 skipped`；Ruff、format、`py_compile`、Compose config 与 diff 检查通过。
+  - 边界: 仅实现与验证修复；不调用模型、不执行或替换任何 pilot，不改写 v1-v5 protocol/ledger。
+
 - 2026-07-25 — 记录有界的 agent 工具失败与无编译动作终态证据
   - 文件: `backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py`、`backend/packages/harness/deerflow/compile/evidence.py`、`scripts/forge_benchmark_runner.py` 及对应测试
   - 动机: Issue #26；区分 endpoint、agent/tool、build、submit/replay 与 completion 失败域，避免 tool exception 仅留在 stderr、模型完成却没有编译动作只表现为 `submit_missing`
@@ -112,8 +118,8 @@
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
 - 评审 stacked Draft PR #9，并在 CI 与基线 manifest 冻结后再转为 ready。
 - 按堆叠顺序评审并合并 Issue #16/#17/#18 与 pilot v3 的 Draft PR；五个 v3 physical attempts 必须使用新 ledger，不能 replacement 或覆盖 v2 的五条原始 ledger。
-- 完成 Issue #26 / PR #29 的推送、完整 CI 与主干合并；保留旧 remote head 供 PR #31 引用，保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- Issue #26 合并后，按堆叠顺序继续处理 Issue #30 / PR #31；只有全部 instrumentation 修复合入并冻结新协议后，才能创建下一批 physical attempts。
+- Issue #30 / PR #31 已完成协议重排、CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
+- 按堆叠顺序处理 Issue #32 / PR #35；完成 event-loop ownership 修复验证后，再进入上层 #36、#37、#39、#41。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -158,3 +164,4 @@
 - `test_create_deerflow_agent.py` 仍有 17 个与当前 factory 不一致的既有 feature/sandbox/anchor 期望，例如要求已删除的 `SandboxMiddleware`；本次扩展执行得到 27 passed/17 failed，而与本次变更直接相关的 `test_always_on_error_handling` 单独通过。不要把这些旧测试失败归因于 agent evidence import，也不要在 #26 中顺手改动。
 - 真实 Docker 集成依赖 GitHub clone，偶发 `Recv failure: Connection reset by peer` 可能在进入待测逻辑前失败；先确认按 label 无遗留容器，再只重跑该场景。本次副作用拒绝场景首次网络失败，单独重跑后 `1 passed in 32.63s`。
 - 完整 `test_client.py` 当前有 3 个与 v4 无关的既有 artifact 路径期望不一致：测试期待 `must start with`/`PathTraversalError`，实际 `Paths.resolve_virtual_path()` 返回 `Unsupported virtual path` 的 `ValueError`；v4 扩大回归为 `431 passed, 3 skipped, 3 failed`，stream/chat 定向测试仍为 `19 passed`。不要在 benchmark 协议提交中顺手修改。
+- 原生 async stream 不自动保证模型 client 的 event-loop ownership。`task_tool` 已在 Lead 的 async loop 中时，不能再通过 `thread pool -> asyncio.run()` 为 compiler 创建第二个 loop；保留同步兼容调用的隔离线程路径，并用 loop-bound 回归保护该边界。

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -365,6 +365,75 @@ class SubagentExecutor:
             _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc))
             return result_holder
 
+    def _execute_on_running_loop(
+        self,
+        task: str,
+        result_holder: SubagentResult,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Start a background execution without crossing event-loop ownership."""
+
+        async def run() -> SubagentResult:
+            with result_holder._status_lock:
+                if result_holder.status == SubagentStatus.PENDING:
+                    result_holder.status = SubagentStatus.RUNNING
+            try:
+                async with asyncio.timeout(self.config.timeout_seconds):
+                    return await self._aexecute(task, result_holder)
+            except TimeoutError:
+                result_holder.cancel_event.set()
+                _mark_terminal(
+                    result_holder,
+                    SubagentStatus.TIMED_OUT,
+                    f"Subagent timed out after {self.config.timeout_seconds} seconds",
+                )
+                return result_holder
+            except asyncio.CancelledError:
+                _mark_terminal(
+                    result_holder,
+                    SubagentStatus.CANCELLED,
+                    result_holder.error or "Cancelled by user",
+                )
+                raise
+            except Exception as exc:
+                logger.exception(
+                    "[trace=%s] Subagent %s execution wrapper failed",
+                    self.trace_id,
+                    self.config.name,
+                )
+                _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc))
+                return result_holder
+
+        execution_task = loop.create_task(run())
+        with result_holder._handle_lock:
+            result_holder._loop = loop
+            result_holder._asyncio_task = execution_task
+
+        def on_done(completed_task: asyncio.Task[SubagentResult]) -> None:
+            if completed_task.cancelled():
+                _mark_terminal(
+                    result_holder,
+                    SubagentStatus.CANCELLED,
+                    result_holder.error or "Cancelled by user",
+                )
+            else:
+                exception = completed_task.exception()
+                if exception is not None:
+                    logger.error(
+                        "[trace=%s] Subagent %s native async task failed",
+                        self.trace_id,
+                        self.config.name,
+                        exc_info=(type(exception), exception, exception.__traceback__),
+                    )
+                    _mark_terminal(result_holder, SubagentStatus.FAILED, str(exception))
+            with result_holder._handle_lock:
+                if result_holder._asyncio_task is completed_task:
+                    result_holder._asyncio_task = None
+                    result_holder._loop = None
+            result_holder.worker_done_event.set()
+
+        execution_task.add_done_callback(on_done)
+
     def execute_async(self, task: str, task_id: str | None = None) -> str:
         task_id = task_id or str(uuid.uuid4())[:8]
 
@@ -377,6 +446,15 @@ class SubagentExecutor:
 
         with _background_tasks_lock:
             _background_tasks[task_id] = result_holder
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is not None:
+            self._execute_on_running_loop(task, result_holder, running_loop)
+            return task_id
 
         def submit_execution() -> SubagentResult:
             with result_holder._status_lock:

--- a/backend/tests/test_forge_benchmark_v4.py
+++ b/backend/tests/test_forge_benchmark_v4.py
@@ -76,13 +76,19 @@ def test_v4_manifest_rejects_protocol_drift(mutation, message: str) -> None:
         forge_benchmark_v4.validate_manifest(manifest)
 
 
-def test_v4_manifest_digest_is_canonical_and_frozen_files_are_current() -> None:
+def test_v4_manifest_digest_is_canonical() -> None:
     manifest = load_v4_manifest()
     digest = forge_benchmark_v4.manifest_sha256(manifest)
     reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
 
     assert forge_benchmark_v4.manifest_sha256(reparsed) == digest
-    forge_benchmark_v4.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v4_current_tree_gate_rejects_later_runtime_component_drift() -> None:
+    manifest = load_v4_manifest()
+
+    with pytest.raises(forge_benchmark_v4.BenchmarkError, match=r"subagents/executor\.py"):
+        forge_benchmark_v4.verify_frozen_components(manifest, REPO_ROOT)
 
 
 def test_v4_runtime_components_match_the_declared_baseline() -> None:

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -712,13 +712,11 @@ class TestCleanupBackgroundTask:
 
     @pytest.fixture
     def executor_module(self, _setup_executor_classes):
-        """Import the executor module with real classes."""
-        # Re-import to get the real module with cleanup_background_task
-        import importlib
+        """Return the session's real executor module without changing class identity."""
 
         from deerflow.subagents import executor
 
-        return importlib.reload(executor)
+        return executor
 
     def test_cleanup_removes_terminal_completed_task(self, executor_module, classes):
         """Test that cleanup removes a COMPLETED task."""
@@ -853,12 +851,11 @@ class TestCooperativeCancellation:
 
     @pytest.fixture
     def executor_module(self, _setup_executor_classes):
-        """Import the executor module with real classes."""
-        import importlib
+        """Return the session's real executor module without changing class identity."""
 
         from deerflow.subagents import executor
 
-        return importlib.reload(executor)
+        return executor
 
     @pytest.mark.anyio
     async def test_aexecute_cancelled_before_streaming(self, classes, base_config, mock_agent, msg):
@@ -1061,6 +1058,50 @@ class TestCooperativeCancellation:
         worker_release.set()
         assert worker_done.wait(timeout=3)
         assert result.status == SubagentStatus.TIMED_OUT
+
+    @pytest.mark.anyio
+    async def test_execute_async_keeps_loop_bound_agent_on_caller_loop(
+        self,
+        executor_module,
+        classes,
+        base_config,
+        msg,
+    ):
+        """Async background execution must not move model clients to another loop."""
+        SubagentExecutor = classes["SubagentExecutor"]
+        SubagentStatus = classes["SubagentStatus"]
+        owner_loop = asyncio.get_running_loop()
+        observed_loops = []
+
+        class LoopBoundAgent:
+            async def astream(self, *_args, **_kwargs):
+                current_loop = asyncio.get_running_loop()
+                if current_loop is not owner_loop:
+                    raise RuntimeError("async model client is bound to a different event loop")
+                observed_loops.append(current_loop)
+                yield {
+                    "messages": [
+                        msg.human("Task"),
+                        msg.ai("Same loop result", "msg-loop"),
+                    ]
+                }
+
+        executor = SubagentExecutor(
+            config=base_config,
+            tools=[],
+            thread_id="test-thread",
+        )
+
+        with patch.object(executor, "_create_agent", return_value=LoopBoundAgent()):
+            task_id = executor.execute_async("Task", task_id="loop-bound-task")
+            assert await executor_module.wait_for_background_task_shutdown(task_id, 3)
+
+        result = executor_module.get_background_task_result(task_id)
+        assert result is not None
+        assert result.status.value == SubagentStatus.COMPLETED.value
+        assert result.result == "Same loop result"
+        assert observed_loops == [owner_loop]
+        executor_module.cleanup_background_task(task_id)
 
     def test_cleanup_removes_cancelled_task(self, executor_module, classes):
         """Test that cleanup removes a CANCELLED task (terminal state)."""


### PR DESCRIPTION
## 变更
- 当 `execute_async()` 已在运行中的 async event loop 内被调用时，直接在该 loop 创建 compiler 后台 task；无运行 loop 的同步兼容调用继续走隔离线程。
- 使用原生 timeout、取消、worker shutdown 和既有 `SubagentResult`/轮询契约，避免 `task_tool -> thread pool -> asyncio.run()` 造成模型 client 跨 loop 复用。
- 保持 v4 manifest 不变：其 current-tree gate 现在明确拒绝本次合法的 runtime 漂移，同时继续以冻结 baseline blob 审计历史证据。
- executor 测试 fixture 不再 reload 模块，避免同一测试会话中 `SubagentStatus` 枚举类身份被拆分而产生伪失败。

## 根因
Lead 的 `task_tool` 已运行在异步 event loop 内，旧实现仍进入线程池并通过 `asyncio.run()` 创建第二个 loop，使异步模型 client/HTTP 连接池可能跨 loop 使用。

## 验证
- v4/executor 聚焦：48 passed，1 skipped。
- 后端全量：1565 passed，27 skipped。
- 真实 Docker build-system mismatch：1 passed。
- Ruff、format、py_compile、Compose config 与 git diff --check 通过。

## 边界
- 未调用模型，未执行或替换任何 pilot physical attempt。
- 不改写 v1-v5 manifest、Schema、validator 或既有 ledger；保持 WSL2 Compose/DooD、Compile Session 与 clean replay。

Closes #32