### PR TITLE
改进：为 artifact oracle 记录结构化差异

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,12 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-07-27 — Issue #52 artifact oracle 结构化差异
+  - 分支: `feat/issue-52-artifact-oracle-diff`，基于 `main@82a29a9e`。`run_oracle()` 在不改变既有 pass 判定公式的前提下，输出排序且最多 64 项的 expected-only、observed-only、type mismatch 与 matched identity；clean replay 比较另输出 type/size/SHA-256/smoke exit+output hash 差异。
+  - 安全: 只保留 `/artifacts` 相对路径、三类 artifact type、非负大小、SHA-256、smoke 退出码和输出哈希；不复制 smoke command/output、模型文本、宿主路径或凭据。旧 replay 没有逐产物比较时明确 `available=false`，不伪造诊断。
+  - 当前证据: runner/protocol/evidence `204 passed`，后端全量 `1665 passed, 29 skipped`，真实 Docker CMake executable、Make static/shared、Autotools static 三组 `3 passed`；22 条本地历史 ledger hash chain 通过，后端 Ruff/format、Compose、前端串行 lint/typecheck 与容器对账通过。未调用模型、未重跑/替换 v6、未创建 v7。
+  - 待完成: 复核 diff、中文提交并推送，创建 Draft PR，等待 Ready CI 后 squash merge；随后更新 Obsidian 并冻结 v7 设计入口。
+
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
@@ -145,7 +151,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #51 的 Draft PR、Ready CI、squash merge、Issue 自动关闭和主干复验；随后处理 Issue #52（artifact oracle 结构化差异）。Issue #52 合入前不创建 v7、不调用模型、不重跑 v6。
+- 完成 Issue #52 的 Draft PR、Ready CI、squash merge、Issue 自动关闭和主干复验；Issue #52 合入前不创建 v7、不调用模型、不重跑 v6。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -964,3 +965,252 @@ def test_gate_recomputation_detects_tampering_and_oracle_is_independent() -> Non
         }
     ]
     assert oracle["passed"] is True
+    assert oracle["replay_artifact_diff"]["available"] is False
+
+
+def _oracle_events(
+    *,
+    artifacts: list[dict],
+    replay_artifacts: list[dict] | None = None,
+    replay_status: str = "passed",
+) -> list[dict]:
+    return [
+        {"event": "experiment.started", "payload": {"policy": {"case_id": "fmt"}}},
+        {
+            "event": "replay.completed",
+            "payload": {
+                "replay_attempt_id": "replay-1",
+                "status": replay_status,
+                "cleanup_succeeded": True,
+                "primary_failure_classification": (None if replay_status == "passed" else "artifact_mismatch"),
+                "artifacts": replay_artifacts or [],
+            },
+        },
+        {
+            "event": "submit.completed",
+            "payload": {
+                "submit_attempt_id": "submit-1",
+                "candidate_status": "passed",
+                "artifacts": artifacts,
+                "replay": {
+                    "replay_attempt_id": "replay-1",
+                    "status": replay_status,
+                    "primary_failure_classification": (None if replay_status == "passed" else "artifact_mismatch"),
+                },
+            },
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("artifact_type", "path"),
+    [
+        ("static_library", "libsample.a"),
+        ("shared_library", "libsample.so"),
+        ("executable", "sample"),
+    ],
+)
+def test_oracle_records_empty_identity_diff_for_matching_artifact_types(
+    artifact_type: str,
+    path: str,
+) -> None:
+    manifest = load_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == "fmt")
+    case["oracle"]["required_artifacts"] = [{"relative_path": path, "artifact_type": artifact_type}]
+    events = _oracle_events(
+        artifacts=[
+            {
+                "path": path,
+                "artifact_type": artifact_type,
+                "size_bytes": 123,
+                "sha256": "1" * 64,
+                "smoke_exit_code": 0 if artifact_type == "executable" else None,
+                "smoke_output_sha256": ("2" * 64 if artifact_type == "executable" else None),
+            }
+        ],
+    )
+
+    oracle = forge_benchmark_runner.run_oracle(manifest, events)
+
+    assert oracle["passed"] is True
+    assert oracle["artifact_oracle_passed"] is True
+    assert oracle["artifact_identity_diff"] == {
+        "expected_count": 1,
+        "observed_count": 1,
+        "matched_count": 1,
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0,
+        "expected_only": [],
+        "observed_only": [],
+        "type_mismatches": [],
+        "truncated": False,
+    }
+    assert oracle["replay_artifact_diff"] == {
+        "available": True,
+        "mismatch_count": 0,
+        "mismatches": [],
+        "truncated": False,
+    }
+
+
+def test_oracle_records_expected_observed_type_diff_with_bounded_identity(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == "fmt")
+    case["oracle"]["required_artifacts"] = [{"relative_path": "libsample.a", "artifact_type": "static_library"}]
+    events = _oracle_events(
+        artifacts=[
+            {
+                "path": "libsample.a",
+                "artifact_type": "shared_library",
+                "size_bytes": 456,
+                "sha256": "3" * 64,
+                "smoke_exit_code": None,
+                "smoke_output_sha256": None,
+            }
+        ],
+        replay_artifacts=[
+            {
+                "path": "libsample.a",
+                "expected_type": "static_library",
+                "actual_type": "shared_library",
+                "expected_size_bytes": 123,
+                "actual_size_bytes": 456,
+                "expected_sha256": "1" * 64,
+                "actual_sha256": "3" * 64,
+                "expected_smoke_exit_code": None,
+                "actual_smoke_exit_code": None,
+                "expected_smoke_output_sha256": None,
+                "actual_smoke_output_sha256": None,
+                "actual_smoke_command": "C:\\Users\\person\\secret.exe --help",
+                "actual_smoke_output": "sensitive model output",
+                "passed": False,
+                "mismatches": ["sha256", "size", "type"],
+            }
+        ],
+    )
+
+    oracle = forge_benchmark_runner.run_oracle(manifest, events)
+
+    assert oracle["passed"] is False
+    assert oracle["artifact_oracle_passed"] is False
+    identity_diff = oracle["artifact_identity_diff"]
+    assert identity_diff["expected_only"] == [{"path": "libsample.a", "artifact_type": "static_library"}]
+    assert identity_diff["observed_only"] == [
+        {
+            "path": "libsample.a",
+            "artifact_type": "shared_library",
+            "size_bytes": 456,
+            "sha256": "3" * 64,
+            "smoke_exit_code": None,
+            "smoke_output_sha256": None,
+        }
+    ]
+    assert identity_diff["type_mismatches"] == [
+        {
+            "path": "libsample.a",
+            "expected_artifact_types": ["static_library"],
+            "observed_artifact_types": ["shared_library"],
+        }
+    ]
+    replay_diff = oracle["replay_artifact_diff"]
+    assert replay_diff["mismatch_count"] == 1
+    assert replay_diff["mismatches"][0]["mismatches"] == ["type", "size", "sha256"]
+    serialized = json.dumps(oracle)
+    assert "C:\\\\Users" not in serialized
+    assert "actual_smoke_command" not in serialized
+    assert "actual_smoke_output" not in serialized
+    assert "sensitive model output" not in serialized
+    ledger = ExperimentLedger.create(
+        tmp_path / "artifact-diff.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"case_id": "fmt"},
+    )
+    ledger.append("oracle.completed", oracle)
+    assert ExperimentLedger.verify_path(ledger.path)[-1]["payload"] == oracle
+
+
+def test_oracle_records_executable_smoke_hash_diff_without_output() -> None:
+    manifest = load_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == "fmt")
+    case["oracle"]["required_artifacts"] = [{"relative_path": "sample", "artifact_type": "executable"}]
+    events = _oracle_events(
+        artifacts=[
+            {
+                "path": "sample",
+                "artifact_type": "executable",
+                "size_bytes": 10,
+                "sha256": "4" * 64,
+                "smoke_exit_code": 0,
+                "smoke_output_sha256": "5" * 64,
+            }
+        ],
+        replay_status="failed",
+        replay_artifacts=[
+            {
+                "path": "sample",
+                "expected_type": "executable",
+                "actual_type": "executable",
+                "expected_size_bytes": 10,
+                "actual_size_bytes": 10,
+                "expected_sha256": "4" * 64,
+                "actual_sha256": "4" * 64,
+                "expected_smoke_exit_code": 0,
+                "actual_smoke_exit_code": 1,
+                "expected_smoke_output_sha256": "5" * 64,
+                "actual_smoke_output_sha256": "6" * 64,
+                "actual_smoke_output": "private output",
+                "passed": False,
+                "mismatches": ["smoke"],
+            }
+        ],
+    )
+
+    oracle = forge_benchmark_runner.run_oracle(manifest, events)
+
+    assert oracle["artifact_oracle_passed"] is True
+    assert oracle["passed"] is False
+    mismatch = oracle["replay_artifact_diff"]["mismatches"][0]
+    assert mismatch["mismatches"] == ["smoke"]
+    assert mismatch["expected_smoke_exit_code"] == 0
+    assert mismatch["observed_smoke_exit_code"] == 1
+    assert mismatch["expected_smoke_output_sha256"] == "5" * 64
+    assert mismatch["observed_smoke_output_sha256"] == "6" * 64
+    assert "private output" not in json.dumps(oracle)
+
+
+def test_oracle_artifact_diff_is_sorted_and_bounded() -> None:
+    manifest = load_manifest()
+    case = next(case for case in manifest["cases"] if case["id"] == "fmt")
+    case["oracle"]["required_artifacts"] = [{"relative_path": "required.a", "artifact_type": "static_library"}]
+    artifacts = [
+        {
+            "path": "required.a",
+            "artifact_type": "static_library",
+        },
+        *[
+            {
+                "path": f"extra-{index:03d}.so",
+                "artifact_type": "shared_library",
+                "size_bytes": index,
+                "sha256": f"{index:064x}",
+            }
+            for index in reversed(range(65))
+        ],
+    ]
+
+    oracle = forge_benchmark_runner.run_oracle(
+        manifest,
+        _oracle_events(artifacts=artifacts),
+    )
+
+    artifact_diff = oracle["artifact_identity_diff"]
+    assert oracle["passed"] is True
+    assert artifact_diff["observed_only_count"] == 65
+    assert len(artifact_diff["observed_only"]) == 64
+    assert artifact_diff["observed_only"][0]["path"] == "extra-000.so"
+    assert artifact_diff["observed_only"][-1]["path"] == "extra-063.so"
+    assert artifact_diff["truncated"] is True

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
@@ -64,6 +64,15 @@ _FAILURE_DOMAIN_NAMES = (
     "build",
     "submit_replay",
     "completion",
+)
+_MAX_ARTIFACT_DIFF_ENTRIES = 64
+_REPLAY_ARTIFACT_MISMATCH_ORDER = (
+    "unexpected_artifact",
+    "missing_artifact",
+    "type",
+    "size",
+    "sha256",
+    "smoke",
 )
 
 
@@ -717,6 +726,174 @@ def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _safe_artifact_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 512 or ".compile-sessions" in value or any(character in value for character in ("\\", ":", "\0", "\r", "\n")):
+        return None
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return value
+
+
+def _safe_artifact_type(value: Any) -> str | None:
+    if isinstance(value, str) and value in {
+        "static_library",
+        "shared_library",
+        "executable",
+    }:
+        return value
+    return None
+
+
+def _safe_nonnegative_int(value: Any) -> int | None:
+    if type(value) is int and value >= 0:
+        return value
+    return None
+
+
+def _safe_int(value: Any) -> int | None:
+    if type(value) is int:
+        return value
+    return None
+
+
+def _safe_sha256(value: Any) -> str | None:
+    if isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value):
+        return value
+    return None
+
+
+def _bounded_artifact_observation(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Return only stable, non-sensitive artifact identity evidence."""
+    return {
+        "path": _safe_artifact_path(artifact.get("path")),
+        "artifact_type": _safe_artifact_type(artifact.get("artifact_type")),
+        "size_bytes": _safe_nonnegative_int(artifact.get("size_bytes")),
+        "sha256": _safe_sha256(artifact.get("sha256")),
+        "smoke_exit_code": _safe_int(artifact.get("smoke_exit_code")),
+        "smoke_output_sha256": _safe_sha256(artifact.get("smoke_output_sha256")),
+    }
+
+
+def _artifact_identity_diff(
+    expected_artifacts: set[tuple[str, str]],
+    actual_artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    observations_by_identity: dict[tuple[str | None, str | None], dict[str, Any]] = {}
+    for artifact in actual_artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        observation = _bounded_artifact_observation(artifact)
+        identity = (observation["path"], observation["artifact_type"])
+        observations_by_identity.setdefault(identity, observation)
+
+    observed_identities = set(observations_by_identity)
+    expected_only_identities = sorted(
+        expected_artifacts - observed_identities,
+        key=lambda value: (value[0], value[1]),
+    )
+    observed_only_identities = sorted(
+        observed_identities - expected_artifacts,
+        key=lambda value: (value[0] or "", value[1] or ""),
+    )
+    matched_identities = sorted(
+        expected_artifacts & observed_identities,
+        key=lambda value: (value[0], value[1]),
+    )
+
+    expected_types_by_path: dict[str, set[str]] = {}
+    for path, artifact_type in expected_only_identities:
+        expected_types_by_path.setdefault(path, set()).add(artifact_type)
+    observed_types_by_path: dict[str, list[dict[str, Any]]] = {}
+    for identity in observed_only_identities:
+        path = identity[0]
+        if path is not None:
+            observed_types_by_path.setdefault(path, []).append(observations_by_identity[identity])
+    type_mismatches = [
+        {
+            "path": path,
+            "expected_artifact_types": sorted(expected_types),
+            "observed_artifact_types": sorted({value["artifact_type"] for value in observed_types_by_path[path] if value["artifact_type"] is not None}),
+        }
+        for path, expected_types in sorted(expected_types_by_path.items())
+        if path in observed_types_by_path
+    ]
+
+    expected_only = [{"path": path, "artifact_type": artifact_type} for path, artifact_type in expected_only_identities]
+    observed_only = [observations_by_identity[identity] for identity in observed_only_identities]
+    return {
+        "expected_count": len(expected_artifacts),
+        "observed_count": len(observed_identities),
+        "matched_count": len(matched_identities),
+        "expected_only_count": len(expected_only),
+        "observed_only_count": len(observed_only),
+        "type_mismatch_count": len(type_mismatches),
+        "expected_only": expected_only[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "observed_only": observed_only[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "type_mismatches": type_mismatches[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "truncated": any(len(values) > _MAX_ARTIFACT_DIFF_ENTRIES for values in (expected_only, observed_only, type_mismatches)),
+    }
+
+
+def _replay_artifact_diff(
+    events: list[dict[str, Any]],
+    replay_attempt_id: str | None,
+) -> dict[str, Any]:
+    replay = next(
+        (event["payload"] for event in reversed(events) if event["event"] == "replay.completed" and event["payload"].get("replay_attempt_id") == replay_attempt_id),
+        None,
+    )
+    if replay is None or not isinstance(replay.get("artifacts"), list):
+        return {
+            "available": False,
+            "mismatch_count": 0,
+            "mismatches": [],
+            "truncated": False,
+        }
+
+    differences: list[dict[str, Any]] = []
+    mismatch_rank = {value: index for index, value in enumerate(_REPLAY_ARTIFACT_MISMATCH_ORDER)}
+    for artifact in replay["artifacts"]:
+        if not isinstance(artifact, dict):
+            continue
+        raw_mismatches = artifact.get("mismatches") or []
+        mismatches = sorted(
+            {value for value in raw_mismatches if value in _REPLAY_ARTIFACT_MISMATCH_ORDER},
+            key=mismatch_rank.__getitem__,
+        )
+        if artifact.get("passed") is True and not mismatches:
+            continue
+        differences.append(
+            {
+                "path": _safe_artifact_path(artifact.get("path")),
+                "expected_artifact_type": _safe_artifact_type(artifact.get("expected_type")),
+                "observed_artifact_type": _safe_artifact_type(artifact.get("actual_type")),
+                "expected_size_bytes": _safe_nonnegative_int(artifact.get("expected_size_bytes")),
+                "observed_size_bytes": _safe_nonnegative_int(artifact.get("actual_size_bytes")),
+                "expected_sha256": _safe_sha256(artifact.get("expected_sha256")),
+                "observed_sha256": _safe_sha256(artifact.get("actual_sha256")),
+                "expected_smoke_exit_code": _safe_int(artifact.get("expected_smoke_exit_code")),
+                "observed_smoke_exit_code": _safe_int(artifact.get("actual_smoke_exit_code")),
+                "expected_smoke_output_sha256": _safe_sha256(artifact.get("expected_smoke_output_sha256")),
+                "observed_smoke_output_sha256": _safe_sha256(artifact.get("actual_smoke_output_sha256")),
+                "mismatches": mismatches,
+            }
+        )
+    differences.sort(
+        key=lambda value: (
+            value["path"] or "",
+            value["expected_artifact_type"] or "",
+            value["observed_artifact_type"] or "",
+        )
+    )
+    return {
+        "available": True,
+        "mismatch_count": len(differences),
+        "mismatches": differences[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "truncated": len(differences) > _MAX_ARTIFACT_DIFF_ENTRIES,
+    }
+
+
 def run_oracle(
     manifest: dict[str, Any],
     events: list[dict[str, Any]],
@@ -728,7 +905,12 @@ def run_oracle(
         return {"passed": False, "classification": "submit_missing"}
     submit = submits[-1]
     expected_artifacts = {(artifact["relative_path"], artifact["artifact_type"]) for artifact in case["oracle"]["required_artifacts"]}
-    actual_artifacts = {(artifact.get("path"), artifact.get("artifact_type")) for artifact in submit.get("artifacts", [])}
+    submitted_artifacts = submit.get("artifacts", [])
+    actual_artifacts = {(artifact.get("path"), artifact.get("artifact_type")) for artifact in submitted_artifacts if isinstance(artifact, dict)}
+    artifact_identity_diff = _artifact_identity_diff(
+        expected_artifacts,
+        submitted_artifacts,
+    )
     replay = submit.get("replay") or {}
     expected_candidate_pass = case["oracle"]["expected_candidate_status"] == "pass"
     expected_replay_pass = case["oracle"]["expected_clean_replay_status"] == "pass"
@@ -743,6 +925,11 @@ def run_oracle(
         "classification": None if passed else "oracle_mismatch",
         "submit_attempt_id": submit["submit_attempt_id"],
         "artifact_oracle_passed": expected_artifacts.issubset(actual_artifacts),
+        "artifact_identity_diff": artifact_identity_diff,
+        "replay_artifact_diff": _replay_artifact_diff(
+            events,
+            replay.get("replay_attempt_id"),
+        ),
         "candidate_expectation_passed": candidate_pass == expected_candidate_pass,
         "replay_expectation_passed": replay_pass == expected_replay_pass,
         "failure_classification_expectation_passed": failure_matches,


### PR DESCRIPTION
## 背景

v6 `hiredis` 已到达 submit、clean replay 与 delivery，但最终只有 `oracle_mismatch` 布尔结果，无法区分产物集合、类型或 replay 内容差异。

## 改动

- 保持既有 artifact oracle、candidate、clean replay 与 failure classification 的通过判定公式不变。
- 为 manifest expected 与 submit observed 产物输出排序、有界的 expected-only、observed-only、type mismatch 和计数。
- 从对应 `replay.completed` 提取 type、size、SHA-256、smoke exit code 与 smoke output hash 差异。
- 最多保留 64 项；不记录 smoke command/output、模型文本、宿主路径或凭据。
- 旧 replay 未包含逐产物 comparison 时明确记录 `available=false`，不伪造诊断。
- 不修改 v1-v6 manifest、Schema、validator 或既有 ledger，也不降低 clean-replay acceptance。

## 验证

- runner/protocol/evidence：`204 passed`
- 后端全量：`1665 passed, 29 skipped`
- 真实 Docker：CMake executable、Make static/shared、Autotools static 三组 `3 passed`
- 22 条本地历史 ledger hash chain 复验通过
- Ruff/format、Compose、前端串行 lint/typecheck、冻结资产和容器对账通过
- 未调用模型，未重跑或替换 v6，未创建 v7

Closes #52