### PR TITLE
功能：冻结 C/C++ pilot v5 协议

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,10 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-26 — 重排 Issue #38 的 C/C++ pilot v5 冻结协议
+  - 范围: 从当前主干冻结独立 v5 manifest、Schema、validator 与 runner 路由，记录 capability、selected 与 executed identity；v1-v4 与既有 ledger 保持字节不变。
+  - 边界: 只重排与审计协议，不调用模型、不创建、执行、覆盖或 replacement 任一 physical-attempt slot，也不启动 v6。
+
 - 2026-07-26 — 重排 Issue #34 的多构建系统 identity policy
   - 范围: 将旧堆叠单提交重放到 `main@1bcf0caa`；分离仓库 capability set、实验 selected path 与 submit 时由成功命令证明的 executed path，保留 `expected_build_system` 的证据兼容性。
   - 边界: identify 只校验 selected 属于 capability set；submit 仍要求 executed 等于 selected，缺少证明或换路均拒绝。v1-v5 manifest、Schema、validator 和既有 ledger 均不改写。

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -43,6 +43,11 @@ def load_v4_manifest() -> dict:
     return forge_benchmark_runner._load_manifest(path)
 
 
+def load_v5_manifest() -> dict:
+    path = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json"
+    return forge_benchmark_runner._load_manifest(path)
+
+
 def ready_preflight(manifest: dict, *, ready: bool = True) -> dict:
     return {
         "ready": ready,
@@ -106,6 +111,7 @@ def test_build_policy_freezes_each_supported_build_system(case_id: str) -> None:
         (load_v2_manifest, "cpp-pilot-v2.json"),
         (load_v3_manifest, "cpp-pilot-v3.json"),
         (load_v4_manifest, "cpp-pilot-v4.json"),
+        (load_v5_manifest, "cpp-pilot-v5.json"),
     ],
 )
 def test_runnable_preflight_accepts_clean_descendant_with_frozen_components(
@@ -169,7 +175,7 @@ def test_runnable_preflight_accepts_clean_descendant_with_frozen_components(
     assert preflight["runtime"]["control_plane_topology"] == "compose-dood"
 
 
-@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest, load_v4_manifest])
+@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest, load_v4_manifest, load_v5_manifest])
 def test_runnable_preflight_rejects_missing_baseline_or_compose_dood(
     monkeypatch: pytest.MonkeyPatch,
     manifest_loader,
@@ -283,7 +289,7 @@ def test_run_refuses_failed_preflight_before_importing_model_client(
     assert not any(event["event"].startswith("model.") for event in ledger.read())
 
 
-@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest, load_v4_manifest])
+@pytest.mark.parametrize("manifest_loader", [load_v2_manifest, load_v3_manifest, load_v4_manifest, load_v5_manifest])
 def test_runnable_run_refuses_non_compose_process_before_model_request(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -317,10 +323,10 @@ def test_runnable_run_refuses_non_compose_process_before_model_request(
     assert not any(event["event"].startswith("model.") for event in events)
 
 
-def test_runner_defaults_to_v4_manifest() -> None:
+def test_runner_defaults_to_v5_manifest() -> None:
     args = forge_benchmark_runner._build_parser().parse_args(["preflight"])
 
-    assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v4.json"
+    assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json"
 
 
 def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(
@@ -724,6 +730,81 @@ def test_offline_failure_domains_keep_missing_evidence_null() -> None:
         "submit_replay": None,
         "completion": None,
     }
+
+
+def test_v5_records_final_build_identity_from_authoritative_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = CompileSessionManager(
+        paths=Paths(
+            base_dir=tmp_path / "state",
+            workspace_root=tmp_path / "workspace",
+            host_workspace_root=str(tmp_path / "workspace"),
+        )
+    )
+    session = manager.create_session(
+        thread_id="thread-v5-identity",
+        repo_url="https://github.com/redis/hiredis",
+    )
+    session.build_system_capabilities = ["cmake", "make"]
+    session.selected_build_system = "make"
+    session.executed_build_system = "make"
+    manager.save_session(session)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace()),
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "identity.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": "thread-v5-identity"},
+    )
+
+    assert forge_benchmark_runner._record_attempt_build_identity("thread-v5-identity", ledger) is True
+    snapshot = ledger.read()[-1]
+    assert snapshot["event"] == "build.identity_snapshot"
+    assert snapshot["payload"] == {
+        "session_id": session.session_id,
+        "build_system_capabilities": ["cmake", "make"],
+        "selected_build_system": "make",
+        "executed_build_system": "make",
+    }
+
+
+def test_v5_offline_identity_gate_requires_snapshot_and_proven_submit_path() -> None:
+    started = {
+        "event": "experiment.started",
+        "payload": {
+            "policy": {
+                "benchmark_id": "forge-cpp-clean-replay-pilot-v5",
+                "expected_build_system": "make",
+            }
+        },
+    }
+    executed_without_snapshot = [started, {"event": "runtime.topology_verified", "payload": {}}]
+
+    assert forge_benchmark_runner.recompute_build_identity(executed_without_snapshot)["valid"] is False
+
+    with_snapshot = [
+        *executed_without_snapshot,
+        {
+            "event": "build.identity_snapshot",
+            "payload": {
+                "session_id": "abcdef123456",
+                "build_system_capabilities": ["cmake", "make"],
+                "selected_build_system": "make",
+                "executed_build_system": "make",
+            },
+        },
+        {"event": "submit.completed", "payload": {"session_id": "abcdef123456"}},
+    ]
+    identity = forge_benchmark_runner.recompute_build_identity(with_snapshot)
+
+    assert identity["valid"] is True
+    assert identity["submit_identity_proven"] is True
 
 
 def test_offline_failure_domains_separate_agent_and_runtime_failures() -> None:

--- a/backend/tests/test_forge_benchmark_v4.py
+++ b/backend/tests/test_forge_benchmark_v4.py
@@ -14,6 +14,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 V4_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v4.json"
 V4_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v4.schema.json"
 V4_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v4.py"
+V4_PROTOCOL_ARTIFACT_COMMITS = {
+    "scripts/forge_benchmark.py": "ec30fac8ada1e00b2863c031999ea7acf5c1a676",
+    "scripts/forge_benchmark_v4.py": "2cfbf79552ba437c67602b6c23bdd1d8d9d231a9",
+    "scripts/forge_benchmark_runner.py": "2cfbf79552ba437c67602b6c23bdd1d8d9d231a9",
+    "benchmarks/schemas/forge-cpp-benchmark-v4.schema.json": "2cfbf79552ba437c67602b6c23bdd1d8d9d231a9",
+}
 
 FROZEN_HISTORICAL_PROTOCOL_FILES = {
     "benchmarks/manifests/cpp-pilot-v1.json": "6d73afaa476eef172fc810a63daf7ad22f0f84434bdb6300de7eb4c34269bbee",
@@ -107,11 +113,19 @@ def test_v4_runtime_components_match_the_declared_baseline() -> None:
         assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
 
 
-def test_v4_protocol_artifacts_match_the_current_tree() -> None:
+def test_v4_protocol_artifacts_match_the_frozen_protocol_commit() -> None:
     manifest = load_v4_manifest()
+    if shutil.which("git") is None:
+        pytest.skip("git is unavailable in the minimal backend image")
 
     for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
-        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected_digest
+        result = subprocess.run(
+            ["git", "show", f"{V4_PROTOCOL_ARTIFACT_COMMITS[relative_path]}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
 
 
 def test_v4_schema_tracks_the_validator_topology_and_identity_contract() -> None:

--- a/backend/tests/test_forge_benchmark_v5.py
+++ b/backend/tests/test_forge_benchmark_v5.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+V5_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json"
+V5_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v5.schema.json"
+V5_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v5.py"
+
+HISTORICAL_PROTOCOL_COMMIT = "2cfbf79552ba437c67602b6c23bdd1d8d9d231a9"
+V4_ORIGINAL_PROTOCOL_COMMIT = "01460235668dcd187809059030ff5d3ec0851b17"
+FROZEN_HISTORICAL_PROTOCOL_FILES = {
+    "benchmarks/manifests/cpp-pilot-v1.json": "6d73afaa476eef172fc810a63daf7ad22f0f84434bdb6300de7eb4c34269bbee",
+    "benchmarks/schemas/forge-cpp-benchmark-v1.schema.json": "ad4d39978cc06ee5c4d5641f4630908a53dc8c8898be49e98632c52f80b28adb",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "benchmarks/manifests/cpp-pilot-v2.json": "2c7b8f3c5921a3c34238f03df24cdd35e99ff598dd4322bfd2da8062b9587e8e",
+    "benchmarks/schemas/forge-cpp-benchmark-v2.schema.json": "3ff392b252f4c97d606b71a8806c4e7d0b866b65bce322afb55b57d2f855f47b",
+    "scripts/forge_benchmark_v2.py": "2cce54a84d625be33b21ecc3effe40c15c2a2ac74a94d2b1afc73a79273ce49f",
+    "benchmarks/manifests/cpp-pilot-v3.json": "e58f278aa5c8d9d32ebfa2d0fff314319860b44138b4a659af72a75ee4d0f6fb",
+    "benchmarks/schemas/forge-cpp-benchmark-v3.schema.json": "33748caa620f8d4c2aedb5b829992a470d5c3c68d5d40e42994d76e8df7087c2",
+    "scripts/forge_benchmark_v3.py": "d18dbd22b2ef7df2063c2b6ed656d089e1c8fc1418d4c1196b73ad84a532bec6",
+    "benchmarks/manifests/cpp-pilot-v4.json": "b82440857acba0235d408c65513e12a61bea856c397929f0d7752eea7ed36f79",
+    "benchmarks/schemas/forge-cpp-benchmark-v4.schema.json": "0e5200eeeb12599529ee30828e5387800bbd0cdec6b332be7850bcf0ca26eb3f",
+    "scripts/forge_benchmark_v4.py": "a1cabe78ec0cabb0455ecea44e5fabf5eab41862aa614f130350d4a21792fc97",
+}
+
+SPEC = importlib.util.spec_from_file_location("forge_benchmark_v5", V5_VALIDATOR_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+forge_benchmark_v5 = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(forge_benchmark_v5)
+
+
+def load_v5_manifest() -> dict:
+    return json.loads(V5_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_sha256"),
+    FROZEN_HISTORICAL_PROTOCOL_FILES.items(),
+)
+def test_v1_v2_v3_v4_protocol_files_remain_byte_for_byte_immutable(
+    relative_path: str,
+    expected_sha256: str,
+) -> None:
+    if shutil.which("git") is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+    revision = V4_ORIGINAL_PROTOCOL_COMMIT if relative_path.endswith(("cpp-pilot-v4.json", "forge-cpp-benchmark-v4.schema.json", "forge_benchmark_v4.py")) else HISTORICAL_PROTOCOL_COMMIT
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{relative_path}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    )
+    assert hashlib.sha256(result.stdout).hexdigest() == expected_sha256
+
+
+def test_v5_manifest_unblocks_only_the_new_compose_dood_protocol() -> None:
+    manifest = load_v5_manifest()
+
+    assert manifest["scope"]["instrumentation_blocker"] is False
+    assert manifest["runtime"]["control_plane_topology"] == "compose-dood"
+    assert manifest["forge"]["commit_sha"] == forge_benchmark_v5.BASELINE_COMMIT
+    assert manifest["forge"]["revision_policy"] == forge_benchmark_v5.REVISION_POLICY
+    assert forge_benchmark_v5.validate_manifest(manifest) is manifest
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda manifest: manifest["scope"].update(instrumentation_blocker=True), "runnable v5 pilot"),
+        (lambda manifest: manifest["runtime"].update(control_plane_topology="wsl-native"), "compose-dood"),
+        (lambda manifest: manifest["forge"].update(commit_sha="f" * 40), "Issue #32/#33/#34"),
+        (lambda manifest: manifest["model"]["roles"].update(compiler="gpt-5.4"), "gpt-5.6-sol"),
+    ],
+)
+def test_v5_manifest_rejects_protocol_drift(mutation, message: str) -> None:
+    manifest = copy.deepcopy(load_v5_manifest())
+    mutation(manifest)
+
+    with pytest.raises(forge_benchmark_v5.BenchmarkError, match=message):
+        forge_benchmark_v5.validate_manifest(manifest)
+
+
+def test_v5_manifest_digest_is_canonical_and_frozen_files_are_current() -> None:
+    manifest = load_v5_manifest()
+    digest = forge_benchmark_v5.manifest_sha256(manifest)
+    reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
+
+    assert forge_benchmark_v5.manifest_sha256(reparsed) == digest
+    forge_benchmark_v5.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v5_runtime_components_match_the_declared_baseline() -> None:
+    manifest = load_v5_manifest()
+    baseline = manifest["forge"]["commit_sha"]
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        result = subprocess.run(
+            [git, "show", f"{baseline}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
+
+
+def test_v5_protocol_artifacts_match_the_current_tree() -> None:
+    manifest = load_v5_manifest()
+
+    for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
+        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected_digest
+
+
+def test_v5_schema_tracks_the_validator_topology_and_identity_contract() -> None:
+    schema = json.loads(V5_SCHEMA_PATH.read_text(encoding="utf-8"))
+    manifest_schema = schema["$defs"]["manifest"]
+    forge_schema = manifest_schema["properties"]["forge"]
+    runtime_schema = manifest_schema["properties"]["runtime"]
+
+    run_record_schema = schema["$defs"]["run_record"]
+    source_schema = run_record_schema["properties"]["source"]
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(load_v5_manifest())
+    assert manifest_schema["properties"]["schema_version"]["const"] == "5.0.0"
+    assert manifest_schema["properties"]["scope"]["properties"]["instrumentation_blocker"]["const"] is False
+    assert forge_schema["properties"]["commit_sha"]["const"] == forge_benchmark_v5.BASELINE_COMMIT
+    assert forge_schema["properties"]["revision_policy"]["const"] == forge_benchmark_v5.REVISION_POLICY
+    assert set(forge_schema["properties"]["component_sha256"]["required"]) == forge_benchmark_v5.COMPONENT_PATHS
+    assert runtime_schema["properties"]["control_plane_topology"]["const"] == "compose-dood"
+    assert run_record_schema["properties"]["schema_version"]["const"] == "5.0.0"
+    assert {"build_system_capabilities", "selected_build_system", "executed_build_system"}.issubset(source_schema["required"])
+
+
+def test_v5_run_record_persists_explicit_build_identity_without_manifest_backfill() -> None:
+    manifest = load_v5_manifest()
+    case = manifest["cases"][0]
+    session = {
+        "session_id": "abcdef123456",
+        "run_id": None,
+        "repo_url": case["repository_url"],
+        "commit_sha": case["commit_sha"],
+        "image": manifest["runtime"]["compile_image"],
+        "image_id": manifest["runtime"]["image_id"],
+        "status": "inspected",
+        "created_at": "2026-07-19T00:00:00+00:00",
+        "completed_at": None,
+        "finalized_at": None,
+        "commands": [],
+        "artifacts": [],
+        "verification": None,
+        "replay_attempts": [],
+        "build_system_capabilities": ["cmake"],
+        "selected_build_system": "cmake",
+        "executed_build_system": None,
+    }
+
+    record = forge_benchmark_v5.build_run_record(
+        manifest=manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        session=session,
+        workflow_events=[],
+    )
+
+    assert record["source"]["build_system_capabilities"] == ["cmake"]
+    assert record["source"]["selected_build_system"] == "cmake"
+    assert record["source"]["executed_build_system"] is None
+    assert record["source"]["build_system"] is None
+    assert forge_benchmark_v5.validate_run_record(record) is record
+    Draft202012Validator(json.loads(V5_SCHEMA_PATH.read_text(encoding="utf-8"))).validate(record)
+
+
+def test_v5_run_record_preserves_selected_executed_identity_drift_before_acceptance() -> None:
+    manifest = load_v5_manifest()
+    case = manifest["cases"][0]
+    session = {
+        "session_id": "abcdef123456",
+        "run_id": None,
+        "repo_url": case["repository_url"],
+        "commit_sha": case["commit_sha"],
+        "image": manifest["runtime"]["compile_image"],
+        "image_id": manifest["runtime"]["image_id"],
+        "status": "inspected",
+        "created_at": "2026-07-19T00:00:00+00:00",
+        "commands": [],
+        "artifacts": [],
+        "replay_attempts": [],
+        "build_system_capabilities": ["cmake", "make"],
+        "selected_build_system": "cmake",
+        "executed_build_system": "make",
+    }
+
+    record = forge_benchmark_v5.build_run_record(
+        manifest=manifest,
+        case_id="fmt",
+        condition_id="baseline",
+        repetition=1,
+        session=session,
+        workflow_events=[],
+    )
+
+    assert record["source"]["selected_build_system"] == "cmake"
+    assert record["source"]["executed_build_system"] == "make"
+    assert record["source"]["build_system"] == "make"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,27 @@
 # Forge C/C++ benchmark protocols
 
-## Runnable pilot v4
+## Runnable pilot v5
+
+`cpp-pilot-v5.json` is the five-case calibration protocol for the runtime that includes the Issue #32 event-loop ownership fix, Issue #33 non-interactive progress repair, and Issue #34 capability/selection/execution identity contract. It preserves every v1-v4 protocol artifact and physical-attempt ledger, keeps `control_plane_topology: "compose-dood"`, and creates a separate v5 evidence stratum.
+
+The runtime implementation baseline is `afe57d60632b6e49cc951185df0f525f6bb1f294`. A clean runtime HEAD must contain that commit as an ancestor and its 22 frozen runtime components must match the baseline. The model and execution controls remain unchanged: `gpt-5.6-sol` for both roles, the RichLab `/v1` endpoint, `OpenAI_AK`, a 120-second request timeout, zero provider retries, no fallback, one serial backend run, and disabled Memory/Skills.
+
+Every executed v5 attempt records a bounded `build.identity_snapshot`. The snapshot keeps repository build-system capabilities, the manifest-selected path, and the path proven by the supporting build command as separate facts. A switched path is retained as observed evidence and rejected by the offline identity gate; a missing observation remains `null` and is never backfilled from the manifest. The v5 run-record source carries the same three explicit fields.
+
+Validate the manifest on Windows and WSL, then run preflight in the frozen Compose/DooD environment:
+
+```powershell
+python scripts/forge_benchmark_v5.py validate-manifest benchmarks/manifests/cpp-pilot-v5.json
+```
+
+```bash
+python3 scripts/forge_benchmark_runner.py preflight \
+  --manifest benchmarks/manifests/cpp-pilot-v5.json
+```
+
+Only `ready: true` on a clean committed tree authorizes collection. Create and run one new v5 physical attempt for each of the five cases, strictly serially. Do not pass `--replacement-for`, edit or delete any v1-v4 ledger, or pool outcomes across protocol versions. Once the first v5 ledger is created, the v5 manifest and protocol artifacts are frozen for that collection stratum.
+
+## Historical pilot v4
 
 `cpp-pilot-v4.json` is the five-case calibration protocol for the runtime that includes the Issue #24 async-only compiler delegation fix, Issue #25 expected/observed build-system identity gate, and Issue #26 bounded agent tool-failure and no-compile-progress evidence. It preserves every v1/v2/v3 protocol artifact and existing physical-attempt ledger, keeps `control_plane_topology: "compose-dood"`, and creates a separate v4 evidence stratum.
 

--- a/benchmarks/manifests/cpp-pilot-v5.json
+++ b/benchmarks/manifests/cpp-pilot-v5.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "5.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "json-sort-keys-compact-utf8",
+  "benchmark": {
+    "id": "forge-cpp-clean-replay-pilot-v5",
+    "name": "Forge C/C++ Clean Replay Pilot v5",
+    "purpose": "clean_replay_collection_calibration",
+    "dataset_provenance": "self_selected_calibration_set"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "pilot",
+    "formal_comparison_enabled": false,
+    "instrumentation_blocker": false
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "7836219b3212c017bfa1adf319aeada903962da3",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "32b80041cff6457c463647dbc32425c6f6eabf587164a67b5e5b7efb2206a651",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "93b40b2047112a8af0ac7eae97e6c3ea404d5c883e5edda9793d03903961779d",
+      "backend/packages/harness/deerflow/compile/schemas.py": "62dc906b8290f46efcf320ff44b3f0e1fa0ef8e0c9ab9b35f2c3cdd1618825ce",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "d39cfc150e73360e913162d55b86821466160feb5a611973e607eeef711bbcf0",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "79c59f2c7127d80d2639027ef48975002447181ba2a2a65678a3dba8fbbbe6b2",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "4ab3b17b3e3368d7f82e7b381af68081d25ac67691ced437dd3938f11350e726",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "c1d7bbd83e5fc5b4616c9758eee4e3b9ff00eef69935787d13a52b5277c81af5"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_v5.py": "eef593f1d9bc9e627817027e370e7dbb6a43e206b5ed870ffc0a18cfee86f415",
+    "scripts/forge_benchmark_runner.py": "11ead601a6497bfc63cd47dcdef5e332569400ccc804ebbe2aea3771dff777e5",
+    "benchmarks/schemas/forge-cpp-benchmark-v5.schema.json": "3203f8a82a57c0681672d3abffa71a92b43e60c5685f4528d480b3cb2235f327"
+  },
+  "model": {
+    "endpoint": "https://richlab-api-x.choosefire.com/v1",
+    "credential_env": "OpenAI_AK",
+    "roles": {
+      "lead": "gpt-5.6-sol",
+      "compiler": "gpt-5.6-sol"
+    },
+    "fallback_policy": "forbidden",
+    "request_timeout_seconds": 120,
+    "max_retries": 0
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "compiler_max_turns": 36,
+    "subagent_timeout_seconds": 180,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "conditions": [
+    {
+      "id": "baseline",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "cases": [
+    {
+      "id": "fmt",
+      "repository_url": "https://github.com/fmtlib/fmt",
+      "commit_sha": "123913715afeb8a437e6388b4473fcc4753e1c9a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfmt.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFMT_TEST=OFF",
+            "-DFMT_DOC=OFF",
+            "-DFMT_INSTALL=OFF",
+            "-DBUILD_SHARED_LIBS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hiredis",
+      "repository_url": "https://github.com/redis/hiredis",
+      "commit_sha": "60e5075d4ac77424809f855ba3e398df7aacefe8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "BSD-3-Clause",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhiredis.a",
+            "artifact_type": "static_library"
+          },
+          {
+            "relative_path": "libhiredis.so",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "make"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libcheck",
+      "repository_url": "https://github.com/libcheck/check",
+      "commit_sha": "11970a7e112dfe243a2e68773f014687df2900e8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcheck.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "autoconf",
+          "automake",
+          "libtool",
+          "pkg-config",
+          "texinfo"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-subunit"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libgit2",
+      "repository_url": "https://github.com/libgit2/libgit2",
+      "commit_sha": "338e6fb681369ff0537719095e22ce9dc602dbf0",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "GPL-2.0-only WITH libgit2-linking-exception",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgit2.so.1.9.0",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "pkg-config",
+          "libssl-dev",
+          "libhttp-parser-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DBUILD_TESTS=OFF",
+            "-DBUILD_CLI=OFF",
+            "-DUSE_HTTPS=OpenSSL",
+            "-DUSE_HTTP_PARSER=system",
+            "-DREGEX_BACKEND=builtin",
+            "-DUSE_SSH=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sysstat-nondeterministic",
+      "repository_url": "https://github.com/sysstat/sysstat",
+      "commit_sha": "b8f987807e7c7ba5c1b2ca8b7b1e9d80e61bce6c",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "reject",
+        "expected_replay_failure_classification": "sha256_mismatch",
+        "required_artifacts": [
+          {
+            "relative_path": "sar",
+            "artifact_type": "executable"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-nls"
+          ]
+        },
+        "environment": {
+          "CFLAGS": "-O2 -DUSE_SCCSID",
+          "SOURCE_DATE_EPOCH": null
+        },
+        "minimum_replay_delay_seconds": 2
+      }
+    }
+  ]
+}

--- a/benchmarks/schemas/forge-cpp-benchmark-v5.schema.json
+++ b/benchmarks/schemas/forge-cpp-benchmark-v5.schema.json
@@ -1,0 +1,3507 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-benchmark-v5.schema.json",
+  "title": "Forge-AutoCompiler C/C++ benchmark pilot protocol v5",
+  "description": "The runnable five-case pilot manifest and explicit build-identity run-record contract.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/manifest"
+    },
+    {
+      "$ref": "#/$defs/run_record"
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_commit_sha": {
+      "type": "string",
+      "description": "A complete SHA-1 or SHA-256 Git object ID; symbolic or abbreviated refs are invalid.",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+/@-]*$"
+    },
+    "safe_repository_url": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS repository URL without userinfo, query parameters, or a fragment.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9._~!$&'()*+,;=:@%/-]+$"
+    },
+    "model_endpoint": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS OpenAI-compatible base URL ending in /v1, without credentials or URL parameters.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/v1/?$"
+    },
+    "environment_variable_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "relative_artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "A POSIX path relative to /artifacts. Absolute, parent-traversal, and backslash paths are invalid.",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "language": {
+      "enum": [
+        "C",
+        "C++"
+      ]
+    },
+    "languages": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/language"
+      }
+    },
+    "build_system": {
+      "enum": [
+        "cmake",
+        "make",
+        "autotools"
+      ]
+    },
+    "gate_status": {
+      "enum": [
+        "pass",
+        "reject"
+      ]
+    },
+    "nullable_gate_status": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/gate_status"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "run_record_lifecycle_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "image_identity_unavailable"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "cancelled"
+                        ]
+                      },
+                      "failure_classification": {
+                        "const": "image_identity_unavailable"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      },
+                      "passed": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.deferred"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "failed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "cancelled"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "cancelled"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "timed_out"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "timed_out"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verified",
+                      "verification_failed",
+                      "completed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verification_failed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "verification_failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "run_record_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  }
+                }
+              },
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "enum": [
+                      "pass",
+                      "reject"
+                    ]
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "maxItems": 1000
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "not_observed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "started"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.started"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "aborted"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.aborted"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "candidate_generation": {
+                    "const": true
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  },
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "failed"
+                      },
+                      "replay_attempt_id": {
+                        "type": "null"
+                      },
+                      "replay_status": {
+                        "const": "not_run"
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "replay_attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "replay_status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "cleanup_failed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "clean_replay": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "passed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          },
+                          "reason": {
+                            "type": "null"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "artifact_type": {
+      "enum": [
+        "executable",
+        "shared_library",
+        "static_library",
+        "object"
+      ]
+    },
+    "nullable_nonnegative_integer": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_nonnegative_number": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_boolean": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullable_sha256": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sha256"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "required_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type"
+      ],
+      "properties": {
+        "relative_path": {
+          "$ref": "#/$defs/relative_artifact_path"
+        },
+        "artifact_type": {
+          "$ref": "#/$defs/artifact_type"
+        }
+      }
+    },
+    "build_argument_vector": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[^\\u0000\\r\\n]+$"
+      }
+    },
+    "case_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required_system_packages",
+        "build_arguments",
+        "environment",
+        "minimum_replay_delay_seconds"
+      ],
+      "properties": {
+        "required_system_packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+-]*$"
+          }
+        },
+        "build_arguments": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cmake",
+            "configure"
+          ],
+          "properties": {
+            "cmake": {
+              "$ref": "#/$defs/build_argument_vector"
+            },
+            "configure": {
+              "$ref": "#/$defs/build_argument_vector"
+            }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "description": "Only reviewed, non-secret process environment controls are permitted.",
+          "additionalProperties": false,
+          "properties": {
+            "CFLAGS": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[^\\u0000\\r\\n]+$"
+            },
+            "SOURCE_DATE_EPOCH": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128,
+                  "pattern": "^[^\\u0000\\r\\n]+$"
+                }
+              ]
+            }
+          }
+        },
+        "minimum_replay_delay_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3600
+        }
+      }
+    },
+    "benchmark_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repository_url",
+        "commit_sha",
+        "languages",
+        "build_system",
+        "license",
+        "oracle",
+        "constraints"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repository_url": {
+          "$ref": "#/$defs/safe_repository_url"
+        },
+        "commit_sha": {
+          "$ref": "#/$defs/git_commit_sha"
+        },
+        "languages": {
+          "$ref": "#/$defs/languages"
+        },
+        "build_system": {
+          "$ref": "#/$defs/build_system"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9 .()+-]*$"
+        },
+        "oracle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "expected_candidate_status",
+            "expected_clean_replay_status",
+            "required_artifacts"
+          ],
+          "properties": {
+            "expected_candidate_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_clean_replay_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required_artifacts": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/required_artifact"
+              }
+            }
+          }
+        },
+        "constraints": {
+          "$ref": "#/$defs/case_constraints"
+        }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark",
+        "scope",
+        "forge",
+        "protocol_artifact_sha256",
+        "model",
+        "runtime",
+        "conditions",
+        "cases"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "5.0.0"
+        },
+        "document_type": {
+          "const": "manifest"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "purpose",
+            "dataset_provenance"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/identifier"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 160
+            },
+            "purpose": {
+              "const": "clean_replay_collection_calibration"
+            },
+            "dataset_provenance": {
+              "const": "self_selected_calibration_set"
+            }
+          }
+        },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "languages",
+            "phase",
+            "formal_comparison_enabled",
+            "instrumentation_blocker"
+          ],
+          "properties": {
+            "languages": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/language"
+              }
+            },
+            "phase": {
+              "const": "pilot"
+            },
+            "formal_comparison_enabled": {
+              "const": false
+            },
+            "instrumentation_blocker": {
+              "const": false
+            }
+          }
+        },
+        "forge": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository_url",
+            "commit_sha",
+            "revision_policy",
+            "component_sha256"
+          ],
+          "properties": {
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "const": "7836219b3212c017bfa1adf319aeada903962da3"
+            },
+            "revision_policy": {
+              "const": "baseline_ancestor_with_frozen_components"
+            },
+            "component_sha256": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+                "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+                "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+                "backend/packages/harness/deerflow/client.py",
+                "backend/packages/harness/deerflow/compile/__init__.py",
+                "backend/packages/harness/deerflow/compile/docker_runtime.py",
+                "backend/packages/harness/deerflow/compile/evidence.py",
+                "backend/packages/harness/deerflow/compile/manager.py",
+                "backend/packages/harness/deerflow/compile/operations.py",
+                "backend/packages/harness/deerflow/compile/schemas.py",
+                "backend/packages/harness/deerflow/models/factory.py",
+                "backend/packages/harness/deerflow/subagents/executor.py",
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+                "docker/compile/Dockerfile",
+                "docker/docker-compose-dev.yaml",
+                "config.example.yaml",
+                "backend/uv.lock"
+              ],
+              "properties": {
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/client.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/__init__.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/evidence.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/manager.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/operations.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/schemas.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/models/factory.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/subagents/executor.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/compile/Dockerfile": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/docker-compose-dev.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "config.example.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/uv.lock": {
+                  "$ref": "#/$defs/sha256"
+                }
+              }
+            }
+          }
+        },
+        "protocol_artifact_sha256": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scripts/forge_benchmark.py",
+            "scripts/forge_benchmark_v5.py",
+            "scripts/forge_benchmark_runner.py",
+            "benchmarks/schemas/forge-cpp-benchmark-v5.schema.json"
+          ],
+          "properties": {
+            "scripts/forge_benchmark.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_v5.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_runner.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "benchmarks/schemas/forge-cpp-benchmark-v5.schema.json": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        },
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "endpoint",
+            "credential_env",
+            "roles",
+            "fallback_policy",
+            "request_timeout_seconds",
+            "max_retries"
+          ],
+          "properties": {
+            "endpoint": {
+              "$ref": "#/$defs/model_endpoint"
+            },
+            "credential_env": {
+              "const": "OpenAI_AK"
+            },
+            "roles": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "lead",
+                "compiler"
+              ],
+              "properties": {
+                "lead": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "compiler": {
+                  "$ref": "#/$defs/safe_token"
+                }
+              }
+            },
+            "fallback_policy": {
+              "const": "forbidden"
+            },
+            "request_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_retries": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "compile_image",
+            "image_id",
+            "control_plane_topology",
+            "replay_timeout_seconds",
+            "cleanup_timeout_seconds",
+            "docker_control_timeout_seconds",
+            "compiler_max_turns",
+            "subagent_timeout_seconds",
+            "max_parallel_runs",
+            "backend_processes",
+            "network_policy",
+            "host"
+          ],
+          "properties": {
+            "compile_image": {
+              "$ref": "#/$defs/safe_token"
+            },
+            "image_id": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "control_plane_topology": {
+              "const": "compose-dood"
+            },
+            "replay_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "cleanup_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "docker_control_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "compiler_max_turns": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "subagent_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_parallel_runs": {
+              "const": 1
+            },
+            "backend_processes": {
+              "const": 1
+            },
+            "network_policy": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "network_name",
+                "egress"
+              ],
+              "properties": {
+                "network_name": {
+                  "const": "compile_network_wwf_v1"
+                },
+                "egress": {
+                  "const": "enabled_for_clone_and_dependencies"
+                }
+              }
+            },
+            "host": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "wsl_distribution",
+                "cpu_count",
+                "memory_kib",
+                "kernel",
+                "architecture",
+                "docker_server_version"
+              ],
+              "properties": {
+                "wsl_distribution": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "cpu_count": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "memory_kib": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "kernel": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "architecture": {
+                  "enum": [
+                    "x86_64",
+                    "aarch64"
+                  ]
+                },
+                "docker_server_version": {
+                  "type": "string",
+                  "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$"
+                }
+              }
+            }
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "memory_enabled",
+              "skills_enabled",
+              "repetitions",
+              "acceptance_gate"
+            ],
+            "properties": {
+              "id": {
+                "const": "baseline"
+              },
+              "memory_enabled": {
+                "const": false
+              },
+              "skills_enabled": {
+                "const": false
+              },
+              "repetitions": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              },
+              "acceptance_gate": {
+                "const": "clean_replay"
+              }
+            }
+          }
+        },
+        "cases": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/benchmark_case"
+          }
+        }
+      }
+    },
+    "normalized_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type",
+        "size_bytes",
+        "sha256",
+        "smoke_exit_code",
+        "smoke_output_sha256"
+      ],
+      "properties": {
+        "relative_path": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/relative_artifact_path"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "artifact_type": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/artifact_type"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "size_bytes": {
+          "$ref": "#/$defs/nullable_nonnegative_integer"
+        },
+        "sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        },
+        "smoke_exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "smoke_output_sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "artifact_type"
+            ],
+            "properties": {
+              "artifact_type": {
+                "const": "executable"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "smoke_exit_code": {
+                "const": 0
+              },
+              "smoke_output_sha256": {
+                "$ref": "#/$defs/sha256"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "failure_classification": {
+      "enum": [
+        "artifact_set_mismatch",
+        "type_mismatch",
+        "size_mismatch",
+        "sha256_mismatch",
+        "smoke_mismatch",
+        "recipe_snapshot_mismatch",
+        "image_identity_unavailable",
+        "recipe_execution_failed",
+        "timeout",
+        "internal_error",
+        "cancelled",
+        "cleanup_failed",
+        "session_terminated"
+      ]
+    },
+    "submit_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "stage",
+            "status",
+            "failed_checks",
+            "replay_attempt_id",
+            "artifact_count",
+            "candidate_status",
+            "replay_status"
+          ],
+          "properties": {
+            "event": {
+              "enum": [
+                "submit.started",
+                "submit.completed",
+                "submit.aborted"
+              ]
+            },
+            "stage": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "entry",
+                "candidate_checkpoint",
+                "final_checkpoint",
+                null
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                "completed",
+                null
+              ]
+            },
+            "failed_checks": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "replay_attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "candidate_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "replay_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                "not_run",
+                null
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.started"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "type": "null"
+                  },
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.aborted"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "candidate_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled",
+                      "not_run"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "const": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  },
+                  "replay_status": {
+                    "const": "passed"
+                  },
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "replay_status": {
+                    "not": {
+                      "const": "passed"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "status": {
+                    "const": "failed"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "const": "not_run"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "completion_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "artifact.finalization_recheck"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.deferred"
+            },
+            "reason": {
+              "const": "container_cleanup_failed"
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "const": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "enum": [
+                "failed",
+                "cancelled",
+                "timed_out"
+              ]
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        }
+      ]
+    },
+    "replay_attempt": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "attempt_id",
+            "image",
+            "image_id",
+            "commit_sha",
+            "status",
+            "failure_classification",
+            "exit_code",
+            "cleanup_succeeded",
+            "duration_seconds",
+            "timeout_seconds",
+            "recipe_sha256"
+          ],
+          "properties": {
+            "attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "pending",
+                "running",
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                null
+              ]
+            },
+            "failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "exit_code": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "timeout_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "recipe_sha256": {
+              "$ref": "#/$defs/nullable_sha256"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "image": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  },
+                  "cleanup_succeeded": {
+                    "type": "boolean"
+                  },
+                  "duration_seconds": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  },
+                  "failure_classification": {
+                    "type": "null"
+                  },
+                  "exit_code": {
+                    "const": 0
+                  },
+                  "cleanup_succeeded": {
+                    "const": true
+                  },
+                  "recipe_sha256": {
+                    "$ref": "#/$defs/sha256"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "$ref": "#/$defs/failure_classification"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  },
+                  "failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "timed_out"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "const": "timeout"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "run_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark_id",
+        "manifest_sha256",
+        "recorded_at",
+        "case_id",
+        "condition",
+        "repetition",
+        "source",
+        "outcome",
+        "failure_attribution",
+        "evidence"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "5.0.0"
+        },
+        "document_type": {
+          "const": "run_record"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "case_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "condition": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repetition": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_id",
+            "run_id",
+            "repository_url",
+            "commit_sha",
+            "build_system",
+            "build_system_capabilities",
+            "selected_build_system",
+            "executed_build_system",
+            "image_id"
+          ],
+          "properties": {
+            "session_id": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{12}$"
+            },
+            "run_id": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 160,
+                  "pattern": "^(?:[0-9a-f]{12,64}|[0-9a-fA-F]{8}-[0-9a-fA-F-]{27,})$"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "build_system_capabilities": {
+              "type": "array",
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/build_system"
+              }
+            },
+            "selected_build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "executed_build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        },
+        "outcome": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_status",
+            "submit_status",
+            "candidate_status",
+            "clean_replay_status",
+            "replay_failure_classification",
+            "replay_cleanup_succeeded",
+            "verification_status",
+            "artifact_count",
+            "finalized",
+            "oracle_match"
+          ],
+          "properties": {
+            "session_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "created",
+                "ready",
+                "source_ready",
+                "inspected",
+                "replay_verifying",
+                "verified",
+                "verification_failed",
+                "completed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                null
+              ]
+            },
+            "submit_status": {
+              "enum": [
+                "not_observed",
+                "started",
+                "aborted",
+                "completed"
+              ]
+            },
+            "candidate_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "clean_replay_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "verification_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "candidate_ready",
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "finalized": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "oracle_match": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "failure_attribution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "model_endpoint",
+            "agent",
+            "build",
+            "candidate_generation",
+            "clean_replay",
+            "cleanup",
+            "completion"
+          ],
+          "properties": {
+            "model_endpoint": {
+              "type": "null"
+            },
+            "agent": {
+              "type": "null"
+            },
+            "build": {
+              "type": "null"
+            },
+            "candidate_generation": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "clean_replay": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "cleanup": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "completion": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "command_summary",
+            "session_duration_seconds",
+            "artifacts",
+            "submit_event",
+            "replay_attempt",
+            "completion_event"
+          ],
+          "properties": {
+            "command_summary": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "total",
+                    "successful_bash",
+                    "failed_bash"
+                  ],
+                  "properties": {
+                    "total": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "successful_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "failed_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    }
+                  }
+                }
+              ]
+            },
+            "session_duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "artifacts": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array",
+                  "maxItems": 1000,
+                  "uniqueItems": true,
+                  "items": {
+                    "$ref": "#/$defs/normalized_artifact"
+                  }
+                }
+              ]
+            },
+            "submit_event": {
+              "$ref": "#/$defs/submit_event"
+            },
+            "replay_attempt": {
+              "$ref": "#/$defs/replay_attempt"
+            },
+            "completion_event": {
+              "$ref": "#/$defs/completion_event"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "source",
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "source": {
+                "required": [
+                  "selected_build_system",
+                  "executed_build_system"
+                ],
+                "properties": {
+                  "selected_build_system": {
+                    "$ref": "#/$defs/build_system"
+                  },
+                  "executed_build_system": {
+                    "$ref": "#/$defs/build_system"
+                  }
+                }
+              },
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "submit_event",
+                  "artifacts"
+                ],
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "required": [
+                      "event",
+                      "candidate_status",
+                      "artifact_count"
+                    ],
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "artifact_count": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "allOf": [
+                        {
+                          "$ref": "#/$defs/normalized_artifact"
+                        },
+                        {
+                          "properties": {
+                            "relative_path": {
+                              "$ref": "#/$defs/relative_artifact_path"
+                            },
+                            "artifact_type": {
+                              "$ref": "#/$defs/artifact_type"
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "sha256": {
+                              "$ref": "#/$defs/sha256"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "candidate_status",
+                  "replay_cleanup_succeeded",
+                  "replay_failure_classification",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "const": false
+                  },
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "attempt_id",
+                      "image",
+                      "image_id",
+                      "commit_sha",
+                      "status",
+                      "failure_classification",
+                      "exit_code",
+                      "cleanup_succeeded",
+                      "duration_seconds",
+                      "timeout_seconds",
+                      "recipe_sha256"
+                    ],
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image_id": {
+                        "type": "string",
+                        "pattern": "^sha256:[0-9a-f]{64}$"
+                      },
+                      "commit_sha": {
+                        "$ref": "#/$defs/git_commit_sha"
+                      },
+                      "status": {
+                        "const": "passed"
+                      },
+                      "failure_classification": {
+                        "type": "null"
+                      },
+                      "exit_code": {
+                        "const": 0
+                      },
+                      "cleanup_succeeded": {
+                        "const": true
+                      },
+                      "duration_seconds": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "recipe_sha256": {
+                        "$ref": "#/$defs/sha256"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "replay_failure_classification"
+                ],
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "cleanup_failed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status",
+                  "replay_cleanup_succeeded"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "failure_classification",
+                      "cleanup_succeeded"
+                    ],
+                    "properties": {
+                      "failure_classification": {
+                        "const": "cleanup_failed"
+                      },
+                      "cleanup_succeeded": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status",
+                  "clean_replay_status",
+                  "replay_failure_classification",
+                  "replay_cleanup_succeeded",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation",
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "type": "null"
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "null"
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/run_record_conditions"
+        },
+        {
+          "$ref": "#/$defs/run_record_lifecycle_conditions"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -30,6 +30,7 @@ import forge_benchmark as protocol  # noqa: E402
 import forge_benchmark_v2 as protocol_v2  # noqa: E402
 import forge_benchmark_v3 as protocol_v3  # noqa: E402
 import forge_benchmark_v4 as protocol_v4  # noqa: E402
+import forge_benchmark_v5 as protocol_v5  # noqa: E402
 
 from deerflow.compile.evidence import (  # noqa: E402
     EvidenceError,
@@ -115,6 +116,8 @@ def _manifest_protocol(manifest: dict[str, Any]):
         return protocol_v3
     if schema_version == protocol_v4.SCHEMA_VERSION:
         return protocol_v4
+    if schema_version == protocol_v5.SCHEMA_VERSION:
+        return protocol_v5
     raise RunnerError(f"Unsupported benchmark schema version: {schema_version}")
 
 
@@ -314,6 +317,7 @@ def collect_preflight(
         protocol_v2.REVISION_POLICY,
         protocol_v3.REVISION_POLICY,
         protocol_v4.REVISION_POLICY,
+        protocol_v5.REVISION_POLICY,
     }
     baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy in runnable_revision_policies else False
     component_results: dict[str, dict[str, Any]] = {}
@@ -363,6 +367,7 @@ def collect_preflight(
         protocol_v2.CONTROL_PLANE_TOPOLOGY,
         protocol_v3.CONTROL_PLANE_TOPOLOGY,
         protocol_v4.CONTROL_PLANE_TOPOLOGY,
+        protocol_v5.CONTROL_PLANE_TOPOLOGY,
     }
     topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
     checks = {
@@ -414,6 +419,7 @@ def collect_preflight(
                 protocol_v2.SCHEMA_VERSION: "cpp-pilot-v2.json",
                 protocol_v3.SCHEMA_VERSION: "cpp-pilot-v3.json",
                 protocol_v4.SCHEMA_VERSION: "cpp-pilot-v4.json",
+                protocol_v5.SCHEMA_VERSION: "cpp-pilot-v5.json",
             }[manifest["schema_version"]]
         ),
         "forge": {
@@ -428,7 +434,7 @@ def collect_preflight(
             "docker_server_version": (docker_version if docker_version_code == 0 else None),
             "platform_system": platform.system(),
             "platform_machine": platform.machine(),
-            "control_plane_topology": (protocol_v4.CONTROL_PLANE_TOPOLOGY if compose_dood_present else None),
+            "control_plane_topology": (expected_topology if compose_dood_present else None),
         },
         "checks": checks,
     }
@@ -601,6 +607,32 @@ def recompute_failure_domains(events: list[dict[str, Any]]) -> dict[str, list[di
     return {name: values or None for name, values in domains.items()}
 
 
+def recompute_build_identity(events: list[dict[str, Any]]) -> dict[str, Any]:
+    started = next((event for event in events if event["event"] == "experiment.started"), None)
+    policy = started["payload"].get("policy", {}) if started is not None else {}
+    expected = policy.get("expected_build_system")
+    benchmark_id = policy.get("benchmark_id")
+    snapshots = [event["payload"] for event in events if event["event"] == "build.identity_snapshot"]
+    attempt_executed = any(event["event"].startswith("model.") or event["event"] in {"runtime.topology_verified", "run.failed", "orphan.reconciled"} for event in events)
+    v5_identity_contract = benchmark_id == "forge-cpp-clean-replay-pilot-v5"
+    snapshot_required = v5_identity_contract and attempt_executed
+    submits = [event for event in events if event["event"] == "submit.completed"]
+    snapshots_by_session = {snapshot["session_id"]: snapshot for snapshot in snapshots if snapshot.get("session_id") is not None}
+    submit_identity_proven = not v5_identity_contract or all(
+        (snapshot := snapshots_by_session.get(submit["payload"].get("session_id"))) is not None and snapshot.get("selected_build_system") == expected and snapshot.get("executed_build_system") == expected for submit in submits
+    )
+    snapshot_present = bool(snapshots)
+    return {
+        "valid": (not snapshot_required or snapshot_present) and submit_identity_proven,
+        "snapshot_required": snapshot_required,
+        "snapshot_present": snapshot_present,
+        "expected_build_system": expected,
+        "session_count": sum(snapshot.get("session_id") is not None for snapshot in snapshots),
+        "submit_identity_proven": submit_identity_proven,
+        "snapshots": snapshots,
+    }
+
+
 def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
     commands: dict[str, dict[str, Any]] = {}
     replays: dict[str, dict[str, Any]] = {}
@@ -660,10 +692,20 @@ def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
                 "gates": recomputed,
             }
         )
+    build_identity = recompute_build_identity(events)
+    if not build_identity["valid"]:
+        mismatches.append(
+            {
+                "gate": "build_identity",
+                "recorded": build_identity["snapshot_present"],
+                "recomputed": False,
+            }
+        )
     return {
         "valid": not mismatches,
         "submits": results,
         "mismatches": mismatches,
+        "build_identity": build_identity,
         "failure_domains": recompute_failure_domains(events),
     }
 
@@ -743,6 +785,52 @@ def _finalize_attempt_sessions(
     return all(session.finalized_at is not None for session in sessions)
 
 
+def _record_attempt_build_identity(thread_id: str, ledger: ExperimentLedger) -> bool:
+    try:
+        from deerflow.compile.operations import get_compile_services
+
+        sessions = sorted(
+            get_compile_services().manager.list_sessions(thread_id),
+            key=lambda session: session.session_id,
+        )
+    except Exception:
+        ledger.append(
+            "failure.recorded",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "domain": "build",
+                "classification": "identity_snapshot_unavailable",
+                "primary": True,
+            },
+        )
+        return False
+
+    snapshots = sessions or [None]
+    try:
+        for session in snapshots:
+            ledger.append(
+                "build.identity_snapshot",
+                {
+                    "session_id": session.session_id if session is not None else None,
+                    "build_system_capabilities": list(session.build_system_capabilities) if session is not None else [],
+                    "selected_build_system": session.selected_build_system if session is not None else None,
+                    "executed_build_system": session.executed_build_system if session is not None else None,
+                },
+            )
+    except EvidenceError:
+        ledger.append(
+            "failure.recorded",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "domain": "build",
+                "classification": "identity_snapshot_invalid",
+                "primary": True,
+            },
+        )
+        return False
+    return True
+
+
 async def _consume_client_stream(
     client: Any,
     message: str,
@@ -795,6 +883,7 @@ def run_attempt(
         protocol_v2.CONTROL_PLANE_TOPOLOGY,
         protocol_v3.CONTROL_PLANE_TOPOLOGY,
         protocol_v4.CONTROL_PLANE_TOPOLOGY,
+        protocol_v5.CONTROL_PLANE_TOPOLOGY,
     }:
         if not _running_inside_compose_dood(REPO_ROOT):
             ledger.append(
@@ -825,6 +914,7 @@ def run_attempt(
     )
     run_status = "failed"
     session_finalization_succeeded = False
+    build_identity_snapshot_recorded = manifest["schema_version"] != protocol_v5.SCHEMA_VERSION
     try:
         from deerflow.client import DeerFlowClient
 
@@ -878,13 +968,15 @@ def run_attempt(
                 interrupted_status=interrupted_status,
                 error=termination_error,
             )
+        if manifest["schema_version"] == protocol_v5.SCHEMA_VERSION:
+            build_identity_snapshot_recorded = _record_attempt_build_identity(thread_id, ledger)
         ledger.append("orphan.reconciled", reconciliation)
 
     events = ledger.read()
     gates = recompute_gates(events)
     oracle = run_oracle(manifest, events)
     ledger.append("oracle.completed", oracle)
-    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] and session_finalization_succeeded else "failed"
+    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] and session_finalization_succeeded and build_identity_snapshot_recorded else "failed"
     ledger.append(
         "experiment.completed",
         {
@@ -893,6 +985,7 @@ def run_attempt(
             "oracle_passed": oracle["passed"],
             "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
             "session_finalization_succeeded": session_finalization_succeeded,
+            "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
         },
     )
     return {
@@ -901,6 +994,7 @@ def run_attempt(
         "oracle": oracle,
         "orphan_reconciliation": reconciliation,
         "session_finalization_succeeded": session_finalization_succeeded,
+        "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
     }
 
 
@@ -915,7 +1009,7 @@ def _build_parser() -> argparse.ArgumentParser:
     common.add_argument(
         "--manifest",
         type=Path,
-        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v4.json",
+        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json",
     )
     common.add_argument("--skip-endpoint-check", action="store_true")
 

--- a/scripts/forge_benchmark_v5.py
+++ b/scripts/forge_benchmark_v5.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Validate the runnable Forge C/C++ pilot v5 protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+
+SCHEMA_VERSION = "5.0.0"
+BASELINE_COMMIT = "7836219b3212c017bfa1adf319aeada903962da3"
+REVISION_POLICY = "baseline_ancestor_with_frozen_components"
+CONTROL_PLANE_TOPOLOGY = "compose-dood"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+COMPONENT_PATHS = {
+    "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+    "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+    "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+    "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+    "backend/packages/harness/deerflow/client.py",
+    "backend/packages/harness/deerflow/compile/__init__.py",
+    "backend/packages/harness/deerflow/compile/docker_runtime.py",
+    "backend/packages/harness/deerflow/compile/evidence.py",
+    "backend/packages/harness/deerflow/compile/manager.py",
+    "backend/packages/harness/deerflow/compile/operations.py",
+    "backend/packages/harness/deerflow/compile/schemas.py",
+    "backend/packages/harness/deerflow/models/factory.py",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+    "backend/packages/harness/deerflow/subagents/executor.py",
+    "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+    "backend/uv.lock",
+    "config.example.yaml",
+    "docker/compile/Dockerfile",
+    "docker/docker-compose-dev.yaml",
+}
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_benchmark.py",
+    "scripts/forge_benchmark_v5.py",
+    "scripts/forge_benchmark_runner.py",
+    "benchmarks/schemas/forge-cpp-benchmark-v5.schema.json",
+}
+
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+
+
+def _validate_hash_map(
+    value: Any,
+    *,
+    expected_paths: set[str],
+    path: str,
+) -> dict[str, Any]:
+    hashes = v1._as_object(value, path)
+    if set(hashes) != expected_paths:
+        v1._fail(path, "must contain exactly the required v5 frozen artifact hashes")
+    for relative_path, digest in hashes.items():
+        pure_path = PurePosixPath(relative_path)
+        if pure_path.is_absolute() or ".." in pure_path.parts or "\\" in relative_path:
+            v1._fail(f"{path}.{relative_path}", "must stay inside the repository")
+        v1._validate_sha256(digest, f"{path}.{relative_path}")
+    return hashes
+
+
+def _validate_manifest_impl(document: Any) -> dict[str, Any]:
+    manifest = v1._as_object(document, "manifest")
+    v1._require_exact_keys(
+        manifest,
+        {
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "forge",
+            "protocol_artifact_sha256",
+            "model",
+            "runtime",
+            "conditions",
+            "cases",
+        },
+        "manifest",
+        optional={"$schema"},
+    )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        v1._fail("manifest.schema_version", f"unsupported version; expected {SCHEMA_VERSION}")
+    v1._scan_for_unsafe_values(manifest)
+
+    scope = v1._as_object(v1._required(manifest, "scope", "manifest"), "manifest.scope")
+    if scope.get("instrumentation_blocker") is not False:
+        v1._fail(
+            "manifest.scope.instrumentation_blocker",
+            "must be false for the runnable v5 pilot",
+        )
+
+    forge = v1._as_object(v1._required(manifest, "forge", "manifest"), "manifest.forge")
+    v1._require_exact_keys(
+        forge,
+        {"repository_url", "commit_sha", "revision_policy", "component_sha256"},
+        "manifest.forge",
+    )
+    if forge.get("commit_sha") != BASELINE_COMMIT:
+        v1._fail(
+            "manifest.forge.commit_sha",
+            "must bind the Issue #32/#33/#34 fixed implementation baseline",
+        )
+    if forge.get("revision_policy") != REVISION_POLICY:
+        v1._fail(
+            "manifest.forge.revision_policy",
+            f"must be {REVISION_POLICY!r}",
+        )
+    _validate_hash_map(
+        v1._required(forge, "component_sha256", "manifest.forge"),
+        expected_paths=COMPONENT_PATHS,
+        path="manifest.forge.component_sha256",
+    )
+    _validate_hash_map(
+        v1._required(manifest, "protocol_artifact_sha256", "manifest"),
+        expected_paths=PROTOCOL_ARTIFACT_PATHS,
+        path="manifest.protocol_artifact_sha256",
+    )
+
+    runtime = v1._as_object(v1._required(manifest, "runtime", "manifest"), "manifest.runtime")
+    if runtime.get("control_plane_topology") != CONTROL_PLANE_TOPOLOGY:
+        v1._fail(
+            "manifest.runtime.control_plane_topology",
+            f"must be {CONTROL_PLANE_TOPOLOGY!r}",
+        )
+
+    model = v1._as_object(v1._required(manifest, "model", "manifest"), "manifest.model")
+    if model.get("endpoint") != "https://richlab-api-x.choosefire.com/v1":
+        v1._fail("manifest.model.endpoint", "must use the frozen pilot endpoint")
+    if model.get("roles") != {"lead": "gpt-5.6-sol", "compiler": "gpt-5.6-sol"}:
+        v1._fail("manifest.model.roles", "must use gpt-5.6-sol for both roles")
+    if model.get("request_timeout_seconds") != 120 or model.get("max_retries") != 0:
+        v1._fail("manifest.model", "must freeze a 120-second timeout and zero retries")
+
+    compatibility_manifest = _compatibility_manifest(manifest)
+    v1.validate_manifest(compatibility_manifest)
+    if manifest["benchmark"]["id"] != "forge-cpp-clean-replay-pilot-v5":
+        v1._fail("manifest.benchmark.id", "must identify the v5 clean-replay pilot")
+    if manifest["conditions"][0]["repetitions"] != 1:
+        v1._fail("manifest.conditions[0].repetitions", "must be 1 for the five-case pilot")
+    return manifest
+
+
+def _compatibility_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    forge = manifest["forge"]
+    compatibility_manifest = copy.deepcopy(manifest)
+    compatibility_manifest["schema_version"] = v1.SCHEMA_VERSION
+    compatibility_manifest["scope"]["instrumentation_blocker"] = True
+    compatibility_manifest["forge"].pop("revision_policy")
+    compatibility_manifest["forge"]["component_sha256"] = {path: forge["component_sha256"][path] for path in v1._COMPONENT_PATHS}
+    compatibility_manifest["runtime"].pop("control_plane_topology")
+    compatibility_manifest["protocol_artifact_sha256"] = {
+        "scripts/forge_benchmark.py": manifest["protocol_artifact_sha256"]["scripts/forge_benchmark.py"],
+        "benchmarks/schemas/forge-cpp-benchmark-v1.schema.json": manifest["protocol_artifact_sha256"]["benchmarks/schemas/forge-cpp-benchmark-v5.schema.json"],
+    }
+    return compatibility_manifest
+
+
+def validate_manifest(document: Any) -> dict[str, Any]:
+    """Validate a v5 manifest without reading repository files."""
+    try:
+        return _validate_manifest_impl(document)
+    except BenchmarkError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: contains a malformed value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    validate_manifest(manifest)
+    try:
+        return json.dumps(
+            manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: cannot be represented as canonical JSON") from exc
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def _validate_build_identity(
+    capabilities: Any,
+    selected: Any,
+    executed: Any,
+    *,
+    path: str,
+) -> tuple[list[str], str | None, str | None]:
+    if not isinstance(capabilities, list) or len(capabilities) > len(v1._BUILD_SYSTEMS) or len(set(capabilities)) != len(capabilities) or any(value not in v1._BUILD_SYSTEMS for value in capabilities):
+        v1._fail(f"{path}.build_system_capabilities", "must be a unique supported build-system list")
+    for key, value in (("selected_build_system", selected), ("executed_build_system", executed)):
+        if value is not None and value not in v1._BUILD_SYSTEMS:
+            v1._fail(f"{path}.{key}", "must be null or a supported build system")
+    if selected is not None and selected not in capabilities:
+        v1._fail(f"{path}.selected_build_system", "must belong to build_system_capabilities")
+    return capabilities, selected, executed
+
+
+def validate_run_record(document: Any) -> dict[str, Any]:
+    """Validate a v5 run record with explicit build-system identity facts."""
+    try:
+        record = v1._as_object(document, "run_record")
+        if record.get("schema_version") != SCHEMA_VERSION:
+            v1._fail("run_record.schema_version", f"must be {SCHEMA_VERSION!r}")
+        source = v1._as_object(v1._required(record, "source", "run_record"), "run_record.source")
+        v1._require_exact_keys(
+            source,
+            {
+                "session_id",
+                "run_id",
+                "repository_url",
+                "commit_sha",
+                "build_system",
+                "build_system_capabilities",
+                "selected_build_system",
+                "executed_build_system",
+                "image_id",
+            },
+            "run_record.source",
+        )
+        _capabilities, selected, executed = _validate_build_identity(
+            source["build_system_capabilities"],
+            source["selected_build_system"],
+            source["executed_build_system"],
+            path="run_record.source",
+        )
+        if source["build_system"] != executed:
+            v1._fail("run_record.source.build_system", "must equal the explicit executed build system")
+        outcome = v1._as_object(v1._required(record, "outcome", "run_record"), "run_record.outcome")
+        if outcome.get("candidate_status") == "pass" and (selected is None or executed is None or executed != selected):
+            v1._fail("run_record.source", "candidate pass requires matching selected and executed build-system evidence")
+
+        compatibility_record = copy.deepcopy(record)
+        compatibility_record["schema_version"] = v1.SCHEMA_VERSION
+        compatibility_source = compatibility_record["source"]
+        compatibility_source.pop("build_system_capabilities")
+        compatibility_source.pop("selected_build_system")
+        compatibility_source.pop("executed_build_system")
+        v1.validate_run_record(compatibility_record)
+        return record
+    except BenchmarkError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("run_record: contains a malformed value") from exc
+
+
+def build_run_record(
+    *,
+    manifest: dict[str, Any],
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    session: dict[str, Any],
+    workflow_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a v5 record without inferring observed identity from the manifest."""
+    validate_manifest(manifest)
+    capabilities = copy.deepcopy(session.get("build_system_capabilities", []))
+    selected = session.get("selected_build_system")
+    executed = session.get("executed_build_system")
+    _validate_build_identity(capabilities, selected, executed, path="session")
+    case = next((candidate for candidate in manifest["cases"] if candidate["id"] == case_id), None)
+    if case is None:
+        v1._fail("record.case_id", "does not name a manifest case")
+    if selected is not None and selected != case["build_system"]:
+        v1._fail("session.selected_build_system", "does not match the selected manifest case")
+
+    compatibility_session = copy.deepcopy(session)
+    compatibility_session["build_system"] = selected
+    record = v1.build_run_record(
+        manifest=_compatibility_manifest(manifest),
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        session=compatibility_session,
+        workflow_events=workflow_events,
+    )
+    record["schema_version"] = SCHEMA_VERSION
+    record["manifest_sha256"] = manifest_sha256(manifest)
+    record["source"].update(
+        {
+            "build_system": executed,
+            "build_system_capabilities": capabilities,
+            "selected_build_system": selected,
+            "executed_build_system": executed,
+        }
+    )
+    return validate_run_record(record)
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path) -> None:
+    """Verify the v5 runtime and protocol files against the current clean tree."""
+    validate_manifest(manifest)
+    try:
+        resolved_root = repo_root.resolve(strict=True)
+    except OSError as exc:
+        raise BenchmarkError("frozen_components: repository root is unavailable") from exc
+    if not resolved_root.is_dir():
+        raise BenchmarkError("frozen_components: repository root must be a directory")
+
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+    ):
+        for relative_path, expected_sha256 in hashes.items():
+            candidate = resolved_root
+            for part in PurePosixPath(relative_path).parts:
+                candidate /= part
+                if candidate.is_symlink():
+                    v1._fail(f"{path_prefix}.{relative_path}", "must reference an ordinary file, not a symlink")
+            if not candidate.is_file():
+                v1._fail(f"{path_prefix}.{relative_path}", "references a missing ordinary file")
+            try:
+                resolved_candidate = candidate.resolve(strict=True)
+                resolved_candidate.relative_to(resolved_root)
+                actual_sha256 = hashlib.sha256(resolved_candidate.read_bytes()).hexdigest()
+            except (OSError, ValueError) as exc:
+                raise BenchmarkError(f"{path_prefix}.{relative_path}: could not be read safely") from exc
+            if actual_sha256 != expected_sha256:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match the current repository file")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser(
+        "validate-manifest",
+        help="validate and hash a runnable v5 benchmark manifest",
+    )
+    validate_parser.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = validate_manifest(load_json_document(args.manifest))
+        verify_frozen_components(manifest, REPOSITORY_ROOT)
+        print(
+            json.dumps(
+                {
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 冻结独立的 C/C++ pilot v5 manifest、Schema、validator 与 runner 路由。
- 将 v5 基线绑定到已合并的 #32、#33、#34 主干实现。
- 在 v5 evidence 中保存 build-system capabilities、selected path 与 executed path。
- 历史 v1-v4 协议按各自冻结 Git blob 审计；不改写旧文件或 ledger。

## 验证

- 聚焦回归：178 passed, 15 skipped
- 后端全量：1590 passed, 41 skipped
- v5 manifest validator、Ruff、格式与 diff 检查通过
- 未调用模型、未创建、执行或替换 pilot slot

Closes #38