### PR TITLE
修复：补齐 WSL2 模型出口与多提供商连通性预检

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,18 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-27 — Issue #56 冻结 C/C++ pilot v7 协议
-  - 分支: `feat/issue-56-pilot-v7-protocol`，基于 `main@c48a0008`。新增独立 v7 manifest、Schema、validator 和 runner 路由，冻结 Issue #50 参数前置 gate、Issue #51 四类 compiler 预算与 Issue #52 artifact oracle 差异语义。
-  - 预算: model turn 36、graph recursion 96、compiler wall clock 900 秒、post-build reserve 120 秒；继续固定五个 exact-commit C/C++ case、CMake/Make/Autotools、Compose/DooD、Compile Session、clean replay、0 retries、no fallback、Memory/Skills 关闭。
-  - 当前证据: v1-v7 protocol/runner/evidence `189 passed, 24 skipped`；后端全量除只读挂载下 4 个 UV 环境失败外为 `1646 passed, 53 skipped`，四项改用独立可写 UV 环境后 `4 passed`；真实 Docker 四类预算、参数前置 gate 与三种构建路径 `8 passed in 260.27s`。Ruff/format、Compose config、前端串行 format/lint/typecheck、冻结 hash 与 0 orphan 对账通过。
-  - 边界: 协议 PR 合并并通过 preflight 前不创建 v7 physical-attempt slot、不调用模型；v1-v6 冻结资产和 ledger 不改写。
+- 2026-07-28 — Issue #59 修复 WSL2 Compose 模型出口并增加多提供商预检
+  - 分支: `fix/issue-59-model-connectivity`，基于 `main@957fb9e3`。根因是 Windows 代理只监听 loopback，WSL2 Docker 容器直连 RichLab 超时，且 `host.docker.internal` 不会自动转发到 Windows loopback。
+  - 实现: 新增仅绑定私有 Docker bridge gateway 的受限 TCP relay、独立 Compose override、RichLab/DeepSeek 模型列表 + 最小对话 + 强制工具调用预检，以及原子写入 Git 忽略 `.env` 的本地凭据工具。基础 `docker-compose-dev.yaml`、`config.example.yaml` 与 v1-v7 冻结资产保持字节不变。
+  - 当前证据: RichLab `gpt-5.5`/`gpt-5.4` 与 DeepSeek `deepseek-v4-flash`/`deepseek-v4-pro` 均从 LangGraph 容器通过模型列表、最小对话和工具调用；聚焦 `32 passed`，后端除只读挂载专用组外 `1673 passed, 53 skipped`，配置升级组在可写挂载中 `4 passed`；Ruff/format、Compose config、v7 current-tree gate、bridge 启停、敏感信息与 0 compile/replay orphan 检查通过。
+  - 边界: 只做非 pilot 连通性预检，不创建、重跑、替换或回填任一 v7 slot；DeepSeek 与较低负载 GPT 只能作为未来独立实验条件，不能在冻结 attempt 内 fallback。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-28 — C/C++ pilot v7 冻结协议进入主干
+  - Issue #56 / PR #57 已 squash 合并为 `main@957fb9e3`。独立 v7 manifest、Schema、validator 和 runner 路由冻结参数前置 gate、四类 compiler 预算与 artifact oracle 差异语义。
+  - 预算继续固定为 model turn 36、graph recursion 96、compiler wall clock 900 秒、post-build reserve 120 秒；五个 exact-commit C/C++ case、Compose/DooD、Compile Session、clean replay、0 retries、no fallback 和 Memory/Skills 关闭保持不变。
 
 - 2026-07-27 — artifact oracle 结构化差异进入主干
   - Issue #52 / PR #55 已 squash 合并为 `main@c48a0008`。`run_oracle()` 在不改变既有 pass 判定公式的前提下，输出有界的 artifact identity 与 clean replay type/size/SHA-256/smoke 差异；旧证据缺少逐产物列表时明确 `available=false`。
@@ -155,7 +159,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #56 的 v7 协议实现、历史冻结校验、Compose/DooD preflight、中文 PR 与主干复验；协议合入前不创建 v7 slot、不调用模型。
+- 完成 Issue #59 的中文 Draft PR 与 CI；合并前不启动新 pilot。下一协议应把 RichLab 与 DeepSeek 设计为可比较的独立 provider condition，并继续禁止 frozen attempt 内 fallback。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -167,6 +171,7 @@
 - PowerShell -> WSL -> `bash -lc` 的多层命令可能提前展开临时 `$repo` 变量，使 Docker bind mount 退化为 `/frontend/...`；一次性容器优先传完整 WSL 绝对路径，启动失败后先按固定名称清理并确认无残留。
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。
 - WSL 的 `127.0.0.1` 代理不能直接传入 Docker build；编译镜像代理必须使用容器可达地址。
+- Windows 代理只监听 loopback 时，WSL2 Docker 的 `host.docker.internal` 只到 Docker/WSL 网关，并不会自动进入 Windows loopback。模型请求必须通过仅绑定 Docker bridge 的受限 relay；不要让代理软件监听 `0.0.0.0` 或局域网地址。模型运行时代理使用独立 Compose override，不能改写 v7 冻结的基础 Compose 文件。
 - 后端全量 Ruff 当前有 4 个本次改动之外且与 `origin/main` 相同的既有错误：`scripts/check.py` 的 3 个 UP045 与 `scripts/forge_benchmark.py` 的 1 个 I001；本次改动文件的 Ruff check/format 已通过。
 - 成功 bash 记录只是候选 recipe；失败命令可能留下持久副作用。进入研究基线前必须在新容器与空 `/workspace`、`/artifacts` 中实际 replay，不能把 `repro_bundle` 生成成功等同于独立复现成功。
 - Windows 挂载目录在编译镜像中可能触发 Git `dubious ownership`；replay 初始化仓库后必须把 `/workspace/repo` 加入 `safe.directory`。

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # COMPILE_RUNTIME_HTTP_PROXY=http://host.docker.internal:7897
 # COMPILE_RUNTIME_HTTPS_PROXY=http://host.docker.internal:7897
 # COMPILE_RUNTIME_NO_PROXY=localhost,127.0.0.1
+# Optional WSL2 model-request bridge. The upstream must be an HTTP proxy on
+# Windows loopback; the bridge binds only the private Docker gateway and never
+# exposes the proxy to the LAN. scripts/docker.sh injects the derived proxy URL
+# into Gateway/LangGraph without logging any API credential.
+# FORGE_MODEL_PROXY_UPSTREAM=http://127.0.0.1:7897
+# FORGE_MODEL_PROXY_BRIDGE_PORT=17897
+# MODEL_RUNTIME_NO_PROXY=localhost,127.0.0.1,gateway,langgraph,nginx,frontend,host.docker.internal
 # Maximum execution/verification time for one automatic clean replay attempt.
 # Network/image inspection, recipe execution, artifact scanning/hashing, and
 # smoke checks share this deadline. The value is persisted with replay evidence.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # DeerFlow - Unified Development Environment
 
-.PHONY: help config config-upgrade check wsl-check compile-image install dev dev-pro dev-daemon dev-daemon-pro start start-pro start-daemon start-daemon-pro stop up up-pro down clean docker-init docker-start docker-start-pro docker-stop docker-logs docker-logs-frontend docker-logs-gateway
+.PHONY: help config config-upgrade check wsl-check compile-image model-preflight install dev dev-pro dev-daemon dev-daemon-pro start start-pro start-daemon start-daemon-pro stop up up-pro down clean docker-init docker-start docker-start-pro docker-stop docker-logs docker-logs-frontend docker-logs-gateway
 
 BASH ?= bash
 
@@ -19,6 +19,7 @@ help:
 	@echo "  make check           - Check if all required tools are installed"
 	@echo "  make wsl-check       - Check WSL2 and Docker prerequisites"
 	@echo "  make compile-image   - Build the C/C++ compile runtime image"
+	@echo "  make model-preflight PROVIDER=deepseek - Check model list, chat, and tool calls"
 	@echo "  make install         - Install all dependencies (frontend + backend)"
 	@echo "  make setup-sandbox   - Pre-pull sandbox container image (recommended)"
 	@echo "  make dev             - Start all services in development mode (with hot-reloading)"
@@ -66,6 +67,9 @@ compile-image:
 			--build-arg HTTP_PROXY="$${COMPILE_HTTP_PROXY:-}" \
 			--build-arg HTTPS_PROXY="$${COMPILE_HTTPS_PROXY:-}" \
 			-t "$${COMPILE_IMAGE:-autocompiler:gcc13}" docker/compile
+
+model-preflight:
+	@./scripts/docker.sh model-preflight "$(or $(PROVIDER),richlab)"
 
 # Install all dependencies
 install:

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -128,13 +128,45 @@ Some models support "thinking" mode for complex reasoning:
 
 ```yaml
 models:
-  - name: deepseek-v3
+  - name: deepseek-v4-flash
+    use: langchain_openai:ChatOpenAI
+    model: deepseek-v4-flash
+    base_url: https://api.deepseek.com
+    api_key: $DEEPSEEK_API_KEY
     supports_thinking: true
     when_thinking_enabled:
       extra_body:
         thinking:
           type: enabled
 ```
+
+For a higher-capability DeepSeek condition, use a separate profile with
+`name` and `model` set to `deepseek-v4-pro`. Do not silently switch profiles
+inside one benchmark attempt.
+
+**WSL2 Compose model connectivity preflight**:
+
+When the Windows proxy only listens on loopback, WSL2 Docker containers cannot
+reach it directly. Configure the optional, Docker-bridge-only relay in the local
+Git-ignored `.env`:
+
+```dotenv
+FORGE_MODEL_PROXY_UPSTREAM=http://127.0.0.1:7897
+```
+
+Start the development stack normally, then run a bounded preflight before
+creating an experimental physical-attempt slot:
+
+```bash
+make model-preflight
+make model-preflight PROVIDER=deepseek
+```
+
+The checks cover the provider model list, a minimal chat request, and a forced
+tool call. Output is limited to status, latency, requested/actual model identity,
+and bounded booleans; credentials, response content, and tool arguments are not
+printed. The relay binds only the private Docker bridge gateway and is stopped by
+`make docker-stop`.
 
 **Gemini with thinking via OpenAI-compatible gateway**:
 

--- a/backend/tests/test_docker_compose_compile_paths.py
+++ b/backend/tests/test_docker_compose_compile_paths.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose-dev.yaml"
+MODEL_PROXY_COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose-model-proxy.yaml"
 
 
 def test_compile_session_mount_and_path_contract_are_applied_to_both_runtimes():
@@ -42,3 +43,19 @@ def test_backend_services_mount_example_config_for_runtime_validation():
 
     assert compose.count("../config.example.yaml:/app/config.example.yaml:ro") == 2
     assert compose.count("../scripts:/app/scripts:ro") == 2
+
+
+def test_backend_services_receive_explicit_model_runtime_proxy_without_credentials():
+    compose = MODEL_PROXY_COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert compose.count("MODEL_RUNTIME_HTTP_PROXY=${MODEL_RUNTIME_HTTP_PROXY:-}") == 2
+    assert compose.count("MODEL_RUNTIME_HTTPS_PROXY=${MODEL_RUNTIME_HTTPS_PROXY:-}") == 2
+    assert compose.count("MODEL_RUNTIME_NO_PROXY=${MODEL_RUNTIME_NO_PROXY:-") == 2
+    assert compose.count('export HTTP_PROXY=\\"$${MODEL_RUNTIME_HTTP_PROXY:-}\\"') == 2
+    assert "FORGE_MODEL_PROXY_UPSTREAM" not in compose
+
+
+def test_frozen_base_compose_does_not_embed_model_proxy_override():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert "MODEL_RUNTIME_HTTP_PROXY" not in compose

--- a/backend/tests/test_model_provider_preflight.py
+++ b/backend/tests/test_model_provider_preflight.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "model_provider_preflight.py"
+SPEC = importlib.util.spec_from_file_location("model_provider_preflight", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+model_provider_preflight = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = model_provider_preflight
+SPEC.loader.exec_module(model_provider_preflight)
+
+
+def test_missing_credential_fails_without_request(monkeypatch, capsys):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setattr(model_provider_preflight, "_request", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("request must not run")))
+
+    assert model_provider_preflight.run_preflight("deepseek", timeout=10) is False
+    output = capsys.readouterr().out
+    assert "credential_missing" in output
+    assert "Authorization" not in output
+
+
+def test_deepseek_success_records_only_bounded_metadata(monkeypatch, capsys):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "secret-value")
+    responses = iter(
+        [
+            (
+                200,
+                {"data": [{"id": "deepseek-v4-flash"}, {"id": "deepseek-v4-pro"}]},
+                0.1,
+            ),
+            (
+                200,
+                {"model": "deepseek-v4-flash", "choices": [{"finish_reason": "stop", "message": {"content": "private response"}}]},
+                0.2,
+            ),
+            (
+                200,
+                {
+                    "model": "deepseek-v4-flash",
+                    "choices": [
+                        {
+                            "finish_reason": "tool_calls",
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "function": {
+                                            "name": "select_build_system",
+                                            "arguments": '{"build_system":"cmake","private":"value"}',
+                                        }
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                },
+                0.3,
+            ),
+            (
+                200,
+                {"model": "deepseek-v4-pro", "choices": [{"finish_reason": "stop", "message": {"content": "private response"}}]},
+                0.4,
+            ),
+            (
+                200,
+                {
+                    "model": "deepseek-v4-pro",
+                    "choices": [{"finish_reason": "tool_calls", "message": {"tool_calls": [{"function": {"name": "select_build_system", "arguments": "{}"}}]}}],
+                },
+                0.5,
+            ),
+        ]
+    )
+    monkeypatch.setattr(model_provider_preflight, "_request", lambda *args, **kwargs: next(responses))
+
+    assert model_provider_preflight.run_preflight("deepseek", timeout=10) is True
+    output = capsys.readouterr().out
+    assert "private response" not in output
+    assert "secret-value" not in output
+    assert '"arguments"' not in output
+    assert output.count('"stage": "tool_call"') == 2
+
+
+def test_actual_model_mismatch_fails(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "secret-value")
+    responses = iter(
+        [
+            (200, {"data": [{"id": "deepseek-v4-flash"}, {"id": "deepseek-v4-pro"}]}, 0.1),
+            (200, {"model": "unexpected-model", "choices": [{"finish_reason": "stop", "message": {"content": "ok"}}]}, 0.2),
+            (200, {"model": "unexpected-model", "choices": [{"finish_reason": "tool_calls", "message": {"tool_calls": []}}]}, 0.3),
+            (200, {"model": "deepseek-v4-pro", "choices": [{"finish_reason": "stop", "message": {"content": "ok"}}]}, 0.4),
+            (
+                200,
+                {
+                    "model": "deepseek-v4-pro",
+                    "choices": [{"finish_reason": "tool_calls", "message": {"tool_calls": [{"function": {"name": "select_build_system"}}]}}],
+                },
+                0.5,
+            ),
+        ]
+    )
+    monkeypatch.setattr(model_provider_preflight, "_request", lambda *args, **kwargs: next(responses))
+
+    assert model_provider_preflight.run_preflight("deepseek", timeout=10) is False

--- a/backend/tests/test_model_proxy_bridge.py
+++ b/backend/tests/test_model_proxy_bridge.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "model_proxy_bridge.py"
+SPEC = importlib.util.spec_from_file_location("model_proxy_bridge", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+model_proxy_bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(model_proxy_bridge)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("http://127.0.0.1:7897", ("127.0.0.1", 7897)),
+        ("http://localhost:8080/", ("localhost", 8080)),
+    ],
+)
+def test_parse_upstream_accepts_only_loopback_http(value, expected):
+    assert model_proxy_bridge._parse_upstream(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://127.0.0.1:7897",
+        "http://0.0.0.0:7897",
+        "http://192.168.1.2:7897",
+        "http://user:password@127.0.0.1:7897",
+        "http://127.0.0.1:7897/path",
+    ],
+)
+def test_parse_upstream_rejects_lan_credentials_and_paths(value):
+    with pytest.raises(model_proxy_bridge.BridgeError):
+        model_proxy_bridge._parse_upstream(value)
+
+
+def test_stale_state_is_removed_without_signalling_unowned_pid(tmp_path, monkeypatch, capsys):
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"pid": 1234}\n', encoding="utf-8")
+    monkeypatch.setattr(model_proxy_bridge, "_owned_process", lambda _pid: False)
+
+    args = type("Args", (), {"state_dir": str(tmp_path)})()
+    assert model_proxy_bridge._stop(args) == 0
+    assert not state_path.exists()
+    assert "stale_state_removed" in capsys.readouterr().out
+
+
+def test_start_reuses_only_an_identical_running_bridge(tmp_path, monkeypatch, capsys):
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        '{"pid": 1234, "listen_host": "172.17.0.1", "listen_port": 17897, "upstream_host": "127.0.0.1", "upstream_port": 7897}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(model_proxy_bridge, "_owned_process", lambda _pid: True)
+    monkeypatch.setattr(model_proxy_bridge, "_docker_gateway", lambda: "172.17.0.1")
+    monkeypatch.setattr(
+        model_proxy_bridge,
+        "_terminate_owned_process",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("identical bridge must not restart")),
+    )
+
+    args = type(
+        "Args",
+        (),
+        {
+            "state_dir": str(tmp_path),
+            "upstream": "http://127.0.0.1:7897",
+            "listen_port": 17897,
+        },
+    )()
+    assert model_proxy_bridge._start(args) == 0
+    assert '"status": "running"' in capsys.readouterr().out
+
+
+def test_start_replaces_a_running_bridge_when_configuration_changes(tmp_path, monkeypatch):
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        '{"pid": 1234, "listen_host": "172.17.0.1", "listen_port": 17897, "upstream_host": "127.0.0.1", "upstream_port": 7897}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(model_proxy_bridge, "_owned_process", lambda _pid: True)
+    monkeypatch.setattr(model_proxy_bridge, "_docker_gateway", lambda: "172.17.0.1")
+    terminated = []
+    monkeypatch.setattr(model_proxy_bridge, "_terminate_owned_process", lambda _state_dir, pid: terminated.append(pid))
+
+    class Started(RuntimeError):
+        pass
+
+    monkeypatch.setattr(model_proxy_bridge.subprocess, "Popen", lambda *_args, **_kwargs: (_ for _ in ()).throw(Started))
+    args = type(
+        "Args",
+        (),
+        {
+            "state_dir": str(tmp_path),
+            "upstream": "http://127.0.0.1:7898",
+            "listen_port": 17897,
+        },
+    )()
+    with pytest.raises(Started):
+        model_proxy_bridge._start(args)
+    assert terminated == [1234]
+
+
+@pytest.mark.parametrize(
+    ("listen_host", "listen_port", "upstream_host", "upstream_port"),
+    [
+        ("0.0.0.0", 17897, "127.0.0.1", 7897),
+        ("172.17.0.1", 17897, "192.168.1.2", 7897),
+        ("172.17.0.1", 0, "127.0.0.1", 7897),
+    ],
+)
+def test_serve_endpoint_validation_rejects_public_or_invalid_addresses(
+    listen_host,
+    listen_port,
+    upstream_host,
+    upstream_port,
+):
+    with pytest.raises(model_proxy_bridge.BridgeError):
+        model_proxy_bridge._validate_relay_endpoint(listen_host, listen_port, upstream_host, upstream_port)

--- a/backend/tests/test_set_local_secret.py
+++ b/backend/tests/test_set_local_secret.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "set_local_secret.py"
+SPEC = importlib.util.spec_from_file_location("set_local_secret", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+set_local_secret = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(set_local_secret)
+
+
+def test_update_env_replaces_once_and_normalizes_lf(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_bytes(b"OTHER=value\r\nDEEPSEEK_API_KEY=old\r\nDEEPSEEK_API_KEY=duplicate\r\n")
+
+    set_local_secret.update_env(env_file, "DEEPSEEK_API_KEY", "sk-new_value")
+
+    payload = env_file.read_bytes()
+    assert payload == b"OTHER=value\nDEEPSEEK_API_KEY=sk-new_value\n"
+
+
+def test_update_env_appends_without_exposing_other_values(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OTHER=private\n", encoding="utf-8")
+
+    set_local_secret.update_env(env_file, "DEEPSEEK_API_KEY", "sk-new")
+
+    assert env_file.read_text(encoding="utf-8") == "OTHER=private\n\nDEEPSEEK_API_KEY=sk-new\n"
+
+
+def test_update_env_accepts_loopback_proxy_without_credentials(tmp_path):
+    env_file = tmp_path / ".env"
+
+    set_local_secret.update_env(env_file, "FORGE_MODEL_PROXY_UPSTREAM", "http://127.0.0.1:7897")
+
+    assert env_file.read_text(encoding="utf-8") == "FORGE_MODEL_PROXY_UPSTREAM=http://127.0.0.1:7897\n"
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("UNSUPPORTED", "sk-valid"),
+        ("DEEPSEEK_API_KEY", "plain-text"),
+        ("DEEPSEEK_API_KEY", "sk-value\nSECOND=leak"),
+        ("FORGE_MODEL_PROXY_UPSTREAM", "http://192.168.1.2:7897"),
+        ("FORGE_MODEL_PROXY_UPSTREAM", "http://user:password@127.0.0.1:7897"),
+    ],
+)
+def test_update_env_rejects_unsafe_name_or_value(tmp_path, name, value):
+    with pytest.raises(set_local_secret.SecretError):
+        set_local_secret.update_env(tmp_path / ".env", name, value)

--- a/docker/docker-compose-model-proxy.yaml
+++ b/docker/docker-compose-model-proxy.yaml
@@ -1,0 +1,14 @@
+services:
+  gateway:
+    command: sh -c "{ cd backend && (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && export HTTP_PROXY=\"$${MODEL_RUNTIME_HTTP_PROXY:-}\" HTTPS_PROXY=\"$${MODEL_RUNTIME_HTTPS_PROXY:-}\" NO_PROXY=\"$${MODEL_RUNTIME_NO_PROXY:-}\" http_proxy=\"$${MODEL_RUNTIME_HTTP_PROXY:-}\" https_proxy=\"$${MODEL_RUNTIME_HTTPS_PROXY:-}\" no_proxy=\"$${MODEL_RUNTIME_NO_PROXY:-}\" && PYTHONPATH=. uv run --frozen uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env'; } > /app/logs/gateway.log 2>&1"
+    environment:
+      - MODEL_RUNTIME_HTTP_PROXY=${MODEL_RUNTIME_HTTP_PROXY:-}
+      - MODEL_RUNTIME_HTTPS_PROXY=${MODEL_RUNTIME_HTTPS_PROXY:-}
+      - MODEL_RUNTIME_NO_PROXY=${MODEL_RUNTIME_NO_PROXY:-localhost,127.0.0.1,gateway,langgraph,nginx,frontend,host.docker.internal}
+
+  langgraph:
+    command: sh -c "cd backend && { (uv sync --frozen || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync --frozen)) && export HTTP_PROXY=\"$${MODEL_RUNTIME_HTTP_PROXY:-}\" HTTPS_PROXY=\"$${MODEL_RUNTIME_HTTPS_PROXY:-}\" NO_PROXY=\"$${MODEL_RUNTIME_NO_PROXY:-}\" http_proxy=\"$${MODEL_RUNTIME_HTTP_PROXY:-}\" https_proxy=\"$${MODEL_RUNTIME_HTTPS_PROXY:-}\" no_proxy=\"$${MODEL_RUNTIME_NO_PROXY:-}\" && allow_blocking='' && if [ \"$${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run --frozen langgraph dev --no-browser $${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker $${LANGGRAPH_JOBS_PER_WORKER:-10}; } > /app/logs/langgraph.log 2>&1"
+    environment:
+      - MODEL_RUNTIME_HTTP_PROXY=${MODEL_RUNTIME_HTTP_PROXY:-}
+      - MODEL_RUNTIME_HTTPS_PROXY=${MODEL_RUNTIME_HTTPS_PROXY:-}
+      - MODEL_RUNTIME_NO_PROXY=${MODEL_RUNTIME_NO_PROXY:-localhost,127.0.0.1,gateway,langgraph,nginx,frontend,host.docker.internal}

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -27,6 +27,29 @@ fi
 
 # Docker Compose command with project name
 COMPOSE_CMD="docker compose -p deer-flow-dev -f docker-compose-dev.yaml"
+if [ -n "${FORGE_MODEL_PROXY_UPSTREAM:-}" ]; then
+    COMPOSE_CMD="$COMPOSE_CMD -f docker-compose-model-proxy.yaml"
+fi
+MODEL_PROXY_BRIDGE_SCRIPT="$SCRIPT_DIR/model_proxy_bridge.py"
+MODEL_PROXY_BRIDGE_ACTIVE=false
+
+start_model_proxy_bridge() {
+    if [ -z "${FORGE_MODEL_PROXY_UPSTREAM:-}" ]; then
+        return 0
+    fi
+    local bridge_port="${FORGE_MODEL_PROXY_BRIDGE_PORT:-17897}"
+    python3 "$MODEL_PROXY_BRIDGE_SCRIPT" start \
+        --upstream "$FORGE_MODEL_PROXY_UPSTREAM" \
+        --listen-port "$bridge_port"
+    export MODEL_RUNTIME_HTTP_PROXY="http://host.docker.internal:${bridge_port}"
+    export MODEL_RUNTIME_HTTPS_PROXY="http://host.docker.internal:${bridge_port}"
+    export MODEL_RUNTIME_NO_PROXY="${MODEL_RUNTIME_NO_PROXY:-localhost,127.0.0.1,gateway,langgraph,nginx,frontend,host.docker.internal}"
+    MODEL_PROXY_BRIDGE_ACTIVE=true
+}
+
+stop_model_proxy_bridge() {
+    python3 "$MODEL_PROXY_BRIDGE_SCRIPT" stop >/dev/null
+}
 
 detect_sandbox_mode() {
     local config_file="$PROJECT_ROOT/config.yaml"
@@ -77,6 +100,9 @@ detect_sandbox_mode() {
 cleanup() {
     echo ""
     echo -e "${YELLOW}Operation interrupted by user${NC}"
+    if $MODEL_PROXY_BRIDGE_ACTIVE; then
+        stop_model_proxy_bridge
+    fi
     exit 130
 }
 
@@ -187,6 +213,7 @@ start() {
     fi
 
     mkdir -p "$PROJECT_ROOT/.compile-sessions"
+    start_model_proxy_bridge
 
     sandbox_mode="$(detect_sandbox_mode)"
 
@@ -256,7 +283,12 @@ start() {
     fi
 
     echo "Building and starting containers..."
-    cd "$DOCKER_DIR" && $COMPOSE_CMD up --build -d --remove-orphans $services
+    if ! (cd "$DOCKER_DIR" && $COMPOSE_CMD up --build -d --remove-orphans $services); then
+        if $MODEL_PROXY_BRIDGE_ACTIVE; then
+            stop_model_proxy_bridge
+        fi
+        exit 1
+    fi
     echo ""
     echo "=========================================="
     echo "  DeerFlow Docker is starting!"
@@ -321,6 +353,7 @@ stop() {
     cd "$DOCKER_DIR" && $COMPOSE_CMD down
     echo "Cleaning up sandbox containers..."
     "$SCRIPT_DIR/cleanup-containers.sh" deer-flow-sandbox 2>/dev/null || true
+    stop_model_proxy_bridge
     echo -e "${GREEN}✓ Docker services stopped${NC}"
 }
 
@@ -330,6 +363,7 @@ restart() {
     echo "  Restarting DeerFlow Docker Services"
     echo "========================================"
     echo ""
+    start_model_proxy_bridge
     echo -e "${BLUE}Restarting containers...${NC}"
     cd "$DOCKER_DIR" && $COMPOSE_CMD restart
     echo ""
@@ -338,6 +372,28 @@ restart() {
     echo "  🌐 Application: http://localhost:8000"
     echo "  📋 View logs: make docker-logs"
     echo ""
+}
+
+model_preflight() {
+    local provider="${1:-richlab}"
+    local runtime_container="deer-flow-langgraph"
+    local proxy_args=()
+    if ! docker inspect "$runtime_container" >/dev/null 2>&1; then
+        runtime_container="deer-flow-gateway"
+    fi
+    if ! docker inspect "$runtime_container" >/dev/null 2>&1; then
+        echo -e "${YELLOW}No Forge runtime container is available. Run make docker-start first.${NC}"
+        exit 1
+    fi
+    start_model_proxy_bridge
+    if [ -n "${MODEL_RUNTIME_HTTP_PROXY:-}" ]; then
+        proxy_args+=("-e" "HTTP_PROXY=$MODEL_RUNTIME_HTTP_PROXY")
+        proxy_args+=("-e" "HTTPS_PROXY=$MODEL_RUNTIME_HTTPS_PROXY")
+        proxy_args+=("-e" "NO_PROXY=$MODEL_RUNTIME_NO_PROXY")
+    fi
+    docker exec "${proxy_args[@]}" "$runtime_container" \
+        /app/backend/.venv/bin/python /app/scripts/model_provider_preflight.py \
+        --provider "$provider"
 }
 
 # Show help
@@ -351,6 +407,7 @@ help() {
     echo "  start             - Start Docker services (auto-detects sandbox mode from config.yaml)"
     echo "  start --gateway   - Start without LangGraph container (Gateway mode, experimental)"
     echo "  restart           - Restart all running Docker services"
+    echo "  model-preflight [richlab|deepseek] - Run bounded provider connectivity checks"
     echo "  logs [option] - View Docker development logs"
     echo "                  --frontend   View frontend logs only"
     echo "                  --gateway    View gateway logs only"
@@ -373,6 +430,9 @@ main() {
             ;;
         restart)
             restart
+            ;;
+        model-preflight)
+            model_preflight "$2"
             ;;
         logs)
             logs "$2"

--- a/scripts/model_provider_preflight.py
+++ b/scripts/model_provider_preflight.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Bounded, secret-safe connectivity checks for supported model providers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._:/-]{1,128}$")
+
+
+@dataclass(frozen=True)
+class Provider:
+    endpoint: str
+    credential_env: str
+    models: tuple[str, ...]
+
+
+PROVIDERS = {
+    "richlab": Provider(
+        endpoint="https://richlab-api-x.choosefire.com/v1",
+        credential_env="OpenAI_AK",
+        models=("gpt-5.5", "gpt-5.4"),
+    ),
+    "deepseek": Provider(
+        endpoint="https://api.deepseek.com",
+        credential_env="DEEPSEEK_API_KEY",
+        models=("deepseek-v4-flash", "deepseek-v4-pro"),
+    ),
+}
+
+
+def _emit(payload: dict) -> None:
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def _safe_model(value: object) -> str | None:
+    return value if isinstance(value, str) and SAFE_MODEL_RE.fullmatch(value) else None
+
+
+def _request(provider: Provider, path: str, credential: str, payload: dict | None, timeout: int) -> tuple[object, dict | None, float]:
+    headers = {"Authorization": f"Bearer {credential}", "User-Agent": "forge-model-preflight/1.0"}
+    data = None
+    method = "GET"
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode()
+        method = "POST"
+    request = urllib.request.Request(f"{provider.endpoint}{path}", data=data, headers=headers, method=method)
+    started = time.monotonic()
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+        return response.status, json.load(response), round(time.monotonic() - started, 3)
+    except urllib.error.HTTPError as error:
+        return error.code, None, round(time.monotonic() - started, 3)
+    except Exception as error:
+        return type(getattr(error, "reason", error)).__name__, None, round(time.monotonic() - started, 3)
+
+
+def run_preflight(provider_name: str, *, timeout: int, include_tool_call: bool = True) -> bool:
+    provider = PROVIDERS[provider_name]
+    credential = os.environ.get(provider.credential_env, "").strip()
+    if not credential:
+        _emit({"provider": provider_name, "stage": "credential", "ok": False, "classification": "credential_missing"})
+        return False
+
+    all_ok = True
+    status, body, latency = _request(provider, "/models", credential, None, timeout)
+    available = {_safe_model(item.get("id")) for item in (body or {}).get("data", []) if isinstance(item, dict)}
+    models_present = [model for model in provider.models if model in available]
+    models_ok = status == 200 and len(models_present) == len(provider.models)
+    _emit(
+        {
+            "provider": provider_name,
+            "stage": "models",
+            "ok": models_ok,
+            "status": status,
+            "latency_seconds": latency,
+            "target_models_present": models_present,
+        }
+    )
+    all_ok &= models_ok
+
+    for model in provider.models:
+        status, body, latency = _request(
+            provider,
+            "/chat/completions",
+            credential,
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with OK."}],
+                "thinking": {"type": "disabled"},
+                "max_tokens": 8,
+                "stream": False,
+            },
+            timeout,
+        )
+        choice = ((body or {}).get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        actual_model = _safe_model((body or {}).get("model"))
+        chat_ok = status == 200 and bool(message.get("content")) and actual_model == model
+        _emit(
+            {
+                "provider": provider_name,
+                "stage": "minimal_chat",
+                "requested_model": model,
+                "actual_model": actual_model,
+                "ok": chat_ok,
+                "status": status,
+                "latency_seconds": latency,
+                "finish_reason": choice.get("finish_reason") if choice.get("finish_reason") in {"stop", "length", "tool_calls"} else None,
+                "content_present": bool(message.get("content")),
+            }
+        )
+        all_ok &= chat_ok
+
+        if not include_tool_call:
+            continue
+        status, body, latency = _request(
+            provider,
+            "/chat/completions",
+            credential,
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "Call select_build_system for a CMake project."}],
+                "thinking": {"type": "disabled"},
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "select_build_system",
+                            "description": "Select the required build system.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"build_system": {"type": "string", "enum": ["cmake", "make", "autotools"]}},
+                                "required": ["build_system"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                ],
+                "tool_choice": {"type": "function", "function": {"name": "select_build_system"}},
+                "max_tokens": 64,
+                "stream": False,
+            },
+            timeout,
+        )
+        choice = ((body or {}).get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        tool_calls = message.get("tool_calls") or []
+        function_name = None
+        if tool_calls:
+            function_name = (tool_calls[0].get("function") or {}).get("name")
+        actual_model = _safe_model((body or {}).get("model"))
+        tool_ok = status == 200 and actual_model == model and function_name == "select_build_system"
+        _emit(
+            {
+                "provider": provider_name,
+                "stage": "tool_call",
+                "requested_model": model,
+                "actual_model": actual_model,
+                "ok": tool_ok,
+                "status": status,
+                "latency_seconds": latency,
+                "finish_reason": choice.get("finish_reason") if choice.get("finish_reason") in {"stop", "length", "tool_calls"} else None,
+                "tool_call_present": bool(tool_calls),
+                "function_name": function_name if function_name == "select_build_system" else None,
+            }
+        )
+        all_ok &= tool_ok
+
+    _emit({"provider": provider_name, "stage": "summary", "ready": all_ok})
+    return all_ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--skip-tool-call", action="store_true")
+    args = parser.parse_args()
+    if not 1 <= args.timeout <= 120:
+        parser.error("--timeout must be between 1 and 120 seconds")
+    return 0 if run_preflight(args.provider, timeout=args.timeout, include_tool_call=not args.skip_tool_call) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model_proxy_bridge.py
+++ b/scripts/model_proxy_bridge.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Expose a Windows loopback HTTP proxy only to the WSL Docker bridge."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import select
+import signal
+import socket
+import socketserver
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STATE_DIR = REPO_ROOT / ".compile-sessions" / "model-proxy-bridge"
+DEFAULT_LISTEN_PORT = 17897
+
+
+class BridgeError(RuntimeError):
+    """Raised when the bridge cannot be managed safely."""
+
+
+def _emit(**payload: object) -> None:
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def _docker_gateway() -> str:
+    result = subprocess.run(
+        ["docker", "network", "inspect", "bridge", "--format", "{{(index .IPAM.Config 0).Gateway}}"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    gateway = result.stdout.strip()
+    address = ipaddress.ip_address(gateway)
+    if not isinstance(address, ipaddress.IPv4Address) or not address.is_private:
+        raise BridgeError("Docker bridge gateway must be a private IPv4 address")
+    return gateway
+
+
+def _parse_upstream(value: str) -> tuple[str, int]:
+    parsed = urlsplit(value)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise BridgeError("Upstream must be an HTTP proxy on Windows loopback")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment or parsed.path not in {"", "/"}:
+        raise BridgeError("Upstream credentials, paths, queries, and fragments are forbidden")
+    if parsed.port is None:
+        raise BridgeError("Upstream proxy port is required")
+    return parsed.hostname, parsed.port
+
+
+def _state_path(state_dir: Path) -> Path:
+    return state_dir / "state.json"
+
+
+def _read_state(state_dir: Path) -> dict | None:
+    try:
+        payload = json.loads(_state_path(state_dir).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _owned_process(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().replace(b"\0", b" ").decode(errors="replace")
+    except OSError:
+        return False
+    return "model_proxy_bridge.py" in cmdline and " serve " in f" {cmdline} "
+
+
+def _remove_state_if_owner(state_dir: Path, pid: int) -> None:
+    state = _read_state(state_dir)
+    if state and state.get("pid") == pid:
+        _state_path(state_dir).unlink(missing_ok=True)
+
+
+def _validate_relay_endpoint(listen_host: str, listen_port: int, upstream_host: str, upstream_port: int) -> None:
+    address = ipaddress.ip_address(listen_host)
+    if not isinstance(address, ipaddress.IPv4Address) or not address.is_private or address.is_unspecified or address.is_loopback or address.is_link_local:
+        raise BridgeError("Listen address must be a private Docker IPv4 gateway")
+    if upstream_host not in {"127.0.0.1", "localhost", "::1"}:
+        raise BridgeError("Upstream host must remain on Windows loopback")
+    if not 1 <= listen_port <= 65_535 or not 1 <= upstream_port <= 65_535:
+        raise BridgeError("Relay ports must be between 1 and 65535")
+
+
+def _terminate_owned_process(state_dir: Path, pid: int) -> None:
+    os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _owned_process(pid):
+        time.sleep(0.05)
+    if _owned_process(pid):
+        raise BridgeError("Proxy bridge did not stop within the deadline")
+    _state_path(state_dir).unlink(missing_ok=True)
+
+
+class _RelayHandler(socketserver.BaseRequestHandler):
+    upstream: tuple[str, int]
+
+    def handle(self) -> None:
+        upstream = socket.create_connection(self.upstream, timeout=5)
+        sockets = [self.request, upstream]
+        try:
+            while True:
+                readable, _, _ = select.select(sockets, [], [], 30)
+                for source in readable:
+                    data = source.recv(65_536)
+                    if not data:
+                        return
+                    target = upstream if source is self.request else self.request
+                    target.sendall(data)
+        finally:
+            upstream.close()
+
+
+class _RelayServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def _serve(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    _validate_relay_endpoint(args.listen_host, args.listen_port, args.upstream_host, args.upstream_port)
+    handler = type("ConfiguredRelayHandler", (_RelayHandler,), {"upstream": (args.upstream_host, args.upstream_port)})
+    server = _RelayServer((args.listen_host, args.listen_port), handler)
+    pid = os.getpid()
+    state = {
+        "pid": pid,
+        "listen_host": args.listen_host,
+        "listen_port": args.listen_port,
+        "upstream_host": args.upstream_host,
+        "upstream_port": args.upstream_port,
+    }
+    _state_path(state_dir).write_text(json.dumps(state, sort_keys=True) + "\n", encoding="utf-8")
+
+    def _terminate(_signum: int, _frame: object) -> None:
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+        _remove_state_if_owner(state_dir, pid)
+    return 0
+
+
+def _start(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    upstream_host, upstream_port = _parse_upstream(args.upstream)
+    listen_host = _docker_gateway()
+    expected = {
+        "listen_host": listen_host,
+        "listen_port": args.listen_port,
+        "upstream_host": upstream_host,
+        "upstream_port": upstream_port,
+    }
+    state = _read_state(state_dir)
+    if state and _owned_process(int(state.get("pid", 0))):
+        if all(state.get(name) == value for name, value in expected.items()):
+            _emit(status="running", **state)
+            return 0
+        _terminate_owned_process(state_dir, int(state["pid"]))
+    if state:
+        _state_path(state_dir).unlink(missing_ok=True)
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log_path = state_dir / "bridge.log"
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "serve",
+        "--state-dir",
+        str(state_dir),
+        "--listen-host",
+        listen_host,
+        "--listen-port",
+        str(args.listen_port),
+        "--upstream-host",
+        upstream_host,
+        "--upstream-port",
+        str(upstream_port),
+    ]
+    with log_path.open("ab") as log:
+        process = subprocess.Popen(command, stdin=subprocess.DEVNULL, stdout=log, stderr=log, start_new_session=True)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        state = _read_state(state_dir)
+        if state and state.get("pid") == process.pid and _owned_process(process.pid):
+            _emit(status="started", **state)
+            return 0
+        if process.poll() is not None:
+            break
+        time.sleep(0.05)
+    if process.poll() is None:
+        process.terminate()
+    raise BridgeError("Proxy bridge did not become ready")
+
+
+def _stop(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    state = _read_state(state_dir)
+    if not state:
+        _emit(status="stopped")
+        return 0
+    pid = int(state.get("pid", 0))
+    if not _owned_process(pid):
+        _state_path(state_dir).unlink(missing_ok=True)
+        _emit(status="stale_state_removed")
+        return 0
+    _terminate_owned_process(state_dir, pid)
+    _emit(status="stopped")
+    return 0
+
+
+def _status(args: argparse.Namespace) -> int:
+    state = _read_state(Path(args.state_dir))
+    if state and _owned_process(int(state.get("pid", 0))):
+        _emit(status="running", **state)
+        return 0
+    _emit(status="stopped")
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.set_defaults(state_dir=str(DEFAULT_STATE_DIR))
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start = subparsers.add_parser("start")
+    start.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    start.add_argument("--upstream", required=True)
+    start.add_argument("--listen-port", type=int, default=DEFAULT_LISTEN_PORT)
+
+    stop = subparsers.add_parser("stop")
+    stop.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+
+    status = subparsers.add_parser("status")
+    status.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+
+    serve = subparsers.add_parser("serve")
+    serve.add_argument("--state-dir", required=True)
+    serve.add_argument("--listen-host", required=True)
+    serve.add_argument("--listen-port", required=True, type=int)
+    serve.add_argument("--upstream-host", required=True)
+    serve.add_argument("--upstream-port", required=True, type=int)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        if args.command == "start":
+            return _start(args)
+        if args.command == "stop":
+            return _stop(args)
+        if args.command == "status":
+            return _status(args)
+        return _serve(args)
+    except (BridgeError, OSError, subprocess.SubprocessError, ValueError) as error:
+        _emit(status="error", classification=type(error).__name__)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/set_local_secret.py
+++ b/scripts/set_local_secret.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Atomically update an allowed secret in the Git-ignored local .env file."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALLOWED_NAMES = {"DEEPSEEK_API_KEY", "FORGE_MODEL_PROXY_BRIDGE_PORT", "FORGE_MODEL_PROXY_UPSTREAM", "OpenAI_AK"}
+SECRET_RE = re.compile(r"^sk-[A-Za-z0-9_-]+$")
+PROXY_RE = re.compile(r"^http://(?:127\.0\.0\.1|localhost):[1-9][0-9]{0,4}/?$")
+PORT_RE = re.compile(r"^[1-9][0-9]{0,4}$")
+
+
+class SecretError(RuntimeError):
+    """Raised when a local secret update is unsafe."""
+
+
+def update_env(path: Path, name: str, value: str) -> None:
+    if name not in ALLOWED_NAMES:
+        raise SecretError("Unsupported secret variable")
+    valid = {
+        "DEEPSEEK_API_KEY": SECRET_RE,
+        "OpenAI_AK": SECRET_RE,
+        "FORGE_MODEL_PROXY_UPSTREAM": PROXY_RE,
+        "FORGE_MODEL_PROXY_BRIDGE_PORT": PORT_RE,
+    }[name].fullmatch(value)
+    if not valid:
+        raise SecretError("Local value does not match the expected format")
+    if path.is_symlink():
+        raise SecretError("Refusing to update a symlink")
+
+    existing = path.read_text(encoding="utf-8-sig") if path.exists() else ""
+    lines = existing.splitlines()
+    replacement = f"{name}={value}"
+    output: list[str] = []
+    replaced = False
+    for line in lines:
+        if line.startswith(f"{name}="):
+            if not replaced:
+                output.append(replacement)
+                replaced = True
+            continue
+        output.append(line)
+    if not replaced:
+        if output and output[-1] != "":
+            output.append("")
+        output.append(replacement)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write("\n".join(output).rstrip("\n") + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", choices=sorted(ALLOWED_NAMES), required=True)
+    parser.add_argument("--env-file", type=Path, default=REPO_ROOT / ".env")
+    args = parser.parse_args()
+    value = sys.stdin.read().strip() if not sys.stdin.isatty() else getpass.getpass(f"{args.name}: ").strip()
+    try:
+        update_env(args.env_file, args.name, value)
+    except (OSError, SecretError) as error:
+        print(json.dumps({"updated": False, "name": args.name, "classification": type(error).__name__}, sort_keys=True))
+        return 2
+    print(json.dumps({"updated": True, "name": args.name}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

Windows 代理仅监听 loopback 时，WSL2 Docker 容器无法经 `host.docker.internal` 自动进入该代理，导致 RichLab 请求在 Windows 宿主正常、在 LangGraph Compose 容器内持续超时。这属于控制面模型出口问题，不是 Compile Session、clean replay 或单一模型热度问题。

Closes #59

## 变更

- 新增仅绑定私有 Docker bridge gateway 的 WSL2 TCP relay，只接受 Windows loopback HTTP 代理作为上游，并提供 PID 所有权、配置一致性、幂等启动/停止与残留状态检查。
- 新增独立 `docker-compose-model-proxy.yaml` override；仅在本地配置代理时由 `scripts/docker.sh` 叠加，基础 `docker-compose-dev.yaml` 与 v7 冻结组件保持字节不变。
- 新增 RichLab 与 DeepSeek 的有界连通性预检，覆盖模型列表、最小对话与强制工具调用，只输出状态、耗时、请求/实际模型身份和有限布尔元数据。
- 新增原子本地 `.env` 写入工具，变量白名单、格式校验、符号链接拒绝和 LF 归一化；凭据只保存在 Git 忽略文件中。
- 补充 Makefile 入口、配置文档和安全/回归测试。

## 验证

- RichLab：`gpt-5.5`、`gpt-5.4` 的模型列表、最小对话和工具调用均从 LangGraph 容器通过。
- DeepSeek：`deepseek-v4-flash`、`deepseek-v4-pro` 的模型列表、最小对话和工具调用均从 LangGraph 容器通过。
- 聚焦测试：`32 passed`。
- 后端全量（排除只读挂载专用的配置升级组）：`1673 passed, 53 skipped`；配置升级组在可写挂载中：`4 passed`。
- Ruff check/format、Shell 语法、Compose 合并配置、v7 current-tree gate、bridge 启停、敏感信息扫描和 0 compile/replay orphan 对账通过。

## 实验边界

- 没有创建、重跑、替换或回填任何 v7 physical-attempt slot。
- 没有修改 v1-v7 manifest、Schema、validator、runner 或 ledger。
- DeepSeek 与较低负载 GPT 仅作为未来独立 provider condition；不会在同一冻结 attempt 内静默 fallback。
