### PR TITLE
修复：建立成功构建后的确定性提交交接

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Historical pilot protocols were intentionally preserved on their
+      # original topic branches after the mainline squash merges.  Fetch them
+      # before running the byte-level provenance audits.
+      - name: Fetch historical benchmark protocol refs
+        run: git fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -30,11 +30,18 @@ jobs:
       # audited objects before running byte-level provenance checks.
       - name: Fetch historical benchmark protocol commits
         run: |
-          git fetch --no-tags --depth=1 origin 0a71ad3204afec9aa36de612265594c1144be4c9
-          git fetch --no-tags --depth=1 origin d845b735576be706f79fcf0666f66c14929a52cc
-          git fetch --no-tags --depth=1 origin 371f678e07acc6ae87f80d7544f573332d74fa88
-          git fetch --no-tags --depth=1 origin 01460235668dcd187809059030ff5d3ec0851b17
-          git fetch --no-tags --depth=1 origin 7836219b3212c017bfa1adf319aeada903962da3
+          git fetch --no-tags origin 0a71ad3204afec9aa36de612265594c1144be4c9
+          git fetch --no-tags origin d845b735576be706f79fcf0666f66c14929a52cc
+          git fetch --no-tags origin 561b38cee9f027b0dfb01ff765b44a28dbf2de8f
+          git fetch --no-tags origin 9e002f4568a77de07fdce65b49373afb7e5cc74e
+          git fetch --no-tags origin 9ef57c50193ace14b6f8b761e09cced21e92f08e
+          git fetch --no-tags origin 371f678e07acc6ae87f80d7544f573332d74fa88
+          git fetch --no-tags origin 17e09f5896ca8bf5739cec413c16402cb441209d
+          git fetch --no-tags origin c4b817f315515d8afcc26d572151276aef7bece4
+          git fetch --no-tags origin 8828329896d92e8550eb1d0b3cf59bed58441987
+          git fetch --no-tags origin 01460235668dcd187809059030ff5d3ec0851b17
+          git fetch --no-tags origin 7836219b3212c017bfa1adf319aeada903962da3
+          git fetch --no-tags origin 83e807d8a441811920ceb8c9ac6ee6afe6584720
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -25,11 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Historical pilot protocols were intentionally preserved on their
-      # original topic branches after the mainline squash merges.  Fetch them
-      # before running the byte-level provenance audits.
-      - name: Fetch historical benchmark protocol refs
-        run: git fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+      # Historical pilot protocols were intentionally preserved as immutable
+      # commit snapshots before the mainline squash merges.  Fetch the exact
+      # audited objects before running byte-level provenance checks.
+      - name: Fetch historical benchmark protocol commits
+        run: |
+          git fetch --no-tags --depth=1 origin 0a71ad3204afec9aa36de612265594c1144be4c9
+          git fetch --no-tags --depth=1 origin d845b735576be706f79fcf0666f66c14929a52cc
+          git fetch --no-tags --depth=1 origin 371f678e07acc6ae87f80d7544f573332d74fa88
+          git fetch --no-tags --depth=1 origin 01460235668dcd187809059030ff5d3ec0851b17
+          git fetch --no-tags --depth=1 origin 7836219b3212c017bfa1adf319aeada903962da3
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/backend/packages/harness/deerflow/agents/middlewares/compile_termination_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/compile_termination_middleware.py
@@ -48,7 +48,7 @@ class CompileTerminationMiddleware(AgentMiddleware[CompileTerminationState]):
             return result
 
         tool_name = request.tool_call.get("name")
-        if tool_name not in {"submit_build_result", "finalize_session"}:
+        if tool_name not in {"run_container_bash", "submit_build_result", "finalize_session"}:
             return result
 
         try:
@@ -56,15 +56,16 @@ class CompileTerminationMiddleware(AgentMiddleware[CompileTerminationState]):
         except (TypeError, json.JSONDecodeError):
             return result
 
-        if tool_name == "submit_build_result":
-            if payload.get("status") != "passed":
+        if tool_name in {"run_container_bash", "submit_build_result"}:
+            submit_payload = payload.get("automatic_submit") if tool_name == "run_container_bash" else payload
+            if not isinstance(submit_payload, dict) or submit_payload.get("status") != "passed":
                 return result
             terminal_payload = {
                 "build_status": "success",
                 "proceed_to_verify": False,
                 "verification_status": "passed",
-                "summary": payload["message"],
-                "artifacts": [artifact["path"] for artifact in payload.get("artifacts", [])],
+                "summary": submit_payload["message"],
+                "artifacts": [artifact["path"] for artifact in submit_payload.get("artifacts", [])],
             }
         else:
             if payload.get("status") not in {"completed", "failed", "cancelled", "timed_out"}:

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -66,6 +66,21 @@ _ALLOWED_COMMAND_ROLES = {
     "replay_delay",
     "other",
 }
+_ALLOWED_SUBAGENT_TERMINAL_STATUSES = {
+    "completed",
+    "failed",
+    "cancelled",
+    "timed_out",
+}
+_ALLOWED_SUBAGENT_FAILURE_CLASSIFICATIONS = {
+    "cancelled",
+    "parent_cancelled",
+    "polling_timeout",
+    "recursion_limit",
+    "subagent_failed",
+    "subagent_timeout",
+    "tracking_lost",
+}
 
 
 class EvidenceError(ValueError):
@@ -142,6 +157,59 @@ def _validate_safe_value(value: Any, path: str = "payload") -> None:
 
 
 def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str = "payload") -> None:
+    if event == "build.identity_snapshot":
+        required = {
+            "session_id",
+            "build_system_capabilities",
+            "selected_build_system",
+            "executed_build_system",
+        }
+        if set(payload) != required:
+            raise EvidenceError(f"{path} has an invalid build.identity_snapshot schema")
+        session_id = payload["session_id"]
+        if session_id is not None and (not isinstance(session_id, str) or not re.fullmatch(r"[0-9a-f]{12}", session_id)):
+            raise EvidenceError(f"{path}.session_id must be null or a compile-session ID")
+        capabilities = payload["build_system_capabilities"]
+        if not isinstance(capabilities, list) or len(capabilities) > len(_ALLOWED_BUILD_SYSTEMS) or len(set(capabilities)) != len(capabilities) or any(value not in _ALLOWED_BUILD_SYSTEMS for value in capabilities):
+            raise EvidenceError(f"{path}.build_system_capabilities must be a unique supported build-system list")
+        selected = payload["selected_build_system"]
+        executed = payload["executed_build_system"]
+        for key, value in (("selected_build_system", selected), ("executed_build_system", executed)):
+            if value is not None and value not in _ALLOWED_BUILD_SYSTEMS:
+                raise EvidenceError(f"{path}.{key} must be null or a supported build system")
+        if selected is not None and selected not in capabilities:
+            raise EvidenceError(f"{path}.selected_build_system must belong to build_system_capabilities")
+        if session_id is None and (capabilities or selected is not None or executed is not None):
+            raise EvidenceError(f"{path} cannot claim build identity without a session")
+        return
+
+    if event == "agent.subagent_terminated":
+        required = {
+            "task_id",
+            "role",
+            "status",
+            "classification",
+            "worker_stopped",
+        }
+        if set(payload) != required:
+            raise EvidenceError(f"{path} has an invalid agent.subagent_terminated schema")
+        if not isinstance(payload["task_id"], str) or not _BOUNDED_IDENTIFIER_RE.fullmatch(payload["task_id"]):
+            raise EvidenceError(f"{path}.task_id must be a bounded identifier")
+        if payload["role"] != "compiler":
+            raise EvidenceError(f"{path}.role must be compiler")
+        status = payload["status"]
+        classification = payload["classification"]
+        if status not in _ALLOWED_SUBAGENT_TERMINAL_STATUSES:
+            raise EvidenceError(f"{path}.status is invalid")
+        if status == "completed":
+            if classification is not None:
+                raise EvidenceError(f"{path}.classification must be null for completed tasks")
+        elif classification not in _ALLOWED_SUBAGENT_FAILURE_CLASSIFICATIONS:
+            raise EvidenceError(f"{path}.classification is invalid")
+        if type(payload["worker_stopped"]) is not bool:
+            raise EvidenceError(f"{path}.worker_stopped must be boolean")
+        return
+
     if event == "agent.tool_failed":
         required = {
             "failure_id",
@@ -686,17 +754,14 @@ def model_response_metadata(response: Any) -> tuple[str | None, dict[str, int | 
             for key in ("model_name", "model"):
                 value = metadata.get(key)
                 if isinstance(value, str) and value and len(value) <= 128:
-                    try:
-                        _validate_safe_value(value, "actual_model")
-                    except EvidenceError:
-                        continue
+                    _validate_safe_value(value, "actual_model")
                     actual_model = value
                     break
         usage_metadata = getattr(candidate, "usage_metadata", None)
         if isinstance(usage_metadata, dict):
             for key in usage:
                 value = usage_metadata.get(key)
-                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                if isinstance(value, int) and value >= 0:
                     usage[key] = value
         if actual_model is not None and any(value is not None for value in usage.values()):
             break

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -754,14 +754,17 @@ def model_response_metadata(response: Any) -> tuple[str | None, dict[str, int | 
             for key in ("model_name", "model"):
                 value = metadata.get(key)
                 if isinstance(value, str) and value and len(value) <= 128:
-                    _validate_safe_value(value, "actual_model")
+                    try:
+                        _validate_safe_value(value, "actual_model")
+                    except EvidenceError:
+                        continue
                     actual_model = value
                     break
         usage_metadata = getattr(candidate, "usage_metadata", None)
         if isinstance(usage_metadata, dict):
             for key in usage:
                 value = usage_metadata.get(key)
-                if isinstance(value, int) and value >= 0:
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
                     usage[key] = value
         if actual_model is not None and any(value is not None for value in usage.values()):
             break

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -102,6 +102,16 @@ _BUILD_TOOL_OPTIONS_WITH_VALUE = {
     "-l",
     "-O",
 }
+_DEPENDENCY_SETUP_EXECUTABLES = {
+    "apk",
+    "apt",
+    "apt-get",
+    "dnf",
+    "pacman",
+    "yum",
+    "zypper",
+}
+_SHELL_COMMAND_SEPARATORS = {"(", ")", ";", "&", "&&", "|", "||"}
 
 
 @dataclass
@@ -1047,64 +1057,144 @@ def _command_invokes(command: str, executable: str) -> bool:
     return False
 
 
-def _build_tool_invokes_real_target(tokens: list[str], executable: str) -> bool:
-    separators = {";", "&", "&&", "|", "||"}
-    for index, token in enumerate(tokens):
-        if PurePosixPath(token).name != executable:
+def _shell_command_segments(command: str) -> list[list[str]]:
+    try:
+        lexer = shlex(command.replace("\n", ";"), posix=True, punctuation_chars="();&|")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return []
+
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SHELL_COMMAND_SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
             continue
-        targets: list[str] = []
-        skip_option_value = False
-        for argument in tokens[index + 1 :]:
-            if argument in separators:
-                break
-            if skip_option_value:
-                skip_option_value = False
-                continue
-            if argument in _BUILD_TOOL_OPTIONS_WITH_VALUE:
-                skip_option_value = True
-                continue
-            if argument.startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", argument):
-                continue
-            targets.append(argument)
-        if not targets or any(target not in _HOUSEKEEPING_BUILD_TARGETS for target in targets):
-            return True
-    return False
+        current.append(token)
+    if current:
+        segments.append(current)
+    return segments
 
 
-def _cmake_invokes_real_build(tokens: list[str]) -> bool:
-    if "--build" not in tokens:
+def _command_invocation(segment: list[str]) -> tuple[str, list[str]] | None:
+    wrappers = {"command", "env", "sudo", "time"}
+    for index, token in enumerate(segment):
+        if token == "--" or token.startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token):
+            continue
+        executable = PurePosixPath(token).name
+        if executable in wrappers:
+            continue
+        return executable, segment[index + 1 :]
+    return None
+
+
+def _build_tool_invokes_real_target(arguments: list[str]) -> bool:
+    targets: list[str] = []
+    skip_option_value = False
+    for argument in arguments:
+        if skip_option_value:
+            skip_option_value = False
+            continue
+        if argument in _BUILD_TOOL_OPTIONS_WITH_VALUE:
+            skip_option_value = True
+            continue
+        if argument.startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", argument):
+            continue
+        targets.append(argument)
+    return not targets or any(target not in _HOUSEKEEPING_BUILD_TARGETS for target in targets)
+
+
+def _cmake_invokes_real_build(arguments: list[str]) -> bool:
+    if "--build" not in arguments:
         return False
-    target_index = next((index for index, token in enumerate(tokens) if token in {"--target", "-t"}), None)
+    target_index = next((index for index, token in enumerate(arguments) if token in {"--target", "-t"}), None)
     if target_index is None:
         return True
     targets: list[str] = []
-    for argument in tokens[target_index + 1 :]:
+    for argument in arguments[target_index + 1 :]:
         if argument == "--" or argument.startswith("-"):
             break
         targets.append(argument)
     return not targets or any(target not in _HOUSEKEEPING_BUILD_TARGETS for target in targets)
 
 
+def _command_mentions_container_path(command: str, path: str) -> bool:
+    return re.search(rf"{re.escape(path)}(?:/|(?![A-Za-z0-9_.-]))", command) is not None
+
+
+def _infer_command_roles(command: str, *, depth: int) -> set[str]:
+    roles: set[str] = set()
+    stages_artifacts = _command_mentions_container_path(command, "/artifacts")
+    for segment in _shell_command_segments(command):
+        invocation = _command_invocation(segment)
+        if invocation is None:
+            continue
+        executable, arguments = invocation
+        segment_text = " ".join(segment)
+
+        if executable in _DEPENDENCY_SETUP_EXECUTABLES:
+            roles.add("dependency_setup")
+        if executable == "sleep":
+            roles.add("replay_delay")
+
+        if executable == "cmake":
+            if "--build" in arguments:
+                roles.add("build" if _cmake_invokes_real_build(arguments) else "housekeeping")
+            elif "--install" not in arguments and "-E" not in arguments and "--open" not in arguments:
+                roles.add("configure")
+            if stages_artifacts and ("--install" in arguments or ("-E" in arguments and any(argument in {"copy", "copy_if_different"} for argument in arguments))):
+                roles.add("artifact_stage")
+            continue
+
+        if executable in {"make", "gmake", "ninja"}:
+            installs_artifacts = stages_artifacts and "install" in arguments
+            if installs_artifacts:
+                roles.add("artifact_stage")
+            else:
+                roles.add("build" if _build_tool_invokes_real_target(arguments) else "housekeeping")
+            continue
+
+        if executable in {"configure", "autogen.sh", "autoreconf"}:
+            roles.add("configure")
+            continue
+
+        if stages_artifacts and executable in {"cp", "install"}:
+            roles.add("artifact_stage")
+            continue
+
+        if executable in {"bash", "sh"}:
+            if any(PurePosixPath(argument).name in {"configure", "autogen.sh"} for argument in arguments):
+                roles.add("configure")
+            inline_command = next(
+                (arguments[index + 1] for index, argument in enumerate(arguments[:-1]) if argument.startswith("-") and "c" in argument[1:]),
+                None,
+            )
+            if inline_command is not None and depth < 2:
+                roles.update(_infer_command_roles(inline_command, depth=depth + 1))
+
+        if stages_artifacts and re.search(r"(?:^|\s)(?:cp|install)\s", segment_text) is not None:
+            roles.add("artifact_stage")
+
+    return roles
+
+
+def infer_command_roles(command: str) -> set[str]:
+    """Infer every control-plane role present in a possibly compound shell command."""
+
+    return _infer_command_roles(command, depth=0)
+
+
 def infer_command_role(command: str) -> str | None:
-    """Infer control-plane roles for the supported C/C++ build systems."""
+    """Resolve the primary evidence role while retaining compound-role analysis."""
 
-    try:
-        tokens = split(command, posix=True)
-    except ValueError:
-        tokens = []
-
-    if "/artifacts" in command and (_command_invokes(command, "cp") or _command_invokes(command, "install") or re.search(r"(?:^|[;&|]\s*|\s)(?:cp|install)\s", command) is not None):
-        return "artifact_stage"
-
-    if _command_invokes(command, "cmake") and _cmake_invokes_real_build(tokens):
-        return "build"
-    if any(_command_invokes(command, executable) and _build_tool_invokes_real_target(tokens, executable) for executable in ("make", "gmake", "ninja")):
-        return "build"
-
-    if _command_invokes(command, "cmake") and "--build" not in tokens:
-        return "configure"
-    if any(_command_invokes(command, executable) for executable in ("configure", "autogen.sh", "autoreconf")):
-        return "configure"
+    roles = infer_command_roles(command)
+    for role in ("build", "configure", "dependency_setup", "replay_delay", "artifact_stage"):
+        if role in roles:
+            return role
     return None
 
 

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -39,9 +39,9 @@ from deerflow.compile.schemas import (
 )
 
 _BUILD_SYSTEM_MARKERS = {
-    "cmake": "CMakeLists.txt",
-    "make": "Makefile",
-    "autotools": "configure",
+    "cmake": ("CMakeLists.txt",),
+    "make": ("Makefile", "GNUmakefile", "makefile"),
+    "autotools": ("configure", "configure.ac", "configure.in", "autogen.sh"),
 }
 
 _ARTIFACT_FILE_EXCLUDES = [
@@ -81,6 +81,27 @@ _REPLAY_SMOKE_TIMEOUT_SECONDS = 30
 _REPLAY_CONTAINER_CREATE_TIMEOUT_SECONDS = 30
 _MAX_PERSISTED_SMOKE_OUTPUT = 4000
 _TERMINAL_SESSION_STATUSES = {"completed", "failed", "cancelled", "timed_out"}
+_HOUSEKEEPING_BUILD_TARGETS = {
+    "clean",
+    "distclean",
+    "help",
+    "maintainer-clean",
+    "mostlyclean",
+}
+_BUILD_TOOL_OPTIONS_WITH_VALUE = {
+    "--directory",
+    "--file",
+    "--include-dir",
+    "--jobs",
+    "--load-average",
+    "--output-sync",
+    "-C",
+    "-f",
+    "-I",
+    "-j",
+    "-l",
+    "-O",
+}
 
 
 @dataclass
@@ -494,8 +515,9 @@ def inspect_build_system_impl(*, session: CompileSession) -> tuple[str, list[tup
     repo_dir = Path(session.leadagent_repo_dir)
     services.manager.log_event(session, "inspect.started", lead_repo_dir=str(repo_dir))
     detected: list[tuple[str, str]] = []
-    for build_system, marker in _BUILD_SYSTEM_MARKERS.items():
-        if (repo_dir / marker).is_file():
+    for build_system, markers in _BUILD_SYSTEM_MARKERS.items():
+        marker = next((candidate for candidate in markers if (repo_dir / candidate).is_file()), None)
+        if marker is not None:
             detected.append((build_system, marker))
 
     session.build_system_capabilities = [build_system for build_system, _marker in detected]
@@ -507,10 +529,17 @@ def inspect_build_system_impl(*, session: CompileSession) -> tuple[str, list[tup
         session.build_system = None
     services.manager.save_session(session)
 
+    autotools_marker = next((marker for build_system, marker in detected if build_system == "autotools"), None)
+    autotools_commands = {
+        "configure": ["chmod +x ./configure && ./configure", "make -j"],
+        "autogen.sh": ["chmod +x ./autogen.sh && ./autogen.sh", "make -j"],
+        "configure.ac": ["autoreconf -fi && ./configure", "make -j"],
+        "configure.in": ["autoreconf -fi && ./configure", "make -j"],
+    }
     suggested_commands = {
         "cmake": ["mkdir -p build && cd build && cmake ..", "cmake --build build -j"],
         "make": ["make -j"],
-        "autotools": ["chmod +x ./configure && ./configure", "make -j"],
+        "autotools": autotools_commands.get(autotools_marker, ["autoreconf -fi && ./configure", "make -j"]),
         "unknown": ["Inspect repository manually and run the appropriate C/C++ build command"],
     }
 
@@ -1018,10 +1047,83 @@ def _command_invokes(command: str, executable: str) -> bool:
     return False
 
 
+def _build_tool_invokes_real_target(tokens: list[str], executable: str) -> bool:
+    separators = {";", "&", "&&", "|", "||"}
+    for index, token in enumerate(tokens):
+        if PurePosixPath(token).name != executable:
+            continue
+        targets: list[str] = []
+        skip_option_value = False
+        for argument in tokens[index + 1 :]:
+            if argument in separators:
+                break
+            if skip_option_value:
+                skip_option_value = False
+                continue
+            if argument in _BUILD_TOOL_OPTIONS_WITH_VALUE:
+                skip_option_value = True
+                continue
+            if argument.startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", argument):
+                continue
+            targets.append(argument)
+        if not targets or any(target not in _HOUSEKEEPING_BUILD_TARGETS for target in targets):
+            return True
+    return False
+
+
+def _cmake_invokes_real_build(tokens: list[str]) -> bool:
+    if "--build" not in tokens:
+        return False
+    target_index = next((index for index, token in enumerate(tokens) if token in {"--target", "-t"}), None)
+    if target_index is None:
+        return True
+    targets: list[str] = []
+    for argument in tokens[target_index + 1 :]:
+        if argument == "--" or argument.startswith("-"):
+            break
+        targets.append(argument)
+    return not targets or any(target not in _HOUSEKEEPING_BUILD_TARGETS for target in targets)
+
+
+def infer_command_role(command: str) -> str | None:
+    """Infer control-plane roles for the supported C/C++ build systems."""
+
+    try:
+        tokens = split(command, posix=True)
+    except ValueError:
+        tokens = []
+
+    if "/artifacts" in command and (_command_invokes(command, "cp") or _command_invokes(command, "install") or re.search(r"(?:^|[;&|]\s*|\s)(?:cp|install)\s", command) is not None):
+        return "artifact_stage"
+
+    if _command_invokes(command, "cmake") and _cmake_invokes_real_build(tokens):
+        return "build"
+    if any(_command_invokes(command, executable) and _build_tool_invokes_real_target(tokens, executable) for executable in ("make", "gmake", "ninja")):
+        return "build"
+
+    if _command_invokes(command, "cmake") and "--build" not in tokens:
+        return "configure"
+    if any(_command_invokes(command, executable) for executable in ("configure", "autogen.sh", "autoreconf")):
+        return "configure"
+    return None
+
+
+def resolve_command_role(command: str, declared_role: str | None) -> tuple[str, str | None]:
+    """Resolve a model-declared role against deterministic command evidence."""
+
+    declared = allowed_command_role(declared_role)
+    inferred = infer_command_role(command)
+    if inferred is not None:
+        return inferred, inferred
+    if declared in {"configure", "build", "artifact_stage"}:
+        return "other", None
+    return declared, None
+
+
 def _configure_command_build_system(command: str) -> str | None:
-    if _command_invokes(command, "cmake"):
+    if infer_command_role(command) == "configure" and _command_invokes(command, "cmake"):
         return "cmake"
-    if _command_invokes(command, "configure"):
+    if infer_command_role(command) == "configure" and any(_command_invokes(command, executable) for executable in ("configure", "autogen.sh", "autoreconf")):
         return "autotools"
     return None
 

--- a/backend/packages/harness/deerflow/compile/schemas.py
+++ b/backend/packages/harness/deerflow/compile/schemas.py
@@ -147,6 +147,9 @@ class CompileSession:
     build_system_capabilities: list[str] = field(default_factory=list)
     selected_build_system: str | None = None
     executed_build_system: str | None = None
+    post_build_supporting_command_id: str | None = None
+    post_build_started_at: str | None = None
+    post_build_commands_remaining: int | None = None
     summary: str | None = None
     error: str | None = None
     metadata_path: str = ""
@@ -170,6 +173,9 @@ class CompileSession:
             "build_system_capabilities": [],
             "selected_build_system": None,
             "executed_build_system": None,
+            "post_build_supporting_command_id": None,
+            "post_build_started_at": None,
+            "post_build_commands_remaining": None,
             "replay_attempts": [],
             **data,
         }

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -15,6 +15,7 @@ from langchain.agents import create_agent
 from langchain.tools import BaseTool
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
+from langgraph.errors import GraphRecursionError
 
 from deerflow.models import create_chat_model
 from deerflow.subagents.config import SubagentConfig
@@ -49,6 +50,7 @@ class SubagentResult:
     status: SubagentStatus
     result: str | None = None
     error: str | None = None
+    failure_classification: str | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
     ai_messages: list[dict[str, Any]] | None = None
@@ -77,12 +79,18 @@ _TERMINAL_STATUSES = {
 }
 
 
-def _mark_terminal(result: SubagentResult, status: SubagentStatus, error: str | None = None) -> bool:
+def _mark_terminal(
+    result: SubagentResult,
+    status: SubagentStatus,
+    error: str | None = None,
+    failure_classification: str | None = None,
+) -> bool:
     with result._status_lock:
         if result.status in _TERMINAL_STATUSES:
             return False
         result.status = status
         result.error = error
+        result.failure_classification = failure_classification
         result.completed_at = datetime.now()
         return True
 
@@ -94,6 +102,7 @@ def _mark_execution_complete(result: SubagentResult) -> None:
         if result.cancel_event.is_set():
             result.status = SubagentStatus.CANCELLED
             result.error = result.error or "Cancelled by user"
+            result.failure_classification = "cancelled"
         else:
             result.status = SubagentStatus.COMPLETED
         result.completed_at = datetime.now()
@@ -264,7 +273,7 @@ class SubagentExecutor:
             final_state = None
 
             if result.cancel_event.is_set():
-                _mark_terminal(result, SubagentStatus.CANCELLED, "Cancelled by user")
+                _mark_terminal(result, SubagentStatus.CANCELLED, "Cancelled by user", "cancelled")
                 return result
 
             async for chunk in agent.astream(
@@ -274,7 +283,7 @@ class SubagentExecutor:
                 stream_mode="values",
             ):
                 if result.cancel_event.is_set():
-                    _mark_terminal(result, SubagentStatus.CANCELLED, "Cancelled by user")
+                    _mark_terminal(result, SubagentStatus.CANCELLED, "Cancelled by user", "cancelled")
                     return result
 
                 final_state = chunk
@@ -312,12 +321,25 @@ class SubagentExecutor:
                     result.result = "No response generated"
 
             _mark_execution_complete(result)
+        except GraphRecursionError as exc:
+            logger.warning("[trace=%s] Subagent %s reached its recursion limit", self.trace_id, self.config.name)
+            _mark_terminal(
+                result,
+                SubagentStatus.FAILED,
+                str(exc),
+                "recursion_limit",
+            )
         except Exception as e:
             logger.exception("[trace=%s] Subagent %s async execution failed", self.trace_id, self.config.name)
             if result.cancel_event.is_set():
-                _mark_terminal(result, SubagentStatus.CANCELLED, result.error or "Cancelled by user")
+                _mark_terminal(
+                    result,
+                    SubagentStatus.CANCELLED,
+                    result.error or "Cancelled by user",
+                    "cancelled",
+                )
             else:
-                _mark_terminal(result, SubagentStatus.FAILED, str(e))
+                _mark_terminal(result, SubagentStatus.FAILED, str(e), "subagent_failed")
 
         return result
 
@@ -333,7 +355,12 @@ class SubagentExecutor:
             try:
                 return await execution_task
             except asyncio.CancelledError:
-                _mark_terminal(result_holder, SubagentStatus.CANCELLED, result_holder.error or "Cancelled by user")
+                _mark_terminal(
+                    result_holder,
+                    SubagentStatus.CANCELLED,
+                    result_holder.error or "Cancelled by user",
+                    "cancelled",
+                )
                 return result_holder
             finally:
                 with result_holder._handle_lock:
@@ -356,13 +383,14 @@ class SubagentExecutor:
                 result_holder.cancel_event.set()
                 result_holder.status = SubagentStatus.TIMED_OUT
                 result_holder.error = timeout_error
+                result_holder.failure_classification = "subagent_timeout"
                 result_holder.completed_at = datetime.now()
             _cancel_running_coroutine(result_holder, force=True)
             future.cancel()
             return result_holder
         except Exception as exc:
             logger.exception("[trace=%s] Subagent %s execution wrapper failed", self.trace_id, self.config.name)
-            _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc))
+            _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc), "subagent_failed")
             return result_holder
 
     def _execute_on_running_loop(
@@ -386,6 +414,7 @@ class SubagentExecutor:
                     result_holder,
                     SubagentStatus.TIMED_OUT,
                     f"Subagent timed out after {self.config.timeout_seconds} seconds",
+                    "subagent_timeout",
                 )
                 return result_holder
             except asyncio.CancelledError:
@@ -393,6 +422,7 @@ class SubagentExecutor:
                     result_holder,
                     SubagentStatus.CANCELLED,
                     result_holder.error or "Cancelled by user",
+                    "cancelled",
                 )
                 raise
             except Exception as exc:
@@ -401,7 +431,7 @@ class SubagentExecutor:
                     self.trace_id,
                     self.config.name,
                 )
-                _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc))
+                _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc), "subagent_failed")
                 return result_holder
 
         execution_task = loop.create_task(run())
@@ -415,6 +445,7 @@ class SubagentExecutor:
                     result_holder,
                     SubagentStatus.CANCELLED,
                     result_holder.error or "Cancelled by user",
+                    "cancelled",
                 )
             else:
                 exception = completed_task.exception()
@@ -425,7 +456,7 @@ class SubagentExecutor:
                         self.config.name,
                         exc_info=(type(exception), exception, exception.__traceback__),
                     )
-                    _mark_terminal(result_holder, SubagentStatus.FAILED, str(exception))
+                    _mark_terminal(result_holder, SubagentStatus.FAILED, str(exception), "subagent_failed")
             with result_holder._handle_lock:
                 if result_holder._asyncio_task is completed_task:
                     result_holder._asyncio_task = None
@@ -467,7 +498,7 @@ class SubagentExecutor:
                 final_result = future.result()
             except Exception as exc:
                 logger.exception("[trace=%s] Subagent execution future failed", self.trace_id)
-                _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc))
+                _mark_terminal(result_holder, SubagentStatus.FAILED, str(exc), "subagent_failed")
                 return
 
             with _background_tasks_lock:

--- a/backend/packages/harness/deerflow/tools/bound_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/bound_compile_tools.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from langchain.tools import tool
 
 from deerflow.compile.evidence import allowed_command_role, new_evidence_id, record_experiment_event
-from deerflow.compile.operations import get_bound_session, get_compile_services, resolve_command_role, submit_build_result_impl
+from deerflow.compile.operations import get_bound_session, get_compile_services, infer_command_roles, resolve_command_role, submit_build_result_impl
 from deerflow.compile.schemas import BuildCommandRecord, CommandResult, CompileSession, utc_now_iso
 
 _MAX_OUTPUT_LINES = 50
@@ -21,6 +21,7 @@ _POST_BUILD_FORBIDDEN_ROLES = {
     "dependency_setup",
     "configure",
     "build",
+    "housekeeping",
     "replay_delay",
 }
 
@@ -130,8 +131,9 @@ def _post_build_rejection(session: CompileSession, *, command: str, command_role
     _reload_session(session)
     if session.post_build_supporting_command_id is None:
         return None
-    if command_role in _POST_BUILD_FORBIDDEN_ROLES:
-        return "A successful build already entered the post-build phase; configure, build, dependency, and replay commands are now blocked. Stage artifacts or submit the existing build."
+    command_roles = infer_command_roles(command) | {command_role}
+    if command_roles & _POST_BUILD_FORBIDDEN_ROLES:
+        return "A successful build already entered the post-build phase; configure, build, housekeeping, dependency, and replay commands are now blocked. Stage artifacts or submit the existing build."
     if command_role != "artifact_stage" and (session.post_build_commands_remaining or 0) <= 0:
         return "The bounded post-build inspection budget is exhausted. Stage final outputs into /artifacts or submit the existing build."
     return None
@@ -164,16 +166,24 @@ def _submit_with_post_build_phase(
 ) -> str:
     _reload_session(session)
     supporting_command_id = supporting_command_id or session.post_build_supporting_command_id
-    if supporting_command_id is None:
-        result = submit_build_result_impl(session=session)
-    else:
-        result = submit_build_result_impl(
-            session=session,
-            supporting_command_id=supporting_command_id,
-        )
+    had_post_build_phase = session.post_build_supporting_command_id is not None
+    try:
+        if supporting_command_id is None:
+            result = submit_build_result_impl(session=session)
+        else:
+            result = submit_build_result_impl(
+                session=session,
+                supporting_command_id=supporting_command_id,
+            )
+    except Exception:
+        if had_post_build_phase:
+            _clear_post_build_phase(session, reason="submit_error")
+        raise
     try:
         payload = json.loads(result)
     except (TypeError, json.JSONDecodeError):
+        if had_post_build_phase:
+            _clear_post_build_phase(session, reason="submit_invalid_response")
         return result
     if payload.get("status") != "passed" and session.post_build_supporting_command_id is not None:
         _clear_post_build_phase(session, reason="submit_failed")
@@ -187,7 +197,7 @@ def _maybe_submit_staged_artifacts(
     message: str,
     record: BuildCommandRecord,
 ) -> str:
-    if result.exit_code != 0 or record.role != "artifact_stage":
+    if result.exit_code != 0 or record.role not in {"artifact_stage", "build"}:
         return message
     _reload_session(session)
     supporting_command_id = session.post_build_supporting_command_id

--- a/backend/packages/harness/deerflow/tools/bound_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/bound_compile_tools.py
@@ -1,16 +1,28 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 from collections import deque
+from pathlib import Path
 
 from langchain.tools import tool
 
-from deerflow.compile.evidence import allowed_command_role, new_evidence_id
-from deerflow.compile.operations import get_bound_session, get_compile_services, submit_build_result_impl
+from deerflow.compile.evidence import allowed_command_role, new_evidence_id, record_experiment_event
+from deerflow.compile.operations import get_bound_session, get_compile_services, resolve_command_role, submit_build_result_impl
 from deerflow.compile.schemas import BuildCommandRecord, CommandResult, CompileSession, utc_now_iso
 
 _MAX_OUTPUT_LINES = 50
+_MAX_POST_BUILD_NON_STAGING_COMMANDS = 2
+_POLICY_REJECTED_EXIT_CODE = 126
+_POST_BUILD_FORBIDDEN_ROLES = {
+    "clone",
+    "inspect",
+    "dependency_setup",
+    "configure",
+    "build",
+    "replay_delay",
+}
 
 
 def _truncate_output_tail(output: str, max_lines: int = _MAX_OUTPUT_LINES) -> str:
@@ -38,6 +50,7 @@ def _record_bash_command(
     timeout_seconds: int,
     duration_seconds: float,
     timed_out: bool,
+    termination: str | None = None,
 ) -> BuildCommandRecord:
     services = get_compile_services()
     record = BuildCommandRecord(
@@ -49,7 +62,7 @@ def _record_bash_command(
         timeout_seconds=timeout_seconds,
         duration_seconds=duration_seconds,
         timed_out=timed_out,
-        termination="timeout" if timed_out else ("failed" if exit_code != 0 else "completed"),
+        termination=termination or ("timeout" if timed_out else ("failed" if exit_code != 0 else "completed")),
         started_at=started_at,
         completed_at=completed_at,
         exit_code=exit_code,
@@ -59,6 +72,150 @@ def _record_bash_command(
     return record
 
 
+def _reload_session(session: CompileSession) -> CompileSession:
+    services = get_compile_services()
+    try:
+        current = services.manager.load_session(session.session_id, session.thread_id)
+    except (OSError, TypeError, ValueError):
+        return session
+    session.__dict__.update(current.__dict__)
+    return session
+
+
+def _set_post_build_phase(session: CompileSession, supporting_command_id: str) -> None:
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _reload_session(session)
+        current.post_build_supporting_command_id = supporting_command_id
+        current.post_build_started_at = utc_now_iso()
+        current.post_build_commands_remaining = _MAX_POST_BUILD_NON_STAGING_COMMANDS
+        services.manager.save_session(current)
+        session.__dict__.update(current.__dict__)
+    services.manager.log_event(
+        session,
+        "post_build.started",
+        supporting_command_id=supporting_command_id,
+        commands_remaining=_MAX_POST_BUILD_NON_STAGING_COMMANDS,
+    )
+    record_experiment_event(
+        session.thread_id,
+        "postbuild.started",
+        session_id=session.session_id,
+        supporting_command_id=supporting_command_id,
+        commands_remaining=_MAX_POST_BUILD_NON_STAGING_COMMANDS,
+    )
+
+
+def _clear_post_build_phase(session: CompileSession, *, reason: str) -> None:
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _reload_session(session)
+        supporting_command_id = current.post_build_supporting_command_id
+        current.post_build_supporting_command_id = None
+        current.post_build_started_at = None
+        current.post_build_commands_remaining = None
+        services.manager.save_session(current)
+        session.__dict__.update(current.__dict__)
+    services.manager.log_event(
+        session,
+        "post_build.released",
+        supporting_command_id=supporting_command_id,
+        reason=reason,
+    )
+
+
+def _post_build_rejection(session: CompileSession, *, command: str, command_role: str) -> str | None:
+    if "/repro" in command:
+        return "Compiler commands may not read or write /repro; replay is controlled by the acceptance service."
+    _reload_session(session)
+    if session.post_build_supporting_command_id is None:
+        return None
+    if command_role in _POST_BUILD_FORBIDDEN_ROLES:
+        return "A successful build already entered the post-build phase; configure, build, dependency, and replay commands are now blocked. Stage artifacts or submit the existing build."
+    if command_role != "artifact_stage" and (session.post_build_commands_remaining or 0) <= 0:
+        return "The bounded post-build inspection budget is exhausted. Stage final outputs into /artifacts or submit the existing build."
+    return None
+
+
+def _consume_post_build_budget(session: CompileSession, *, command_role: str) -> None:
+    if command_role == "artifact_stage":
+        return
+    services = get_compile_services()
+    with services.manager.session_lock(session.thread_id, session.session_id):
+        current = _reload_session(session)
+        if current.post_build_supporting_command_id is None or current.post_build_commands_remaining is None:
+            return
+        current.post_build_commands_remaining = max(0, current.post_build_commands_remaining - 1)
+        services.manager.save_session(current)
+        session.__dict__.update(current.__dict__)
+
+
+def _has_staged_artifacts(session: CompileSession) -> bool:
+    artifacts_dir = Path(session.leadagent_artifacts_dir)
+    if not artifacts_dir.is_dir():
+        return False
+    return any(path.is_file() and not path.is_symlink() for path in artifacts_dir.rglob("*"))
+
+
+def _submit_with_post_build_phase(
+    session: CompileSession,
+    *,
+    supporting_command_id: str | None = None,
+) -> str:
+    _reload_session(session)
+    supporting_command_id = supporting_command_id or session.post_build_supporting_command_id
+    if supporting_command_id is None:
+        result = submit_build_result_impl(session=session)
+    else:
+        result = submit_build_result_impl(
+            session=session,
+            supporting_command_id=supporting_command_id,
+        )
+    try:
+        payload = json.loads(result)
+    except (TypeError, json.JSONDecodeError):
+        return result
+    if payload.get("status") != "passed" and session.post_build_supporting_command_id is not None:
+        _clear_post_build_phase(session, reason="submit_failed")
+    return result
+
+
+def _maybe_submit_staged_artifacts(
+    *,
+    session: CompileSession,
+    result: CommandResult,
+    message: str,
+    record: BuildCommandRecord,
+) -> str:
+    if result.exit_code != 0 or record.role != "artifact_stage":
+        return message
+    _reload_session(session)
+    supporting_command_id = session.post_build_supporting_command_id
+    if supporting_command_id is None or not _has_staged_artifacts(session):
+        return message
+    submit_result = _submit_with_post_build_phase(
+        session,
+        supporting_command_id=supporting_command_id,
+    )
+    try:
+        submit_payload = json.loads(submit_result)
+    except (TypeError, json.JSONDecodeError):
+        return message
+    return json.dumps(
+        {
+            "command": {
+                "command_id": record.command_id,
+                "command_role": record.role,
+                "exit_code": result.exit_code,
+                "message": message,
+            },
+            "automatic_submit": submit_payload,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
 def _run_container_bash_impl(
     *,
     session: CompileSession,
@@ -66,12 +223,73 @@ def _run_container_bash_impl(
     timeout_seconds: int = 1200,
     workdir: str | None = None,
     command_role: str = "other",
-) -> tuple[CommandResult, str]:
+) -> tuple[CommandResult, str, BuildCommandRecord]:
     services = get_compile_services()
     effective_workdir = workdir or "/workspace/repo"
-    effective_role = allowed_command_role(command_role)
+    declared_role = allowed_command_role(command_role)
+    effective_role, inferred_role = resolve_command_role(command, declared_role)
     command_id = new_evidence_id("command")
     log_path = str(services.manager.local_logs_dir(session) / f"{len(session.commands) + 1:03d}_bash.log")
+
+    services.manager.log_event(
+        session,
+        "command.role_resolved",
+        command_id=command_id,
+        declared_role=declared_role,
+        inferred_role=inferred_role,
+        effective_role=effective_role,
+        corrected=effective_role != declared_role,
+    )
+    record_experiment_event(
+        session.thread_id,
+        "command.role_resolved",
+        command_id=command_id,
+        session_id=session.session_id,
+        declared_role=declared_role,
+        inferred_role=inferred_role,
+        effective_role=effective_role,
+        corrected=effective_role != declared_role,
+    )
+
+    rejection = _post_build_rejection(
+        session,
+        command=command,
+        command_role=effective_role,
+    )
+    if rejection is not None:
+        now = utc_now_iso()
+        record = _record_bash_command(
+            session=session,
+            command=command,
+            workdir=effective_workdir,
+            started_at=now,
+            completed_at=now,
+            exit_code=_POLICY_REJECTED_EXIT_CODE,
+            log_path=log_path,
+            command_id=command_id,
+            command_role=effective_role,
+            timeout_seconds=timeout_seconds,
+            duration_seconds=0.0,
+            timed_out=False,
+            termination="policy_rejected",
+        )
+        services.manager.log_event(
+            session,
+            "post_build.command_rejected",
+            command_id=command_id,
+            command_role=effective_role,
+            reason=rejection,
+        )
+        result = CommandResult(
+            exit_code=_POLICY_REJECTED_EXIT_CODE,
+            stdout="",
+            stderr=rejection,
+            combined_output=rejection,
+            log_path=log_path,
+        )
+        return result, f"command_id={command_id}\ncommand_role={effective_role}\nexit_code={_POLICY_REJECTED_EXIT_CODE} (Policy rejected)\nworkdir={effective_workdir}\nerror: {rejection}", record
+
+    _consume_post_build_budget(session, command_role=effective_role)
 
     services.manager.log_event(
         session,
@@ -97,7 +315,7 @@ def _run_container_bash_impl(
     except subprocess.TimeoutExpired as exc:
         completed_at = utc_now_iso()
         timeout_message = _build_timeout_message(command, timeout_seconds)
-        _record_bash_command(
+        record = _record_bash_command(
             session=session,
             command=command,
             workdir=effective_workdir,
@@ -133,10 +351,10 @@ def _run_container_bash_impl(
             combined_output=combined_output or timeout_message,
             log_path=log_path,
         )
-        return result, message
+        return result, message, record
 
     completed_at = utc_now_iso()
-    _record_bash_command(
+    record = _record_bash_command(
         session=session,
         command=command,
         workdir=effective_workdir,
@@ -164,7 +382,9 @@ def _run_container_bash_impl(
         command_role=effective_role,
     )
     message = f"command_id={command_id}\ncommand_role={effective_role}\nexit_code={result.exit_code}\nworkdir={effective_workdir}\nlog_path={log_path}\noutput_tail:\n{truncated_output}"
-    return result, message
+    if result.exit_code == 0 and effective_role == "build":
+        _set_post_build_phase(session, record.command_id)
+    return result, message, record
 
 
 @tool("run_container_bash", parse_docstring=True)
@@ -191,14 +411,19 @@ def run_container_bash(
         command_role: Evidence role: configure, build, artifact_stage, smoke, or other.
     """
     session = get_bound_session(session_id=session_id, thread_id=thread_id)
-    _, message = _run_container_bash_impl(
+    result, message, record = _run_container_bash_impl(
         session=session,
         command=command,
         timeout_seconds=timeout_seconds,
         workdir=workdir,
         command_role=command_role,
     )
-    return message
+    return _maybe_submit_staged_artifacts(
+        session=session,
+        result=result,
+        message=message,
+        record=record,
+    )
 
 
 @tool("submit_build_result", parse_docstring=True)
@@ -215,9 +440,7 @@ def submit_build_result(
         supporting_command_id: Stable ID of the successful build command supporting this submission.
     """
     session = get_bound_session(session_id=session_id, thread_id=thread_id)
-    if supporting_command_id is None:
-        return submit_build_result_impl(session=session)
-    return submit_build_result_impl(
+    return _submit_with_post_build_phase(
         session=session,
         supporting_command_id=supporting_command_id,
     )
@@ -239,14 +462,19 @@ def get_bound_compile_tools(session: CompileSession):
             workdir: Optional absolute working directory inside the compile container.
             command_role: Evidence role: configure, build, artifact_stage, smoke, or other.
         """
-        _, message = _run_container_bash_impl(
+        result, message, record = _run_container_bash_impl(
             session=session,
             command=command,
             timeout_seconds=timeout_seconds,
             workdir=workdir,
             command_role=command_role,
         )
-        return message
+        return _maybe_submit_staged_artifacts(
+            session=session,
+            result=result,
+            message=message,
+            record=record,
+        )
 
     @tool("submit_build_result", parse_docstring=True)
     def bound_submit_build_result(supporting_command_id: str | None = None) -> str:
@@ -255,9 +483,7 @@ def get_bound_compile_tools(session: CompileSession):
         Args:
             supporting_command_id: Stable ID of the successful build command supporting this submission.
         """
-        if supporting_command_id is None:
-            return submit_build_result_impl(session=session)
-        return submit_build_result_impl(
+        return _submit_with_post_build_phase(
             session=session,
             supporting_command_id=supporting_command_id,
         )

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -14,7 +14,7 @@ from langgraph.typing import ContextT
 
 from deerflow.agents.lead_agent.prompt import get_skills_prompt_section
 from deerflow.agents.thread_state import ThreadState
-from deerflow.compile.evidence import ExperimentPolicy
+from deerflow.compile.evidence import ExperimentPolicy, new_evidence_id, record_experiment_event
 from deerflow.subagents import SubagentExecutor, get_available_subagent_names, get_subagent_config
 from deerflow.subagents.executor import (
     SubagentStatus,
@@ -30,6 +30,39 @@ from deerflow.tools.builtins.agent_compile_tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _record_subagent_terminal_evidence(
+    *,
+    thread_id: str | None,
+    task_id: str,
+    subagent_type: str,
+    status: str,
+    classification: str | None,
+    worker_stopped: bool,
+) -> None:
+    if subagent_type != "compiler":
+        return
+    record_experiment_event(
+        thread_id,
+        "agent.subagent_terminated",
+        task_id=task_id,
+        role="compiler",
+        status=status,
+        classification=classification,
+        worker_stopped=worker_stopped,
+    )
+    if status == "completed":
+        return
+    record_experiment_event(
+        thread_id,
+        "failure.recorded",
+        failure_id=new_evidence_id("failure"),
+        domain="agent_tool",
+        classification=classification or "subagent_failed",
+        primary=True,
+        secondary_classifications=([] if worker_stopped else ["worker_shutdown_incomplete"]),
+    )
 
 
 def _apply_max_turns_override(config, *, subagent_type: str, requested_max_turns: int | None):
@@ -53,6 +86,7 @@ def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
         [
             "- Set command_role on every run_container_bash call; use configure for configuration and build for the successful command that supports final acceptance.",
             "- Pass that successful build command's returned command_id as supporting_command_id to submit_build_result.",
+            "- Do not write /repro or run a manual replay. After the first successful build, use only bounded smoke/artifact staging work; staging into /artifacts may submit automatically in the same tool call.",
         ]
     )
     return f"{prompt.rstrip()}\n\n" + "\n".join(requirements)
@@ -286,7 +320,7 @@ async def task_tool(
             if result is None:
                 logger.error(f"[trace={trace_id}] Task {task_id} not found in background tasks")
                 writer({"type": "task_failed", "task_id": task_id, "error": "Task disappeared from background tasks"})
-                await _cancel_and_reap_task(
+                worker_stopped = await _cancel_and_reap_task(
                     task_id=task_id,
                     subagent_type=subagent_type,
                     compile_state=compile_state,
@@ -294,6 +328,14 @@ async def task_tool(
                     terminal_status="failed",
                     error="Compiler task disappeared from background task tracking.",
                     shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="failed",
+                    classification="tracking_lost",
+                    worker_stopped=worker_stopped,
                 )
                 return f"Error: Task {task_id} disappeared from background tasks"
 
@@ -320,12 +362,22 @@ async def task_tool(
             if result.status == SubagentStatus.COMPLETED:
                 writer({"type": "task_completed", "task_id": task_id, "result": result.result})
                 logger.info(f"[trace={trace_id}] Task {task_id} completed after {poll_count} polls")
+                shutdown_result = wait_for_background_task_shutdown(task_id, shutdown_timeout_seconds)
+                worker_stopped = await shutdown_result if inspect.isawaitable(shutdown_result) else bool(shutdown_result)
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="completed",
+                    classification=None,
+                    worker_stopped=worker_stopped,
+                )
                 cleanup_background_task(task_id)
                 return f"Task Succeeded. Result: {result.result}"
             elif result.status == SubagentStatus.FAILED:
                 writer({"type": "task_failed", "task_id": task_id, "error": result.error})
                 logger.error(f"[trace={trace_id}] Task {task_id} failed: {result.error}")
-                await _cancel_and_reap_task(
+                worker_stopped = await _cancel_and_reap_task(
                     task_id=task_id,
                     subagent_type=subagent_type,
                     compile_state=compile_state,
@@ -334,11 +386,19 @@ async def task_tool(
                     error=result.error or "Compiler task failed.",
                     shutdown_timeout_seconds=shutdown_timeout_seconds,
                 )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="failed",
+                    classification=getattr(result, "failure_classification", None) or "subagent_failed",
+                    worker_stopped=worker_stopped,
+                )
                 return f"Task failed. Error: {result.error}"
             elif result.status == SubagentStatus.CANCELLED:
                 writer({"type": "task_cancelled", "task_id": task_id, "error": result.error})
                 logger.info(f"[trace={trace_id}] Task {task_id} cancelled: {result.error}")
-                await _cancel_and_reap_task(
+                worker_stopped = await _cancel_and_reap_task(
                     task_id=task_id,
                     subagent_type=subagent_type,
                     compile_state=compile_state,
@@ -347,11 +407,19 @@ async def task_tool(
                     error=result.error or "Compiler task cancelled by user.",
                     shutdown_timeout_seconds=shutdown_timeout_seconds,
                 )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="cancelled",
+                    classification=getattr(result, "failure_classification", None) or "cancelled",
+                    worker_stopped=worker_stopped,
+                )
                 return "Task cancelled by user."
             elif result.status == SubagentStatus.TIMED_OUT:
                 writer({"type": "task_timed_out", "task_id": task_id, "error": result.error})
                 logger.warning(f"[trace={trace_id}] Task {task_id} timed out: {result.error}")
-                await _cancel_and_reap_task(
+                worker_stopped = await _cancel_and_reap_task(
                     task_id=task_id,
                     subagent_type=subagent_type,
                     compile_state=compile_state,
@@ -359,6 +427,14 @@ async def task_tool(
                     terminal_status="timed_out",
                     error=result.error or "Compiler task timed out.",
                     shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="timed_out",
+                    classification=getattr(result, "failure_classification", None) or "subagent_timeout",
+                    worker_stopped=worker_stopped,
                 )
                 return f"Task timed out. Error: {result.error}"
 
@@ -369,7 +445,7 @@ async def task_tool(
                 timeout_minutes = config.timeout_seconds // 60
                 logger.error(f"[trace={trace_id}] Task {task_id} polling timed out after {poll_count} polls (should have been caught by thread pool timeout)")
                 writer({"type": "task_timed_out", "task_id": task_id})
-                await _cancel_and_reap_task(
+                worker_stopped = await _cancel_and_reap_task(
                     task_id=task_id,
                     subagent_type=subagent_type,
                     compile_state=compile_state,
@@ -378,9 +454,17 @@ async def task_tool(
                     error=f"Compiler task polling timed out after {timeout_minutes} minutes.",
                     shutdown_timeout_seconds=shutdown_timeout_seconds,
                 )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="timed_out",
+                    classification="polling_timeout",
+                    worker_stopped=worker_stopped,
+                )
                 return f"Task polling timed out after {timeout_minutes} minutes. This may indicate the background task is stuck. Status: {result.status.value}"
     except asyncio.CancelledError:
-        await _cancel_and_reap_task(
+        worker_stopped = await _cancel_and_reap_task(
             task_id=task_id,
             subagent_type=subagent_type,
             compile_state=compile_state,
@@ -388,5 +472,13 @@ async def task_tool(
             terminal_status="cancelled",
             error="Compiler task cancelled with its parent run.",
             shutdown_timeout_seconds=shutdown_timeout_seconds,
+        )
+        _record_subagent_terminal_evidence(
+            thread_id=thread_id,
+            task_id=task_id,
+            subagent_type=subagent_type,
+            status="cancelled",
+            classification="parent_cancelled",
+            worker_stopped=worker_stopped,
         )
         raise

--- a/backend/tests/test_compile_cancellation.py
+++ b/backend/tests/test_compile_cancellation.py
@@ -63,6 +63,16 @@ class BlockingAgent:
             self.stopped.set()
 
 
+class RecursionLimitAgent:
+    async def astream(self, *args, **kwargs):
+        del args, kwargs
+        if False:
+            yield {}
+        from langgraph.errors import GraphRecursionError
+
+        raise GraphRecursionError("recursion limit reached")
+
+
 def make_executor(executor_module, *, timeout_seconds: int, started: threading.Event, stopped: threading.Event):
     executor = executor_module.SubagentExecutor(
         config=SubagentConfig(
@@ -121,6 +131,7 @@ def test_background_subagent_timeout_cannot_be_overwritten_by_late_completion(re
 
         assert result is not None
         assert result.status == real_executor_module.SubagentStatus.TIMED_OUT
+        assert result.failure_classification == "subagent_timeout"
         assert await real_executor_module.wait_for_background_task_shutdown(task_id, 3)
         await asyncio.sleep(0.05)
         assert result.status == real_executor_module.SubagentStatus.TIMED_OUT
@@ -128,6 +139,52 @@ def test_background_subagent_timeout_cannot_be_overwritten_by_late_completion(re
         real_executor_module.cleanup_background_task(task_id)
 
     asyncio.run(scenario())
+
+
+def test_subagent_recursion_limit_has_a_stable_failure_classification(real_executor_module):
+    started = threading.Event()
+    stopped = threading.Event()
+    executor = make_executor(real_executor_module, timeout_seconds=30, started=started, stopped=stopped)
+    executor._create_agent = lambda: RecursionLimitAgent()
+
+    result = asyncio.run(executor._aexecute("reach the graph limit"))
+
+    assert result.status == real_executor_module.SubagentStatus.FAILED
+    assert result.failure_classification == "recursion_limit"
+
+
+def test_compiler_terminal_evidence_records_bounded_failure_domain(monkeypatch):
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        task_tool_module,
+        "record_experiment_event",
+        lambda _thread_id, event, **payload: events.append((event, payload)),
+    )
+    monkeypatch.setattr(task_tool_module, "new_evidence_id", lambda _prefix: "failure_" + "a" * 32)
+
+    task_tool_module._record_subagent_terminal_evidence(
+        thread_id="thread-123",
+        task_id="task-123",
+        subagent_type="compiler",
+        status="timed_out",
+        classification="subagent_timeout",
+        worker_stopped=True,
+    )
+
+    assert [event for event, _payload in events] == [
+        "agent.subagent_terminated",
+        "failure.recorded",
+    ]
+    assert events[0][1] == {
+        "task_id": "task-123",
+        "role": "compiler",
+        "status": "timed_out",
+        "classification": "subagent_timeout",
+        "worker_stopped": True,
+    }
+    assert events[1][1]["domain"] == "agent_tool"
+    assert events[1][1]["classification"] == "subagent_timeout"
+    assert events[1][1]["secondary_classifications"] == []
 
 
 def test_timeout_terminal_transition_blocks_boundary_completion(real_executor_module):

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -7,6 +7,7 @@ the autocompiler:gcc13 image. The default backend test suite skips this file.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import subprocess
@@ -20,14 +21,29 @@ from deerflow.compile import operations
 from deerflow.compile.docker_runtime import CompileDockerRuntime
 from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
 from deerflow.compile.manager import CompileSessionManager
-from deerflow.compile.operations import CompileOperationsServices, _classify_compiled_artifact, _write_repro_bundle, clone_repository_impl, finalize_unfinished_thread_sessions_impl, verify_clean_replay_impl
+from deerflow.compile.operations import (
+    CompileOperationsServices,
+    _classify_compiled_artifact,
+    _write_repro_bundle,
+    cleanup_and_finalize_compile_session_impl,
+    clone_repository_impl,
+    finalize_unfinished_thread_sessions_impl,
+    inspect_build_system_impl,
+    verify_clean_replay_impl,
+)
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
 from deerflow.config.paths import Paths
+from deerflow.tools import bound_compile_tools
 from deerflow.tools.builtins import agent_compile_tools
 
 REPO_URL = "https://github.com/MattClarkson/CMakeHelloWorld.git"
 COMMIT_SHA = "6fda0b169299b1241ed883c8d4af8519da30ce52"
+HIREDIS_REPO_URL = "https://github.com/redis/hiredis"
+HIREDIS_COMMIT_SHA = "60e5075d4ac77424809f855ba3e398df7aacefe8"
+LIBCHECK_REPO_URL = "https://github.com/libcheck/check"
+LIBCHECK_COMMIT_SHA = "11970a7e112dfe243a2e68773f014687df2900e8"
 COMPILE_IMAGE = "autocompiler:gcc13"
+COMPILE_IMAGE_ID = "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554"
 DOCKER_INTEGRATION_ENABLED = os.getenv("FORGE_RUN_DOCKER_INTEGRATION") == "1"
 
 pytestmark = pytest.mark.skipif(
@@ -192,6 +208,143 @@ def _assert_no_replay_container(session: CompileSession) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+def _run_post_build_fixture(
+    monkeypatch,
+    *,
+    case_id: str,
+    repo_url: str,
+    commit_sha: str,
+    build_system: str,
+    required_system_packages: tuple[str, ...],
+    dependency_command: str | None,
+    configure_arguments: tuple[str, ...],
+    configure_command: str | None,
+    build_command: str,
+    stage_command: str,
+    expected_marker: str,
+    expected_artifact_names: set[str],
+) -> None:
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-post-build-{case_id}-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=repo_url,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    ledger = ExperimentLedger.create(
+        Path(session.metadata_path).parent / f"{case_id}.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-post-build-e2e",
+        manifest_sha256="4" * 64,
+        case_id=case_id,
+        condition="non-pilot-integration",
+        repetition=1,
+        expected_repo_url=repo_url,
+        expected_commit_sha=commit_sha,
+        expected_build_system=build_system,
+        compile_image=COMPILE_IMAGE,
+        image_id=COMPILE_IMAGE_ID,
+        model_name="deterministic-tools",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=300,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=required_system_packages,
+        cmake_arguments=(),
+        configure_arguments=configure_arguments,
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        clone_result, _message = clone_repository_impl(
+            session=session,
+            repo_url=repo_url,
+            max_retries=3,
+        )
+        assert clone_result.exit_code == 0, clone_result.combined_output
+        assert session.commit_sha == commit_sha
+
+        identify_result = agent_compile_tools.identify_build_system.func(
+            runtime=SimpleNamespace(
+                state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+                context={"thread_id": thread_id},
+                config={"configurable": {}},
+            ),
+            tool_call_id=f"tool-identify-{case_id}",
+        )
+        assert identify_result.update.get("compile_terminal") is not True
+        selected = manager.load_session(session.session_id, thread_id)
+        assert selected.selected_build_system == build_system
+        assert build_system in selected.build_system_capabilities
+        assert (Path(selected.leadagent_repo_dir) / expected_marker).is_file()
+
+        run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
+        if dependency_command is not None:
+            dependency_setup = run_tool.func(
+                command=dependency_command,
+                command_role="dependency_setup",
+            )
+            assert "command_role=dependency_setup" in dependency_setup
+            assert "exit_code=0\n" in dependency_setup, dependency_setup
+        if configure_command is not None:
+            configured = run_tool.func(
+                command=configure_command,
+                command_role="other",
+            )
+            assert "command_role=configure" in configured
+            assert "exit_code=0\n" in configured, configured
+
+        built = run_tool.func(
+            command=build_command,
+            command_role="other",
+        )
+        assert "command_role=build" in built
+        assert "exit_code=0\n" in built, built
+        staged = json.loads(
+            run_tool.func(
+                command=stage_command,
+                command_role="other",
+            )
+        )
+        assert staged["command"]["command_role"] == "artifact_stage"
+        assert staged["automatic_submit"]["status"] == "passed"
+        assert staged["automatic_submit"]["replay_status"] == "passed"
+
+        finalized, cleanup = cleanup_and_finalize_compile_session_impl(session=session)
+        assert cleanup.succeeded is True
+        assert cleanup.removed is True
+        assert finalized.status == "completed"
+        assert finalized.selected_build_system == build_system
+        assert finalized.executed_build_system == build_system
+        assert {Path(artifact.path).name for artifact in finalized.artifacts} == expected_artifact_names
+        assert ExperimentLedger.verify_path(ledger.path)[-1]["event"] == "delivery.completed"
+        _assert_no_replay_container(finalized)
+    finally:
+        deactivate_experiment(thread_id)
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
 
 
 def _run_replay_scenario(monkeypatch, *, failed_configure_side_effect: bool):
@@ -406,6 +559,108 @@ def test_build_system_mismatch_stops_before_real_compiler_delegation(monkeypatch
         deactivate_experiment(thread_id)
         runtime.stop_and_remove_container(session)
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
+def test_post_build_handoff_corrects_role_and_auto_submits_cmake_fixture(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-post-build-handoff-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        clone_result, _message = clone_repository_impl(
+            session=session,
+            repo_url=REPO_URL,
+            max_retries=1,
+        )
+        assert clone_result.exit_code == 0, clone_result.combined_output
+        primary, detected, _suggested = inspect_build_system_impl(session=session)
+        assert primary == "cmake"
+        assert ("cmake", "CMakeLists.txt") in detected
+
+        run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
+        configure_result = run_tool.func(
+            command="cmake -S . -B build",
+            command_role="other",
+        )
+        assert "command_role=configure" in configure_result
+        build_result = run_tool.func(
+            command="cmake --build build --parallel",
+            command_role="other",
+        )
+        assert "command_role=build" in build_result
+
+        post_build = manager.load_session(session.session_id, thread_id)
+        assert post_build.post_build_supporting_command_id is not None
+        rejected = run_tool.func(
+            command="cmake -S . -B build-again",
+            command_role="other",
+        )
+        assert "exit_code=126 (Policy rejected)" in rejected
+
+        staged = json.loads(
+            run_tool.func(
+                command="cp build/hello /artifacts/hello",
+                command_role="other",
+            )
+        )
+        assert staged["command"]["command_role"] == "artifact_stage"
+        assert staged["automatic_submit"]["status"] == "passed"
+        assert staged["automatic_submit"]["replay_status"] == "passed"
+
+        finalized, cleanup = cleanup_and_finalize_compile_session_impl(session=session)
+        assert cleanup.succeeded is True
+        assert cleanup.removed is True
+        assert finalized.status == "completed"
+        assert finalized.finalized_at is not None
+        assert len(finalized.artifacts) == 1
+        _assert_no_replay_container(finalized)
+    finally:
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
+def test_post_build_handoff_auto_submits_make_fixture(monkeypatch):
+    _run_post_build_fixture(
+        monkeypatch,
+        case_id="hiredis-make",
+        repo_url=HIREDIS_REPO_URL,
+        commit_sha=HIREDIS_COMMIT_SHA,
+        build_system="make",
+        required_system_packages=(),
+        dependency_command=None,
+        configure_arguments=(),
+        configure_command=None,
+        build_command="make -j2",
+        stage_command="cp libhiredis.a libhiredis.so /artifacts/",
+        expected_marker="Makefile",
+        expected_artifact_names={"libhiredis.a", "libhiredis.so"},
+    )
+
+
+def test_post_build_handoff_detects_source_autotools_and_auto_submits(monkeypatch):
+    _run_post_build_fixture(
+        monkeypatch,
+        case_id="libcheck-autotools",
+        repo_url=LIBCHECK_REPO_URL,
+        commit_sha=LIBCHECK_COMMIT_SHA,
+        build_system="autotools",
+        required_system_packages=("texinfo",),
+        dependency_command="apt-get update && apt-get install -y --no-install-recommends texinfo",
+        configure_arguments=("--disable-subunit",),
+        configure_command="autoreconf -fi && ./configure --disable-subunit",
+        build_command="make -j2",
+        stage_command="cp src/.libs/libcheck.a /artifacts/libcheck.a",
+        expected_marker="configure.ac",
+        expected_artifact_names={"libcheck.a"},
+    )
 
 
 def test_clean_replay_rebuilds_pinned_cmake_fixture_in_fresh_container(monkeypatch):

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -627,6 +627,56 @@ def test_post_build_handoff_corrects_role_and_auto_submits_cmake_fixture(monkeyp
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
 
 
+def test_post_build_handoff_auto_submits_compound_build_and_stage(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-post-build-compound-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        clone_result, _message = clone_repository_impl(
+            session=session,
+            repo_url=REPO_URL,
+            max_retries=1,
+        )
+        assert clone_result.exit_code == 0, clone_result.combined_output
+        primary, _detected, _suggested = inspect_build_system_impl(session=session)
+        assert primary == "cmake"
+
+        run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
+        configured = run_tool.func(
+            command="cmake -S . -B build",
+            command_role="other",
+        )
+        assert "command_role=configure" in configured
+        submitted = json.loads(
+            run_tool.func(
+                command="cmake --build build --parallel && cp build/hello /artifacts/hello",
+                command_role="other",
+            )
+        )
+        assert submitted["command"]["command_role"] == "build"
+        assert submitted["automatic_submit"]["status"] == "passed"
+        assert submitted["automatic_submit"]["replay_status"] == "passed"
+
+        finalized, cleanup = cleanup_and_finalize_compile_session_impl(session=session)
+        assert cleanup.succeeded is True
+        assert cleanup.removed is True
+        assert finalized.status == "completed"
+        assert {Path(artifact.path).name for artifact in finalized.artifacts} == {"hello"}
+        _assert_no_replay_container(finalized)
+    finally:
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
 def test_post_build_handoff_auto_submits_make_fixture(monkeypatch):
     _run_post_build_fixture(
         monkeypatch,

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -31,6 +31,7 @@ from deerflow.compile.paths import (
 )
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, ReplayArtifactComparison, ReplayVerificationResult, VerificationCheck, VerificationResult
 from deerflow.config.paths import Paths
+from deerflow.tools import bound_compile_tools
 
 VALID_IMAGE_ID = f"sha256:{'1' * 64}"
 
@@ -107,6 +108,114 @@ def test_inspect_build_system_persists_all_repository_capabilities(tmp_path: Pat
     assert reloaded.build_system_capabilities == ["cmake", "make", "autotools"]
     assert reloaded.selected_build_system is None
     assert reloaded.executed_build_system is None
+
+
+@pytest.mark.parametrize(
+    ("marker", "first_suggestion"),
+    [
+        ("configure.ac", "autoreconf -fi && ./configure"),
+        ("configure.in", "autoreconf -fi && ./configure"),
+        ("autogen.sh", "chmod +x ./autogen.sh && ./autogen.sh"),
+    ],
+)
+def test_inspect_build_system_detects_source_autotools_markers(
+    tmp_path: Path,
+    monkeypatch,
+    marker: str,
+    first_suggestion: str,
+) -> None:
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id=f"thread-autotools-{marker.replace('.', '-')}",
+        repo_url="https://example.com/repo.git",
+    )
+    repo_dir = Path(session.leadagent_repo_dir)
+    repo_dir.mkdir(parents=True)
+    (repo_dir / marker).write_text("fixture\n", encoding="utf-8")
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace()),
+    )
+
+    primary, detected, suggested = operations.inspect_build_system_impl(session=session)
+
+    assert primary == "autotools"
+    assert detected == [("autotools", marker)]
+    assert suggested[0] == first_suggestion
+    assert manager.load_session(session.session_id, session.thread_id).build_system_capabilities == ["autotools"]
+
+
+@pytest.mark.parametrize(
+    ("command", "declared", "effective", "inferred"),
+    [
+        ("cmake --build build -j2", "other", "build", "build"),
+        ("make -j2", "other", "build", "build"),
+        ("ninja -C build", "other", "build", "build"),
+        ("cmake -S . -B build", "other", "configure", "configure"),
+        ("autoreconf -fi && ./configure", "other", "configure", "configure"),
+        ("cp build/libexample.a /artifacts/", "other", "artifact_stage", "artifact_stage"),
+        ("make clean", "other", "other", None),
+        ("ninja -C build clean", "build", "other", None),
+        ("cmake --build build --target clean", "build", "other", None),
+        ("make clean all", "other", "build", "build"),
+        ("printf 'not a build'", "build", "other", None),
+        ("find build -type f", "smoke", "smoke", None),
+    ],
+)
+def test_command_role_is_resolved_from_server_side_evidence(
+    command: str,
+    declared: str,
+    effective: str,
+    inferred: str | None,
+) -> None:
+    assert operations.resolve_command_role(command, declared) == (effective, inferred)
+
+
+def test_successful_mislabelled_build_enters_persisted_post_build_fence(tmp_path: Path, monkeypatch) -> None:
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-post-build-fence",
+        repo_url="https://example.com/repo.git",
+    )
+    runtime_calls: list[str] = []
+
+    def fake_exec(_session, command, **kwargs):
+        runtime_calls.append(command)
+        return CommandResult(
+            exit_code=0,
+            stdout="built\n",
+            stderr="",
+            combined_output="built\n",
+            log_path=kwargs.get("log_path"),
+        )
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)),
+    )
+
+    build_result, _message, build_record = bound_compile_tools._run_container_bash_impl(
+        session=session,
+        command="cmake --build build -j2",
+        command_role="other",
+    )
+    rejected_result, _rejected_message, rejected_record = bound_compile_tools._run_container_bash_impl(
+        session=session,
+        command="cmake -S . -B build-again",
+        command_role="other",
+    )
+
+    reloaded = manager.load_session(session.session_id, session.thread_id)
+    assert build_result.exit_code == 0
+    assert build_record.role == "build"
+    assert reloaded.post_build_supporting_command_id == build_record.command_id
+    assert reloaded.post_build_commands_remaining == 2
+    assert rejected_result.exit_code == 126
+    assert rejected_record.role == "configure"
+    assert rejected_record.termination == "policy_rejected"
+    assert runtime_calls == ["cmake --build build -j2"]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -155,6 +155,12 @@ def test_inspect_build_system_detects_source_autotools_markers(
         ("cmake -S . -B build", "other", "configure", "configure"),
         ("autoreconf -fi && ./configure", "other", "configure", "configure"),
         ("cp build/libexample.a /artifacts/", "other", "artifact_stage", "artifact_stage"),
+        ("cmake --install build --prefix /artifacts", "other", "artifact_stage", "artifact_stage"),
+        ("make install DESTDIR=/artifacts", "other", "artifact_stage", "artifact_stage"),
+        ("apt-get install -y texinfo", "other", "dependency_setup", "dependency_setup"),
+        ("make -j2 && cp libexample.a /artifacts/", "other", "build", "build"),
+        ("bash -lc 'apt-get install -y texinfo && make -j2 && cp libexample.a /artifacts/'", "other", "build", "build"),
+        ("make clean && cp old.a /artifacts/", "other", "artifact_stage", "artifact_stage"),
         ("make clean", "other", "other", None),
         ("ninja -C build clean", "build", "other", None),
         ("cmake --build build --target clean", "build", "other", None),
@@ -170,6 +176,23 @@ def test_command_role_is_resolved_from_server_side_evidence(
     inferred: str | None,
 ) -> None:
     assert operations.resolve_command_role(command, declared) == (effective, inferred)
+
+
+def test_compound_command_analysis_retains_every_control_plane_role() -> None:
+    assert operations.infer_command_roles("apt-get install -y texinfo && make -j2 && cp lib.a /artifacts/") == {
+        "dependency_setup",
+        "build",
+        "artifact_stage",
+    }
+    assert operations.infer_command_roles("make clean && cp old.a /artifacts/") == {
+        "housekeeping",
+        "artifact_stage",
+    }
+    assert operations.infer_command_roles("bash -lc 'apt-get install -y texinfo && make -j2 && cp lib.a /artifacts/'") == {
+        "dependency_setup",
+        "build",
+        "artifact_stage",
+    }
 
 
 def test_successful_mislabelled_build_enters_persisted_post_build_fence(tmp_path: Path, monkeypatch) -> None:

--- a/backend/tests/test_compile_terminal_tools.py
+++ b/backend/tests/test_compile_terminal_tools.py
@@ -143,6 +143,114 @@ def test_failed_bound_submit_remains_repairable(monkeypatch):
     assert json.loads(result)["status"] == "failed"
 
 
+def test_staged_artifacts_submit_automatically_in_same_tool_call(monkeypatch):
+    session = make_session()
+    session.status = "inspected"
+    session.post_build_supporting_command_id = "command-build"
+    record = BuildCommandRecord(
+        stage="bash",
+        command="cp build/hello /artifacts/hello",
+        workdir="/workspace/repo",
+        command_id="command-stage",
+        role="artifact_stage",
+        exit_code=0,
+    )
+    command_result = SimpleNamespace(exit_code=0)
+    submitted: list[str | None] = []
+    submit_payload = {
+        "status": "passed",
+        "message": "Build artifacts and clean replay accepted.",
+        "artifacts": [{"path": "thread-123/session-123/artifacts/hello"}],
+    }
+    monkeypatch.setattr(
+        bound_compile_tools,
+        "_run_container_bash_impl",
+        lambda **_kwargs: (command_result, "command completed", record),
+    )
+    monkeypatch.setattr(bound_compile_tools, "_reload_session", lambda current: current)
+    monkeypatch.setattr(bound_compile_tools, "_has_staged_artifacts", lambda _session: True)
+
+    def submit(*, session, supporting_command_id):
+        del session
+        submitted.append(supporting_command_id)
+        return json.dumps(submit_payload)
+
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", submit)
+    run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
+
+    result = json.loads(run_tool.func(command="cp build/hello /artifacts/hello"))
+
+    assert submitted == ["command-build"]
+    assert result["command"]["command_id"] == "command-stage"
+    assert result["automatic_submit"] == submit_payload
+
+
+def test_post_build_fence_blocks_reconfigure_rebuild_and_manual_replay(monkeypatch):
+    session = make_session()
+    session.post_build_supporting_command_id = "command-build"
+    session.post_build_commands_remaining = 2
+    monkeypatch.setattr(bound_compile_tools, "_reload_session", lambda current: current)
+
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="cmake -S . -B build-again",
+        command_role="configure",
+    )
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="make -j2",
+        command_role="build",
+    )
+    assert "/repro" in bound_compile_tools._post_build_rejection(
+        session,
+        command="bash /repro/build.sh",
+        command_role="other",
+    )
+
+    session.post_build_commands_remaining = 0
+    assert "budget is exhausted" in bound_compile_tools._post_build_rejection(
+        session,
+        command="find build -type f",
+        command_role="other",
+    )
+    assert (
+        bound_compile_tools._post_build_rejection(
+            session,
+            command="cp build/hello /artifacts/hello",
+            command_role="artifact_stage",
+        )
+        is None
+    )
+
+
+def test_automatic_submit_ends_compiler_graph_without_another_model_call():
+    payload = {
+        "command": {
+            "command_id": "command-stage",
+            "command_role": "artifact_stage",
+            "exit_code": 0,
+            "message": "command completed",
+        },
+        "automatic_submit": {
+            "status": "passed",
+            "message": "Build artifacts and clean replay accepted.",
+            "artifacts": [{"path": "thread-123/session-123/artifacts/hello"}],
+        },
+    }
+    request = SimpleNamespace(tool_call={"name": "run_container_bash", "id": "tool-stage", "args": {}})
+    tool_message = ToolMessage(
+        content=json.dumps(payload),
+        tool_call_id="tool-stage",
+        name="run_container_bash",
+    )
+
+    terminal = CompileTerminationMiddleware().wrap_tool_call(request, lambda _request: tool_message)
+
+    assert isinstance(terminal, Command)
+    assert terminal.update["compile_terminal"] is True
+    assert json.loads(terminal.update["messages"][-1].content)["verification_status"] == "passed"
+
+
 def test_compile_session_skips_post_run_memory_model_work(monkeypatch):
     monkeypatch.setattr(
         "deerflow.agents.middlewares.memory_middleware.get_memory_queue",

--- a/backend/tests/test_compile_terminal_tools.py
+++ b/backend/tests/test_compile_terminal_tools.py
@@ -184,6 +184,27 @@ def test_staged_artifacts_submit_automatically_in_same_tool_call(monkeypatch):
     assert result["command"]["command_id"] == "command-stage"
     assert result["automatic_submit"] == submit_payload
 
+    record.role = "build"
+    combined_result = json.loads(run_tool.func(command="make -j2 && cp build/hello /artifacts/hello"))
+
+    assert submitted == ["command-build", "command-build"]
+    assert combined_result["command"]["command_role"] == "build"
+    assert combined_result["automatic_submit"] == submit_payload
+
+
+def test_invalid_submit_response_releases_post_build_fence(monkeypatch):
+    session = make_session()
+    session.post_build_supporting_command_id = "command-build"
+    released: list[str] = []
+    monkeypatch.setattr(bound_compile_tools, "_reload_session", lambda current: current)
+    monkeypatch.setattr(bound_compile_tools, "_clear_post_build_phase", lambda _session, *, reason: released.append(reason))
+    monkeypatch.setattr(bound_compile_tools, "submit_build_result_impl", lambda **_kwargs: "not-json")
+
+    result = bound_compile_tools._submit_with_post_build_phase(session)
+
+    assert result == "not-json"
+    assert released == ["submit_invalid_response"]
+
 
 def test_post_build_fence_blocks_reconfigure_rebuild_and_manual_replay(monkeypatch):
     session = make_session()
@@ -200,6 +221,34 @@ def test_post_build_fence_blocks_reconfigure_rebuild_and_manual_replay(monkeypat
         session,
         command="make -j2",
         command_role="build",
+    )
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="make -j2 && cp build/hello /artifacts/hello",
+        command_role="artifact_stage",
+    )
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="make clean && cp build/hello /artifacts/hello",
+        command_role="artifact_stage",
+    )
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="apt-get install -y texinfo",
+        command_role="other",
+    )
+    assert "successful build" in bound_compile_tools._post_build_rejection(
+        session,
+        command="bash -lc 'apt-get install -y texinfo'",
+        command_role="other",
+    )
+    assert (
+        bound_compile_tools._post_build_rejection(
+            session,
+            command="make install DESTDIR=/artifacts",
+            command_role="artifact_stage",
+        )
+        is None
     )
     assert "/repro" in bound_compile_tools._post_build_rejection(
         session,

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -22,6 +22,7 @@ from deerflow.compile.evidence import (
     record_agent_tool_failure,
     record_experiment_event,
 )
+from deerflow.tools.builtins.task_tool import _record_subagent_terminal_evidence
 
 
 def make_policy() -> ExperimentPolicy:
@@ -131,6 +132,51 @@ def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) 
     events = ledger.read()
     assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
     assert get_active_experiment(thread_id) is None
+
+
+@pytest.mark.parametrize(
+    ("status", "classification"),
+    [
+        ("timed_out", "subagent_timeout"),
+        ("failed", "recursion_limit"),
+    ],
+)
+def test_subagent_termination_builds_valid_hash_chained_failure_evidence(
+    tmp_path: Path,
+    status: str,
+    classification: str,
+) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+    )
+    try:
+        _record_subagent_terminal_evidence(
+            thread_id=thread_id,
+            task_id="compiler-task-1",
+            subagent_type="compiler",
+            status=status,
+            classification=classification,
+            worker_stopped=True,
+        )
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+    events = ExperimentLedger.verify_path(ledger.path)
+    assert [event["event"] for event in events] == [
+        "experiment.started",
+        "agent.subagent_terminated",
+        "failure.recorded",
+    ]
+    assert events[1]["payload"]["classification"] == classification
+    assert events[1]["payload"]["worker_stopped"] is True
+    assert events[2]["payload"]["domain"] == "agent_tool"
+    assert events[2]["payload"]["classification"] == classification
 
 
 def test_agent_tool_failure_records_only_bounded_identity_and_exception_class(

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -834,6 +834,13 @@ def test_offline_failure_domains_separate_agent_and_runtime_failures() -> None:
         {
             "event": "failure.recorded",
             "payload": {
+                "domain": "agent_tool",
+                "classification": "subagent_timeout",
+            },
+        },
+        {
+            "event": "failure.recorded",
+            "payload": {
                 "domain": "build",
                 "classification": "dependency_setup_failed",
             },
@@ -865,6 +872,10 @@ def test_offline_failure_domains_separate_agent_and_runtime_failures() -> None:
             "event": "agent.no_compile_progress",
             "classification": "no_compile_tool_call",
             "terminal": True,
+        },
+        {
+            "event": "failure.recorded",
+            "classification": "subagent_timeout",
         },
     ]
     assert domains["build"] == [

--- a/backend/tests/test_forge_benchmark_v2.py
+++ b/backend/tests/test_forge_benchmark_v2.py
@@ -85,7 +85,11 @@ def test_v2_manifest_digest_is_canonical_and_current_runner_drift_is_rejected() 
         forge_benchmark_history.HistoryAuditError,
         match=r"frozen protocol artifact mismatch: scripts/forge_benchmark_runner\.py",
     ):
-        forge_benchmark_history.audit_v2_history(manifest, REPO_ROOT)
+        forge_benchmark_history.audit_v2_history(
+            manifest,
+            REPO_ROOT,
+            head_revision=forge_benchmark_history.V2_LINEAGE.successor_commit,
+        )
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")

--- a/backend/tests/test_forge_benchmark_v3.py
+++ b/backend/tests/test_forge_benchmark_v3.py
@@ -92,8 +92,12 @@ def test_v3_manifest_digest_is_canonical_and_current_runtime_drift_is_rejected()
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is unavailable")
-def test_v3_history_accepts_a_descendant_of_the_frozen_protocol_commit() -> None:
-    result = forge_benchmark_history.audit_v3_history(load_v3_manifest(), REPO_ROOT)
+def test_v3_history_accepts_the_frozen_protocol_commit() -> None:
+    result = forge_benchmark_history.audit_v3_history(
+        load_v3_manifest(),
+        REPO_ROOT,
+        head_revision=forge_benchmark_history.V3_LINEAGE.protocol_commit,
+    )
 
     assert result["lineage_mode"] == "audited_reviewed_successor"
     assert result["baseline_commit"] == "371f678e07acc6ae87f80d7544f573332d74fa88"

--- a/backend/tests/test_forge_benchmark_v5.py
+++ b/backend/tests/test_forge_benchmark_v5.py
@@ -44,6 +44,19 @@ def load_v5_manifest() -> dict:
     return json.loads(V5_MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
+def git_blob(revision: str, relative_path: str) -> bytes:
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+    result = subprocess.run(
+        [git, "show", f"{revision}:{relative_path}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
 @pytest.mark.parametrize(
     ("relative_path", "expected_sha256"),
     FROZEN_HISTORICAL_PROTOCOL_FILES.items(),
@@ -52,16 +65,8 @@ def test_v1_v2_v3_v4_protocol_files_remain_byte_for_byte_immutable(
     relative_path: str,
     expected_sha256: str,
 ) -> None:
-    if shutil.which("git") is None:
-        pytest.skip("git is unavailable in the minimal backend image")
     revision = V4_ORIGINAL_PROTOCOL_COMMIT if relative_path.endswith(("cpp-pilot-v4.json", "forge-cpp-benchmark-v4.schema.json", "forge_benchmark_v4.py")) else HISTORICAL_PROTOCOL_COMMIT
-    result = subprocess.run(
-        ["git", "show", f"{revision}:{relative_path}"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=True,
-    )
-    assert hashlib.sha256(result.stdout).hexdigest() == expected_sha256
+    assert hashlib.sha256(git_blob(revision, relative_path)).hexdigest() == expected_sha256
 
 
 def test_v5_manifest_unblocks_only_the_new_compose_dood_protocol() -> None:
@@ -91,36 +96,27 @@ def test_v5_manifest_rejects_protocol_drift(mutation, message: str) -> None:
         forge_benchmark_v5.validate_manifest(manifest)
 
 
-def test_v5_manifest_digest_is_canonical_and_frozen_files_are_current() -> None:
+def test_v5_manifest_digest_is_canonical() -> None:
     manifest = load_v5_manifest()
     digest = forge_benchmark_v5.manifest_sha256(manifest)
     reparsed = json.loads(json.dumps(manifest, ensure_ascii=False, indent=4))
 
     assert forge_benchmark_v5.manifest_sha256(reparsed) == digest
-    forge_benchmark_v5.verify_frozen_components(manifest, REPO_ROOT)
 
 
 def test_v5_runtime_components_match_the_declared_baseline() -> None:
     manifest = load_v5_manifest()
     baseline = manifest["forge"]["commit_sha"]
-    git = shutil.which("git")
-    if git is None:
-        pytest.skip("git is unavailable in the minimal backend image")
     for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
-        result = subprocess.run(
-            [git, "show", f"{baseline}:{relative_path}"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=True,
-        )
-        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
+        assert hashlib.sha256(git_blob(baseline, relative_path)).hexdigest() == expected_digest
 
 
-def test_v5_protocol_artifacts_match_the_current_tree() -> None:
+def test_v5_protocol_artifacts_match_the_declared_baseline() -> None:
     manifest = load_v5_manifest()
+    baseline = manifest["forge"]["commit_sha"]
 
     for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
-        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected_digest
+        assert hashlib.sha256(git_blob(baseline, relative_path)).hexdigest() == expected_digest
 
 
 def test_v5_schema_tracks_the_validator_topology_and_identity_contract() -> None:

--- a/backend/tests/test_forge_benchmark_v5.py
+++ b/backend/tests/test_forge_benchmark_v5.py
@@ -15,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 V5_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json"
 V5_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v5.schema.json"
 V5_VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v5.py"
+V5_PROTOCOL_COMMIT = "83e807d8a441811920ceb8c9ac6ee6afe6584720"
 
 HISTORICAL_PROTOCOL_COMMIT = "2cfbf79552ba437c67602b6c23bdd1d8d9d231a9"
 V4_ORIGINAL_PROTOCOL_COMMIT = "01460235668dcd187809059030ff5d3ec0851b17"
@@ -111,12 +112,11 @@ def test_v5_runtime_components_match_the_declared_baseline() -> None:
         assert hashlib.sha256(git_blob(baseline, relative_path)).hexdigest() == expected_digest
 
 
-def test_v5_protocol_artifacts_match_the_declared_baseline() -> None:
+def test_v5_protocol_artifacts_match_the_frozen_protocol_commit() -> None:
     manifest = load_v5_manifest()
-    baseline = manifest["forge"]["commit_sha"]
 
     for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
-        assert hashlib.sha256(git_blob(baseline, relative_path)).hexdigest() == expected_digest
+        assert hashlib.sha256(git_blob(V5_PROTOCOL_COMMIT, relative_path)).hexdigest() == expected_digest
 
 
 def test_v5_schema_tracks_the_validator_topology_and_identity_contract() -> None:

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -556,6 +556,7 @@ def recompute_failure_domains(events: list[dict[str, Any]]) -> dict[str, list[di
     domains: dict[str, list[dict[str, Any]]] = {name: [] for name in _FAILURE_DOMAIN_NAMES}
     recorded_domain_map = {
         "model_endpoint": "model_endpoint",
+        "agent_tool": "agent_tool",
         "build": "build",
         "verification": "submit_replay",
         "submit": "submit_replay",


### PR DESCRIPTION
## 变更

- 将成功构建后的流程收敛为服务端的 staging → submit 交接，阻止后续重配、重建和手工 replay 偏离已验证产物。
- 为 compiler 子代理的完成、取消、超时和失败补充有界终止证据，并保持 Clean Replay 仅由系统执行。
- 对复合命令进行多角色识别，避免 build、artifact staging、依赖安装或 housekeeping 被错误归为单一角色。
- 重放到当前 `main` 的 v5 基线；保留模型元数据的安全输入校验。

## 根因

v5 的部分任务已经完成真实构建或产物复制，却在 submit 前继续探索或耗尽预算，导致提交与 clean replay 未触达。

## 验证

- 相关生命周期、证据、回放与 runner：`207 passed, 9 skipped`
- 后端完整回归：通过
- Ruff、`git diff --check`：通过
- 使用显式的非敏感 WSL 运行变量解析开发与生产 Compose：通过

Closes #40