### PR TITLE
修复：分离 compiler 四类预算并闭合终结证据

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -2,8 +2,16 @@
 
 跨 Claude Code session 的项目状态流水。按 CLAUDE.md §7 维护。
 
+## 进行中 (In Progress)
+<!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
+
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-27 — 分离 compiler 四类预算并闭合终结证据
+  - 范围: 为未来协议显式分离模型轮次、LangGraph 递归、compiler 总墙钟与 post-build 预留；旧 `compiler_max_turns` / `subagent_timeout_seconds` 继续作为兼容回退，v1-v6 policy payload、manifest、Schema、validator、runner 与 ledger 保持不变。
+  - 终结: 新增 `model_turn_limit`、`graph_recursion_limit`、`compiler_wall_clock_timeout`、`post_build_reserve_exhausted` 单一分类；终结事件只记录有界数字/布尔预算快照，所有失败路径继续先停 worker、清理真实编译容器再 finalize。
+  - 证据: 聚焦 `68 passed`，后端全量 `1674 passed, 28 skipped`，Ruff 与 Compose config 通过；真实 Docker 四预算分支 `4 passed`，前端 lint/typecheck 通过，冻结实验资产无差异。未调用模型、未重跑或替换 v6，也未创建 v7。
 
 - 2026-07-26 — 实现 Issue #50 的冻结构建参数前置契约
   - 范围: 在实验真实 build 执行前，从此前成功 configure 或当前复合 configure+build 命令中按有序 token 子序列验证 CMake/Autotools 冻结参数；缺参返回 `126 policy_rejected`，不执行 build、不进入 post-build、不启动 replay。submit gate 继续作为第二道防线。
@@ -137,13 +145,14 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 先完成 Issue #50 / Draft PR #53 的 Ready CI、审阅、squash merge、Issue 自动关闭和主干复验；head 必须保持 `3c18eb98`。
-- #50 完成后依次处理 Issue #51（provider/subagent/recursion/收口预算与配对终止 evidence）和 Issue #52（artifact oracle 结构化差异）；三项合入前不创建 v7、不调用模型、不重跑 v6。
+- 完成 Issue #51 的 Draft PR、Ready CI、squash merge、Issue 自动关闭和主干复验；随后处理 Issue #52（artifact oracle 结构化差异）。Issue #52 合入前不创建 v7、不调用模型、不重跑 v6。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- WSL 用户目录中的 `.local` / `.cache/uv` 可能由旧容器以 root 创建，原生 WSL 执行 `uv` 会报 `Permission denied`；不要改写权限掩盖来源，测试可把 `UV_CACHE_DIR`、`UV_PYTHON_INSTALL_DIR` 与 `UV_PROJECT_ENVIRONMENT` 指向用户可写的独立目录。
+- Docker Hub 匿名 token 与 Ubuntu archive 在当前网络下可能分别超时或返回 502；本机可从 Canonical 官方 Amazon ECR 拉取同源 Ubuntu 基础镜像并改回本地 `ubuntu:24.04` 标签，apt 构建可显式传可信镜像站，但不得把临时镜像源写进冻结实验协议或伪装成既有 image ID。
 - 协作语言约定：后续 GitHub Issue、Pull Request、评论、评审说明和提交说明默认使用中文；分支名、代码标识、命令和必要技术术语继续遵循仓库的 ASCII/既有命名规范。若外部协作明确要求英文，先向用户确认。
 - PowerShell -> WSL -> `bash -lc` 的多层命令可能提前展开临时 `$repo` 变量，使 Docker bind mount 退化为 `/frontend/...`；一次性容器优先传完整 WSL 绝对路径，启动失败后先按固定名称清理并确认无残留。
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -74,8 +74,12 @@ _ALLOWED_SUBAGENT_TERMINAL_STATUSES = {
 }
 _ALLOWED_SUBAGENT_FAILURE_CLASSIFICATIONS = {
     "cancelled",
+    "compiler_wall_clock_timeout",
+    "graph_recursion_limit",
+    "model_turn_limit",
     "parent_cancelled",
     "polling_timeout",
+    "post_build_reserve_exhausted",
     "recursion_limit",
     "subagent_failed",
     "subagent_timeout",
@@ -191,7 +195,7 @@ def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str
             "classification",
             "worker_stopped",
         }
-        if set(payload) != required:
+        if set(payload) not in (required, required | {"budget_snapshot"}):
             raise EvidenceError(f"{path} has an invalid agent.subagent_terminated schema")
         if not isinstance(payload["task_id"], str) or not _BOUNDED_IDENTIFIER_RE.fullmatch(payload["task_id"]):
             raise EvidenceError(f"{path}.task_id must be a bounded identifier")
@@ -208,6 +212,36 @@ def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str
             raise EvidenceError(f"{path}.classification is invalid")
         if type(payload["worker_stopped"]) is not bool:
             raise EvidenceError(f"{path}.worker_stopped must be boolean")
+        if "budget_snapshot" in payload:
+            budget_snapshot = payload["budget_snapshot"]
+            budget_keys = {
+                "model_turn_limit",
+                "model_turn_count",
+                "graph_recursion_limit",
+                "wall_clock_limit_seconds",
+                "elapsed_seconds",
+                "post_build_reserve_seconds",
+                "post_build_started",
+            }
+            if not isinstance(budget_snapshot, dict) or set(budget_snapshot) != budget_keys:
+                raise EvidenceError(f"{path}.budget_snapshot has an invalid schema")
+            for key in (
+                "model_turn_limit",
+                "graph_recursion_limit",
+                "wall_clock_limit_seconds",
+            ):
+                value = budget_snapshot[key]
+                if value is not None and (type(value) is not int or value < 1):
+                    raise EvidenceError(f"{path}.budget_snapshot.{key} must be null or positive")
+            for key in ("model_turn_count", "post_build_reserve_seconds"):
+                value = budget_snapshot[key]
+                if type(value) is not int or value < 0:
+                    raise EvidenceError(f"{path}.budget_snapshot.{key} must be non-negative")
+            elapsed_seconds = budget_snapshot["elapsed_seconds"]
+            if type(elapsed_seconds) not in (int, float) or not math.isfinite(elapsed_seconds) or elapsed_seconds < 0:
+                raise EvidenceError(f"{path}.budget_snapshot.elapsed_seconds must be finite and non-negative")
+            if type(budget_snapshot["post_build_started"]) is not bool:
+                raise EvidenceError(f"{path}.budget_snapshot.post_build_started must be boolean")
         return
 
     if event == "agent.tool_failed":
@@ -326,6 +360,10 @@ class ExperimentPolicy:
     configure_arguments: tuple[str, ...]
     environment: tuple[tuple[str, str | None], ...]
     minimum_replay_delay_seconds: int
+    compiler_model_turn_limit: int | None = None
+    compiler_graph_recursion_limit: int | None = None
+    compiler_wall_clock_seconds: int | None = None
+    compiler_post_build_reserve_seconds: int = 0
 
     def __post_init__(self) -> None:
         _validate_sha256(self.manifest_sha256, "manifest_sha256")
@@ -337,6 +375,17 @@ class ExperimentPolicy:
             raise EvidenceError("The C/C++ baseline requires Memory and Skills to be disabled")
         if self.minimum_replay_delay_seconds < 0:
             raise EvidenceError("minimum replay delay cannot be negative")
+        for name, value in (
+            ("compiler_model_turn_limit", self.compiler_model_turn_limit),
+            ("compiler_graph_recursion_limit", self.compiler_graph_recursion_limit),
+            ("compiler_wall_clock_seconds", self.compiler_wall_clock_seconds),
+        ):
+            if value is not None and value < 1:
+                raise EvidenceError(f"{name} must be positive when configured")
+        if self.compiler_post_build_reserve_seconds < 0:
+            raise EvidenceError("compiler_post_build_reserve_seconds cannot be negative")
+        if self.compiler_wall_clock_seconds is not None and self.compiler_post_build_reserve_seconds >= self.compiler_wall_clock_seconds:
+            raise EvidenceError("compiler_post_build_reserve_seconds must be smaller than compiler_wall_clock_seconds")
         if self.expected_build_system not in _ALLOWED_BUILD_SYSTEMS:
             raise EvidenceError("expected_build_system must be cmake, make, or autotools")
         if self.expected_build_system != "cmake" and self.cmake_arguments:
@@ -355,7 +404,7 @@ class ExperimentPolicy:
         return self.expected_build_system
 
     def to_payload(self) -> dict[str, Any]:
-        return {
+        payload = {
             "benchmark_id": self.benchmark_id,
             "manifest_sha256": self.manifest_sha256,
             "case_id": self.case_id,
@@ -381,6 +430,23 @@ class ExperimentPolicy:
             "environment": dict(self.environment),
             "minimum_replay_delay_seconds": self.minimum_replay_delay_seconds,
         }
+        if any(
+            (
+                self.compiler_model_turn_limit is not None,
+                self.compiler_graph_recursion_limit is not None,
+                self.compiler_wall_clock_seconds is not None,
+                self.compiler_post_build_reserve_seconds > 0,
+            )
+        ):
+            payload.update(
+                {
+                    "compiler_model_turn_limit": self.compiler_model_turn_limit,
+                    "compiler_graph_recursion_limit": self.compiler_graph_recursion_limit,
+                    "compiler_wall_clock_seconds": self.compiler_wall_clock_seconds,
+                    "compiler_post_build_reserve_seconds": self.compiler_post_build_reserve_seconds,
+                }
+            )
+        return payload
 
 
 @dataclass(frozen=True)

--- a/backend/packages/harness/deerflow/subagents/config.py
+++ b/backend/packages/harness/deerflow/subagents/config.py
@@ -23,6 +23,31 @@ class SubagentConfig:
     max_turns: int | None = None
     timeout_seconds: int = 900
     runtime_profile: SubagentRuntimeProfile = field(default_factory=SubagentRuntimeProfile)
+    model_turn_limit: int | None = None
+    graph_recursion_limit: int | None = None
+    wall_clock_timeout_seconds: int | None = None
+    post_build_reserve_seconds: int = 0
 
     def with_overrides(self, **kwargs) -> SubagentConfig:
         return replace(self, **kwargs)
+
+    @property
+    def effective_graph_recursion_limit(self) -> int | None:
+        """Return the explicit graph budget, falling back to the legacy field."""
+        return self.graph_recursion_limit if self.graph_recursion_limit is not None else self.max_turns
+
+    @property
+    def effective_wall_clock_timeout_seconds(self) -> int:
+        """Return the explicit wall-clock budget, falling back to the legacy field."""
+        return self.wall_clock_timeout_seconds or self.timeout_seconds
+
+    @property
+    def has_explicit_compiler_budgets(self) -> bool:
+        return any(
+            (
+                self.model_turn_limit is not None,
+                self.graph_recursion_limit is not None,
+                self.wall_clock_timeout_seconds is not None,
+                self.post_build_reserve_seconds > 0,
+            )
+        )

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -262,7 +262,7 @@ class SubagentExecutor:
             state = self._build_initial_state(task)
 
             run_config: RunnableConfig = {
-                "recursion_limit": self.config.max_turns,
+                "recursion_limit": self.config.effective_graph_recursion_limit,
             }
             context: dict[str, Any] = {}
             if self.thread_id:
@@ -300,6 +300,14 @@ class SubagentExecutor:
                             is_duplicate = message_dict in result.ai_messages
                         if not is_duplicate:
                             result.ai_messages.append(message_dict)
+                            if self.config.model_turn_limit is not None and len(result.ai_messages) >= self.config.model_turn_limit and last_message.tool_calls:
+                                _mark_terminal(
+                                    result,
+                                    SubagentStatus.FAILED,
+                                    f"Subagent reached its model turn limit of {self.config.model_turn_limit}",
+                                    "model_turn_limit",
+                                )
+                                return result
 
             if final_state is None:
                 result.result = "No response generated"
@@ -327,7 +335,7 @@ class SubagentExecutor:
                 result,
                 SubagentStatus.FAILED,
                 str(exc),
-                "recursion_limit",
+                "graph_recursion_limit" if self.config.graph_recursion_limit is not None else "recursion_limit",
             )
         except Exception as e:
             logger.exception("[trace=%s] Subagent %s async execution failed", self.trace_id, self.config.name)
@@ -373,17 +381,19 @@ class SubagentExecutor:
     def _execute_with_timeout(self, task: str, result_holder: SubagentResult) -> SubagentResult:
         future = _isolated_loop_pool.submit(self._run_with_isolated_loop, task, result_holder)
         try:
-            return future.result(timeout=self.config.timeout_seconds)
+            timeout_seconds = self.config.effective_wall_clock_timeout_seconds
+            return future.result(timeout=timeout_seconds)
         except FuturesTimeoutError:
-            logger.warning("[trace=%s] Subagent %s timed out after %ss", self.trace_id, self.config.name, self.config.timeout_seconds)
-            timeout_error = f"Subagent timed out after {self.config.timeout_seconds} seconds"
+            timeout_seconds = self.config.effective_wall_clock_timeout_seconds
+            logger.warning("[trace=%s] Subagent %s timed out after %ss", self.trace_id, self.config.name, timeout_seconds)
+            timeout_error = f"Subagent timed out after {timeout_seconds} seconds"
             with result_holder._status_lock:
                 if result_holder.status in _TERMINAL_STATUSES:
                     return result_holder
                 result_holder.cancel_event.set()
                 result_holder.status = SubagentStatus.TIMED_OUT
                 result_holder.error = timeout_error
-                result_holder.failure_classification = "subagent_timeout"
+                result_holder.failure_classification = "compiler_wall_clock_timeout" if self.config.wall_clock_timeout_seconds is not None else "subagent_timeout"
                 result_holder.completed_at = datetime.now()
             _cancel_running_coroutine(result_holder, force=True)
             future.cancel()
@@ -406,15 +416,16 @@ class SubagentExecutor:
                 if result_holder.status == SubagentStatus.PENDING:
                     result_holder.status = SubagentStatus.RUNNING
             try:
-                async with asyncio.timeout(self.config.timeout_seconds):
+                timeout_seconds = self.config.effective_wall_clock_timeout_seconds
+                async with asyncio.timeout(timeout_seconds):
                     return await self._aexecute(task, result_holder)
             except TimeoutError:
                 result_holder.cancel_event.set()
                 _mark_terminal(
                     result_holder,
                     SubagentStatus.TIMED_OUT,
-                    f"Subagent timed out after {self.config.timeout_seconds} seconds",
-                    "subagent_timeout",
+                    f"Subagent timed out after {timeout_seconds} seconds",
+                    ("compiler_wall_clock_timeout" if self.config.wall_clock_timeout_seconds is not None else "subagent_timeout"),
                 )
                 return result_holder
             except asyncio.CancelledError:

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -6,7 +6,8 @@ import json
 import logging
 import uuid
 from dataclasses import replace
-from typing import Annotated
+from time import monotonic
+from typing import Annotated, Any
 
 from langchain.tools import InjectedToolCallId, ToolRuntime, tool
 from langgraph.config import get_stream_writer
@@ -40,18 +41,20 @@ def _record_subagent_terminal_evidence(
     status: str,
     classification: str | None,
     worker_stopped: bool,
+    budget_snapshot: dict[str, Any] | None = None,
 ) -> None:
     if subagent_type != "compiler":
         return
-    record_experiment_event(
-        thread_id,
-        "agent.subagent_terminated",
-        task_id=task_id,
-        role="compiler",
-        status=status,
-        classification=classification,
-        worker_stopped=worker_stopped,
-    )
+    payload = {
+        "task_id": task_id,
+        "role": "compiler",
+        "status": status,
+        "classification": classification,
+        "worker_stopped": worker_stopped,
+    }
+    if budget_snapshot is not None:
+        payload["budget_snapshot"] = budget_snapshot
+    record_experiment_event(thread_id, "agent.subagent_terminated", **payload)
     if status == "completed":
         return
     record_experiment_event(
@@ -69,6 +72,41 @@ def _apply_max_turns_override(config, *, subagent_type: str, requested_max_turns
     if requested_max_turns is None or subagent_type == "compiler":
         return config
     return replace(config, max_turns=requested_max_turns)
+
+
+def _compiler_budget_snapshot(
+    config,
+    result,
+    session,
+    *,
+    elapsed_seconds: float,
+) -> dict[str, Any] | None:
+    if not config.has_explicit_compiler_budgets:
+        return None
+    return {
+        "model_turn_limit": config.model_turn_limit,
+        "model_turn_count": len(result.ai_messages) if result is not None else 0,
+        "graph_recursion_limit": config.effective_graph_recursion_limit,
+        "wall_clock_limit_seconds": config.effective_wall_clock_timeout_seconds,
+        "elapsed_seconds": round(max(0.0, elapsed_seconds), 3),
+        "post_build_reserve_seconds": config.post_build_reserve_seconds,
+        "post_build_started": bool(session is not None and getattr(session, "post_build_supporting_command_id", None)),
+    }
+
+
+def _post_build_reserve_exhausted(
+    config,
+    session,
+    *,
+    elapsed_seconds: float,
+) -> bool:
+    reserve_seconds = config.post_build_reserve_seconds
+    if reserve_seconds <= 0 or session is None:
+        return False
+    if getattr(session, "post_build_supporting_command_id", None):
+        return False
+    exploration_seconds = config.effective_wall_clock_timeout_seconds - reserve_seconds
+    return elapsed_seconds >= exploration_seconds
 
 
 def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
@@ -251,6 +289,7 @@ async def task_tool(
     parent_model = None
     trace_id = None
     compile_state: dict[str, str] = {}
+    session = None
 
     if runtime is not None:
         sandbox_state = runtime.state.get("sandbox")
@@ -284,6 +323,10 @@ async def task_tool(
             config = config.with_overrides(
                 max_turns=active.policy.compiler_max_turns,
                 timeout_seconds=active.policy.subagent_timeout_seconds,
+                model_turn_limit=active.policy.compiler_model_turn_limit,
+                graph_recursion_limit=active.policy.compiler_graph_recursion_limit,
+                wall_clock_timeout_seconds=active.policy.compiler_wall_clock_seconds,
+                post_build_reserve_seconds=active.policy.compiler_post_build_reserve_seconds,
             )
             prompt = _with_benchmark_constraints(prompt, active.policy)
     else:
@@ -300,22 +343,26 @@ async def task_tool(
         initial_state=compile_state,
     )
 
+    task_started_at = monotonic()
     task_id = executor.execute_async(prompt, task_id=tool_call_id)
 
     poll_count = 0
     last_status = None
     last_message_count = 0
-    max_poll_count = (config.timeout_seconds + 60) // 5
-    shutdown_timeout_seconds = max(30.0, min(float(config.timeout_seconds), 180.0))
+    wall_clock_timeout_seconds = config.effective_wall_clock_timeout_seconds
+    max_poll_count = (wall_clock_timeout_seconds + 60) // 5
+    shutdown_timeout_seconds = max(30.0, min(float(wall_clock_timeout_seconds), 180.0))
 
-    logger.info(f"[trace={trace_id}] Started background task {task_id} (subagent={subagent_type}, timeout={config.timeout_seconds}s, polling_limit={max_poll_count} polls)")
+    logger.info(f"[trace={trace_id}] Started background task {task_id} (subagent={subagent_type}, timeout={wall_clock_timeout_seconds}s, polling_limit={max_poll_count} polls)")
 
     writer = get_stream_writer()
     writer({"type": "task_started", "task_id": task_id, "description": description})
 
+    result = None
     try:
         while True:
             result = get_background_task_result(task_id)
+            elapsed_seconds = monotonic() - task_started_at
 
             if result is None:
                 logger.error(f"[trace={trace_id}] Task {task_id} not found in background tasks")
@@ -336,6 +383,12 @@ async def task_tool(
                     status="failed",
                     classification="tracking_lost",
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
                 )
                 return f"Error: Task {task_id} disappeared from background tasks"
 
@@ -371,6 +424,12 @@ async def task_tool(
                     status="completed",
                     classification=None,
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
                 )
                 cleanup_background_task(task_id)
                 return f"Task Succeeded. Result: {result.result}"
@@ -393,6 +452,12 @@ async def task_tool(
                     status="failed",
                     classification=getattr(result, "failure_classification", None) or "subagent_failed",
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
                 )
                 return f"Task failed. Error: {result.error}"
             elif result.status == SubagentStatus.CANCELLED:
@@ -414,6 +479,12 @@ async def task_tool(
                     status="cancelled",
                     classification=getattr(result, "failure_classification", None) or "cancelled",
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
                 )
                 return "Task cancelled by user."
             elif result.status == SubagentStatus.TIMED_OUT:
@@ -435,14 +506,52 @@ async def task_tool(
                     status="timed_out",
                     classification=getattr(result, "failure_classification", None) or "subagent_timeout",
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
                 )
                 return f"Task timed out. Error: {result.error}"
+
+            if subagent_type == "compiler" and _post_build_reserve_exhausted(
+                config,
+                session,
+                elapsed_seconds=elapsed_seconds,
+            ):
+                error = "Compiler exploration exhausted its wall-clock allowance before the reserved post-build phase began."
+                writer({"type": "task_timed_out", "task_id": task_id, "error": error})
+                worker_stopped = await _cancel_and_reap_task(
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    compile_state=compile_state,
+                    thread_id=thread_id,
+                    terminal_status="timed_out",
+                    error=error,
+                    shutdown_timeout_seconds=shutdown_timeout_seconds,
+                )
+                _record_subagent_terminal_evidence(
+                    thread_id=thread_id,
+                    task_id=task_id,
+                    subagent_type=subagent_type,
+                    status="timed_out",
+                    classification="post_build_reserve_exhausted",
+                    worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=elapsed_seconds,
+                    ),
+                )
+                return f"Task timed out. Error: {error}"
 
             await asyncio.sleep(5)
             poll_count += 1
 
             if poll_count > max_poll_count:
-                timeout_minutes = config.timeout_seconds // 60
+                timeout_minutes = wall_clock_timeout_seconds // 60
                 logger.error(f"[trace={trace_id}] Task {task_id} polling timed out after {poll_count} polls (should have been caught by thread pool timeout)")
                 writer({"type": "task_timed_out", "task_id": task_id})
                 worker_stopped = await _cancel_and_reap_task(
@@ -461,6 +570,12 @@ async def task_tool(
                     status="timed_out",
                     classification="polling_timeout",
                     worker_stopped=worker_stopped,
+                    budget_snapshot=_compiler_budget_snapshot(
+                        config,
+                        result,
+                        session,
+                        elapsed_seconds=monotonic() - task_started_at,
+                    ),
                 )
                 return f"Task polling timed out after {timeout_minutes} minutes. This may indicate the background task is stuck. Status: {result.status.value}"
     except asyncio.CancelledError:
@@ -480,5 +595,11 @@ async def task_tool(
             status="cancelled",
             classification="parent_cancelled",
             worker_stopped=worker_stopped,
+            budget_snapshot=_compiler_budget_snapshot(
+                config,
+                result,
+                session,
+                elapsed_seconds=monotonic() - task_started_at,
+            ),
         )
         raise

--- a/backend/tests/test_compile_cancellation.py
+++ b/backend/tests/test_compile_cancellation.py
@@ -153,6 +153,54 @@ def test_subagent_recursion_limit_has_a_stable_failure_classification(real_execu
     assert result.failure_classification == "recursion_limit"
 
 
+def test_explicit_compiler_recursion_limit_has_distinct_failure_classification(real_executor_module):
+    config = SubagentConfig(
+        name="compiler",
+        description="test compiler",
+        system_prompt="test",
+        max_turns=36,
+        timeout_seconds=30,
+        model_turn_limit=12,
+        graph_recursion_limit=48,
+    )
+    executor = real_executor_module.SubagentExecutor(config=config, tools=[])
+    executor._create_agent = lambda: RecursionLimitAgent()
+
+    result = asyncio.run(executor._aexecute("reach the explicit graph limit"))
+
+    assert result.status == real_executor_module.SubagentStatus.FAILED
+    assert result.failure_classification == "graph_recursion_limit"
+
+
+def test_explicit_compiler_wall_clock_has_distinct_failure_classification(real_executor_module):
+    started = threading.Event()
+    stopped = threading.Event()
+    config = SubagentConfig(
+        name="compiler",
+        description="test compiler",
+        system_prompt="test",
+        max_turns=36,
+        timeout_seconds=30,
+        wall_clock_timeout_seconds=0.05,
+    )
+    executor = real_executor_module.SubagentExecutor(config=config, tools=[])
+    executor._create_agent = lambda: BlockingAgent(started, stopped)
+    result = real_executor_module.SubagentResult(
+        task_id="wall-clock-task",
+        trace_id="test-trace",
+        status=real_executor_module.SubagentStatus.RUNNING,
+    )
+
+    terminal = executor._execute_with_timeout("block", result)
+
+    assert started.is_set()
+    assert terminal.status == real_executor_module.SubagentStatus.TIMED_OUT
+    assert terminal.failure_classification == "compiler_wall_clock_timeout"
+    assert terminal.cancel_event.is_set()
+    assert terminal.worker_done_event.wait(timeout=3)
+    assert stopped.is_set()
+
+
 def test_compiler_terminal_evidence_records_bounded_failure_domain(monkeypatch):
     events: list[tuple[str, dict]] = []
     monkeypatch.setattr(
@@ -470,3 +518,85 @@ def test_compiler_model_cannot_lower_server_owned_turn_limit():
 
     assert compiler.max_turns == 36
     assert general.max_turns == 10
+
+
+def test_post_build_reserve_only_expires_before_successful_build():
+    config = SubagentConfig(
+        name="compiler",
+        description="compiler",
+        system_prompt="test",
+        timeout_seconds=300,
+        wall_clock_timeout_seconds=120,
+        post_build_reserve_seconds=30,
+    )
+    session = SimpleNamespace(post_build_supporting_command_id=None)
+
+    assert not task_tool_module._post_build_reserve_exhausted(
+        config,
+        session,
+        elapsed_seconds=89.9,
+    )
+    assert task_tool_module._post_build_reserve_exhausted(
+        config,
+        session,
+        elapsed_seconds=90,
+    )
+
+    session.post_build_supporting_command_id = "command-123"
+    assert not task_tool_module._post_build_reserve_exhausted(
+        config,
+        session,
+        elapsed_seconds=119,
+    )
+
+
+def test_budget_snapshot_is_bounded_and_legacy_config_emits_none(real_executor_module):
+    explicit = SubagentConfig(
+        name="compiler",
+        description="compiler",
+        system_prompt="test",
+        max_turns=36,
+        timeout_seconds=300,
+        model_turn_limit=12,
+        graph_recursion_limit=48,
+        wall_clock_timeout_seconds=120,
+        post_build_reserve_seconds=30,
+    )
+    result = real_executor_module.SubagentResult(
+        task_id="budget-task",
+        trace_id="trace",
+        status=real_executor_module.SubagentStatus.RUNNING,
+        ai_messages=[{"id": "one"}, {"id": "two"}],
+    )
+    session = SimpleNamespace(post_build_supporting_command_id="command-123")
+
+    assert task_tool_module._compiler_budget_snapshot(
+        explicit,
+        result,
+        session,
+        elapsed_seconds=4.56789,
+    ) == {
+        "model_turn_limit": 12,
+        "model_turn_count": 2,
+        "graph_recursion_limit": 48,
+        "wall_clock_limit_seconds": 120,
+        "elapsed_seconds": 4.568,
+        "post_build_reserve_seconds": 30,
+        "post_build_started": True,
+    }
+
+    legacy = explicit.with_overrides(
+        model_turn_limit=None,
+        graph_recursion_limit=None,
+        wall_clock_timeout_seconds=None,
+        post_build_reserve_seconds=0,
+    )
+    assert (
+        task_tool_module._compiler_budget_snapshot(
+            legacy,
+            result,
+            session,
+            elapsed_seconds=4.5,
+        )
+        is None
+    )

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -6,7 +6,9 @@ the autocompiler:gcc13 image. The default backend test suite skips this file.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import importlib
 import json
 import os
 import shutil
@@ -35,6 +37,8 @@ from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandR
 from deerflow.config.paths import Paths
 from deerflow.tools import bound_compile_tools
 from deerflow.tools.builtins import agent_compile_tools
+
+task_tool_module = importlib.import_module("deerflow.tools.builtins.task_tool")
 
 REPO_URL = "https://github.com/MattClarkson/CMakeHelloWorld.git"
 COMMIT_SHA = "6fda0b169299b1241ed883c8d4af8519da30ce52"
@@ -555,6 +559,133 @@ def test_build_system_mismatch_stops_before_real_compiler_delegation(monkeypatch
         assert deviation["payload"]["compiler_allowed"] is False
         assert deviation["payload"]["cleanup_succeeded"] is True
         assert deviation["payload"]["session_finalized"] is True
+    finally:
+        deactivate_experiment(thread_id)
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("classification", "terminal_status"),
+    [
+        ("model_turn_limit", "failed"),
+        ("graph_recursion_limit", "failed"),
+        ("compiler_wall_clock_timeout", "timed_out"),
+        ("post_build_reserve_exhausted", "timed_out"),
+    ],
+)
+def test_compiler_budget_termination_cleans_real_container_and_records_bounded_evidence(
+    monkeypatch,
+    classification: str,
+    terminal_status: str,
+):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-budget-{classification}-{uuid.uuid4().hex[:8]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    ledger = ExperimentLedger.create(
+        Path(session.metadata_path).parent / "compiler-budget.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-post-v6-budget-fixture",
+        manifest_sha256="6" * 64,
+        case_id="compiler-budget-fixture",
+        condition="non-pilot-integration",
+        repetition=1,
+        expected_repo_url=REPO_URL,
+        expected_commit_sha=COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=COMPILE_IMAGE,
+        image_id=COMPILE_IMAGE_ID,
+        model_name="deterministic-tools",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=300,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=12,
+        compiler_graph_recursion_limit=48,
+        compiler_wall_clock_seconds=300,
+        compiler_post_build_reserve_seconds=60,
+    )
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    monkeypatch.setattr(task_tool_module, "request_cancel_background_task", lambda _task_id: True)
+    monkeypatch.setattr(task_tool_module, "wait_for_background_task_shutdown", lambda _task_id, _timeout: True)
+    monkeypatch.setattr(task_tool_module, "cleanup_background_task", lambda _task_id: None)
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+        manager.mark_session_status(session, "ready")
+
+        worker_stopped = asyncio.run(
+            task_tool_module._cancel_and_reap_task(
+                task_id=f"task-{classification}",
+                subagent_type="compiler",
+                compile_state={agent_compile_tools.COMPILE_SESSION_STATE_KEY: session.session_id},
+                thread_id=thread_id,
+                terminal_status=terminal_status,
+                error=f"deterministic {classification} fixture",
+                shutdown_timeout_seconds=30,
+            )
+        )
+        budget_snapshot = {
+            "model_turn_limit": 12,
+            "model_turn_count": 4,
+            "graph_recursion_limit": 48,
+            "wall_clock_limit_seconds": 300,
+            "elapsed_seconds": 45.0,
+            "post_build_reserve_seconds": 60,
+            "post_build_started": False,
+        }
+        task_tool_module._record_subagent_terminal_evidence(
+            thread_id=thread_id,
+            task_id=f"task-{classification}",
+            subagent_type="compiler",
+            status=terminal_status,
+            classification=classification,
+            worker_stopped=worker_stopped,
+            budget_snapshot=budget_snapshot,
+        )
+
+        assert worker_stopped is True
+        reloaded = manager.load_session(session.session_id, thread_id)
+        assert reloaded.status == terminal_status
+        assert reloaded.finalized_at is not None
+        inspect = subprocess.run(
+            ["docker", "inspect", session.container_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert inspect.returncode != 0
+        terminal_events = [event for event in ledger.read() if event["event"] == "agent.subagent_terminated"]
+        assert len(terminal_events) == 1
+        assert terminal_events[0]["payload"]["classification"] == classification
+        assert terminal_events[0]["payload"]["budget_snapshot"] == budget_snapshot
     finally:
         deactivate_experiment(thread_id)
         runtime.stop_and_remove_container(session)

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -63,6 +63,36 @@ def create_ledger(tmp_path: Path) -> ExperimentLedger:
     )
 
 
+def test_legacy_policy_payload_is_unchanged_and_future_budgets_are_explicit() -> None:
+    legacy_payload = make_policy().to_payload()
+
+    assert "compiler_model_turn_limit" not in legacy_payload
+    assert "compiler_graph_recursion_limit" not in legacy_payload
+    assert "compiler_wall_clock_seconds" not in legacy_payload
+    assert "compiler_post_build_reserve_seconds" not in legacy_payload
+
+    future_payload = replace(
+        make_policy(),
+        compiler_model_turn_limit=12,
+        compiler_graph_recursion_limit=48,
+        compiler_wall_clock_seconds=300,
+        compiler_post_build_reserve_seconds=60,
+    ).to_payload()
+    assert future_payload["compiler_model_turn_limit"] == 12
+    assert future_payload["compiler_graph_recursion_limit"] == 48
+    assert future_payload["compiler_wall_clock_seconds"] == 300
+    assert future_payload["compiler_post_build_reserve_seconds"] == 60
+
+
+def test_future_budget_policy_rejects_reserve_without_execution_window() -> None:
+    with pytest.raises(EvidenceError, match="must be smaller"):
+        replace(
+            make_policy(),
+            compiler_wall_clock_seconds=60,
+            compiler_post_build_reserve_seconds=60,
+        )
+
+
 def test_ledger_builds_contiguous_hash_chain_and_becomes_immutable(tmp_path: Path) -> None:
     ledger = create_ledger(tmp_path)
     ledger.append("preflight.completed", {"ready": True})
@@ -177,6 +207,46 @@ def test_subagent_termination_builds_valid_hash_chained_failure_evidence(
     assert events[1]["payload"]["worker_stopped"] is True
     assert events[2]["payload"]["domain"] == "agent_tool"
     assert events[2]["payload"]["classification"] == classification
+
+
+def test_subagent_termination_accepts_only_bounded_budget_snapshot(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    snapshot = {
+        "model_turn_limit": 12,
+        "model_turn_count": 4,
+        "graph_recursion_limit": 48,
+        "wall_clock_limit_seconds": 300,
+        "elapsed_seconds": 45.125,
+        "post_build_reserve_seconds": 60,
+        "post_build_started": False,
+    }
+
+    ledger.append(
+        "agent.subagent_terminated",
+        {
+            "task_id": "compiler-task-1",
+            "role": "compiler",
+            "status": "failed",
+            "classification": "model_turn_limit",
+            "worker_stopped": True,
+            "budget_snapshot": snapshot,
+        },
+    )
+
+    assert ExperimentLedger.verify_path(ledger.path)[-1]["payload"]["budget_snapshot"] == snapshot
+
+    with pytest.raises(EvidenceError, match="budget_snapshot has an invalid schema"):
+        ledger.append(
+            "agent.subagent_terminated",
+            {
+                "task_id": "compiler-task-2",
+                "role": "compiler",
+                "status": "failed",
+                "classification": "model_turn_limit",
+                "worker_stopped": True,
+                "budget_snapshot": {**snapshot, "detail": "must not be recorded"},
+            },
+        )
 
 
 def test_agent_tool_failure_records_only_bounded_identity_and_exception_class(

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -215,6 +215,71 @@ class TestAsyncExecutionPath:
         assert result.completed_at is not None
 
     @pytest.mark.anyio
+    async def test_explicit_graph_budget_is_independent_from_model_turn_budget(
+        self,
+        classes,
+        base_config,
+        msg,
+    ):
+        observed_config = {}
+
+        class CapturingAgent:
+            async def astream(self, _state, *, config, **_kwargs):
+                observed_config.update(config)
+                yield {"messages": [msg.human("Task"), msg.ai("Done", "msg-1")]}
+
+        config = base_config.with_overrides(
+            model_turn_limit=2,
+            graph_recursion_limit=17,
+        )
+        executor = classes["SubagentExecutor"](config=config, tools=[])
+
+        with patch.object(executor, "_create_agent", return_value=CapturingAgent()):
+            result = await executor._aexecute("Task")
+
+        assert result.status == classes["SubagentStatus"].COMPLETED
+        assert observed_config["recursion_limit"] == 17
+        assert len(result.ai_messages) == 1
+
+    @pytest.mark.anyio
+    async def test_model_turn_limit_stops_before_another_model_request(
+        self,
+        classes,
+        base_config,
+        msg,
+    ):
+        ai_message = classes["AIMessage"](
+            content="",
+            id="msg-tool",
+            tool_calls=[
+                {
+                    "name": "run_container_bash",
+                    "args": {},
+                    "id": "call-1",
+                    "type": "tool_call",
+                }
+            ],
+        )
+
+        class ToolCallingAgent:
+            async def astream(self, *_args, **_kwargs):
+                yield {"messages": [msg.human("Task"), ai_message]}
+                raise AssertionError("the stream must close before another model turn")
+
+        config = base_config.with_overrides(
+            model_turn_limit=1,
+            graph_recursion_limit=17,
+        )
+        executor = classes["SubagentExecutor"](config=config, tools=[])
+
+        with patch.object(executor, "_create_agent", return_value=ToolCallingAgent()):
+            result = await executor._aexecute("Task")
+
+        assert result.status == classes["SubagentStatus"].FAILED
+        assert result.failure_classification == "model_turn_limit"
+        assert len(result.ai_messages) == 1
+
+    @pytest.mark.anyio
     async def test_aexecute_collects_ai_messages(self, classes, base_config, mock_agent, msg):
         """Test that AI messages are collected during streaming."""
         SubagentExecutor = classes["SubagentExecutor"]


### PR DESCRIPTION
## 背景

v6 中 `compiler_max_turns` 被直接映射为 LangGraph recursion limit，而统一的 subagent timeout 无法区分模型轮次、图递归、compiler 总墙钟与 post-build 收口预算，导致 libcheck/libgit2/sysstat 的终结证据诊断粒度不足。

## 修改

- 为未来协议显式分离模型轮次、图递归、compiler 总墙钟和 post-build 预留；旧字段继续兼容回退。
- 模型轮次耗尽时在下一次模型请求前终止；图递归、总墙钟和 post-build 预留分别使用稳定的单一分类。
- `agent.subagent_terminated` 可附带仅含数字/布尔值的有界预算快照；旧五字段事件仍可验证。
- 所有预算失败继续先取消 worker、清理真实编译容器，再 finalize Session。
- v1-v6 manifest、Schema、validator、runner、policy payload 与既有 ledger 均未修改；未调用模型、未重跑或替换 v6，也未创建 v7。

## 验证

- 聚焦回归：68 passed
- 后端全量：1674 passed, 28 skipped
- Ruff：260 files formatted，check 全绿
- 真实 Docker 非模型四预算分支：4 passed
- Docker Compose config：通过
- 前端 lint / typecheck：通过
- 冻结实验资产差异审计：通过

Closes #51