### PR TITLE
修复：在构建前强制校验冻结参数契约

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,15 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-26 — 实现 Issue #50 的冻结构建参数前置契约
+  - 范围: 在实验真实 build 执行前，从此前成功 configure 或当前复合 configure+build 命令中按有序 token 子序列验证 CMake/Autotools 冻结参数；缺参返回 `126 policy_rejected`，不执行 build、不进入 post-build、不启动 replay。submit gate 继续作为第二道防线。
+  - 证据: CMake/Autotools 正反例及复合命令 `8 passed`，相关回归 `173 passed, 1 skipped`，后端全量 `1626 passed, 48 skipped`；Ruff、Compose config、v6 五条 ledger 和 22 个 baseline component 审计通过；真实 Docker 非模型场景确认 build 未执行且无 replay。
+  - GitHub: 中文提交 `3c18eb98`，Draft PR #53；Draft backend/frontend lint 已通过，Unit Tests 在 Draft 状态下 skipped。v1-v6 manifest、Schema、validator 与 ledger 未改写，没有模型调用或 v7 运行。
+
+- 2026-07-26 — 完成 C/C++ pilot v6 五个不可替换 physical attempt
+  - 结果: 五条 ledger 的 hash chain、离线 gate、终结与 orphan reconciliation 有效，0 orphan、0/5 oracle pass。`hiredis` 到达 submit/clean replay/delivery 后被 artifact oracle 拒绝；`libcheck`/`libgit2` 暴露 subagent timeout，`sysstat` 暴露 recursion limit，`libgit2`/`sysstat` 同时暴露参数契约过晚。
+  - 边界: v6 证据冻结，不 retry、replacement、fallback 或回填；后续修复只能进入新协议。
+
 - 2026-07-26 — 重排 Issue #38 的 C/C++ pilot v5 冻结协议
   - 范围: 从当前主干冻结独立 v5 manifest、Schema、validator 与 runner 路由，记录 capability、selected 与 executed identity；v1-v4 与既有 ledger 保持字节不变。
   - 边界: 只重排与审计协议，不调用模型、不创建、执行、覆盖或 replacement 任一 physical-attempt slot，也不启动 v6。
@@ -128,10 +137,8 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 评审 stacked Draft PR #9，并在 CI 与基线 manifest 冻结后再转为 ready。
-- 按堆叠顺序评审并合并 Issue #16/#17/#18 与 pilot v3 的 Draft PR；五个 v3 physical attempts 必须使用新 ledger，不能 replacement 或覆盖 v2 的五条原始 ledger。
-- Issue #30 / PR #31 已完成协议重排、CI 与主干合并；保持 v1-v5 协议和 ledger 不变，不启动 v6 pilot。
-- 按堆叠顺序处理 Issue #32 / PR #35；完成 event-loop ownership 修复验证后，再进入上层 #36、#37、#39、#41。
+- 先完成 Issue #50 / Draft PR #53 的 Ready CI、审阅、squash merge、Issue 自动关闭和主干复验；head 必须保持 `3c18eb98`。
+- #50 完成后依次处理 Issue #51（provider/subagent/recursion/收口预算与配对终止 evidence）和 Issue #52（artifact oracle 结构化差异）；三项合入前不创建 v7、不调用模型、不重跑 v6。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -177,3 +184,4 @@
 - 真实 Docker 集成依赖 GitHub clone，偶发 `Recv failure: Connection reset by peer` 可能在进入待测逻辑前失败；先确认按 label 无遗留容器，再只重跑该场景。本次副作用拒绝场景首次网络失败，单独重跑后 `1 passed in 32.63s`。
 - 完整 `test_client.py` 当前有 3 个与 v4 无关的既有 artifact 路径期望不一致：测试期待 `must start with`/`PathTraversalError`，实际 `Paths.resolve_virtual_path()` 返回 `Unsupported virtual path` 的 `ValueError`；v4 扩大回归为 `431 passed, 3 skipped, 3 failed`，stream/chat 定向测试仍为 `19 passed`。不要在 benchmark 协议提交中顺手修改。
 - 原生 async stream 不自动保证模型 client 的 event-loop ownership。`task_tool` 已在 Lead 的 async loop 中时，不能再通过 `thread pool -> asyncio.run()` 为 compiler 创建第二个 loop；保留同步兼容调用的隔离线程路径，并用 loop-bound 回归保护该边界。
+- Windows Git 的 HTTPS push/ls-remote 可能无输出挂起，而 `gh api` 正常。回退到 Git Data API 时要以 base tree 和 changed blobs 创建单提交，比较本地/远端 tree SHA，并把本地分支 ref 对齐远端 commit；不能只验证 PR 页面可见。

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -1029,6 +1029,13 @@ def _command_contains_arguments(command: str, expected: tuple[str, ...]) -> bool
     return all(any(token == argument for token in token_iterator) for argument in expected)
 
 
+def _successful_configure_arguments_observed(
+    commands: list[BuildCommandRecord],
+    expected: tuple[str, ...],
+) -> bool:
+    return any(command.exit_code == 0 and not command.timed_out and "configure" in infer_command_roles(command.command) and _command_contains_arguments(command.command, expected) for command in commands)
+
+
 def _command_invokes(command: str, executable: str) -> bool:
     try:
         lexer = shlex(command.replace("\n", ";"), posix=True, punctuation_chars="();&|")
@@ -1210,6 +1217,40 @@ def resolve_command_role(command: str, declared_role: str | None) -> tuple[str, 
     return declared, None
 
 
+def validate_experiment_build_arguments(
+    session: CompileSession,
+    command: str,
+) -> tuple[bool, str | None, int]:
+    """Validate frozen configure arguments before an experiment build executes."""
+
+    active = get_active_experiment(session.thread_id)
+    command_roles = infer_command_roles(command)
+    if active is None or "build" not in command_roles:
+        return True, None, 0
+
+    expected_arguments: tuple[str, ...]
+    failure: str
+    if active.policy.selected_build_system == "cmake":
+        expected_arguments = active.policy.cmake_arguments
+        failure = "cmake_arguments_not_observed"
+    elif active.policy.selected_build_system == "autotools":
+        expected_arguments = active.policy.configure_arguments
+        failure = "configure_arguments_not_observed"
+    else:
+        return True, None, 0
+
+    if not expected_arguments:
+        return True, None, 0
+
+    observed = _successful_configure_arguments_observed(
+        session.commands,
+        expected_arguments,
+    )
+    if "configure" in command_roles:
+        observed = observed or _command_contains_arguments(command, expected_arguments)
+    return observed, None if observed else failure, len(expected_arguments)
+
+
 def _configure_command_build_system(command: str) -> str | None:
     if infer_command_role(command) == "configure" and _command_invokes(command, "cmake"):
         return "cmake"
@@ -1315,9 +1356,15 @@ def _experiment_submit_constraints(
     successful_commands = [command for command in session.commands if command.exit_code == 0 and not command.timed_out]
     if active.policy.required_system_packages and not any(command.role == "dependency_setup" for command in successful_commands):
         failures.append("dependency_setup_not_observed")
-    if active.policy.cmake_arguments and not any(command.role == "configure" and _command_contains_arguments(command.command, active.policy.cmake_arguments) for command in successful_commands):
+    if active.policy.cmake_arguments and not _successful_configure_arguments_observed(
+        successful_commands,
+        active.policy.cmake_arguments,
+    ):
         failures.append("cmake_arguments_not_observed")
-    if active.policy.configure_arguments and not any(command.role == "configure" and _command_contains_arguments(command.command, active.policy.configure_arguments) for command in successful_commands):
+    if active.policy.configure_arguments and not _successful_configure_arguments_observed(
+        successful_commands,
+        active.policy.configure_arguments,
+    ):
         failures.append("configure_arguments_not_observed")
     return not failures, failures, executed_build_system
 

--- a/backend/packages/harness/deerflow/tools/bound_compile_tools.py
+++ b/backend/packages/harness/deerflow/tools/bound_compile_tools.py
@@ -9,7 +9,14 @@ from pathlib import Path
 from langchain.tools import tool
 
 from deerflow.compile.evidence import allowed_command_role, new_evidence_id, record_experiment_event
-from deerflow.compile.operations import get_bound_session, get_compile_services, infer_command_roles, resolve_command_role, submit_build_result_impl
+from deerflow.compile.operations import (
+    get_bound_session,
+    get_compile_services,
+    infer_command_roles,
+    resolve_command_role,
+    submit_build_result_impl,
+    validate_experiment_build_arguments,
+)
 from deerflow.compile.schemas import BuildCommandRecord, CommandResult, CompileSession, utc_now_iso
 
 _MAX_OUTPUT_LINES = 50
@@ -298,6 +305,69 @@ def _run_container_bash_impl(
             log_path=log_path,
         )
         return result, f"command_id={command_id}\ncommand_role={effective_role}\nexit_code={_POLICY_REJECTED_EXIT_CODE} (Policy rejected)\nworkdir={effective_workdir}\nerror: {rejection}", record
+
+    arguments_match, argument_failure, required_argument_count = validate_experiment_build_arguments(
+        session,
+        command,
+    )
+    if required_argument_count:
+        record_experiment_event(
+            session.thread_id,
+            "build.arguments_checked",
+            phase="pre_build",
+            session_id=session.session_id,
+            command_id=command_id,
+            build_system=session.selected_build_system,
+            required_argument_count=required_argument_count,
+            matches=arguments_match,
+            command_executed=arguments_match,
+        )
+    if argument_failure is not None:
+        rejection = "The build command was not executed because no successful configure command observed every frozen build argument in order. Correct the configure command with the experiment policy arguments, then retry the build."
+        now = utc_now_iso()
+        record = _record_bash_command(
+            session=session,
+            command=command,
+            workdir=effective_workdir,
+            started_at=now,
+            completed_at=now,
+            exit_code=_POLICY_REJECTED_EXIT_CODE,
+            log_path=log_path,
+            command_id=command_id,
+            command_role=effective_role,
+            timeout_seconds=timeout_seconds,
+            duration_seconds=0.0,
+            timed_out=False,
+            termination="policy_rejected",
+        )
+        services.manager.log_event(
+            session,
+            "build.arguments_rejected",
+            command_id=command_id,
+            command_role=effective_role,
+            classification=argument_failure,
+        )
+        record_experiment_event(
+            session.thread_id,
+            "protocol.deviation",
+            phase="pre_build",
+            classification=argument_failure,
+            session_id=session.session_id,
+            command_id=command_id,
+            build_system=session.selected_build_system,
+            required_argument_count=required_argument_count,
+            submit_allowed=False,
+            command_executed=False,
+        )
+        result = CommandResult(
+            exit_code=_POLICY_REJECTED_EXIT_CODE,
+            stdout="",
+            stderr=rejection,
+            combined_output=rejection,
+            log_path=log_path,
+        )
+        message = f"command_id={command_id}\ncommand_role={effective_role}\nexit_code={_POLICY_REJECTED_EXIT_CODE} (Policy rejected)\nworkdir={effective_workdir}\nclassification={argument_failure}\nerror: {rejection}"
+        return result, message, record
 
     _consume_post_build_budget(session, command_role=effective_role)
 

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -561,6 +561,115 @@ def test_build_system_mismatch_stops_before_real_compiler_delegation(monkeypatch
         shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
 
 
+def test_missing_frozen_arguments_stop_before_real_build_and_replay(monkeypatch):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-build-argument-gate-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    ledger = ExperimentLedger.create(
+        Path(session.metadata_path).parent / "build-argument-gate.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-post-v6-argument-gate",
+        manifest_sha256="5" * 64,
+        case_id="cmake-argument-fixture",
+        condition="non-pilot-integration",
+        repetition=1,
+        expected_repo_url=REPO_URL,
+        expected_commit_sha=COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=COMPILE_IMAGE,
+        image_id=COMPILE_IMAGE_ID,
+        model_name="deterministic-tools",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=300,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=("-DBUILD_TESTING=OFF",),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        clone_result, _message = clone_repository_impl(
+            session=session,
+            repo_url=REPO_URL,
+            max_retries=1,
+        )
+        assert clone_result.exit_code == 0, clone_result.combined_output
+
+        identify_result = agent_compile_tools.identify_build_system.func(
+            runtime=SimpleNamespace(
+                state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+                context={"thread_id": thread_id},
+                config={"configurable": {}},
+            ),
+            tool_call_id="tool-real-build-argument-gate",
+        )
+        assert identify_result.update.get("compile_terminal") is not True
+
+        run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
+        configured = run_tool.func(
+            command="cmake -S . -B build",
+            command_role="other",
+        )
+        rejected = run_tool.func(
+            command="cmake --build build -j2",
+            command_role="other",
+        )
+
+        assert "command_role=configure" in configured
+        assert "exit_code=0\n" in configured, configured
+        assert "exit_code=126 (Policy rejected)" in rejected
+        assert "classification=cmake_arguments_not_observed" in rejected
+        reloaded = manager.load_session(session.session_id, thread_id)
+        assert reloaded.post_build_supporting_command_id is None
+        assert reloaded.replay_attempts == []
+        assert (
+            runtime.exec(
+                reloaded,
+                "test ! -e build/hello",
+                workdir="/workspace/repo",
+                timeout_seconds=30,
+            ).exit_code
+            == 0
+        )
+        _assert_no_replay_container(reloaded)
+
+        events = ledger.read()
+        deviation = next(event for event in events if event["event"] == "protocol.deviation")
+        assert deviation["payload"]["phase"] == "pre_build"
+        assert deviation["payload"]["classification"] == "cmake_arguments_not_observed"
+        assert deviation["payload"]["command_executed"] is False
+    finally:
+        deactivate_experiment(thread_id)
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
 def test_post_build_handoff_corrects_role_and_auto_submits_cmake_fixture(monkeypatch):
     paths = Paths()
     manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -51,6 +51,41 @@ def make_test_paths(tmp_path: Path, *, host_workspace_root: str | None = None) -
     )
 
 
+def make_experiment_policy(
+    session: CompileSession,
+    *,
+    build_system: str,
+    cmake_arguments: tuple[str, ...] = (),
+    configure_arguments: tuple[str, ...] = (),
+) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v6",
+        manifest_sha256="1" * 64,
+        case_id="fixture",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url=session.repo_url,
+        expected_commit_sha="2" * 40,
+        expected_build_system=build_system,
+        compile_image=session.image,
+        image_id=VALID_IMAGE_ID,
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=cmake_arguments,
+        configure_arguments=configure_arguments,
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+
+
 def add_replayable_build_command(session: CompileSession, command: str = "cmake --build build") -> None:
     session.commands.append(
         BuildCommandRecord(
@@ -239,6 +274,180 @@ def test_successful_mislabelled_build_enters_persisted_post_build_fence(tmp_path
     assert rejected_record.role == "configure"
     assert rejected_record.termination == "policy_rejected"
     assert runtime_calls == ["cmake --build build -j2"]
+
+
+@pytest.mark.parametrize(
+    ("build_system", "arguments", "configure_command", "build_command", "classification"),
+    [
+        (
+            "cmake",
+            ("-DBUILD_TESTING=OFF", "-DCMAKE_BUILD_TYPE=Release"),
+            "cmake -S . -B build -DBUILD_TESTING=OFF",
+            "cmake --build build -j2",
+            "cmake_arguments_not_observed",
+        ),
+        (
+            "autotools",
+            ("--disable-shared", "--enable-static"),
+            "./configure --disable-shared",
+            "make -j2",
+            "configure_arguments_not_observed",
+        ),
+    ],
+)
+def test_experiment_build_is_rejected_before_runtime_when_frozen_arguments_are_missing(
+    tmp_path: Path,
+    monkeypatch,
+    build_system: str,
+    arguments: tuple[str, ...],
+    configure_command: str,
+    build_command: str,
+    classification: str,
+) -> None:
+    thread_id = f"thread-pre-build-arguments-rejected-{build_system}"
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url="https://example.com/repo.git",
+    )
+    session.selected_build_system = build_system
+    manager.save_session(session)
+    runtime_calls: list[str] = []
+
+    def fake_exec(_session, command, **kwargs):
+        runtime_calls.append(command)
+        return CommandResult(
+            exit_code=0,
+            stdout="ok\n",
+            stderr="",
+            combined_output="ok\n",
+            log_path=kwargs.get("log_path"),
+        )
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)),
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "pre-build-arguments-rejected.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = make_experiment_policy(
+        session,
+        build_system=build_system,
+        cmake_arguments=arguments if build_system == "cmake" else (),
+        configure_arguments=arguments if build_system == "autotools" else (),
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        configure_result, _configure_message, _configure_record = bound_compile_tools._run_container_bash_impl(
+            session=session,
+            command=configure_command,
+        )
+        build_result, build_message, build_record = bound_compile_tools._run_container_bash_impl(
+            session=session,
+            command=build_command,
+        )
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert configure_result.exit_code == 0
+    assert build_result.exit_code == 126
+    assert build_record.role == "build"
+    assert build_record.termination == "policy_rejected"
+    assert f"classification={classification}" in build_message
+    assert runtime_calls == [configure_command]
+    events = ledger.read()
+    argument_check = next(event for event in events if event["event"] == "build.arguments_checked")
+    deviation = next(event for event in events if event["event"] == "protocol.deviation")
+    assert argument_check["payload"]["matches"] is False
+    assert argument_check["payload"]["command_executed"] is False
+    assert deviation["payload"]["phase"] == "pre_build"
+    assert deviation["payload"]["classification"] == classification
+
+
+@pytest.mark.parametrize(
+    ("build_system", "arguments", "commands", "build_command"),
+    [
+        (
+            "cmake",
+            ("-DBUILD_TESTING=OFF", "-DCMAKE_BUILD_TYPE=Release"),
+            [
+                BuildCommandRecord(
+                    stage="bash",
+                    command="cmake -S . -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release",
+                    workdir="/workspace/repo",
+                    role="configure",
+                    exit_code=0,
+                )
+            ],
+            "cmake --build build -j2",
+        ),
+        (
+            "autotools",
+            ("--disable-shared", "--enable-static"),
+            [],
+            "./configure --disable-shared --enable-static && make -j2",
+        ),
+    ],
+)
+def test_experiment_build_arguments_accept_prior_or_compound_configure_evidence(
+    tmp_path: Path,
+    build_system: str,
+    arguments: tuple[str, ...],
+    commands: list[BuildCommandRecord],
+    build_command: str,
+) -> None:
+    thread_id = f"thread-pre-build-arguments-{build_system}"
+    session = CompileSession(
+        session_id=f"session-pre-build-arguments-{build_system}",
+        thread_id=thread_id,
+        repo_url="https://example.com/repo.git",
+        branch=None,
+        image="autocompiler:gcc13",
+        status="inspected",
+        selected_build_system=build_system,
+        commands=commands,
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / f"pre-build-arguments-{build_system}.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = make_experiment_policy(
+        session,
+        build_system=build_system,
+        cmake_arguments=arguments if build_system == "cmake" else (),
+        configure_arguments=arguments if build_system == "autotools" else (),
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        matches, failure, required_argument_count = operations.validate_experiment_build_arguments(
+            session,
+            build_command,
+        )
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert matches is True
+    assert failure is None
+    assert required_argument_count == 2
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_forge_benchmark_v6.py
+++ b/backend/tests/test_forge_benchmark_v6.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 from jsonschema import Draft202012Validator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -26,7 +30,32 @@ def test_v6_manifest_freezes_post_build_handoff_baseline() -> None:
     assert manifest["model"]["request_timeout_seconds"] == 120
     assert manifest["model"]["max_retries"] == 0
     assert forge_benchmark_v6.validate_manifest(manifest) is manifest
-    forge_benchmark_v6.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v6_current_tree_gate_rejects_later_runtime_component_drift() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    with pytest.raises(
+        forge_benchmark_v6.BenchmarkError,
+        match="does not match the current repository file",
+    ):
+        forge_benchmark_v6.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_v6_runtime_components_match_the_declared_baseline() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        result = subprocess.run(
+            [git, "show", f"{manifest['forge']['commit_sha']}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
 
 
 def test_v6_schema_validates_the_frozen_manifest() -> None:


### PR DESCRIPTION
## 背景

v6 的 `libgit2` 与 `sysstat-nondeterministic` 在消耗编译预算后，才分别被提交门禁判定为 `cmake_arguments_not_observed` 与 `configure_arguments_not_observed`。这会让确定性的参数契约错误过晚暴露。

## 修改

- 在实验 build 命令进入真实容器前，检查此前成功 configure 或当前复合命令是否按顺序包含全部冻结参数。
- 缺少参数时以退出码 126 拒绝 build，不执行真实构建、不进入 post-build、不触发 replay，并写入脱敏的 `build.arguments_checked` 与 `protocol.deviation` 证据。
- 保留 submit 门禁作为第二道防线，并让复合 configure+build 命令也能被正确识别。
- 保持 v1-v6 manifest、schema、validator 与 ledger 不变；v6 current-tree gate 继续拒绝后续运行时漂移，同时从基线提交审计冻结组件。
- 新增 CMake/Autotools 正反例、复合命令、role 纠正和真实 Docker 非模型回归。

## 验证

- 后端全量：1626 passed，48 skipped。
- 参数契约聚焦测试：8 passed。
- 真实 Docker 非模型门禁：1 passed；确认 build 未执行且无 replay 容器。
- Ruff：通过。
- Compose config：通过。
- v6 ledger：5/5 哈希链离线验证通过。
- v6 基线组件：22/22 与冻结哈希一致。

Closes #50