### PR TITLE
修复：让非交互编译越过澄清中断

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,10 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-26 — 重排 Issue #33 的非交互澄清修复
+  - 范围: 将旧堆叠的单提交重放到 `main@b0e9b0e5`；标准仓库 URL + exact commit 明确允许直接进入隔离编译，活跃实验只对 Lead 的首次澄清返回冻结 policy，并记录有界 `agent.clarification_auto_answered` 证据。
+  - 安全与兼容: 不记录问题、回答、prompt 或模型文本；第二次澄清与普通交互仍结束回合等待用户。v1-v5 manifest、Schema、validator 与既有 ledger 均不改写。
+
 - 2026-07-25 — 重排并验证 Issue #32 的运行级异步 event-loop ownership 修复
   - 范围: 将旧堆叠中的单提交增量重放到 `main@2cfbf795`；已有运行 loop 时直接创建 compiler 后台 task，无运行 loop 的同步兼容调用仍使用隔离线程。
   - 兼容: v4 runtime current-tree gate 仍拒绝随后合法的 `executor.py` 漂移；历史 component blob 审计与冻结 manifest/Schema/validator/ledger 保持不变。executor 测试 fixture 不再 reload 模块，避免 enum class identity 伪失败。

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -252,6 +252,8 @@ You are {agent_name}, an open-source compilation-focused agent.
 - Break down the task: What is clear? What is ambiguous? What is missing?
 - First determine whether the request is a repository compilation/build task, a compile-result analysis task, or a different kind of task
 - **PRIORITY CHECK: If anything is unclear, missing, or has multiple interpretations, you MUST ask for clarification FIRST - do NOT proceed with work**
+- Exception: a standard repository compilation request that supplies a repository URL and exact commit is sufficiently specified to start.
+- Discover the build system and dependencies with compile tools instead of asking the user to choose them.
 {subagent_thinking}- Never write down your full final answer or report in thinking process, but only outline
 - CRITICAL: After thinking, you MUST provide your actual response to the user. Thinking is for planning, the response is for delivery.
 - Your response must contain the actual answer, not just a reference to what you thought about
@@ -262,6 +264,7 @@ You are {agent_name}, an open-source compilation-focused agent.
 1. **FIRST**: Analyze the request in your thinking - identify what's unclear, missing, or ambiguous
 2. **SECOND**: If clarification is needed, call `ask_clarification` tool IMMEDIATELY - do NOT start working
 3. **THIRD**: Only after all clarifications are resolved, proceed with planning and execution
+4. **COMPILE EXCEPTION**: A repository URL plus exact commit authorizes the standard isolated compile workflow. Do not ask for routine build-system, dependency, or artifact-discovery choices that the compile tools can resolve safely.
 </clarification_system>
 
 <compile_task_model>
@@ -306,7 +309,7 @@ You are {agent_name}, an open-source compilation-focused agent.
 </working_model>
 
 <critical_reminders>
-- **Clarification First**: ALWAYS clarify unclear/missing/ambiguous requirements BEFORE starting work - never assume or guess
+- **Clarification First**: Clarify requirements that materially change scope or external effects. For a repository URL plus exact commit, start the isolated compile workflow and let compile tools resolve routine build details.
 {subagent_reminder}- Skill First: Always load the relevant skill before starting **complex** tasks.
 - Prefer compile-session tooling and compile-tool outputs over hard-coded directory assumptions
 - Prefer compiler-subagent verification outputs over ad-hoc repeated verification work

--- a/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
@@ -11,6 +11,8 @@ from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
+from deerflow.compile.evidence import claim_experiment_clarification_auto_answer
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,15 +93,48 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
 
         return "\n".join(message_parts)
 
-    def _handle_clarification(self, request: ToolCallRequest) -> Command:
-        """Handle clarification request and return command to interrupt execution.
+    def _policy_clarification_message(self, policy) -> str:
+        packages = ", ".join(policy.required_system_packages) or "none"
+        if policy.expected_build_system == "cmake":
+            build_arguments = " ".join(policy.cmake_arguments) or "none"
+            argument_label = "ordered CMake arguments"
+        elif policy.expected_build_system == "autotools":
+            build_arguments = " ".join(policy.configure_arguments) or "none"
+            argument_label = "ordered configure arguments"
+        else:
+            build_arguments = "none"
+            argument_label = "additional build arguments"
+        return (
+            "This is a non-interactive compilation experiment with a frozen policy. "
+            "Proceed without requesting more user input. "
+            f"Use repository {policy.expected_repo_url} at exact commit "
+            f"{policy.expected_commit_sha}, expected build system "
+            f"{policy.expected_build_system}, required system packages {packages}, "
+            f"and {argument_label}: {build_arguments}. "
+            "Use the standard compile-session workflow; deterministic submission and "
+            "clean replay decide success."
+        )
+
+    def _handle_clarification(self, request: ToolCallRequest) -> ToolMessage | Command:
+        """Handle a clarification request or resolve it from frozen experiment policy.
 
         Args:
             request: Tool call request
 
         Returns:
-            Command that interrupts execution with the formatted clarification message
+            A policy-backed ToolMessage for the first experiment clarification, or a
+            Command that interrupts execution for interactive and repeated requests.
         """
+        policy = claim_experiment_clarification_auto_answer(request)
+        tool_call_id = request.tool_call.get("id", "")
+        if policy is not None:
+            logger.info("Resolved one non-interactive clarification from frozen policy")
+            return ToolMessage(
+                content=self._policy_clarification_message(policy),
+                tool_call_id=tool_call_id,
+                name="ask_clarification",
+            )
+
         # Extract clarification arguments
         args = request.tool_call.get("args", {})
         question = args.get("question", "")
@@ -109,9 +144,6 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
 
         # Format the clarification message
         formatted_message = self._format_clarification_message(args)
-
-        # Get the tool call ID
-        tool_call_id = request.tool_call.get("id", "")
 
         # Create a ToolMessage with the formatted question
         # This will be added to the message history

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -166,6 +166,28 @@ def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str
             raise EvidenceError(f"{path}.terminal must be false for a recoverable tool error")
         return
 
+    if event == "agent.clarification_auto_answered":
+        required = {
+            "repair_id",
+            "role",
+            "reason",
+            "auto_answer_count",
+            "max_auto_answers",
+            "terminal",
+        }
+        if set(payload) != required:
+            raise EvidenceError(f"{path} has an invalid agent.clarification_auto_answered schema")
+        _validate_id(payload["repair_id"], f"{path}.repair_id")
+        if payload["role"] != "lead":
+            raise EvidenceError(f"{path}.role must be lead")
+        if payload["reason"] != "non_interactive_frozen_policy":
+            raise EvidenceError(f"{path}.reason is invalid")
+        if payload["auto_answer_count"] != 1 or payload["max_auto_answers"] != 1:
+            raise EvidenceError(f"{path} must describe the single allowed auto-answer")
+        if payload["terminal"] is not False:
+            raise EvidenceError(f"{path}.terminal must be false")
+        return
+
     if event == "agent.no_compile_progress":
         required = {
             "failure_id",
@@ -554,6 +576,33 @@ def request_model_role(request: Any) -> str:
         if isinstance(role, str) and role in _ALLOWED_MODEL_ROLES:
             return role
     return "lead"
+
+
+def claim_experiment_clarification_auto_answer(
+    request: Any,
+) -> ExperimentPolicy | None:
+    """Claim the one policy-backed clarification response allowed per experiment."""
+    thread_id = request_thread_id(request)
+    if request_model_role(request) != "lead":
+        return None
+    with _ACTIVE_EXPERIMENTS_GUARD:
+        active = _ACTIVE_EXPERIMENTS.get(thread_id or "")
+        if active is None:
+            return None
+        if any(event["event"] == "agent.clarification_auto_answered" for event in active.ledger.read()):
+            return None
+        active.ledger.append(
+            "agent.clarification_auto_answered",
+            {
+                "repair_id": new_evidence_id("repair"),
+                "role": "lead",
+                "reason": "non_interactive_frozen_policy",
+                "auto_answer_count": 1,
+                "max_auto_answers": 1,
+                "terminal": False,
+            },
+        )
+        return active.policy
 
 
 def record_agent_tool_failure(

--- a/backend/tests/test_clarification_middleware.py
+++ b/backend/tests/test_clarification_middleware.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from langchain_core.messages import ToolMessage
+from langgraph.graph import END
+from langgraph.types import Command
+
+from deerflow.agents.middlewares import clarification_middleware as module
+
+
+def _request() -> SimpleNamespace:
+    return SimpleNamespace(
+        tool_call={
+            "name": "ask_clarification",
+            "id": "call-clarify-1",
+            "args": {
+                "question": "Which build option should I use?",
+                "clarification_type": "approach_choice",
+            },
+        }
+    )
+
+
+def test_interactive_clarification_still_ends_the_turn(monkeypatch) -> None:
+    monkeypatch.setattr(
+        module,
+        "claim_experiment_clarification_auto_answer",
+        lambda request: None,
+    )
+
+    result = module.ClarificationMiddleware()._handle_clarification(_request())
+
+    assert isinstance(result, Command)
+    assert result.goto == END
+    assert "Which build option" in result.update["messages"][0].content
+
+
+def test_experiment_clarification_uses_only_frozen_policy(monkeypatch) -> None:
+    policy = SimpleNamespace(
+        expected_repo_url="https://github.com/fmtlib/fmt",
+        expected_commit_sha="1" * 40,
+        expected_build_system="cmake",
+        required_system_packages=("build-essential", "cmake"),
+        cmake_arguments=("-DFMT_TEST=OFF", "-DBUILD_SHARED_LIBS=OFF"),
+        configure_arguments=(),
+    )
+    monkeypatch.setattr(
+        module,
+        "claim_experiment_clarification_auto_answer",
+        lambda request: policy,
+    )
+
+    result = module.ClarificationMiddleware()._handle_clarification(_request())
+
+    assert isinstance(result, ToolMessage)
+    assert result.name == "ask_clarification"
+    assert result.tool_call_id == "call-clarify-1"
+    assert policy.expected_repo_url in result.content
+    assert policy.expected_commit_sha in result.content
+    assert "-DFMT_TEST=OFF -DBUILD_SHARED_LIBS=OFF" in result.content
+    assert "Which build option" not in result.content

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -14,6 +14,7 @@ from deerflow.compile.evidence import (
     ExperimentPolicy,
     activate_experiment,
     canonical_json_bytes,
+    claim_experiment_clarification_auto_answer,
     deactivate_experiment,
     get_active_experiment,
     model_response_metadata,
@@ -205,6 +206,48 @@ def test_agent_event_schema_rejects_raw_or_inconsistent_payloads(
                 "terminal": True,
             },
         )
+
+
+def test_experiment_clarification_auto_answer_is_claimed_once(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = new_evidence_id("thread")
+    request = SimpleNamespace(
+        runtime=SimpleNamespace(
+            context={"thread_id": thread_id},
+            config={"configurable": {}},
+        )
+    )
+    policy = make_policy()
+    compiler_request = SimpleNamespace(
+        runtime=SimpleNamespace(
+            context={"thread_id": thread_id, "agent_name": "compiler"},
+            config={"configurable": {}},
+        )
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        assert claim_experiment_clarification_auto_answer(compiler_request) is None
+        assert claim_experiment_clarification_auto_answer(request) is policy
+        assert claim_experiment_clarification_auto_answer(request) is None
+    finally:
+        deactivate_experiment(thread_id)
+
+    repair_events = [event for event in ledger.read() if event["event"] == "agent.clarification_auto_answered"]
+    assert len(repair_events) == 1
+    assert repair_events[0]["payload"] == {
+        "repair_id": repair_events[0]["payload"]["repair_id"],
+        "role": "lead",
+        "reason": "non_interactive_frozen_policy",
+        "auto_answer_count": 1,
+        "max_auto_answers": 1,
+        "terminal": False,
+    }
 
 
 def test_agent_event_schema_rejects_digest_valid_tampering(tmp_path: Path) -> None:

--- a/backend/tests/test_forge_benchmark_v4.py
+++ b/backend/tests/test_forge_benchmark_v4.py
@@ -87,7 +87,7 @@ def test_v4_manifest_digest_is_canonical() -> None:
 def test_v4_current_tree_gate_rejects_later_runtime_component_drift() -> None:
     manifest = load_v4_manifest()
 
-    with pytest.raises(forge_benchmark_v4.BenchmarkError, match=r"subagents/executor\.py"):
+    with pytest.raises(forge_benchmark_v4.BenchmarkError, match="does not match the current repository file"):
         forge_benchmark_v4.verify_frozen_components(manifest, REPO_ROOT)
 
 

--- a/backend/tests/test_lead_agent_prompt.py
+++ b/backend/tests/test_lead_agent_prompt.py
@@ -35,6 +35,9 @@ def test_lead_prompt_uses_registered_compile_workflow(monkeypatch):
         positions = [prompt_text.index(tool_name) for tool_name in workflow]
         assert positions == sorted(positions)
 
+    assert "repository URL and exact commit is sufficiently specified" in prompt_module.SYSTEM_PROMPT_TEMPLATE
+    assert "routine build-system, dependency, or artifact-discovery choices" in prompt_module.SYSTEM_PROMPT_TEMPLATE
+
 
 def test_build_custom_mounts_section_returns_empty_when_no_mounts(monkeypatch):
     config = SimpleNamespace(custom_mounts=[])


### PR DESCRIPTION
## 根因

活跃实验中的 Lead 首次调用 ask_clarification 会被 Clarification middleware 直接终止；因此模型请求成功、工具调用完整时仍可能出现零编译动作。

## 变更

- 对提供仓库 URL 与 exact commit 的标准编译任务，明确由隔离编译工作流解析构建系统、依赖与产物。
- 活跃实验仅允许 Lead 的首次澄清由冻结 policy 自动回答并继续同一回合；第二次澄清和普通交互仍等待用户。
- 记录严格白名单的 agent.clarification_auto_answered 证据，不保存问题、回答、提示词或模型输出。
- 修正 v4 current-tree 防漂移测试，使其验证拒绝语义而不依赖文件遍历顺序。

## 验证

- 聚焦回归：77 passed, 1 skipped
- 后端全量：1568 passed, 27 skipped
- Ruff、格式、py_compile 与 git diff --check 通过
- Compose 基础配置通过；开发配置需要本机运行时变量，未在无变量环境展开

## 协议边界

- 不改写或替换 v1-v5 manifest、Schema、validator 与既有 ledger。
- 本次未调用模型、未运行或替换 pilot。

Closes #33