### PR TITLE
实验：冻结 C/C++ pilot v6 协议

### DIFF
--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -323,10 +323,10 @@ def test_runnable_run_refuses_non_compose_process_before_model_request(
     assert not any(event["event"].startswith("model.") for event in events)
 
 
-def test_runner_defaults_to_v5_manifest() -> None:
+def test_runner_defaults_to_v6_manifest() -> None:
     args = forge_benchmark_runner._build_parser().parse_args(["preflight"])
 
-    assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json"
+    assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v6.json"
 
 
 def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(

--- a/backend/tests/test_forge_benchmark_v6.py
+++ b/backend/tests/test_forge_benchmark_v6.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v6.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v6.schema.json"
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v6.py"
+
+SPEC = importlib.util.spec_from_file_location("forge_benchmark_v6", VALIDATOR_PATH)
+assert SPEC is not None and SPEC.loader is not None
+forge_benchmark_v6 = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(forge_benchmark_v6)
+
+
+def test_v6_manifest_freezes_post_build_handoff_baseline() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["schema_version"] == "6.0.0"
+    assert manifest["forge"]["commit_sha"] == forge_benchmark_v6.BASELINE_COMMIT
+    assert manifest["runtime"]["subagent_timeout_seconds"] == 300
+    assert manifest["model"]["request_timeout_seconds"] == 120
+    assert manifest["model"]["max_retries"] == 0
+    assert forge_benchmark_v6.validate_manifest(manifest) is manifest
+    forge_benchmark_v6.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v6_schema_validates_the_frozen_manifest() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)

--- a/benchmarks/manifests/cpp-pilot-v6.json
+++ b/benchmarks/manifests/cpp-pilot-v6.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "6.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "json-sort-keys-compact-utf8",
+  "benchmark": {
+    "id": "forge-cpp-clean-replay-pilot-v6",
+    "name": "Forge C/C++ Clean Replay Pilot v6",
+    "purpose": "clean_replay_collection_calibration",
+    "dataset_provenance": "self_selected_calibration_set"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "pilot",
+    "formal_comparison_enabled": false,
+    "instrumentation_blocker": false
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "4432325202d831d4f16980b82582dfd63c109922",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7d8d59a488b1b426a7f4430a654caf945e3b7e0ee634125c0b9f6db621bdd547",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "3e97f9ef930445f5c0911aca7b758ec531eae791546f2a04ffee686432361d76",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "f44666a7afb5a88c73e0fb008ccba142e2d78b94700a3b721d1c32d0ceb5dbb4",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "2eb625975f3b83d4c6f13bb0b1a29ba08c6af6bf36232b47311ada3ada56754a",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "cb7c20c9ee9f980f3ac26b446898fbc85451b7cc45005cc4b56e7654df291eff",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "c1d7bbd83e5fc5b4616c9758eee4e3b9ff00eef69935787d13a52b5277c81af5"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_v6.py": "12925adfbf4d2ea9ac7d19a78b1360e4ff2403ef46c2bc02ddd18d455ea79626",
+    "scripts/forge_benchmark_runner.py": "d34d5111fa0ac67f27307beb84743a2b3cbfada2f801cdfb14ec5d6374f1980a",
+    "benchmarks/schemas/forge-cpp-benchmark-v6.schema.json": "46b10e532d7c33b4a9895464d57f1e092fc51d9dc1d41da3af2efc469b7fffc5"
+  },
+  "model": {
+    "endpoint": "https://richlab-api-x.choosefire.com/v1",
+    "credential_env": "OpenAI_AK",
+    "roles": {
+      "lead": "gpt-5.6-sol",
+      "compiler": "gpt-5.6-sol"
+    },
+    "fallback_policy": "forbidden",
+    "request_timeout_seconds": 120,
+    "max_retries": 0
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "compiler_max_turns": 36,
+    "subagent_timeout_seconds": 300,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "conditions": [
+    {
+      "id": "baseline",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "cases": [
+    {
+      "id": "fmt",
+      "repository_url": "https://github.com/fmtlib/fmt",
+      "commit_sha": "123913715afeb8a437e6388b4473fcc4753e1c9a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfmt.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFMT_TEST=OFF",
+            "-DFMT_DOC=OFF",
+            "-DFMT_INSTALL=OFF",
+            "-DBUILD_SHARED_LIBS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hiredis",
+      "repository_url": "https://github.com/redis/hiredis",
+      "commit_sha": "60e5075d4ac77424809f855ba3e398df7aacefe8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "BSD-3-Clause",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhiredis.a",
+            "artifact_type": "static_library"
+          },
+          {
+            "relative_path": "libhiredis.so",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "make"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libcheck",
+      "repository_url": "https://github.com/libcheck/check",
+      "commit_sha": "11970a7e112dfe243a2e68773f014687df2900e8",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcheck.a",
+            "artifact_type": "static_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "autoconf",
+          "automake",
+          "libtool",
+          "pkg-config",
+          "texinfo"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-subunit"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libgit2",
+      "repository_url": "https://github.com/libgit2/libgit2",
+      "commit_sha": "338e6fb681369ff0537719095e22ce9dc602dbf0",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "GPL-2.0-only WITH libgit2-linking-exception",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgit2.so.1.9.0",
+            "artifact_type": "shared_library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "pkg-config",
+          "libssl-dev",
+          "libhttp-parser-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DBUILD_TESTS=OFF",
+            "-DBUILD_CLI=OFF",
+            "-DUSE_HTTPS=OpenSSL",
+            "-DUSE_HTTP_PARSER=system",
+            "-DREGEX_BACKEND=builtin",
+            "-DUSE_SSH=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sysstat-nondeterministic",
+      "repository_url": "https://github.com/sysstat/sysstat",
+      "commit_sha": "b8f987807e7c7ba5c1b2ca8b7b1e9d80e61bce6c",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0-or-later",
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "reject",
+        "expected_replay_failure_classification": "sha256_mismatch",
+        "required_artifacts": [
+          {
+            "relative_path": "sar",
+            "artifact_type": "executable"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-nls"
+          ]
+        },
+        "environment": {
+          "CFLAGS": "-O2 -DUSE_SCCSID",
+          "SOURCE_DATE_EPOCH": null
+        },
+        "minimum_replay_delay_seconds": 2
+      }
+    }
+  ]
+}

--- a/benchmarks/schemas/forge-cpp-benchmark-v6.schema.json
+++ b/benchmarks/schemas/forge-cpp-benchmark-v6.schema.json
@@ -1,0 +1,3507 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-benchmark-v6.schema.json",
+  "title": "Forge-AutoCompiler C/C++ benchmark pilot protocol v6",
+  "description": "The runnable five-case pilot manifest and explicit build-identity run-record contract.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/manifest"
+    },
+    {
+      "$ref": "#/$defs/run_record"
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_commit_sha": {
+      "type": "string",
+      "description": "A complete SHA-1 or SHA-256 Git object ID; symbolic or abbreviated refs are invalid.",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+    },
+    "safe_token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+/@-]*$"
+    },
+    "safe_repository_url": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS repository URL without userinfo, query parameters, or a fragment.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/[A-Za-z0-9._~!$&'()*+,;=:@%/-]+$"
+    },
+    "model_endpoint": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2048,
+      "description": "An HTTPS OpenAI-compatible base URL ending in /v1, without credentials or URL parameters.",
+      "pattern": "^https://(?![^/?#]*@)[A-Za-z0-9.-]+(?::[0-9]{1,5})?/v1/?$"
+    },
+    "environment_variable_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "relative_artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "A POSIX path relative to /artifacts. Absolute, parent-traversal, and backslash paths are invalid.",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "language": {
+      "enum": [
+        "C",
+        "C++"
+      ]
+    },
+    "languages": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/language"
+      }
+    },
+    "build_system": {
+      "enum": [
+        "cmake",
+        "make",
+        "autotools"
+      ]
+    },
+    "gate_status": {
+      "enum": [
+        "pass",
+        "reject"
+      ]
+    },
+    "nullable_gate_status": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/gate_status"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "run_record_lifecycle_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "image_identity_unavailable"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "cancelled"
+                        ]
+                      },
+                      "failure_classification": {
+                        "const": "image_identity_unavailable"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "artifact.finalization_recheck"
+                      },
+                      "passed": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.deferred"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "type": "null"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "failed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "cancelled"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "cancelled"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "finalize.completed"
+                      },
+                      "reason": {
+                        "const": "timed_out"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "timed_out"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verified",
+                      "verification_failed",
+                      "completed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "verification_failed",
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "verification_failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "enum": [
+                      "failed",
+                      "cancelled",
+                      "timed_out"
+                    ]
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "run_record_conditions": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  }
+                }
+              },
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "enum": [
+                      "pass",
+                      "reject"
+                    ]
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "maxItems": 1000
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "not_observed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "started"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.started"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "aborted"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.aborted"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "candidate_generation": {
+                    "const": true
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  },
+                  "completion": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "failed"
+                      },
+                      "replay_attempt_id": {
+                        "type": "null"
+                      },
+                      "replay_status": {
+                        "const": "not_run"
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "status": {
+                        "const": "failed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "replay_attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "replay_status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "status": {
+                        "enum": [
+                          "failed",
+                          "timed_out",
+                          "cancelled"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_failure_classification": {
+                    "not": {
+                      "const": "cleanup_failed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "clean_replay": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  },
+                  "verification_status": {
+                    "const": "passed"
+                  },
+                  "finalized": {
+                    "const": true
+                  }
+                }
+              },
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.completed"
+                          },
+                          "reason": {
+                            "type": "null"
+                          },
+                          "passed": {
+                            "const": true
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "session_status": {
+                    "const": "completed"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "failure_attribution": {
+                "properties": {
+                  "completion": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "evidence": {
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "const": "passed"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "completion_event": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "artifact.finalization_recheck"
+                          },
+                          "passed": {
+                            "const": false
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "event": {
+                            "const": "finalize.deferred"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "artifact_type": {
+      "enum": [
+        "executable",
+        "shared_library",
+        "static_library",
+        "object"
+      ]
+    },
+    "nullable_nonnegative_integer": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_nonnegative_number": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "nullable_boolean": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "nullable_sha256": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sha256"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "required_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type"
+      ],
+      "properties": {
+        "relative_path": {
+          "$ref": "#/$defs/relative_artifact_path"
+        },
+        "artifact_type": {
+          "$ref": "#/$defs/artifact_type"
+        }
+      }
+    },
+    "build_argument_vector": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": "^[^\\u0000\\r\\n]+$"
+      }
+    },
+    "case_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required_system_packages",
+        "build_arguments",
+        "environment",
+        "minimum_replay_delay_seconds"
+      ],
+      "properties": {
+        "required_system_packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+-]*$"
+          }
+        },
+        "build_arguments": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cmake",
+            "configure"
+          ],
+          "properties": {
+            "cmake": {
+              "$ref": "#/$defs/build_argument_vector"
+            },
+            "configure": {
+              "$ref": "#/$defs/build_argument_vector"
+            }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "description": "Only reviewed, non-secret process environment controls are permitted.",
+          "additionalProperties": false,
+          "properties": {
+            "CFLAGS": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[^\\u0000\\r\\n]+$"
+            },
+            "SOURCE_DATE_EPOCH": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128,
+                  "pattern": "^[^\\u0000\\r\\n]+$"
+                }
+              ]
+            }
+          }
+        },
+        "minimum_replay_delay_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 3600
+        }
+      }
+    },
+    "benchmark_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repository_url",
+        "commit_sha",
+        "languages",
+        "build_system",
+        "license",
+        "oracle",
+        "constraints"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repository_url": {
+          "$ref": "#/$defs/safe_repository_url"
+        },
+        "commit_sha": {
+          "$ref": "#/$defs/git_commit_sha"
+        },
+        "languages": {
+          "$ref": "#/$defs/languages"
+        },
+        "build_system": {
+          "$ref": "#/$defs/build_system"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9 .()+-]*$"
+        },
+        "oracle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "expected_candidate_status",
+            "expected_clean_replay_status",
+            "required_artifacts"
+          ],
+          "properties": {
+            "expected_candidate_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_clean_replay_status": {
+              "$ref": "#/$defs/gate_status"
+            },
+            "expected_replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required_artifacts": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/required_artifact"
+              }
+            }
+          }
+        },
+        "constraints": {
+          "$ref": "#/$defs/case_constraints"
+        }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark",
+        "scope",
+        "forge",
+        "protocol_artifact_sha256",
+        "model",
+        "runtime",
+        "conditions",
+        "cases"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "6.0.0"
+        },
+        "document_type": {
+          "const": "manifest"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "purpose",
+            "dataset_provenance"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/identifier"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 160
+            },
+            "purpose": {
+              "const": "clean_replay_collection_calibration"
+            },
+            "dataset_provenance": {
+              "const": "self_selected_calibration_set"
+            }
+          }
+        },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "languages",
+            "phase",
+            "formal_comparison_enabled",
+            "instrumentation_blocker"
+          ],
+          "properties": {
+            "languages": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/language"
+              }
+            },
+            "phase": {
+              "const": "pilot"
+            },
+            "formal_comparison_enabled": {
+              "const": false
+            },
+            "instrumentation_blocker": {
+              "const": false
+            }
+          }
+        },
+        "forge": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "repository_url",
+            "commit_sha",
+            "revision_policy",
+            "component_sha256"
+          ],
+          "properties": {
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "const": "4432325202d831d4f16980b82582dfd63c109922"
+            },
+            "revision_policy": {
+              "const": "baseline_ancestor_with_frozen_components"
+            },
+            "component_sha256": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+                "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+                "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+                "backend/packages/harness/deerflow/client.py",
+                "backend/packages/harness/deerflow/compile/__init__.py",
+                "backend/packages/harness/deerflow/compile/docker_runtime.py",
+                "backend/packages/harness/deerflow/compile/evidence.py",
+                "backend/packages/harness/deerflow/compile/manager.py",
+                "backend/packages/harness/deerflow/compile/operations.py",
+                "backend/packages/harness/deerflow/compile/schemas.py",
+                "backend/packages/harness/deerflow/models/factory.py",
+                "backend/packages/harness/deerflow/subagents/executor.py",
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+                "docker/compile/Dockerfile",
+                "docker/docker-compose-dev.yaml",
+                "config.example.yaml",
+                "backend/uv.lock"
+              ],
+              "properties": {
+                "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/client.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/__init__.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/evidence.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/manager.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/operations.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/compile/schemas.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/models/factory.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/subagents/executor.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/compile/Dockerfile": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "docker/docker-compose-dev.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "config.example.yaml": {
+                  "$ref": "#/$defs/sha256"
+                },
+                "backend/uv.lock": {
+                  "$ref": "#/$defs/sha256"
+                }
+              }
+            }
+          }
+        },
+        "protocol_artifact_sha256": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scripts/forge_benchmark.py",
+            "scripts/forge_benchmark_v6.py",
+            "scripts/forge_benchmark_runner.py",
+            "benchmarks/schemas/forge-cpp-benchmark-v6.schema.json"
+          ],
+          "properties": {
+            "scripts/forge_benchmark.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_v6.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "scripts/forge_benchmark_runner.py": {
+              "$ref": "#/$defs/sha256"
+            },
+            "benchmarks/schemas/forge-cpp-benchmark-v6.schema.json": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        },
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "endpoint",
+            "credential_env",
+            "roles",
+            "fallback_policy",
+            "request_timeout_seconds",
+            "max_retries"
+          ],
+          "properties": {
+            "endpoint": {
+              "$ref": "#/$defs/model_endpoint"
+            },
+            "credential_env": {
+              "const": "OpenAI_AK"
+            },
+            "roles": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "lead",
+                "compiler"
+              ],
+              "properties": {
+                "lead": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "compiler": {
+                  "$ref": "#/$defs/safe_token"
+                }
+              }
+            },
+            "fallback_policy": {
+              "const": "forbidden"
+            },
+            "request_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_retries": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "compile_image",
+            "image_id",
+            "control_plane_topology",
+            "replay_timeout_seconds",
+            "cleanup_timeout_seconds",
+            "docker_control_timeout_seconds",
+            "compiler_max_turns",
+            "subagent_timeout_seconds",
+            "max_parallel_runs",
+            "backend_processes",
+            "network_policy",
+            "host"
+          ],
+          "properties": {
+            "compile_image": {
+              "$ref": "#/$defs/safe_token"
+            },
+            "image_id": {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "control_plane_topology": {
+              "const": "compose-dood"
+            },
+            "replay_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "cleanup_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "docker_control_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3600
+            },
+            "compiler_max_turns": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "subagent_timeout_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400
+            },
+            "max_parallel_runs": {
+              "const": 1
+            },
+            "backend_processes": {
+              "const": 1
+            },
+            "network_policy": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "network_name",
+                "egress"
+              ],
+              "properties": {
+                "network_name": {
+                  "const": "compile_network_wwf_v1"
+                },
+                "egress": {
+                  "const": "enabled_for_clone_and_dependencies"
+                }
+              }
+            },
+            "host": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "wsl_distribution",
+                "cpu_count",
+                "memory_kib",
+                "kernel",
+                "architecture",
+                "docker_server_version"
+              ],
+              "properties": {
+                "wsl_distribution": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "cpu_count": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "memory_kib": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "kernel": {
+                  "$ref": "#/$defs/safe_token"
+                },
+                "architecture": {
+                  "enum": [
+                    "x86_64",
+                    "aarch64"
+                  ]
+                },
+                "docker_server_version": {
+                  "type": "string",
+                  "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$"
+                }
+              }
+            }
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "memory_enabled",
+              "skills_enabled",
+              "repetitions",
+              "acceptance_gate"
+            ],
+            "properties": {
+              "id": {
+                "const": "baseline"
+              },
+              "memory_enabled": {
+                "const": false
+              },
+              "skills_enabled": {
+                "const": false
+              },
+              "repetitions": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000
+              },
+              "acceptance_gate": {
+                "const": "clean_replay"
+              }
+            }
+          }
+        },
+        "cases": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/$defs/benchmark_case"
+          }
+        }
+      }
+    },
+    "normalized_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relative_path",
+        "artifact_type",
+        "size_bytes",
+        "sha256",
+        "smoke_exit_code",
+        "smoke_output_sha256"
+      ],
+      "properties": {
+        "relative_path": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/relative_artifact_path"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "artifact_type": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/artifact_type"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "size_bytes": {
+          "$ref": "#/$defs/nullable_nonnegative_integer"
+        },
+        "sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        },
+        "smoke_exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "smoke_output_sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "artifact_type"
+            ],
+            "properties": {
+              "artifact_type": {
+                "const": "executable"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "smoke_exit_code": {
+                "const": 0
+              },
+              "smoke_output_sha256": {
+                "$ref": "#/$defs/sha256"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "failure_classification": {
+      "enum": [
+        "artifact_set_mismatch",
+        "type_mismatch",
+        "size_mismatch",
+        "sha256_mismatch",
+        "smoke_mismatch",
+        "recipe_snapshot_mismatch",
+        "image_identity_unavailable",
+        "recipe_execution_failed",
+        "timeout",
+        "internal_error",
+        "cancelled",
+        "cleanup_failed",
+        "session_terminated"
+      ]
+    },
+    "submit_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "stage",
+            "status",
+            "failed_checks",
+            "replay_attempt_id",
+            "artifact_count",
+            "candidate_status",
+            "replay_status"
+          ],
+          "properties": {
+            "event": {
+              "enum": [
+                "submit.started",
+                "submit.completed",
+                "submit.aborted"
+              ]
+            },
+            "stage": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "entry",
+                "candidate_checkpoint",
+                "final_checkpoint",
+                null
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                "completed",
+                null
+              ]
+            },
+            "failed_checks": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "replay_attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "candidate_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "replay_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                "not_run",
+                null
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.started"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "type": "null"
+                  },
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.aborted"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "null"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  },
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "type": "null"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "stage": {
+                    "type": "null"
+                  },
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "candidate_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled",
+                      "not_run"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "const": 0
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  },
+                  "replay_status": {
+                    "const": "passed"
+                  },
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failed_checks": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "replay_status": {
+                    "not": {
+                      "const": "passed"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "failed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "status": {
+                    "const": "failed"
+                  },
+                  "replay_attempt_id": {
+                    "type": "null"
+                  },
+                  "replay_status": {
+                    "const": "not_run"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "event": {
+                    "const": "submit.completed"
+                  },
+                  "candidate_status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "replay_attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "replay_status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "completion_event": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "artifact.finalization_recheck"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.deferred"
+            },
+            "reason": {
+              "const": "container_cleanup_failed"
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "type": "null"
+            },
+            "passed": {
+              "const": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "reason",
+            "passed"
+          ],
+          "properties": {
+            "event": {
+              "const": "finalize.completed"
+            },
+            "reason": {
+              "enum": [
+                "failed",
+                "cancelled",
+                "timed_out"
+              ]
+            },
+            "passed": {
+              "type": "null"
+            }
+          }
+        }
+      ]
+    },
+    "replay_attempt": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "attempt_id",
+            "image",
+            "image_id",
+            "commit_sha",
+            "status",
+            "failure_classification",
+            "exit_code",
+            "cleanup_succeeded",
+            "duration_seconds",
+            "timeout_seconds",
+            "recipe_sha256"
+          ],
+          "properties": {
+            "attempt_id": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/safe_token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "pending",
+                "running",
+                "passed",
+                "failed",
+                "timed_out",
+                "cancelled",
+                null
+              ]
+            },
+            "failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "exit_code": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "timeout_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "recipe_sha256": {
+              "$ref": "#/$defs/nullable_sha256"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "passed",
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "attempt_id": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "image": {
+                    "$ref": "#/$defs/safe_token"
+                  },
+                  "commit_sha": {
+                    "$ref": "#/$defs/git_commit_sha"
+                  },
+                  "cleanup_succeeded": {
+                    "type": "boolean"
+                  },
+                  "duration_seconds": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "passed"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  },
+                  "failure_classification": {
+                    "type": "null"
+                  },
+                  "exit_code": {
+                    "const": 0
+                  },
+                  "cleanup_succeeded": {
+                    "const": true
+                  },
+                  "recipe_sha256": {
+                    "$ref": "#/$defs/sha256"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "$ref": "#/$defs/failure_classification"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "failed",
+                      "timed_out",
+                      "cancelled"
+                    ]
+                  },
+                  "failure_classification": {
+                    "not": {
+                      "const": "image_identity_unavailable"
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "image_id": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "status": {
+                    "const": "timed_out"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "failure_classification": {
+                    "const": "timeout"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "run_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark_id",
+        "manifest_sha256",
+        "recorded_at",
+        "case_id",
+        "condition",
+        "repetition",
+        "source",
+        "outcome",
+        "failure_attribution",
+        "evidence"
+      ],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "schema_version": {
+          "const": "6.0.0"
+        },
+        "document_type": {
+          "const": "run_record"
+        },
+        "manifest_canonicalization": {
+          "const": "json-sort-keys-compact-utf8"
+        },
+        "benchmark_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "case_id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "condition": {
+          "$ref": "#/$defs/identifier"
+        },
+        "repetition": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_id",
+            "run_id",
+            "repository_url",
+            "commit_sha",
+            "build_system",
+            "build_system_capabilities",
+            "selected_build_system",
+            "executed_build_system",
+            "image_id"
+          ],
+          "properties": {
+            "session_id": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{12}$"
+            },
+            "run_id": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 160,
+                  "pattern": "^(?:[0-9a-f]{12,64}|[0-9a-fA-F]{8}-[0-9a-fA-F-]{27,})$"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "repository_url": {
+              "$ref": "#/$defs/safe_repository_url"
+            },
+            "commit_sha": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/git_commit_sha"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "build_system_capabilities": {
+              "type": "array",
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/build_system"
+              }
+            },
+            "selected_build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "executed_build_system": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/build_system"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "image_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          }
+        },
+        "outcome": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "session_status",
+            "submit_status",
+            "candidate_status",
+            "clean_replay_status",
+            "replay_failure_classification",
+            "replay_cleanup_succeeded",
+            "verification_status",
+            "artifact_count",
+            "finalized",
+            "oracle_match"
+          ],
+          "properties": {
+            "session_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "created",
+                "ready",
+                "source_ready",
+                "inspected",
+                "replay_verifying",
+                "verified",
+                "verification_failed",
+                "completed",
+                "failed",
+                "cancelled",
+                "timed_out",
+                null
+              ]
+            },
+            "submit_status": {
+              "enum": [
+                "not_observed",
+                "started",
+                "aborted",
+                "completed"
+              ]
+            },
+            "candidate_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "clean_replay_status": {
+              "$ref": "#/$defs/nullable_gate_status"
+            },
+            "replay_failure_classification": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/failure_classification"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "replay_cleanup_succeeded": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "verification_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "candidate_ready",
+                "passed",
+                "failed",
+                null
+              ]
+            },
+            "artifact_count": {
+              "$ref": "#/$defs/nullable_nonnegative_integer"
+            },
+            "finalized": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "oracle_match": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "failure_attribution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "model_endpoint",
+            "agent",
+            "build",
+            "candidate_generation",
+            "clean_replay",
+            "cleanup",
+            "completion"
+          ],
+          "properties": {
+            "model_endpoint": {
+              "type": "null"
+            },
+            "agent": {
+              "type": "null"
+            },
+            "build": {
+              "type": "null"
+            },
+            "candidate_generation": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "clean_replay": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "cleanup": {
+              "$ref": "#/$defs/nullable_boolean"
+            },
+            "completion": {
+              "$ref": "#/$defs/nullable_boolean"
+            }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "command_summary",
+            "session_duration_seconds",
+            "artifacts",
+            "submit_event",
+            "replay_attempt",
+            "completion_event"
+          ],
+          "properties": {
+            "command_summary": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "total",
+                    "successful_bash",
+                    "failed_bash"
+                  ],
+                  "properties": {
+                    "total": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "successful_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    },
+                    "failed_bash": {
+                      "$ref": "#/$defs/nullable_nonnegative_integer"
+                    }
+                  }
+                }
+              ]
+            },
+            "session_duration_seconds": {
+              "$ref": "#/$defs/nullable_nonnegative_number"
+            },
+            "artifacts": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array",
+                  "maxItems": 1000,
+                  "uniqueItems": true,
+                  "items": {
+                    "$ref": "#/$defs/normalized_artifact"
+                  }
+                }
+              ]
+            },
+            "submit_event": {
+              "$ref": "#/$defs/submit_event"
+            },
+            "replay_attempt": {
+              "$ref": "#/$defs/replay_attempt"
+            },
+            "completion_event": {
+              "$ref": "#/$defs/completion_event"
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "source",
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "source": {
+                "required": [
+                  "selected_build_system",
+                  "executed_build_system"
+                ],
+                "properties": {
+                  "selected_build_system": {
+                    "$ref": "#/$defs/build_system"
+                  },
+                  "executed_build_system": {
+                    "$ref": "#/$defs/build_system"
+                  }
+                }
+              },
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "submit_event",
+                  "artifacts"
+                ],
+                "properties": {
+                  "submit_event": {
+                    "type": "object",
+                    "required": [
+                      "event",
+                      "candidate_status",
+                      "artifact_count"
+                    ],
+                    "properties": {
+                      "event": {
+                        "const": "submit.completed"
+                      },
+                      "candidate_status": {
+                        "const": "passed"
+                      },
+                      "artifact_count": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
+                  },
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "allOf": [
+                        {
+                          "$ref": "#/$defs/normalized_artifact"
+                        },
+                        {
+                          "properties": {
+                            "relative_path": {
+                              "$ref": "#/$defs/relative_artifact_path"
+                            },
+                            "artifact_type": {
+                              "$ref": "#/$defs/artifact_type"
+                            },
+                            "size_bytes": {
+                              "type": "integer",
+                              "minimum": 1
+                            },
+                            "sha256": {
+                              "$ref": "#/$defs/sha256"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "pass"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "outcome",
+              "failure_attribution",
+              "evidence"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status",
+                  "candidate_status",
+                  "replay_cleanup_succeeded",
+                  "replay_failure_classification",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "const": "completed"
+                  },
+                  "candidate_status": {
+                    "const": "pass"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": true
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "enum": [
+                      "passed",
+                      "failed"
+                    ]
+                  },
+                  "artifact_count": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "const": false
+                  },
+                  "cleanup": {
+                    "const": false
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "array",
+                    "minItems": 1
+                  },
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "attempt_id",
+                      "image",
+                      "image_id",
+                      "commit_sha",
+                      "status",
+                      "failure_classification",
+                      "exit_code",
+                      "cleanup_succeeded",
+                      "duration_seconds",
+                      "timeout_seconds",
+                      "recipe_sha256"
+                    ],
+                    "properties": {
+                      "attempt_id": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image": {
+                        "$ref": "#/$defs/safe_token"
+                      },
+                      "image_id": {
+                        "type": "string",
+                        "pattern": "^sha256:[0-9a-f]{64}$"
+                      },
+                      "commit_sha": {
+                        "$ref": "#/$defs/git_commit_sha"
+                      },
+                      "status": {
+                        "const": "passed"
+                      },
+                      "failure_classification": {
+                        "type": "null"
+                      },
+                      "exit_code": {
+                        "const": 0
+                      },
+                      "cleanup_succeeded": {
+                        "const": true
+                      },
+                      "duration_seconds": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "recipe_sha256": {
+                        "$ref": "#/$defs/sha256"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "replay_failure_classification"
+                ],
+                "properties": {
+                  "replay_failure_classification": {
+                    "const": "cleanup_failed"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "clean_replay_status",
+                  "replay_cleanup_succeeded"
+                ],
+                "properties": {
+                  "clean_replay_status": {
+                    "const": "reject"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "const": false
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "const": true
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "replay_attempt": {
+                    "type": "object",
+                    "required": [
+                      "failure_classification",
+                      "cleanup_succeeded"
+                    ],
+                    "properties": {
+                      "failure_classification": {
+                        "const": "cleanup_failed"
+                      },
+                      "cleanup_succeeded": {
+                        "const": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "outcome"
+            ],
+            "properties": {
+              "outcome": {
+                "required": [
+                  "submit_status"
+                ],
+                "properties": {
+                  "submit_status": {
+                    "enum": [
+                      "not_observed",
+                      "started",
+                      "aborted"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "outcome": {
+                "required": [
+                  "candidate_status",
+                  "clean_replay_status",
+                  "replay_failure_classification",
+                  "replay_cleanup_succeeded",
+                  "verification_status",
+                  "artifact_count"
+                ],
+                "properties": {
+                  "candidate_status": {
+                    "type": "null"
+                  },
+                  "clean_replay_status": {
+                    "type": "null"
+                  },
+                  "replay_failure_classification": {
+                    "type": "null"
+                  },
+                  "replay_cleanup_succeeded": {
+                    "type": "null"
+                  },
+                  "verification_status": {
+                    "type": "null"
+                  },
+                  "artifact_count": {
+                    "type": "null"
+                  }
+                }
+              },
+              "failure_attribution": {
+                "required": [
+                  "candidate_generation",
+                  "clean_replay",
+                  "cleanup"
+                ],
+                "properties": {
+                  "candidate_generation": {
+                    "type": "null"
+                  },
+                  "clean_replay": {
+                    "type": "null"
+                  },
+                  "cleanup": {
+                    "type": "null"
+                  }
+                }
+              },
+              "evidence": {
+                "required": [
+                  "artifacts",
+                  "replay_attempt"
+                ],
+                "properties": {
+                  "artifacts": {
+                    "type": "null"
+                  },
+                  "replay_attempt": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/run_record_conditions"
+        },
+        {
+          "$ref": "#/$defs/run_record_lifecycle_conditions"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -31,6 +31,7 @@ import forge_benchmark_v2 as protocol_v2  # noqa: E402
 import forge_benchmark_v3 as protocol_v3  # noqa: E402
 import forge_benchmark_v4 as protocol_v4  # noqa: E402
 import forge_benchmark_v5 as protocol_v5  # noqa: E402
+import forge_benchmark_v6 as protocol_v6  # noqa: E402
 
 from deerflow.compile.evidence import (  # noqa: E402
     EvidenceError,
@@ -118,6 +119,8 @@ def _manifest_protocol(manifest: dict[str, Any]):
         return protocol_v4
     if schema_version == protocol_v5.SCHEMA_VERSION:
         return protocol_v5
+    if schema_version == protocol_v6.SCHEMA_VERSION:
+        return protocol_v6
     raise RunnerError(f"Unsupported benchmark schema version: {schema_version}")
 
 
@@ -318,6 +321,7 @@ def collect_preflight(
         protocol_v3.REVISION_POLICY,
         protocol_v4.REVISION_POLICY,
         protocol_v5.REVISION_POLICY,
+        protocol_v6.REVISION_POLICY,
     }
     baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy in runnable_revision_policies else False
     component_results: dict[str, dict[str, Any]] = {}
@@ -368,6 +372,7 @@ def collect_preflight(
         protocol_v3.CONTROL_PLANE_TOPOLOGY,
         protocol_v4.CONTROL_PLANE_TOPOLOGY,
         protocol_v5.CONTROL_PLANE_TOPOLOGY,
+        protocol_v6.CONTROL_PLANE_TOPOLOGY,
     }
     topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
     checks = {
@@ -420,6 +425,7 @@ def collect_preflight(
                 protocol_v3.SCHEMA_VERSION: "cpp-pilot-v3.json",
                 protocol_v4.SCHEMA_VERSION: "cpp-pilot-v4.json",
                 protocol_v5.SCHEMA_VERSION: "cpp-pilot-v5.json",
+                protocol_v6.SCHEMA_VERSION: "cpp-pilot-v6.json",
             }[manifest["schema_version"]]
         ),
         "forge": {
@@ -615,11 +621,11 @@ def recompute_build_identity(events: list[dict[str, Any]]) -> dict[str, Any]:
     benchmark_id = policy.get("benchmark_id")
     snapshots = [event["payload"] for event in events if event["event"] == "build.identity_snapshot"]
     attempt_executed = any(event["event"].startswith("model.") or event["event"] in {"runtime.topology_verified", "run.failed", "orphan.reconciled"} for event in events)
-    v5_identity_contract = benchmark_id == "forge-cpp-clean-replay-pilot-v5"
-    snapshot_required = v5_identity_contract and attempt_executed
+    identity_contract = benchmark_id in {"forge-cpp-clean-replay-pilot-v5", "forge-cpp-clean-replay-pilot-v6"}
+    snapshot_required = identity_contract and attempt_executed
     submits = [event for event in events if event["event"] == "submit.completed"]
     snapshots_by_session = {snapshot["session_id"]: snapshot for snapshot in snapshots if snapshot.get("session_id") is not None}
-    submit_identity_proven = not v5_identity_contract or all(
+    submit_identity_proven = not identity_contract or all(
         (snapshot := snapshots_by_session.get(submit["payload"].get("session_id"))) is not None and snapshot.get("selected_build_system") == expected and snapshot.get("executed_build_system") == expected for submit in submits
     )
     snapshot_present = bool(snapshots)
@@ -885,6 +891,7 @@ def run_attempt(
         protocol_v3.CONTROL_PLANE_TOPOLOGY,
         protocol_v4.CONTROL_PLANE_TOPOLOGY,
         protocol_v5.CONTROL_PLANE_TOPOLOGY,
+        protocol_v6.CONTROL_PLANE_TOPOLOGY,
     }:
         if not _running_inside_compose_dood(REPO_ROOT):
             ledger.append(
@@ -915,7 +922,7 @@ def run_attempt(
     )
     run_status = "failed"
     session_finalization_succeeded = False
-    build_identity_snapshot_recorded = manifest["schema_version"] != protocol_v5.SCHEMA_VERSION
+    build_identity_snapshot_recorded = manifest["schema_version"] not in {protocol_v5.SCHEMA_VERSION, protocol_v6.SCHEMA_VERSION}
     try:
         from deerflow.client import DeerFlowClient
 
@@ -969,7 +976,7 @@ def run_attempt(
                 interrupted_status=interrupted_status,
                 error=termination_error,
             )
-        if manifest["schema_version"] == protocol_v5.SCHEMA_VERSION:
+        if manifest["schema_version"] in {protocol_v5.SCHEMA_VERSION, protocol_v6.SCHEMA_VERSION}:
             build_identity_snapshot_recorded = _record_attempt_build_identity(thread_id, ledger)
         ledger.append("orphan.reconciled", reconciliation)
 
@@ -1010,7 +1017,7 @@ def _build_parser() -> argparse.ArgumentParser:
     common.add_argument(
         "--manifest",
         type=Path,
-        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v5.json",
+        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v6.json",
     )
     common.add_argument("--skip-endpoint-check", action="store_true")
 

--- a/scripts/forge_benchmark_v6.py
+++ b/scripts/forge_benchmark_v6.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Validate the runnable Forge C/C++ pilot v6 protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+
+SCHEMA_VERSION = "6.0.0"
+BASELINE_COMMIT = "4432325202d831d4f16980b82582dfd63c109922"
+REVISION_POLICY = "baseline_ancestor_with_frozen_components"
+CONTROL_PLANE_TOPOLOGY = "compose-dood"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+COMPONENT_PATHS = {
+    "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+    "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+    "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+    "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+    "backend/packages/harness/deerflow/client.py",
+    "backend/packages/harness/deerflow/compile/__init__.py",
+    "backend/packages/harness/deerflow/compile/docker_runtime.py",
+    "backend/packages/harness/deerflow/compile/evidence.py",
+    "backend/packages/harness/deerflow/compile/manager.py",
+    "backend/packages/harness/deerflow/compile/operations.py",
+    "backend/packages/harness/deerflow/compile/schemas.py",
+    "backend/packages/harness/deerflow/models/factory.py",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+    "backend/packages/harness/deerflow/subagents/executor.py",
+    "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+    "backend/uv.lock",
+    "config.example.yaml",
+    "docker/compile/Dockerfile",
+    "docker/docker-compose-dev.yaml",
+}
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_benchmark.py",
+    "scripts/forge_benchmark_v6.py",
+    "scripts/forge_benchmark_runner.py",
+    "benchmarks/schemas/forge-cpp-benchmark-v6.schema.json",
+}
+
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+
+
+def _validate_hash_map(
+    value: Any,
+    *,
+    expected_paths: set[str],
+    path: str,
+) -> dict[str, Any]:
+    hashes = v1._as_object(value, path)
+    if set(hashes) != expected_paths:
+        v1._fail(path, "must contain exactly the required v6 frozen artifact hashes")
+    for relative_path, digest in hashes.items():
+        pure_path = PurePosixPath(relative_path)
+        if pure_path.is_absolute() or ".." in pure_path.parts or "\\" in relative_path:
+            v1._fail(f"{path}.{relative_path}", "must stay inside the repository")
+        v1._validate_sha256(digest, f"{path}.{relative_path}")
+    return hashes
+
+
+def _validate_manifest_impl(document: Any) -> dict[str, Any]:
+    manifest = v1._as_object(document, "manifest")
+    v1._require_exact_keys(
+        manifest,
+        {
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "forge",
+            "protocol_artifact_sha256",
+            "model",
+            "runtime",
+            "conditions",
+            "cases",
+        },
+        "manifest",
+        optional={"$schema"},
+    )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        v1._fail("manifest.schema_version", f"unsupported version; expected {SCHEMA_VERSION}")
+    v1._scan_for_unsafe_values(manifest)
+
+    scope = v1._as_object(v1._required(manifest, "scope", "manifest"), "manifest.scope")
+    if scope.get("instrumentation_blocker") is not False:
+        v1._fail(
+            "manifest.scope.instrumentation_blocker",
+            "must be false for the runnable v6 pilot",
+        )
+
+    forge = v1._as_object(v1._required(manifest, "forge", "manifest"), "manifest.forge")
+    v1._require_exact_keys(
+        forge,
+        {"repository_url", "commit_sha", "revision_policy", "component_sha256"},
+        "manifest.forge",
+    )
+    if forge.get("commit_sha") != BASELINE_COMMIT:
+        v1._fail(
+            "manifest.forge.commit_sha",
+            "must bind the Issue #40 post-build handoff baseline",
+        )
+    if forge.get("revision_policy") != REVISION_POLICY:
+        v1._fail(
+            "manifest.forge.revision_policy",
+            f"must be {REVISION_POLICY!r}",
+        )
+    _validate_hash_map(
+        v1._required(forge, "component_sha256", "manifest.forge"),
+        expected_paths=COMPONENT_PATHS,
+        path="manifest.forge.component_sha256",
+    )
+    _validate_hash_map(
+        v1._required(manifest, "protocol_artifact_sha256", "manifest"),
+        expected_paths=PROTOCOL_ARTIFACT_PATHS,
+        path="manifest.protocol_artifact_sha256",
+    )
+
+    runtime = v1._as_object(v1._required(manifest, "runtime", "manifest"), "manifest.runtime")
+    if runtime.get("control_plane_topology") != CONTROL_PLANE_TOPOLOGY:
+        v1._fail(
+            "manifest.runtime.control_plane_topology",
+            f"must be {CONTROL_PLANE_TOPOLOGY!r}",
+        )
+
+    model = v1._as_object(v1._required(manifest, "model", "manifest"), "manifest.model")
+    if model.get("endpoint") != "https://richlab-api-x.choosefire.com/v1":
+        v1._fail("manifest.model.endpoint", "must use the frozen pilot endpoint")
+    if model.get("roles") != {"lead": "gpt-5.6-sol", "compiler": "gpt-5.6-sol"}:
+        v1._fail("manifest.model.roles", "must use gpt-5.6-sol for both roles")
+    if model.get("request_timeout_seconds") != 120 or model.get("max_retries") != 0:
+        v1._fail("manifest.model", "must freeze a 120-second timeout and zero retries")
+
+    compatibility_manifest = _compatibility_manifest(manifest)
+    v1.validate_manifest(compatibility_manifest)
+    if manifest["benchmark"]["id"] != "forge-cpp-clean-replay-pilot-v6":
+        v1._fail("manifest.benchmark.id", "must identify the v6 clean-replay pilot")
+    if manifest["conditions"][0]["repetitions"] != 1:
+        v1._fail("manifest.conditions[0].repetitions", "must be 1 for the five-case pilot")
+    return manifest
+
+
+def _compatibility_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    forge = manifest["forge"]
+    compatibility_manifest = copy.deepcopy(manifest)
+    compatibility_manifest["schema_version"] = v1.SCHEMA_VERSION
+    compatibility_manifest["scope"]["instrumentation_blocker"] = True
+    compatibility_manifest["forge"].pop("revision_policy")
+    compatibility_manifest["forge"]["component_sha256"] = {path: forge["component_sha256"][path] for path in v1._COMPONENT_PATHS}
+    compatibility_manifest["runtime"].pop("control_plane_topology")
+    compatibility_manifest["protocol_artifact_sha256"] = {
+        "scripts/forge_benchmark.py": manifest["protocol_artifact_sha256"]["scripts/forge_benchmark.py"],
+        "benchmarks/schemas/forge-cpp-benchmark-v1.schema.json": manifest["protocol_artifact_sha256"]["benchmarks/schemas/forge-cpp-benchmark-v6.schema.json"],
+    }
+    return compatibility_manifest
+
+
+def validate_manifest(document: Any) -> dict[str, Any]:
+    """Validate a v6 manifest without reading repository files."""
+    try:
+        return _validate_manifest_impl(document)
+    except BenchmarkError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: contains a malformed value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    validate_manifest(manifest)
+    try:
+        return json.dumps(
+            manifest,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: cannot be represented as canonical JSON") from exc
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def _validate_build_identity(
+    capabilities: Any,
+    selected: Any,
+    executed: Any,
+    *,
+    path: str,
+) -> tuple[list[str], str | None, str | None]:
+    if not isinstance(capabilities, list) or len(capabilities) > len(v1._BUILD_SYSTEMS) or len(set(capabilities)) != len(capabilities) or any(value not in v1._BUILD_SYSTEMS for value in capabilities):
+        v1._fail(f"{path}.build_system_capabilities", "must be a unique supported build-system list")
+    for key, value in (("selected_build_system", selected), ("executed_build_system", executed)):
+        if value is not None and value not in v1._BUILD_SYSTEMS:
+            v1._fail(f"{path}.{key}", "must be null or a supported build system")
+    if selected is not None and selected not in capabilities:
+        v1._fail(f"{path}.selected_build_system", "must belong to build_system_capabilities")
+    return capabilities, selected, executed
+
+
+def validate_run_record(document: Any) -> dict[str, Any]:
+    """Validate a v6 run record with explicit build-system identity facts."""
+    try:
+        record = v1._as_object(document, "run_record")
+        if record.get("schema_version") != SCHEMA_VERSION:
+            v1._fail("run_record.schema_version", f"must be {SCHEMA_VERSION!r}")
+        source = v1._as_object(v1._required(record, "source", "run_record"), "run_record.source")
+        v1._require_exact_keys(
+            source,
+            {
+                "session_id",
+                "run_id",
+                "repository_url",
+                "commit_sha",
+                "build_system",
+                "build_system_capabilities",
+                "selected_build_system",
+                "executed_build_system",
+                "image_id",
+            },
+            "run_record.source",
+        )
+        _capabilities, selected, executed = _validate_build_identity(
+            source["build_system_capabilities"],
+            source["selected_build_system"],
+            source["executed_build_system"],
+            path="run_record.source",
+        )
+        if source["build_system"] != executed:
+            v1._fail("run_record.source.build_system", "must equal the explicit executed build system")
+        outcome = v1._as_object(v1._required(record, "outcome", "run_record"), "run_record.outcome")
+        if outcome.get("candidate_status") == "pass" and (selected is None or executed is None or executed != selected):
+            v1._fail("run_record.source", "candidate pass requires matching selected and executed build-system evidence")
+
+        compatibility_record = copy.deepcopy(record)
+        compatibility_record["schema_version"] = v1.SCHEMA_VERSION
+        compatibility_source = compatibility_record["source"]
+        compatibility_source.pop("build_system_capabilities")
+        compatibility_source.pop("selected_build_system")
+        compatibility_source.pop("executed_build_system")
+        v1.validate_run_record(compatibility_record)
+        return record
+    except BenchmarkError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("run_record: contains a malformed value") from exc
+
+
+def build_run_record(
+    *,
+    manifest: dict[str, Any],
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    session: dict[str, Any],
+    workflow_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a v6 record without inferring observed identity from the manifest."""
+    validate_manifest(manifest)
+    capabilities = copy.deepcopy(session.get("build_system_capabilities", []))
+    selected = session.get("selected_build_system")
+    executed = session.get("executed_build_system")
+    _validate_build_identity(capabilities, selected, executed, path="session")
+    case = next((candidate for candidate in manifest["cases"] if candidate["id"] == case_id), None)
+    if case is None:
+        v1._fail("record.case_id", "does not name a manifest case")
+    if selected is not None and selected != case["build_system"]:
+        v1._fail("session.selected_build_system", "does not match the selected manifest case")
+
+    compatibility_session = copy.deepcopy(session)
+    compatibility_session["build_system"] = selected
+    record = v1.build_run_record(
+        manifest=_compatibility_manifest(manifest),
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        session=compatibility_session,
+        workflow_events=workflow_events,
+    )
+    record["schema_version"] = SCHEMA_VERSION
+    record["manifest_sha256"] = manifest_sha256(manifest)
+    record["source"].update(
+        {
+            "build_system": executed,
+            "build_system_capabilities": capabilities,
+            "selected_build_system": selected,
+            "executed_build_system": executed,
+        }
+    )
+    return validate_run_record(record)
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path) -> None:
+    """Verify the v6 runtime and protocol files against the current clean tree."""
+    validate_manifest(manifest)
+    try:
+        resolved_root = repo_root.resolve(strict=True)
+    except OSError as exc:
+        raise BenchmarkError("frozen_components: repository root is unavailable") from exc
+    if not resolved_root.is_dir():
+        raise BenchmarkError("frozen_components: repository root must be a directory")
+
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+    ):
+        for relative_path, expected_sha256 in hashes.items():
+            candidate = resolved_root
+            for part in PurePosixPath(relative_path).parts:
+                candidate /= part
+                if candidate.is_symlink():
+                    v1._fail(f"{path_prefix}.{relative_path}", "must reference an ordinary file, not a symlink")
+            if not candidate.is_file():
+                v1._fail(f"{path_prefix}.{relative_path}", "references a missing ordinary file")
+            try:
+                resolved_candidate = candidate.resolve(strict=True)
+                resolved_candidate.relative_to(resolved_root)
+                actual_sha256 = hashlib.sha256(resolved_candidate.read_bytes()).hexdigest()
+            except (OSError, ValueError) as exc:
+                raise BenchmarkError(f"{path_prefix}.{relative_path}: could not be read safely") from exc
+            if actual_sha256 != expected_sha256:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match the current repository file")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser(
+        "validate-manifest",
+        help="validate and hash a runnable v6 benchmark manifest",
+    )
+    validate_parser.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = validate_manifest(load_json_document(args.manifest))
+        verify_frozen_components(manifest, REPOSITORY_ROOT)
+        print(
+            json.dumps(
+                {
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 在 Issue #40 的 post-build handoff 主干基线上创建独立的 C/C++ pilot v6 manifest、Schema 与 validator。
- 冻结 v6 的运行时与协议哈希；固定 `gpt-5.6-sol`、120 秒 provider timeout、0 retries、Compose/DooD、Memory/Skills 关闭与 Clean Replay。
- 子代理总超时固定为 300 秒，保留 post-build 交接控制。
- 共享 runner 支持 v6，默认执行 v6，但不修改 v1-v5 冻结资产或既有 ledger。

## 验证

- v6 manifest/Schema/runner：34 passed
- WSL 主机 preflight：ready=true，运行时与协议哈希一致

Closes #46