### PR TITLE
修复：分离多构建系统的选择与执行身份

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,10 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-26 — 重排 Issue #34 的多构建系统 identity policy
+  - 范围: 将旧堆叠单提交重放到 `main@1bcf0caa`；分离仓库 capability set、实验 selected path 与 submit 时由成功命令证明的 executed path，保留 `expected_build_system` 的证据兼容性。
+  - 边界: identify 只校验 selected 属于 capability set；submit 仍要求 executed 等于 selected，缺少证明或换路均拒绝。v1-v5 manifest、Schema、validator 和既有 ledger 均不改写。
+
 - 2026-07-26 — 重排 Issue #33 的非交互澄清修复
   - 范围: 将旧堆叠的单提交重放到 `main@b0e9b0e5`；标准仓库 URL + exact commit 明确允许直接进入隔离编译，活跃实验只对 Lead 的首次澄清返回冻结 policy，并记录有界 `agent.clarification_auto_answered` 证据。
   - 安全与兼容: 不记录问题、回答、prompt 或模型文本；第二次澄清与普通交互仍结束回合等待用户。v1-v5 manifest、Schema、validator 与既有 ledger 均不改写。

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -282,6 +282,10 @@ class ExperimentPolicy:
     def process_environment(self) -> dict[str, str | None]:
         return dict(self.environment)
 
+    @property
+    def selected_build_system(self) -> str:
+        return self.expected_build_system
+
     def to_payload(self) -> dict[str, Any]:
         return {
             "benchmark_id": self.benchmark_id,

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -12,7 +12,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path, PurePosixPath
-from shlex import quote, split
+from shlex import quote, shlex, split
 from typing import BinaryIO
 from urllib.parse import urlsplit
 
@@ -498,12 +498,14 @@ def inspect_build_system_impl(*, session: CompileSession) -> tuple[str, list[tup
         if (repo_dir / marker).is_file():
             detected.append((build_system, marker))
 
+    session.build_system_capabilities = [build_system for build_system, _marker in detected]
     if detected:
         primary_system = detected[0][0]
         session.build_system = primary_system
-        services.manager.save_session(session)
     else:
         primary_system = "unknown"
+        session.build_system = None
+    services.manager.save_session(session)
 
     suggested_commands = {
         "cmake": ["mkdir -p build && cd build && cmake ..", "cmake --build build -j"],
@@ -529,6 +531,7 @@ def inspect_build_system_json(*, session: CompileSession) -> str:
     return json.dumps(
         {
             "build_system": primary_system,
+            "build_system_capabilities": session.build_system_capabilities,
             "detected": detected,
             "suggested_commands": suggested_commands,
         },
@@ -987,24 +990,126 @@ def _command_contains_arguments(command: str, expected: tuple[str, ...]) -> bool
     return all(any(token == argument for token in token_iterator) for argument in expected)
 
 
+def _command_invokes(command: str, executable: str) -> bool:
+    try:
+        lexer = shlex(command.replace("\n", ";"), posix=True, punctuation_chars="();&|")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return False
+    expect_executable = True
+    wrappers = {"command", "env", "sudo", "time"}
+    separators = {"(", ")", ";", "&", "&&", "|", "||"}
+    for token in tokens:
+        if token in separators:
+            expect_executable = True
+            continue
+        if not expect_executable:
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token) or token.startswith("-"):
+            continue
+        candidate = PurePosixPath(token).name
+        if candidate in wrappers:
+            continue
+        if candidate == executable:
+            return True
+        expect_executable = False
+    return False
+
+
+def _configure_command_build_system(command: str) -> str | None:
+    if _command_invokes(command, "cmake"):
+        return "cmake"
+    if _command_invokes(command, "configure"):
+        return "autotools"
+    return None
+
+
+def _infer_executed_build_system(
+    commands: list[BuildCommandRecord],
+    supporting_command_id: str | None,
+) -> str | None:
+    supporting_index = next(
+        (index for index, command in enumerate(commands) if command.command_id == supporting_command_id),
+        None,
+    )
+    if supporting_index is None:
+        return None
+    supporting = commands[supporting_index]
+    if supporting.role != "build" or supporting.exit_code != 0 or supporting.timed_out:
+        return None
+
+    if _command_invokes(supporting.command, "cmake"):
+        return "cmake"
+    if _command_invokes(supporting.command, "configure"):
+        return "autotools"
+
+    successful_configures = [command for command in commands[:supporting_index] if command.role == "configure" and command.exit_code == 0 and not command.timed_out]
+    for configure in reversed(successful_configures):
+        configured_system = _configure_command_build_system(configure.command)
+        if configured_system is not None:
+            return configured_system
+
+    if _command_invokes(supporting.command, "make") or _command_invokes(supporting.command, "gmake"):
+        return "make"
+    return None
+
+
+def _persist_executed_build_system(session: CompileSession, executed_build_system: str | None) -> None:
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _load_authoritative_session(session)
+        current.executed_build_system = executed_build_system
+        if executed_build_system is not None:
+            current.build_system = executed_build_system
+        services.manager.save_session(current)
+        session.__dict__.update(current.__dict__)
+
+
 def _experiment_submit_constraints(
     session: CompileSession,
     supporting_command_id: str | None,
-) -> tuple[bool, list[str]]:
+) -> tuple[bool, list[str], str | None]:
     active = get_active_experiment(session.thread_id)
     if active is None:
-        return True, []
+        return True, [], None
     failures: list[str] = []
-    if session.build_system != active.policy.expected_build_system:
-        failures.append("build_system_mismatch")
+    selected_build_system = session.selected_build_system
+    expected_build_system = active.policy.selected_build_system
+    executed_build_system = _infer_executed_build_system(session.commands, supporting_command_id)
+    selection_matches = selected_build_system == expected_build_system
+    execution_matches = executed_build_system is not None and executed_build_system == selected_build_system
+    record_experiment_event(
+        session.thread_id,
+        "build.execution_checked",
+        session_id=session.session_id,
+        expected_build_system=expected_build_system,
+        selected_build_system=selected_build_system,
+        observed_build_system=executed_build_system,
+        detected_build_systems=list(session.build_system_capabilities),
+        matches=selection_matches and execution_matches,
+        submit_allowed=selection_matches and execution_matches,
+    )
+    identity_failure: str | None = None
+    if not selection_matches:
+        identity_failure = "build_system_selection_mismatch"
+    elif executed_build_system is None:
+        identity_failure = "build_system_unproven"
+    elif not execution_matches:
+        identity_failure = "build_system_mismatch"
+    if identity_failure is not None:
+        failures.append(identity_failure)
         record_experiment_event(
             session.thread_id,
             "protocol.deviation",
             phase="submit",
-            classification="build_system_mismatch",
+            classification=identity_failure,
             session_id=session.session_id,
-            expected_build_system=active.policy.expected_build_system,
-            observed_build_system=session.build_system,
+            expected_build_system=expected_build_system,
+            selected_build_system=selected_build_system,
+            observed_build_system=executed_build_system,
+            detected_build_systems=list(session.build_system_capabilities),
             submit_allowed=False,
         )
     supporting = next((command for command in session.commands if command.command_id == supporting_command_id), None)
@@ -1022,7 +1127,7 @@ def _experiment_submit_constraints(
         failures.append("cmake_arguments_not_observed")
     if active.policy.configure_arguments and not any(command.role == "configure" and _command_contains_arguments(command.command, active.policy.configure_arguments) for command in successful_commands):
         failures.append("configure_arguments_not_observed")
-    return not failures, failures
+    return not failures, failures, executed_build_system
 
 
 def _apply_experiment_replay_delay(session: CompileSession) -> None:
@@ -1079,7 +1184,9 @@ def submit_build_result_impl(
                 supporting_command_id=supporting_command_id,
             )
         session.__dict__.update(current.__dict__)
-    constraints_passed, constraint_failures = _experiment_submit_constraints(session, supporting_command_id)
+    constraints_passed, constraint_failures, executed_build_system = _experiment_submit_constraints(session, supporting_command_id)
+    if get_active_experiment(session.thread_id) is not None:
+        _persist_executed_build_system(session, executed_build_system)
     submit_index = len(session.commands) + 1
     summary_log_path = local_log_path(session, f"{submit_index:03d}_submit.log")
     while Path(summary_log_path).exists():

--- a/backend/packages/harness/deerflow/compile/schemas.py
+++ b/backend/packages/harness/deerflow/compile/schemas.py
@@ -144,6 +144,9 @@ class CompileSession:
     container_id: str | None = None
     container_name: str | None = None
     build_system: str | None = None
+    build_system_capabilities: list[str] = field(default_factory=list)
+    selected_build_system: str | None = None
+    executed_build_system: str | None = None
     summary: str | None = None
     error: str | None = None
     metadata_path: str = ""
@@ -161,7 +164,15 @@ class CompileSession:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CompileSession:
-        data = {"run_id": None, "image_id": None, "replay_attempts": [], **data}
+        data = {
+            "run_id": None,
+            "image_id": None,
+            "build_system_capabilities": [],
+            "selected_build_system": None,
+            "executed_build_system": None,
+            "replay_attempts": [],
+            **data,
+        }
         commands = [BuildCommandRecord(**item) for item in data.get("commands", [])]
         artifacts = [BuildArtifact(**item) for item in data.get("artifacts", [])]
         verification_data = data.get("verification")

--- a/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py
@@ -9,7 +9,7 @@ from langgraph.types import Command
 from langgraph.typing import ContextT
 
 from deerflow.compile.evidence import get_active_experiment, record_experiment_event
-from deerflow.compile.operations import cleanup_and_finalize_compile_session_impl, clone_repository_impl, get_bound_session, inspect_build_system_impl, prepare_compile_session_impl
+from deerflow.compile.operations import cleanup_and_finalize_compile_session_impl, clone_repository_impl, get_bound_session, get_compile_services, inspect_build_system_impl, prepare_compile_session_impl
 from deerflow.compile.schemas import CompileSession
 
 if TYPE_CHECKING:
@@ -63,26 +63,35 @@ def _enforce_experiment_build_system(
     *,
     session: CompileSession,
     observed_build_system: str,
-) -> tuple[bool, str | None]:
+    detected_build_systems: list[str],
+) -> tuple[bool, str | None, str | None]:
     active = get_active_experiment(session.thread_id)
     if active is None:
-        return True, None
+        selected_build_system = observed_build_system if observed_build_system != "unknown" else None
+        session.selected_build_system = selected_build_system
+        get_compile_services().manager.save_session(session)
+        return True, selected_build_system, None
 
-    expected_build_system = active.policy.expected_build_system
-    matches = observed_build_system == expected_build_system
+    expected_build_system = active.policy.selected_build_system
+    matches = expected_build_system in detected_build_systems
     record_experiment_event(
         session.thread_id,
         "build.system_checked",
         session_id=session.session_id,
         expected_build_system=expected_build_system,
+        selected_build_system=expected_build_system if matches else None,
         observed_build_system=observed_build_system,
+        detected_build_systems=detected_build_systems,
         matches=matches,
         compiler_allowed=matches,
     )
     if matches:
-        return True, None
+        session.selected_build_system = expected_build_system
+        get_compile_services().manager.save_session(session)
+        return True, expected_build_system, None
 
-    error = f"Benchmark protocol deviation: expected build system {expected_build_system}, observed {observed_build_system}."
+    detected_summary = ", ".join(detected_build_systems) or "none"
+    error = f"Benchmark protocol deviation: selected build system {expected_build_system} is not supported by detected repository capabilities ({detected_summary})."
     updated, cleanup_result = cleanup_and_finalize_compile_session_impl(
         session=session,
         interrupted_status="failed",
@@ -95,12 +104,14 @@ def _enforce_experiment_build_system(
         classification="build_system_mismatch",
         session_id=session.session_id,
         expected_build_system=expected_build_system,
+        selected_build_system=None,
         observed_build_system=observed_build_system,
+        detected_build_systems=detected_build_systems,
         compiler_allowed=False,
         cleanup_succeeded=cleanup_result.succeeded and cleanup_result.removed,
         session_finalized=updated.finalized_at is not None,
     )
-    return False, error
+    return False, None, error
 
 
 @tool("prepare_compile_session", parse_docstring=True)
@@ -216,16 +227,18 @@ def identify_build_system(
 
     session = get_bound_session(session_id=effective_session_id, thread_id=_get_thread_id(runtime))
     primary_system, detected, suggested_commands = inspect_build_system_impl(session=session)
-    root_file = detected[0][1] if detected else None
-    build_system_matches, deviation_error = _enforce_experiment_build_system(
+    detected_build_systems = [build_system for build_system, _marker in detected]
+    build_system_matches, selected_build_system, deviation_error = _enforce_experiment_build_system(
         session=session,
         observed_build_system=primary_system,
+        detected_build_systems=detected_build_systems,
     )
-    message = f'Build system identified: system={primary_system}, root_file={root_file or "none"}. Next call task(..., subagent_type="compiler") directly.'
+    selected_marker = next((marker for build_system, marker in detected if build_system == selected_build_system), None)
+    message = f'Build systems identified: capabilities={detected_build_systems or ["unknown"]}, selected={selected_build_system or "none"}, root_file={selected_marker or "none"}. Next call task(..., subagent_type="compiler") directly.'
     update = _build_compile_state_update(
         session_id=effective_session_id,
         container_id=session.container_id,
-        build_system=primary_system,
+        build_system=selected_build_system,
     )
     if not build_system_matches:
         update["compile_terminal"] = True
@@ -267,6 +280,9 @@ def finalize_session(
         "image": updated.image,
         "image_id": updated.image_id,
         "build_system": updated.build_system,
+        "build_system_capabilities": updated.build_system_capabilities,
+        "selected_build_system": updated.selected_build_system,
+        "executed_build_system": updated.executed_build_system,
         "commands": [command.command for command in updated.commands],
         "verification": updated.verification.status if updated.verification else "not_run",
         "replay_verification": updated.replay_attempts[-1].status if updated.replay_attempts else "not_run",

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -42,7 +42,7 @@ def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
     requirements = [
         "Active C/C++ benchmark constraints:",
         f"- Build exact commit {policy.expected_commit_sha} from {policy.expected_repo_url}.",
-        f"- Use the frozen {policy.expected_build_system} build-system path; do not switch to another detected build system.",
+        f"- Use the selected {policy.selected_build_system} build-system path; do not switch to another detected build system.",
         "- The runner already applies the declared system packages, container environment, and replay delay.",
     ]
     if policy.cmake_arguments:

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -78,6 +78,88 @@ def test_benchmark_arguments_must_be_observed_in_declared_order(
     assert operations._command_contains_arguments(command, expected) is matches
 
 
+def test_inspect_build_system_persists_all_repository_capabilities(tmp_path: Path, monkeypatch) -> None:
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-multi-build-system",
+        repo_url="https://example.com/repo.git",
+    )
+    repo_dir = Path(session.leadagent_repo_dir)
+    repo_dir.mkdir(parents=True)
+    for marker in ("CMakeLists.txt", "Makefile", "configure"):
+        (repo_dir / marker).write_text("fixture\n", encoding="utf-8")
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace()),
+    )
+
+    primary, detected, _suggested = operations.inspect_build_system_impl(session=session)
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert primary == "cmake"
+    assert detected == [
+        ("cmake", "CMakeLists.txt"),
+        ("make", "Makefile"),
+        ("autotools", "configure"),
+    ]
+    assert reloaded.build_system == "cmake"
+    assert reloaded.build_system_capabilities == ["cmake", "make", "autotools"]
+    assert reloaded.selected_build_system is None
+    assert reloaded.executed_build_system is None
+
+
+@pytest.mark.parametrize(
+    ("commands", "supporting_command_id", "expected"),
+    [
+        (
+            [BuildCommandRecord(stage="bash", command="cmake --build build -j2", workdir="/workspace/repo", command_id="build", role="build", exit_code=0)],
+            "build",
+            "cmake",
+        ),
+        (
+            [BuildCommandRecord(stage="bash", command="cmake -S . -B build && make -C build -j2", workdir="/workspace/repo", command_id="build", role="build", exit_code=0)],
+            "build",
+            "cmake",
+        ),
+        (
+            [BuildCommandRecord(stage="bash", command="make -j2", workdir="/workspace/repo", command_id="build", role="build", exit_code=0)],
+            "build",
+            "make",
+        ),
+        (
+            [
+                BuildCommandRecord(stage="bash", command="./configure --disable-shared", workdir="/workspace/repo", command_id="configure", role="configure", exit_code=0),
+                BuildCommandRecord(stage="bash", command="make -j2", workdir="/workspace/repo", command_id="build", role="build", exit_code=0),
+            ],
+            "build",
+            "autotools",
+        ),
+    ],
+)
+def test_submit_gate_infers_executed_build_system_from_successful_commands(
+    commands: list[BuildCommandRecord],
+    supporting_command_id: str,
+    expected: str,
+) -> None:
+    assert operations._infer_executed_build_system(commands, supporting_command_id) == expected
+
+
+def test_submit_gate_does_not_treat_build_system_name_as_command_evidence() -> None:
+    commands = [
+        BuildCommandRecord(
+            stage="bash",
+            command="printf 'make build finished'",
+            workdir="/workspace/repo",
+            command_id="build",
+            role="build",
+            exit_code=0,
+        )
+    ]
+
+    assert operations._infer_executed_build_system(commands, "build") is None
+
+
 def test_submit_gate_rejects_observed_build_system_mismatch(tmp_path: Path) -> None:
     thread_id = "thread-build-system-submit-gate"
     session = CompileSession(
@@ -87,7 +169,9 @@ def test_submit_gate_rejects_observed_build_system_mismatch(tmp_path: Path) -> N
         branch=None,
         image="autocompiler:gcc13",
         status="inspected",
-        build_system="make",
+        build_system="cmake",
+        build_system_capabilities=["cmake", "make"],
+        selected_build_system="cmake",
         metadata_path="session.json",
         leadagent_repo_dir="workspace/repo",
         leadagent_artifacts_dir="artifacts",
@@ -144,7 +228,7 @@ def test_submit_gate_rejects_observed_build_system_mismatch(tmp_path: Path) -> N
         policy=policy,
     )
     try:
-        passed, failures = operations._experiment_submit_constraints(
+        passed, failures, executed_build_system = operations._experiment_submit_constraints(
             session,
             "command-build",
         )
@@ -153,10 +237,77 @@ def test_submit_gate_rejects_observed_build_system_mismatch(tmp_path: Path) -> N
 
     assert passed is False
     assert failures == ["build_system_mismatch"]
+    assert executed_build_system == "make"
     deviation = ledger.read()[-1]
     assert deviation["event"] == "protocol.deviation"
     assert deviation["payload"]["phase"] == "submit"
+    assert deviation["payload"]["selected_build_system"] == "cmake"
+    assert deviation["payload"]["observed_build_system"] == "make"
     assert deviation["payload"]["submit_allowed"] is False
+
+
+def test_submit_gate_rejects_unproven_build_system(tmp_path: Path) -> None:
+    thread_id = "thread-build-system-unproven"
+    session = CompileSession(
+        session_id="session-build-system-unproven",
+        thread_id=thread_id,
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="inspected",
+        build_system="cmake",
+        build_system_capabilities=["cmake"],
+        selected_build_system="cmake",
+        commands=[BuildCommandRecord(stage="bash", command="ninja -C build", workdir="/workspace/repo", command_id="command-build", role="build", exit_code=0)],
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "build-system-unproven.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v4",
+        manifest_sha256="1" * 64,
+        case_id="fixture",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url=session.repo_url,
+        expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
+        compile_image=session.image,
+        image_id=VALID_IMAGE_ID,
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        passed, failures, executed_build_system = operations._experiment_submit_constraints(session, "command-build")
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert passed is False
+    assert failures == ["build_system_unproven"]
+    assert executed_build_system is None
+    assert ledger.read()[-1]["payload"]["classification"] == "build_system_unproven"
 
 
 def install_passed_replay_stub(monkeypatch) -> None:
@@ -435,6 +586,9 @@ def test_save_and_load_session_roundtrip(tmp_path: Path):
     session.container_id = "container-123"
     session.container_name = "demo-container"
     session.build_system = "make"
+    session.build_system_capabilities = ["cmake", "make"]
+    session.selected_build_system = "make"
+    session.executed_build_system = "make"
     session.summary = "done"
     session.commands.append(BuildCommandRecord(stage="clone", command="git clone ...", workdir="/workspace"))
     session.artifacts.append(BuildArtifact(path="artifacts/app", artifact_type="binary", size_bytes=123))
@@ -445,6 +599,9 @@ def test_save_and_load_session_roundtrip(tmp_path: Path):
     assert isinstance(loaded, CompileSession)
     assert loaded.container_id == "container-123"
     assert loaded.build_system == "make"
+    assert loaded.build_system_capabilities == ["cmake", "make"]
+    assert loaded.selected_build_system == "make"
+    assert loaded.executed_build_system == "make"
     assert loaded.summary == "done"
     assert len(loaded.commands) == 1
     assert len(loaded.artifacts) == 1

--- a/backend/tests/test_compile_terminal_tools.py
+++ b/backend/tests/test_compile_terminal_tools.py
@@ -224,7 +224,7 @@ def test_build_system_mismatch_cleans_session_and_stops_before_compiler(monkeypa
     def cleanup_and_finalize(*, session: CompileSession, interrupted_status: str, error: str):
         cleanup_calls.append(session.session_id)
         assert interrupted_status == "failed"
-        assert "expected build system autotools" in error
+        assert "selected build system autotools" in error
         session.status = "failed"
         session.finalized_at = "2026-07-19T00:00:00+00:00"
         return session, ContainerCleanupResult(succeeded=True, stopped=True, removed=True)
@@ -234,7 +234,7 @@ def test_build_system_mismatch_cleans_session_and_stops_before_compiler(monkeypa
     monkeypatch.setattr(
         agent_compile_tools,
         "get_active_experiment",
-        lambda _thread_id: SimpleNamespace(policy=SimpleNamespace(expected_build_system="autotools")),
+        lambda _thread_id: SimpleNamespace(policy=SimpleNamespace(selected_build_system="autotools")),
     )
     monkeypatch.setattr(
         agent_compile_tools,
@@ -254,14 +254,69 @@ def test_build_system_mismatch_cleans_session_and_stops_before_compiler(monkeypa
 
     assert cleanup_calls == [session.session_id]
     assert result.update["compile_terminal"] is True
-    assert result.update[agent_compile_tools.COMPILE_BUILD_SYSTEM_STATE_KEY] == "cmake"
-    assert "expected build system autotools" in result.update["messages"][0].content
+    assert agent_compile_tools.COMPILE_BUILD_SYSTEM_STATE_KEY not in result.update
+    assert "selected build system autotools" in result.update["messages"][0].content
     assert [event for event, _payload in recorded_events] == [
         "build.system_checked",
         "protocol.deviation",
     ]
     assert recorded_events[-1][1]["compiler_allowed"] is False
     assert recorded_events[-1][1]["session_finalized"] is True
+
+
+def test_multi_entry_repository_selects_manifest_build_path(monkeypatch):
+    session = make_session()
+    session.status = "source_ready"
+    session.build_system = None
+    session.selected_build_system = None
+    recorded_events: list[tuple[str, dict]] = []
+    saved_sessions: list[CompileSession] = []
+
+    monkeypatch.setattr(agent_compile_tools, "get_bound_session", lambda session_id, thread_id: session)
+
+    def inspect_build_system(*, session: CompileSession):
+        session.build_system = "cmake"
+        session.build_system_capabilities = ["cmake", "make"]
+        return "cmake", [("cmake", "CMakeLists.txt"), ("make", "Makefile")], ["cmake --build build"]
+
+    monkeypatch.setattr(agent_compile_tools, "inspect_build_system_impl", inspect_build_system)
+    monkeypatch.setattr(
+        agent_compile_tools,
+        "get_compile_services",
+        lambda: SimpleNamespace(manager=SimpleNamespace(save_session=lambda current: saved_sessions.append(current))),
+    )
+    monkeypatch.setattr(
+        agent_compile_tools,
+        "get_active_experiment",
+        lambda _thread_id: SimpleNamespace(policy=SimpleNamespace(selected_build_system="make")),
+    )
+    monkeypatch.setattr(
+        agent_compile_tools,
+        "record_experiment_event",
+        lambda _thread_id, event, **payload: recorded_events.append((event, payload)),
+    )
+    runtime = SimpleNamespace(
+        state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+        context={"thread_id": session.thread_id},
+        config={"configurable": {}},
+    )
+
+    result = agent_compile_tools.identify_build_system.func(
+        runtime=runtime,
+        tool_call_id="tool-build-system-selection",
+    )
+
+    assert "compile_terminal" not in result.update
+    assert result.update[agent_compile_tools.COMPILE_BUILD_SYSTEM_STATE_KEY] == "make"
+    assert session.build_system == "cmake"
+    assert session.build_system_capabilities == ["cmake", "make"]
+    assert session.selected_build_system == "make"
+    assert saved_sessions == [session]
+    assert [event for event, _payload in recorded_events] == ["build.system_checked"]
+    assert recorded_events[0][1]["observed_build_system"] == "cmake"
+    assert recorded_events[0][1]["detected_build_systems"] == ["cmake", "make"]
+    assert recorded_events[0][1]["selected_build_system"] == "make"
+    assert recorded_events[0][1]["compiler_allowed"] is True
 
 
 def test_finalize_ends_lead_graph_after_one_model_call(monkeypatch):

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -309,6 +309,7 @@ def test_experiment_policy_persists_supported_build_system_identity(build_system
     )
 
     assert policy.to_payload()["expected_build_system"] == build_system
+    assert policy.selected_build_system == build_system
 
 
 def test_experiment_policy_rejects_build_system_argument_drift() -> None:

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -211,6 +211,7 @@ def test_compiler_prompt_receives_ordered_manifest_constraints() -> None:
     assert "command_role" in prompt
     assert "supporting_command_id" in prompt
     assert policy.expected_build_system in prompt
+    assert f"selected {policy.selected_build_system}" in prompt
     assert policy.credential_env not in prompt
 
 


### PR DESCRIPTION
## 根因

多入口仓库 hiredis 同时提供 CMake 和 Make。旧 detector 的固定优先级把 CMake 当作唯一 observed identity，导致实验选择 Make 时被误判为协议漂移。

## 变更

- 分离 repository capability set、selected build path 与 executed build path。
- identify gate 校验 selected path 属于 capability set，不让 detector 优先级替代实验条件。
- submit gate 从成功 configure/build supporting command 推断 executed path，并继续要求它等于 selected path。
- 不能证明执行路径或实际换路时继续拒绝提交。
- 保留 expected_build_system payload 兼容性；不改写 v1-v5 冻结协议或 ledger。

## 验证

- 聚焦回归：183 passed, 1 skipped
- 后端全量：1576 passed, 27 skipped
- Ruff、格式、py_compile 与 diff 检查通过
- Compose 基础配置需要本机运行时变量，未在无变量环境展开

## 边界

- 本次未调用模型、未运行或替换 pilot。

Closes #34