### PR TITLE
修复：规范 Harness 文档代码示例格式

### DIFF
--- a/backend/docs/HARNESS_APP_SPLIT.md
+++ b/backend/docs/HARNESS_APP_SPLIT.md
@@ -158,6 +158,7 @@ from deerflow.agents.lead_agent.agent import make_lead_agent
 from deerflow.models import create_chat_model
 from deerflow.config import get_app_config
 
+
 async def create_chat_session(thread_id: str, model_name: str):
     config = get_app_config()
     model = create_chat_model(name=model_name)
@@ -171,6 +172,7 @@ async def create_chat_session(thread_id: str, model_name: str):
 # app/channels/manager.py
 from deerflow.skills import load_skills
 from deerflow.agents.memory.updater import get_memory_data
+
 
 def handle_status_command():
     skills = load_skills(enabled_only=True)


### PR DESCRIPTION
## 修复内容

仅为 `backend/docs/HARNESS_APP_SPLIT.md` 中两段 Python fenced code 增加 Ruff 所需的空行。

## 根因

`main@1e4bad22` 的 Lint Check 在 `ruff format --check .` 处失败，报告该文档需要格式化。

## 验证

在开发容器中以与 CI 相同的 Ruff 版本执行：

- `ruff check --no-cache .` 通过
- `ruff format --check --no-cache .` 通过（`256 files already formatted`）

不改动运行时代码、冻结 benchmark/evidence 资产或 pilot 记录。

Closes #44