### PR TITLE
修复：在未来 attempt 前验证 runner 运行环境

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,18 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-28 — Issue #59 修复 WSL2 Compose 模型出口并增加多提供商预检
-  - 分支: `fix/issue-59-model-connectivity`，基于 `main@957fb9e3`。根因是 Windows 代理只监听 loopback，WSL2 Docker 容器直连 RichLab 超时，且 `host.docker.internal` 不会自动转发到 Windows loopback。
-  - 实现: 新增仅绑定私有 Docker bridge gateway 的受限 TCP relay、独立 Compose override、RichLab/DeepSeek 模型列表 + 最小对话 + 强制工具调用预检，以及原子写入 Git 忽略 `.env` 的本地凭据工具。基础 `docker-compose-dev.yaml`、`config.example.yaml` 与 v1-v7 冻结资产保持字节不变。
-  - 当前证据: RichLab `gpt-5.5`/`gpt-5.4` 与 DeepSeek `deepseek-v4-flash`/`deepseek-v4-pro` 均从 LangGraph 容器通过模型列表、最小对话和工具调用；聚焦 `32 passed`，后端除只读挂载专用组外 `1673 passed, 53 skipped`，配置升级组在可写挂载中 `4 passed`；Ruff/format、Compose config、v7 current-tree gate、bridge 启停、敏感信息与 0 compile/replay orphan 检查通过。
-  - 边界: 只做非 pilot 连通性预检，不创建、重跑、替换或回填任一 v7 slot；DeepSeek 与较低负载 GPT 只能作为未来独立实验条件，不能在冻结 attempt 内 fallback。
+- 2026-07-29 — Issue #61 为未来 attempt 增加 runner runtime launch gate
+  - 分支: `fix/issue-61-runtime-preflight`，基于 `main@aa200d55`。v7 `fmt` 暴露正式 runner 使用容器 system Python、权威 evidence 必须位于 `/workspace/.compile-sessions` 的启动入口风险。
+  - 实现: 新增独立 `runtime-preflight`，验证 LangGraph Compose 身份、可写 Docker socket、后端 venv、必要 runtime import、可写 bind evidence mount 与 output directory 的真实 sentinel 写入/删除；`preflight`/`create-attempt` 要求显式 output directory，launch failure 在 evidence ID 和 ledger 创建前终止。
+  - 当前证据: system Python 负例、后端 venv 正例和 mount 外目录负例均按预期返回且 0 ledger/0 sentinel；协议/runner/evidence 聚焦 `199 passed, 24 skipped`，后端主体 `1683 passed, 53 skipped`，可写配置升级组 `4 passed`；Ruff/format 与 Compose config 通过。
+  - 边界: v1-v7 manifest、Schema、validator、协议哈希和 ledger 不改写；共享 runner 的合法 post-v7 漂移由 v7 current-tree gate 明确拒绝，冻结 Git blob 继续可审计。本阶段不运行双 provider canary，也不创建 v8 slot。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-29 — WSL2 Compose 模型出口与多提供商预检进入主干
+  - Issue #59 / PR #60 已 squash 合并为 `main@aa200d55`。受限 relay 只绑定私有 Docker bridge，独立 Compose override 保持 v7 冻结基础 Compose 字节不变；本地凭据只进入 Git 忽略 `.env`。
+  - RichLab `gpt-5.5`/`gpt-5.4` 与 DeepSeek `deepseek-v4-flash`/`deepseek-v4-pro` 均从 LangGraph 容器通过模型列表、最小对话和强制工具调用；Ready Unit Tests、后端 lint 与前端 lint 全绿。没有重跑、替换或回填 v7。
 
 - 2026-07-28 — C/C++ pilot v7 冻结协议进入主干
   - Issue #56 / PR #57 已 squash 合并为 `main@957fb9e3`。独立 v7 manifest、Schema、validator 和 runner 路由冻结参数前置 gate、四类 compiler 预算与 artifact oracle 差异语义。
@@ -159,7 +163,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #59 的中文 Draft PR 与 CI；合并前不启动新 pilot。下一协议应把 RichLab 与 DeepSeek 设计为可比较的独立 provider condition，并继续禁止 frozen attempt 内 fallback。
+- 完成 Issue #61 的中文 Draft PR、CI 与主干复验；合并后先做不计入正式样本的双 provider 端到端 canary，再冻结 v8。RichLab 与 DeepSeek 必须是可比较的独立 condition，禁止 frozen attempt 内 fallback。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)
@@ -172,6 +176,7 @@
 - Docker Desktop 与 WSL 原生 Docker Engine 是两个独立 daemon，镜像、网络和容器不共享；Forge 命令必须始终在同一套 daemon 上执行。
 - WSL 的 `127.0.0.1` 代理不能直接传入 Docker build；编译镜像代理必须使用容器可达地址。
 - Windows 代理只监听 loopback 时，WSL2 Docker 的 `host.docker.internal` 只到 Docker/WSL 网关，并不会自动进入 Windows loopback。模型请求必须通过仅绑定 Docker bridge 的受限 relay；不要让代理软件监听 `0.0.0.0` 或局域网地址。模型运行时代理使用独立 Compose override，不能改写 v7 冻结的基础 Compose 文件。
+- Compose 内运行正式 benchmark runner 必须显式使用 `/app/backend/.venv/bin/python`；容器 system Python 可能足以导入最小 evidence 模块，却缺少完整 `deerflow.client` 运行时。权威 output directory 必须显式位于 `/workspace/.compile-sessions` 的可写 bind mount，不能使用只读 `/repo` 或仅凭目录可写性推断宿主可见。
 - 后端全量 Ruff 当前有 4 个本次改动之外且与 `origin/main` 相同的既有错误：`scripts/check.py` 的 3 个 UP045 与 `scripts/forge_benchmark.py` 的 1 个 I001；本次改动文件的 Ruff check/format 已通过。
 - 成功 bash 记录只是候选 recipe；失败命令可能留下持久副作用。进入研究基线前必须在新容器与空 `/workspace`、`/artifacts` 中实际 replay，不能把 `repro_bundle` 生成成功等同于独立复现成功。
 - Windows 挂载目录在编译镜像中可能触发 Git `dubious ownership`；replay 初始化仓库后必须把 `/workspace/repo` 加入 `safe.directory`。

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -62,6 +62,7 @@ def load_v7_manifest() -> dict:
 def ready_preflight(manifest: dict, *, ready: bool = True) -> dict:
     return {
         "ready": ready,
+        "launch_ready": True,
         "manifest_sha256": forge_benchmark_runner._manifest_sha256(manifest),
         "manifest_file_sha256": "1" * 64,
         "forge": {
@@ -79,6 +80,28 @@ def ready_preflight(manifest: dict, *, ready: bool = True) -> dict:
         },
         "checks": {"fixture_ready": ready},
     }
+
+
+def ready_runtime_launch() -> dict:
+    checks = {
+        "runtime_process_is_langgraph_compose": True,
+        "docker_socket_is_bind_rw": True,
+        "runner_interpreter_matches": True,
+        "runtime_imports_available": True,
+        "evidence_mount_is_bind_rw": True,
+        "evidence_output_within_mount": True,
+        "evidence_output_writable": True,
+    }
+    return {"ready": True, "checks": checks}
+
+
+@pytest.fixture(autouse=True)
+def _runtime_launch_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda *_args, **_kwargs: ready_runtime_launch(),
+    )
 
 
 def test_build_policy_applies_frozen_case_and_model_constraints() -> None:
@@ -198,6 +221,11 @@ def test_runnable_preflight_accepts_clean_descendant_with_frozen_components(
     monkeypatch.setattr(forge_benchmark_runner, "_credential_present", lambda _name: True)
     monkeypatch.setattr(forge_benchmark_runner, "_endpoint_reachable", lambda _endpoint: True)
     monkeypatch.setattr(forge_benchmark_runner, "_compose_dood_present", lambda _repo_root: True)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda *_args, **_kwargs: ready_runtime_launch(),
+    )
 
     def docker_state(arguments: list[str], *, cwd: Path = REPO_ROOT) -> tuple[int, str]:
         del cwd
@@ -239,6 +267,14 @@ def test_runnable_preflight_rejects_missing_baseline_or_compose_dood(
     )
     monkeypatch.setattr(forge_benchmark_runner, "_baseline_is_ancestor", lambda *_args: False)
     monkeypatch.setattr(forge_benchmark_runner, "_compose_dood_present", lambda _repo_root: False)
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda *_args, **_kwargs: {
+            "ready": False,
+            "checks": {key: False for key in ready_runtime_launch()["checks"]},
+        },
+    )
     monkeypatch.setattr(forge_benchmark_runner, "_sha256_file", lambda _path: None)
     monkeypatch.setattr(forge_benchmark_runner, "_credential_present", lambda _name: True)
     monkeypatch.setattr(forge_benchmark_runner, "_endpoint_reachable", lambda _endpoint: True)
@@ -315,6 +351,39 @@ def test_create_attempt_rejects_duplicate_slot_and_links_explicit_replacement(
     assert replacement.read()[0]["payload"]["replacement_for_physical_attempt_id"] == original.physical_attempt_id
 
 
+def test_create_attempt_rejects_runtime_launch_failure_before_creating_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda *args, **kwargs: {
+            "ready": False,
+            "checks": {"runner_interpreter_matches": False},
+        },
+    )
+    monkeypatch.setattr(
+        forge_benchmark_runner,
+        "collect_preflight",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("full preflight must not run"),
+        ),
+    )
+
+    with pytest.raises(forge_benchmark_runner.RunnerError, match="before physical-attempt ledger"):
+        forge_benchmark_runner.create_attempt(
+            manifest,
+            case_id="fmt",
+            condition_id="baseline",
+            repetition=1,
+            output_dir=tmp_path,
+        )
+
+    assert not list(tmp_path.rglob("*.jsonl"))
+
+
 def test_run_refuses_failed_preflight_before_importing_model_client(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -375,9 +444,132 @@ def test_runnable_run_refuses_non_compose_process_before_model_request(
 
 
 def test_runner_defaults_to_v7_manifest() -> None:
-    args = forge_benchmark_runner._build_parser().parse_args(["preflight"])
+    args = forge_benchmark_runner._build_parser().parse_args(
+        [
+            "preflight",
+            "--output-dir",
+            "/workspace/.compile-sessions/benchmark-evidence-v8",
+        ]
+    )
 
     assert args.manifest == REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v7.json"
+
+
+def test_runtime_preflight_requires_explicit_output_directory() -> None:
+    with pytest.raises(SystemExit):
+        forge_benchmark_runner._build_parser().parse_args(["runtime-preflight"])
+
+
+def test_runner_interpreter_requires_backend_virtual_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(forge_benchmark_runner.sys, "prefix", "/usr/local")
+    monkeypatch.setattr(forge_benchmark_runner.sys, "base_prefix", "/usr/local")
+    monkeypatch.setattr(forge_benchmark_runner.sys, "executable", "/usr/local/bin/python3")
+
+    assert forge_benchmark_runner._runner_interpreter_matches() is False
+
+    monkeypatch.setattr(forge_benchmark_runner.sys, "prefix", "/app/backend/.venv")
+    monkeypatch.setattr(forge_benchmark_runner.sys, "base_prefix", "/usr/local")
+    monkeypatch.setattr(forge_benchmark_runner.sys, "executable", "/app/backend/.venv/bin/python")
+
+    assert forge_benchmark_runner._runner_interpreter_matches() is True
+
+
+def test_runtime_import_failure_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        forge_benchmark_runner.importlib,
+        "import_module",
+        lambda _name: (_ for _ in ()).throw(ModuleNotFoundError("private details")),
+    )
+
+    assert forge_benchmark_runner._runtime_imports_available() is False
+
+
+def test_evidence_output_checks_require_mount_containment_and_writability(
+    tmp_path: Path,
+) -> None:
+    mount_root = tmp_path / "compile-sessions"
+    mount_root.mkdir()
+    output_dir = mount_root / "benchmark-evidence-v8"
+
+    assert forge_benchmark_runner._evidence_output_checks(
+        output_dir,
+        mount_root=mount_root,
+    ) == (True, True)
+    assert not list(output_dir.glob(".forge-runtime-preflight-*"))
+    assert forge_benchmark_runner._evidence_output_checks(
+        tmp_path / "outside",
+        mount_root=mount_root,
+    ) == (False, False)
+    assert forge_benchmark_runner._evidence_output_checks(
+        mount_root,
+        mount_root=mount_root,
+    ) == (False, False)
+
+
+def test_evidence_output_checks_report_unwritable_without_error_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mount_root = tmp_path / "compile-sessions"
+    mount_root.mkdir()
+    output_dir = mount_root / "benchmark-evidence-v8"
+    monkeypatch.setattr(
+        forge_benchmark_runner.tempfile,
+        "mkstemp",
+        lambda **_kwargs: (_ for _ in ()).throw(PermissionError("private path details")),
+    )
+
+    assert forge_benchmark_runner._evidence_output_checks(
+        output_dir,
+        mount_root=mount_root,
+    ) == (True, False)
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        {
+            "Type": "volume",
+            "Destination": "/workspace/.compile-sessions",
+            "RW": True,
+        },
+        {
+            "Type": "bind",
+            "Destination": "/workspace/.compile-sessions",
+            "RW": False,
+        },
+        {
+            "Type": "bind",
+            "Destination": "/workspace/other",
+            "RW": True,
+        },
+    ],
+)
+def test_evidence_mount_requires_exact_writable_bind(mount: dict) -> None:
+    assert forge_benchmark_runner._evidence_mount_is_bind_rw([mount]) is False
+
+
+def test_evidence_output_checks_reject_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    mount_root = tmp_path / "compile-sessions"
+    outside = tmp_path / "outside"
+    mount_root.mkdir()
+    outside.mkdir()
+    link = mount_root / "linked"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+
+    assert forge_benchmark_runner._evidence_output_checks(
+        link / "evidence",
+        mount_root=mount_root,
+    ) == (False, False)
 
 
 def test_keyboard_interrupt_keeps_attempt_recoverable_and_reconciles_orphans(

--- a/backend/tests/test_forge_benchmark_v7.py
+++ b/backend/tests/test_forge_benchmark_v7.py
@@ -56,10 +56,14 @@ def test_v7_validator_rejects_budget_drift(
         forge_benchmark_v7.validate_manifest(drifted)
 
 
-def test_v7_current_tree_gate_accepts_frozen_runtime_and_protocol() -> None:
+def test_v7_current_tree_gate_rejects_post_collection_runner_drift() -> None:
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
-    forge_benchmark_v7.verify_frozen_components(manifest, REPO_ROOT)
+    with pytest.raises(
+        forge_benchmark_v7.BenchmarkError,
+        match="scripts/forge_benchmark_runner.py",
+    ):
+        forge_benchmark_v7.verify_frozen_components(manifest, REPO_ROOT)
 
 
 def test_v7_runtime_components_match_the_declared_baseline() -> None:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,32 @@
 # Forge C/C++ benchmark protocols
 
+## Post-v7 runtime launch gate
+
+The five v7 physical attempts are complete and immutable. Later runner changes
+must not be used to retry, replace, or backfill a v7 slot.
+
+Before freezing a future protocol, verify the runner process and evidence mount
+from inside the LangGraph Compose container:
+
+```bash
+/app/backend/.venv/bin/python /app/scripts/forge_benchmark_runner.py \
+  runtime-preflight \
+  --output-dir /workspace/.compile-sessions/benchmark-evidence-v8
+```
+
+The gate requires the backend virtual environment, required runtime imports, the
+`deer-flow-dev` LangGraph service, a writable Docker socket, and a writable bind
+mount at `/workspace/.compile-sessions`. It also writes and removes a temporary
+sentinel in the specified output directory. Only bounded booleans are printed;
+container source paths, credentials, exception text, and environment values are
+not emitted.
+
+Both `preflight` and `create-attempt` now require an explicit `--output-dir`.
+Launch-gate failure occurs before a physical-attempt ID or ledger is created.
+The current shared runner intentionally no longer passes the v7 current-tree
+collection gate; v7 Git blobs and existing ledgers remain the historical source
+of truth.
+
 ## Runnable pilot v7 protocol
 
 `cpp-pilot-v7.json` is the five-case protocol frozen after the v6 calibration exposed three instrumentation gaps. Its runtime baseline includes the Issue #50 pre-build argument gate, Issue #51 separate compiler budgets, and Issue #52 structured artifact-oracle diagnostics. It preserves every v1-v6 manifest, schema, validator, and ledger as historical evidence.

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import importlib
 import json
 import os
 import platform
 import subprocess
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path, PurePosixPath
@@ -75,6 +77,10 @@ _REPLAY_ARTIFACT_MISMATCH_ORDER = (
     "sha256",
     "smoke",
 )
+_BACKEND_VENV_ROOT = Path("/app/backend/.venv")
+_EVIDENCE_MOUNT_ROOT = Path("/workspace/.compile-sessions")
+_DEFAULT_EVIDENCE_DIR = _EVIDENCE_MOUNT_ROOT / "benchmark-evidence"
+_REQUIRED_RUNTIME_IMPORTS = ("deerflow.client",)
 
 
 def _sha256_file(path: Path) -> str | None:
@@ -179,12 +185,12 @@ def _compose_dood_present(repo_root: Path) -> bool:
     return False
 
 
-def _running_inside_compose_dood(repo_root: Path) -> bool:
+def _current_container_metadata(repo_root: Path) -> tuple[dict[str, Any] | None, list[dict[str, Any]] | None]:
     if not Path("/.dockerenv").is_file():
-        return False
+        return None, None
     container_id = os.environ.get("HOSTNAME", "").strip()
     if not container_id:
-        return False
+        return None, None
     labels_code, labels_json = _run_command(
         ["docker", "inspect", "--format", "{{json .Config.Labels}}", container_id],
         cwd=repo_root,
@@ -194,18 +200,114 @@ def _running_inside_compose_dood(repo_root: Path) -> bool:
         cwd=repo_root,
     )
     if labels_code != 0 or mounts_code != 0:
-        return False
+        return None, None
     try:
         labels = json.loads(labels_json)
         mounts = json.loads(mounts_json)
     except (TypeError, ValueError):
-        return False
+        return None, None
+    return (
+        labels if isinstance(labels, dict) else None,
+        mounts if isinstance(mounts, list) and all(isinstance(mount, dict) for mount in mounts) else None,
+    )
+
+
+def _running_inside_compose_dood(repo_root: Path) -> bool:
+    labels, mounts = _current_container_metadata(repo_root)
     return (
         isinstance(labels, dict)
+        and isinstance(mounts, list)
         and labels.get("com.docker.compose.project") == "deer-flow-dev"
         and labels.get("com.docker.compose.service") == "langgraph"
         and any(isinstance(mount, dict) and mount.get("Destination") == "/var/run/docker.sock" and mount.get("RW") is True for mount in mounts)
     )
+
+
+def _runner_interpreter_matches() -> bool:
+    return sys.prefix != sys.base_prefix and Path(sys.prefix) == _BACKEND_VENV_ROOT and Path(sys.executable).parent == _BACKEND_VENV_ROOT / "bin"
+
+
+def _runtime_imports_available() -> bool:
+    try:
+        for module_name in _REQUIRED_RUNTIME_IMPORTS:
+            importlib.import_module(module_name)
+    except Exception:
+        return False
+    return True
+
+
+def _evidence_mount_is_bind_rw(mounts: list[dict[str, Any]] | None) -> bool:
+    return bool(mounts and any(mount.get("Type") == "bind" and mount.get("Destination") == _EVIDENCE_MOUNT_ROOT.as_posix() and mount.get("RW") is True for mount in mounts))
+
+
+def _docker_socket_is_bind_rw(mounts: list[dict[str, Any]] | None) -> bool:
+    return bool(mounts and any(mount.get("Type") == "bind" and mount.get("Destination") == "/var/run/docker.sock" and mount.get("RW") is True for mount in mounts))
+
+
+def _evidence_output_checks(
+    output_dir: Path,
+    *,
+    mount_root: Path = _EVIDENCE_MOUNT_ROOT,
+) -> tuple[bool, bool]:
+    if not output_dir.is_absolute():
+        return False, False
+    try:
+        resolved_mount = mount_root.resolve(strict=True)
+        if resolved_mount != mount_root or mount_root.is_symlink():
+            return False, False
+        resolved_output = output_dir.resolve(strict=False)
+        relative_output = resolved_output.relative_to(resolved_mount)
+    except (OSError, ValueError):
+        return False, False
+    if not relative_output.parts:
+        return False, False
+
+    candidate = resolved_mount
+    for part in relative_output.parts:
+        candidate /= part
+        if candidate.is_symlink():
+            return False, False
+
+    temporary_path: Path | None = None
+    try:
+        resolved_output.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".forge-runtime-preflight-",
+            dir=resolved_output,
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(b"forge-runtime-preflight\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.unlink()
+    except OSError:
+        return True, False
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return True, True
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    labels, mounts = _current_container_metadata(repo_root)
+    compose_process = bool(labels and labels.get("com.docker.compose.project") == "deer-flow-dev" and labels.get("com.docker.compose.service") == "langgraph")
+    evidence_mount = _evidence_mount_is_bind_rw(mounts)
+    output_within_mount, output_writable = _evidence_output_checks(output_dir) if evidence_mount else (False, False)
+    checks = {
+        "runtime_process_is_langgraph_compose": compose_process,
+        "docker_socket_is_bind_rw": _docker_socket_is_bind_rw(mounts),
+        "runner_interpreter_matches": _runner_interpreter_matches(),
+        "runtime_imports_available": _runtime_imports_available(),
+        "evidence_mount_is_bind_rw": evidence_mount,
+        "evidence_output_within_mount": output_within_mount,
+        "evidence_output_writable": output_writable,
+    }
+    return {"ready": all(checks.values()), "checks": checks}
 
 
 def _manifest_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
@@ -329,6 +431,8 @@ def collect_preflight(
     *,
     repo_root: Path = REPO_ROOT,
     manifest_path: Path | None = None,
+    output_dir: Path = _DEFAULT_EVIDENCE_DIR,
+    runtime_launch: dict[str, Any] | None = None,
     check_endpoint: bool = True,
 ) -> dict[str, Any]:
     forge_state = _git_state(repo_root)
@@ -396,6 +500,11 @@ def collect_preflight(
         protocol_v7.CONTROL_PLANE_TOPOLOGY,
     }
     topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
+    if runtime_launch is None:
+        runtime_launch = collect_runtime_launch_preflight(
+            output_dir,
+            repo_root=repo_root,
+        )
     checks = {
         "credential_present": _credential_present(model["credential_env"]),
         "endpoint_reachable": endpoint_reachable,
@@ -415,6 +524,7 @@ def collect_preflight(
         "memory_skills_disabled": condition_baseline,
         "instrumentation_unblocked": not manifest["scope"]["instrumentation_blocker"],
         "control_plane_topology_matches": topology_matches,
+        **runtime_launch["checks"],
     }
     required_checks = [
         checks["credential_present"],
@@ -429,11 +539,13 @@ def collect_preflight(
         checks["memory_skills_disabled"],
         checks["instrumentation_unblocked"],
         checks["control_plane_topology_matches"],
+        runtime_launch["ready"],
     ]
     if check_endpoint:
         required_checks.append(checks["endpoint_reachable"] is True)
     return {
         "ready": all(required_checks),
+        "launch_ready": runtime_launch["ready"],
         "manifest_sha256": _manifest_sha256(manifest),
         "manifest_file_sha256": _sha256_file(
             manifest_path
@@ -528,6 +640,12 @@ def create_attempt(
         condition_id=condition_id,
         repetition=repetition,
     )
+    runtime_launch = collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+    if runtime_launch["ready"] is not True:
+        raise RunnerError("Runtime launch preflight failed before physical-attempt ledger creation")
     existing = find_slot_ledgers(output_dir, policy)
     if existing and replacement_for is None:
         raise RunnerError("This benchmark slot already has physical evidence; create an explicit replacement attempt")
@@ -544,6 +662,8 @@ def create_attempt(
         manifest,
         repo_root=repo_root,
         manifest_path=manifest_path,
+        output_dir=output_dir,
+        runtime_launch=runtime_launch,
         check_endpoint=check_endpoint,
     )
     experiment_id = replacement_event["experiment_id"] if replacement_event is not None else new_evidence_id("experiment")
@@ -1234,7 +1354,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     common.add_argument("--skip-endpoint-check", action="store_true")
 
-    subparsers.add_parser("preflight", parents=[common])
+    runtime_preflight = subparsers.add_parser("runtime-preflight")
+    runtime_preflight.add_argument("--output-dir", type=Path, required=True)
+    preflight = subparsers.add_parser("preflight", parents=[common])
+    preflight.add_argument("--output-dir", type=Path, required=True)
     create = subparsers.add_parser("create-attempt", parents=[common])
     create.add_argument("--case", required=True)
     create.add_argument("--condition", default="baseline")
@@ -1242,7 +1365,7 @@ def _build_parser() -> argparse.ArgumentParser:
     create.add_argument(
         "--output-dir",
         type=Path,
-        default=REPO_ROOT / "benchmarks" / "evidence",
+        required=True,
     )
     create.add_argument("--replacement-for")
 
@@ -1256,11 +1379,16 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
+        if args.command == "runtime-preflight":
+            result = collect_runtime_launch_preflight(args.output_dir)
+            _json_print(result)
+            return 0 if result["ready"] else 2
         manifest = _load_manifest(args.manifest)
         if args.command == "preflight":
             result = collect_preflight(
                 manifest,
                 manifest_path=args.manifest,
+                output_dir=args.output_dir,
                 check_endpoint=not args.skip_endpoint_check,
             )
             _json_print(result)


### PR DESCRIPTION
## 背景

v7 的 `fmt` physical attempt 在 0 模型请求、0 Compile Session 时失败：正式 runner 使用了容器 system Python，而不是后端项目 venv。v7 还确认权威 ledger 必须位于 Compose 映射的 `/workspace/.compile-sessions`，不能落在只读 `/repo` 或不可从宿主访问的位置。

Closes #61

## 变更

- 新增独立 `runtime-preflight` 命令，验证当前进程是 `deer-flow-dev` LangGraph Compose 服务、Docker socket 可写、解释器属于 `/app/backend/.venv`，且 `deerflow.client` runtime import 可用。
- 验证 `/workspace/.compile-sessions` 是可写 bind mount，指定 output directory 位于其子目录，并通过临时 sentinel 的创建、`fsync` 与删除证明真实可写。
- `preflight` 与 `create-attempt` 现在必须显式传入 `--output-dir`；launch gate 在 output 目录遍历、provider endpoint 检查、physical-attempt ID 和 ledger 创建之前执行。
- 所有检查只输出有界布尔值，不输出 Docker mount source、宿主路径、异常文本、环境变量值或凭据。
- 更新 v7 current-tree 测试：共享 runner 的合法 post-v7 漂移应被旧 collection gate 拒绝；v7 的冻结 Git blob、manifest、Schema、validator、协议哈希和既有 ledger 不改写。

## 验证

- 真实 Docker system Python：`runner_interpreter_matches=false`、`runtime_imports_available=false`，退出 2。
- 真实 Docker 后端 venv + 正确 evidence mount：全部 launch checks 为 true，退出 0。
- 真实 Docker mount 外 `/repo`：output containment/writability 为 false，退出 2。
- 三组均为 0 ledger、0 sentinel、0 模型请求、0 Compile Session。
- 协议/runner/evidence 聚焦：`199 passed, 24 skipped`。
- 后端全量主体：`1683 passed, 53 skipped`；可写配置升级组：`4 passed`。
- Ruff check/format、Compose config、敏感信息、冻结资产与 0 compile/replay orphan 对账通过。

## 实验边界

- 不重跑、替换或回填 v7。
- 本 PR 不运行 RichLab/DeepSeek canary，不创建 v8 physical-attempt slot。
- 合并后才进入双 provider 非 pilot canary 和 v8 condition 设计。
