### PR TITLE
实验：增加双提供商端到端 canary 入口

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,18 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-29 — Issue #61 为未来 attempt 增加 runner runtime launch gate
-  - 分支: `fix/issue-61-runtime-preflight`，基于 `main@aa200d55`。v7 `fmt` 暴露正式 runner 使用容器 system Python、权威 evidence 必须位于 `/workspace/.compile-sessions` 的启动入口风险。
-  - 实现: 新增独立 `runtime-preflight`，验证 LangGraph Compose 身份、可写 Docker socket、后端 venv、必要 runtime import、可写 bind evidence mount 与 output directory 的真实 sentinel 写入/删除；`preflight`/`create-attempt` 要求显式 output directory，launch failure 在 evidence ID 和 ledger 创建前终止。
-  - 当前证据: system Python 负例、后端 venv 正例和 mount 外目录负例均按预期返回且 0 ledger/0 sentinel；协议/runner/evidence 聚焦 `199 passed, 24 skipped`，后端主体 `1683 passed, 53 skipped`，可写配置升级组 `4 passed`；Ruff/format 与 Compose config 通过。
-  - 边界: v1-v7 manifest、Schema、validator、协议哈希和 ledger 不改写；共享 runner 的合法 post-v7 漂移由 v7 current-tree gate 明确拒绝，冻结 Git blob 继续可审计。本阶段不运行双 provider canary，也不创建 v8 slot。
+- 2026-07-29 — Issue #63 双提供商非 pilot 端到端 canary
+  - 分支: `experiment/issue-63-provider-canary`，基于 `main@70fe40d6`。固定 `CMakeHelloWorld@6fda0b1`、`autocompiler:gcc13`，RichLab 使用 `gpt-5.5`，DeepSeek 使用 `deepseek-v4-flash`，两条件严格串行且各 1 次。
+  - 已实现: 独立 `forge-provider-canary-v1` 入口；每个条件在模型请求前创建独立 append-only ledger 并激活 exact repo/commit/CMake/image/model/endpoint policy，关闭 Memory/Skills、provider retries 与 fallback；输出只含布尔门禁、计数、usage、身份和哈希，不含模型文本、tool args、命令输出、异常文本、凭据或宿主路径。
+  - 接受门禁: 完整 stream、模型请求闭合、恰好 1 个 terminal compiler task、唯一 Compile Session、repo/commit/build-system identity、产物、submit verification、clean replay/cleanup、finalize 与 0 remaining orphan 必须同时成立。
+  - 当前证据: 聚焦 `11 passed`，runner/evidence/compile 回归 `232 passed`，后端主体（排除只读挂载配置升级组）通过，配置升级组 `4 passed`；Ruff/format、Compose config、前端串行 lint/typecheck/format、冻结资产与敏感模式扫描通过；真实 runtime launch gate 为 `ready=true`。尚未调用 canary 模型，也未创建 v8 slot。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-29 — 修复未来 attempt 的 runner 解释器与 evidence 挂载门禁
+  - Issue #61 / PR #62 已 squash 合并为 `main@70fe40d6`。新增独立 `runtime-preflight`，验证 LangGraph Compose 身份、可写 Docker socket、后端 venv、必要 runtime import、可写 bind evidence mount 与 output directory 的真实 sentinel 写入/删除；`preflight`/`create-attempt` 要求显式 output directory，launch failure 在 evidence ID 和 ledger 创建前终止。
+  - system Python 负例、后端 venv 正例和 mount 外目录负例均按预期返回且 0 ledger/0 sentinel；v1-v7 manifest、Schema、validator、协议哈希和 ledger 未改写，v7 current-tree gate继续拒绝 post-collection runner 漂移。
 
 - 2026-07-29 — WSL2 Compose 模型出口与多提供商预检进入主干
   - Issue #59 / PR #60 已 squash 合并为 `main@aa200d55`。受限 relay 只绑定私有 Docker bridge，独立 Compose override 保持 v7 冻结基础 Compose 字节不变；本地凭据只进入 Git 忽略 `.env`。
@@ -163,7 +167,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #61 的中文 Draft PR、CI 与主干复验；合并后先做不计入正式样本的双 provider 端到端 canary，再冻结 v8。RichLab 与 DeepSeek 必须是可比较的独立 condition，禁止 frozen attempt 内 fallback。
+- 完成 Issue #63 的中文 Draft PR、CI 与主干复验；合并后严格串行执行 RichLab/DeepSeek 两个非 pilot canary，保留每个条件的首次结果，再据此冻结 v8。两个提供商必须是可比较的独立 condition，禁止 frozen attempt 内 fallback。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)

--- a/backend/tests/test_forge_provider_canary.py
+++ b/backend/tests/test_forge_provider_canary.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_provider_canary.py"
+SPEC = importlib.util.spec_from_file_location("forge_provider_canary", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+forge_provider_canary = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = forge_provider_canary
+SPEC.loader.exec_module(forge_provider_canary)
+
+
+def _successful_session():
+    return SimpleNamespace(
+        status="completed",
+        repo_url=forge_provider_canary.TARGET_REPOSITORY,
+        commit_sha=forge_provider_canary.TARGET_COMMIT,
+        build_system_capabilities=["cmake"],
+        selected_build_system="cmake",
+        executed_build_system="cmake",
+        artifacts=[
+            SimpleNamespace(artifact_type="executable"),
+            SimpleNamespace(artifact_type="executable"),
+        ],
+        verification=SimpleNamespace(status="passed"),
+        replay_attempts=[
+            SimpleNamespace(status="passed", cleanup_succeeded=True),
+        ],
+        finalized_at="2026-07-29T00:00:00+00:00",
+    )
+
+
+def test_protocol_separates_provider_credentials_and_endpoints():
+    richlab = forge_provider_canary._protocol_payload(
+        "gpt-5.5",
+        "sha256:" + "1" * 64,
+    )
+    deepseek = forge_provider_canary._protocol_payload(
+        "deepseek-v4-flash",
+        "sha256:" + "1" * 64,
+    )
+
+    assert richlab["provider"] == "richlab"
+    assert richlab["credential_env"] == "OpenAI_AK"
+    assert deepseek["provider"] == "deepseek"
+    assert deepseek["credential_env"] == "DEEPSEEK_API_KEY"
+    assert richlab["endpoint"] != deepseek["endpoint"]
+    assert richlab["model_max_retries"] == 0
+    assert deepseek["fallback_enabled"] is False
+
+
+def test_policy_pins_exact_target_and_build_system():
+    image_id = "sha256:" + "1" * 64
+    policy = forge_provider_canary._build_policy("gpt-5.5", image_id)
+
+    assert policy.expected_repo_url == forge_provider_canary.TARGET_REPOSITORY
+    assert policy.expected_commit_sha == forge_provider_canary.TARGET_COMMIT
+    assert policy.expected_build_system == "cmake"
+    assert policy.image_id == image_id
+    assert policy.model_name == "gpt-5.5"
+    assert policy.memory_enabled is False
+    assert policy.skills_enabled is False
+
+
+def test_safe_session_summary_excludes_paths_commands_and_model_content():
+    summary = forge_provider_canary._safe_session_summary(_successful_session())
+
+    assert summary["commit_matches"] is True
+    assert summary["build_system_matches"] is True
+    assert summary["artifact_count"] == 2
+    assert summary["artifact_types"] == ["executable"]
+    assert set(summary) == {
+        "session_count",
+        "status",
+        "repo_matches",
+        "commit_matches",
+        "build_system_matches",
+        "artifact_count",
+        "artifact_types",
+        "verification_status",
+        "replay_status",
+        "replay_cleanup_succeeded",
+        "finalized",
+    }
+
+
+def test_acceptance_requires_full_clean_replay_and_finalization():
+    session = forge_provider_canary._safe_session_summary(_successful_session())
+    stream = {
+        "stream_completed": True,
+        "compile_tool_call_count": 6,
+    }
+    reconciliation = {
+        "remaining_count": 0,
+        "cleanup_succeeded": True,
+    }
+    evidence = {
+        "model_request_started_count": 3,
+        "model_request_completed_count": 3,
+        "compiler_task_terminal_count": 1,
+    }
+
+    assert forge_provider_canary._accepted(
+        stream_summary=stream,
+        session_summary=session,
+        evidence_summary=evidence,
+        reconciliation=reconciliation,
+    )
+
+    session["replay_cleanup_succeeded"] = False
+    assert not forge_provider_canary._accepted(
+        stream_summary=stream,
+        session_summary=session,
+        evidence_summary=evidence,
+        reconciliation=reconciliation,
+    )
+
+    session["replay_cleanup_succeeded"] = True
+    evidence["compiler_task_terminal_count"] = 2
+    assert not forge_provider_canary._accepted(
+        stream_summary=stream,
+        session_summary=session,
+        evidence_summary=evidence,
+        reconciliation=reconciliation,
+    )
+
+
+def test_stream_consumer_counts_tools_without_returning_content_or_arguments():
+    class Client:
+        async def astream(self, _message: str, *, thread_id: str):
+            assert thread_id == "thread-safe"
+            yield SimpleNamespace(
+                type="messages-tuple",
+                data={
+                    "type": "ai",
+                    "content": "private model text",
+                    "tool_calls": [
+                        {
+                            "name": "prepare_compile_session",
+                            "args": {"credential": "must-not-be-returned"},
+                        },
+                        {
+                            "name": "unrelated_tool",
+                            "args": {"path": "private"},
+                        },
+                    ],
+                },
+            )
+            yield SimpleNamespace(
+                type="end",
+                data={
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "total_tokens": 15,
+                        "provider_payload": "private",
+                    }
+                },
+            )
+
+    summary = asyncio.run(
+        forge_provider_canary._consume_stream(
+            Client(),
+            "message",
+            thread_id="thread-safe",
+        )
+    )
+
+    assert summary == {
+        "stream_completed": True,
+        "event_count": 2,
+        "tool_call_count": 2,
+        "compile_tool_call_count": 1,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+
+def test_runtime_preflight_failure_issues_no_model_call(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        forge_provider_canary.forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda _output_dir: {
+            "ready": False,
+            "checks": {"runtime_imports_available": False},
+        },
+    )
+
+    result = forge_provider_canary.run_canary(
+        model_name="gpt-5.5",
+        output_dir=tmp_path,
+        wall_clock_timeout_seconds=1000,
+    )
+
+    assert result["status"] == "rejected"
+    assert result["classification"] == "runtime_preflight_failed"
+    assert result["model_call_issued"] is False
+
+
+def test_missing_credential_issues_no_model_call(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        forge_provider_canary.forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda _output_dir: {"ready": True, "checks": {}},
+    )
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    result = forge_provider_canary.run_canary(
+        model_name="deepseek-v4-flash",
+        output_dir=tmp_path,
+        wall_clock_timeout_seconds=1000,
+    )
+
+    assert result["status"] == "rejected"
+    assert result["classification"] == "credential_missing"
+    assert result["model_call_issued"] is False
+
+
+def test_unallowed_model_is_rejected_before_runtime_preflight(tmp_path):
+    with pytest.raises(
+        forge_provider_canary.CanaryError,
+        match="model_not_allowed",
+    ):
+        forge_provider_canary.run_canary(
+            model_name="deepseek-v4-pro",
+            output_dir=tmp_path,
+            wall_clock_timeout_seconds=1000,
+        )
+
+
+def test_thread_container_scan_uses_exact_label(monkeypatch):
+    observed: list[list[str]] = []
+
+    def fake_run(arguments, **_kwargs):
+        observed.append(arguments)
+        return SimpleNamespace(returncode=0, stdout="abc123def456\n")
+
+    monkeypatch.setattr(forge_provider_canary.subprocess, "run", fake_run)
+
+    assert forge_provider_canary._thread_containers("provider-canary-richlab-safe") == (True, ["abc123def456"])
+    assert observed == [
+        [
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+            "label=deerflow.compile.thread_id=provider-canary-richlab-safe",
+        ]
+    ]
+
+
+def test_mocked_canary_writes_separate_non_pilot_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    session = _successful_session()
+    session.session_id = "123456789abc"
+    monkeypatch.setenv("OpenAI_AK", "present-only-in-process")
+    monkeypatch.setattr(
+        forge_provider_canary.forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda _output_dir: {"ready": True, "checks": {"fixture": True}},
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "_inspect_image_id",
+        lambda: "sha256:" + "1" * 64,
+    )
+
+    async def run_agent(_model_name, _thread_id):
+        return {
+            "stream_completed": True,
+            "event_count": 10,
+            "tool_call_count": 6,
+            "compile_tool_call_count": 6,
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        }
+
+    monkeypatch.setattr(forge_provider_canary, "_run_agent", run_agent)
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "finalize_unfinished_thread_sessions_impl",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "get_compile_services",
+        lambda: SimpleNamespace(manager=SimpleNamespace(list_sessions=lambda _thread_id: [session])),
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "_reconcile_thread_containers",
+        lambda _thread_id: {
+            "scan_succeeded": True,
+            "observed_count": 0,
+            "removed_count": 0,
+            "remaining_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "_evidence_summary",
+        lambda _events: {
+            "model_request_started_count": 3,
+            "model_request_completed_count": 3,
+            "compiler_task_terminal_count": 1,
+        },
+    )
+
+    result = forge_provider_canary.run_canary(
+        model_name="gpt-5.5",
+        output_dir=tmp_path,
+        wall_clock_timeout_seconds=1000,
+    )
+
+    assert result["status"] == "passed"
+    ledger_text = (tmp_path / result["ledger_name"]).read_text(encoding="utf-8")
+    assert '"formal_pilot":false' in ledger_text
+    assert '"event":"canary.completed"' in ledger_text
+    assert '"event":"experiment.completed"' in ledger_text
+    assert "present-only-in-process" not in ledger_text
+
+
+def test_model_exception_text_is_not_emitted_or_persisted(
+    tmp_path,
+    monkeypatch,
+):
+    secret_marker = "private-credential-marker"
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "present-only-in-process")
+    monkeypatch.setattr(
+        forge_provider_canary.forge_benchmark_runner,
+        "collect_runtime_launch_preflight",
+        lambda _output_dir: {"ready": True, "checks": {"fixture": True}},
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "_inspect_image_id",
+        lambda: "sha256:" + "1" * 64,
+    )
+
+    async def fail_agent(_model_name, _thread_id):
+        raise RuntimeError(secret_marker)
+
+    monkeypatch.setattr(forge_provider_canary, "_run_agent", fail_agent)
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "finalize_unfinished_thread_sessions_impl",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "get_compile_services",
+        lambda: SimpleNamespace(manager=SimpleNamespace(list_sessions=lambda _thread_id: [])),
+    )
+    monkeypatch.setattr(
+        forge_provider_canary,
+        "_reconcile_thread_containers",
+        lambda _thread_id: {
+            "scan_succeeded": True,
+            "observed_count": 0,
+            "removed_count": 0,
+            "remaining_count": 0,
+            "cleanup_succeeded": True,
+        },
+    )
+
+    result = forge_provider_canary.run_canary(
+        model_name="deepseek-v4-flash",
+        output_dir=tmp_path,
+        wall_clock_timeout_seconds=1000,
+    )
+
+    assert result["status"] == "failed"
+    assert result["classification"] == "RuntimeError"
+    serialized = json.dumps(result)
+    ledger_text = (tmp_path / result["ledger_name"]).read_text(encoding="utf-8")
+    assert secret_marker not in serialized
+    assert secret_marker not in ledger_text

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,6 +27,32 @@ The current shared runner intentionally no longer passes the v7 current-tree
 collection gate; v7 Git blobs and existing ledgers remain the historical source
 of truth.
 
+## Provider canary after v7
+
+Issue #63 defines a non-pilot, single-attempt canary for comparing the RichLab
+and DeepSeek provider paths before designing v8. Both conditions use the same
+commit-pinned CMake repository and the complete Compile Session plus clean
+replay lifecycle. They run serially, never fall back to another model, and
+write separate evidence outside the frozen v1-v7 ledgers.
+
+Run each condition from the `deer-flow-dev` LangGraph container with the
+backend virtual-environment interpreter:
+
+```bash
+/app/backend/.venv/bin/python /app/scripts/forge_provider_canary.py \
+  --model gpt-5.5 \
+  --output-dir /workspace/.compile-sessions/provider-canary-evidence/richlab
+
+/app/backend/.venv/bin/python /app/scripts/forge_provider_canary.py \
+  --model deepseek-v4-flash \
+  --output-dir /workspace/.compile-sessions/provider-canary-evidence/deepseek
+```
+
+The runner emits only bounded status, counts, timings, identities, and boolean
+acceptance gates. It does not emit model text, tool arguments, command output,
+credentials, or host paths. A failed condition is preserved as-is and is not
+retried or replaced.
+
 ## Runnable pilot v7 protocol
 
 `cpp-pilot-v7.json` is the five-case protocol frozen after the v6 calibration exposed three instrumentation gaps. Its runtime baseline includes the Issue #50 pre-build argument gate, Issue #51 separate compiler budgets, and Issue #52 structured artifact-oracle diagnostics. It preserves every v1-v6 manifest, schema, validator, and ledger as historical evidence.

--- a/scripts/forge_provider_canary.py
+++ b/scripts/forge_provider_canary.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Run one bounded, secret-safe provider canary outside the frozen pilots."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(
+    os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])
+).resolve()
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+for import_root in (str(HARNESS_ROOT), str(Path(__file__).resolve().parent)):
+    if import_root not in sys.path:
+        sys.path.insert(0, import_root)
+
+from deerflow.compile.evidence import (  # noqa: E402
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+from deerflow.compile.operations import (  # noqa: E402
+    finalize_unfinished_thread_sessions_impl,
+    get_compile_services,
+)
+
+import forge_benchmark_runner  # noqa: E402
+
+PROTOCOL_VERSION = "forge-provider-canary-v1"
+TARGET_REPOSITORY = "https://github.com/MattClarkson/CMakeHelloWorld.git"
+TARGET_COMMIT = "6fda0b169299b1241ed883c8d4af8519da30ce52"
+TARGET_BUILD_SYSTEM = "cmake"
+COMPILE_IMAGE = "autocompiler:gcc13"
+ALLOWED_MODELS = {
+    "gpt-5.5": {
+        "provider": "richlab",
+        "endpoint": "https://richlab-api-x.choosefire.com/v1",
+        "credential_env": "OpenAI_AK",
+    },
+    "deepseek-v4-flash": {
+        "provider": "deepseek",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+    },
+}
+_SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_USAGE_KEYS = ("input_tokens", "output_tokens", "total_tokens")
+_COMPILE_TOOL_NAMES = frozenset(
+    {
+        "prepare_compile_session",
+        "clone_repository",
+        "identify_build_system",
+        "task",
+        "run_container_bash",
+        "submit_build_result",
+        "finalize_session",
+    }
+)
+
+
+class CanaryError(ValueError):
+    """A bounded canary validation failure."""
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _protocol_payload(model_name: str, image_id: str) -> dict[str, Any]:
+    model = ALLOWED_MODELS[model_name]
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "repository_url": TARGET_REPOSITORY,
+        "commit_sha": TARGET_COMMIT,
+        "build_system": TARGET_BUILD_SYSTEM,
+        "compile_image": COMPILE_IMAGE,
+        "image_id": image_id,
+        "provider": model["provider"],
+        "model_name": model_name,
+        "endpoint": model["endpoint"],
+        "credential_env": model["credential_env"],
+        "request_timeout_seconds": 120,
+        "model_max_retries": 0,
+        "compiler_model_turn_limit": 36,
+        "compiler_graph_recursion_limit": 96,
+        "compiler_wall_clock_seconds": 900,
+        "compiler_post_build_reserve_seconds": 120,
+        "memory_enabled": False,
+        "skills_enabled": False,
+        "condition_attempt_limit": 1,
+        "fallback_enabled": False,
+    }
+
+
+def _inspect_image_id() -> str:
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{.Id}}", COMPILE_IMAGE],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CanaryError("compile_image_unavailable") from exc
+    image_id = result.stdout.strip()
+    if result.returncode != 0 or not re.fullmatch(r"sha256:[0-9a-f]{64}", image_id):
+        raise CanaryError("compile_image_unavailable")
+    return image_id
+
+
+def _build_policy(model_name: str, image_id: str) -> ExperimentPolicy:
+    model = ALLOWED_MODELS[model_name]
+    protocol = _protocol_payload(model_name, image_id)
+    return ExperimentPolicy(
+        benchmark_id=PROTOCOL_VERSION,
+        manifest_sha256=_canonical_sha256(protocol),
+        case_id="cmake-hello-world",
+        condition=model["provider"],
+        repetition=1,
+        expected_repo_url=TARGET_REPOSITORY,
+        expected_commit_sha=TARGET_COMMIT,
+        expected_build_system=TARGET_BUILD_SYSTEM,
+        compile_image=COMPILE_IMAGE,
+        image_id=image_id,
+        model_name=model_name,
+        endpoint=model["endpoint"],
+        credential_env=model["credential_env"],
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=900,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=36,
+        compiler_graph_recursion_limit=96,
+        compiler_wall_clock_seconds=900,
+        compiler_post_build_reserve_seconds=120,
+    )
+
+
+async def _consume_stream(
+    client: Any, message: str, *, thread_id: str
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "stream_completed": False,
+        "event_count": 0,
+        "tool_call_count": 0,
+        "compile_tool_call_count": 0,
+        "usage": {key: 0 for key in _USAGE_KEYS},
+    }
+    async for event in client.astream(message, thread_id=thread_id):
+        summary["event_count"] += 1
+        if event.type == "end":
+            summary["stream_completed"] = True
+            usage = event.data.get("usage") if isinstance(event.data, dict) else None
+            if isinstance(usage, dict):
+                summary["usage"] = {
+                    key: value if type(value) is int and value >= 0 else 0
+                    for key in _USAGE_KEYS
+                    for value in [usage.get(key)]
+                }
+            continue
+        if event.type != "messages-tuple" or not isinstance(event.data, dict):
+            continue
+        if event.data.get("type") != "ai":
+            continue
+        tool_calls = event.data.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            tool_name = tool_call.get("name")
+            if not isinstance(tool_name, str):
+                continue
+            summary["tool_call_count"] += 1
+            if tool_name in _COMPILE_TOOL_NAMES:
+                summary["compile_tool_call_count"] += 1
+    return summary
+
+
+def _thread_containers(thread_id: str) -> tuple[bool, list[str]]:
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-aq",
+                "--filter",
+                f"label=deerflow.compile.thread_id={thread_id}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False, []
+    if result.returncode != 0:
+        return False, []
+    return True, [
+        value
+        for value in result.stdout.splitlines()
+        if re.fullmatch(r"[0-9a-f]{12,64}", value)
+    ]
+
+
+def _reconcile_thread_containers(thread_id: str) -> dict[str, Any]:
+    initial_scan_succeeded, observed = _thread_containers(thread_id)
+    removed = 0
+    for identifier in observed:
+        try:
+            result = subprocess.run(
+                ["docker", "rm", "-f", identifier],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            removed += 1
+    final_scan_succeeded, remaining = _thread_containers(thread_id)
+    scan_succeeded = initial_scan_succeeded and final_scan_succeeded
+    return {
+        "scan_succeeded": scan_succeeded,
+        "observed_count": len(observed),
+        "removed_count": removed,
+        "remaining_count": len(remaining),
+        "cleanup_succeeded": (
+            scan_succeeded and not remaining and removed == len(observed)
+        ),
+    }
+
+
+def _safe_session_summary(session: Any | None) -> dict[str, Any]:
+    if session is None:
+        return {
+            "session_count": 0,
+            "status": None,
+            "repo_matches": False,
+            "commit_matches": False,
+            "build_system_matches": False,
+            "artifact_count": 0,
+            "artifact_types": [],
+            "verification_status": None,
+            "replay_status": None,
+            "replay_cleanup_succeeded": False,
+            "finalized": False,
+        }
+    verification = session.verification
+    replay = session.replay_attempts[-1] if session.replay_attempts else None
+    artifact_types = sorted(
+        {
+            artifact.artifact_type
+            for artifact in session.artifacts
+            if isinstance(artifact.artifact_type, str)
+        }
+    )
+    build_system_matches = (
+        TARGET_BUILD_SYSTEM in session.build_system_capabilities
+        and session.selected_build_system == TARGET_BUILD_SYSTEM
+        and session.executed_build_system == TARGET_BUILD_SYSTEM
+    )
+    return {
+        "session_count": 1,
+        "status": session.status,
+        "repo_matches": session.repo_url.rstrip("/") == TARGET_REPOSITORY.rstrip("/"),
+        "commit_matches": session.commit_sha == TARGET_COMMIT,
+        "build_system_matches": build_system_matches,
+        "artifact_count": len(session.artifacts),
+        "artifact_types": artifact_types,
+        "verification_status": verification.status
+        if verification is not None
+        else None,
+        "replay_status": replay.status if replay is not None else None,
+        "replay_cleanup_succeeded": replay.cleanup_succeeded is True
+        if replay is not None
+        else False,
+        "finalized": session.finalized_at is not None,
+    }
+
+
+def _evidence_summary(events: list[dict[str, Any]]) -> dict[str, int]:
+    model_started = [
+        event for event in events if event.get("event") == "model.request_started"
+    ]
+    model_completed = [
+        event for event in events if event.get("event") == "model.request_completed"
+    ]
+    compiler_terminal = [
+        event
+        for event in events
+        if event.get("event") == "agent.subagent_terminated"
+        and event.get("payload", {}).get("role") == "compiler"
+    ]
+    return {
+        "model_request_started_count": len(model_started),
+        "model_request_completed_count": len(model_completed),
+        "compiler_task_terminal_count": len(compiler_terminal),
+    }
+
+
+def _accepted(
+    *,
+    stream_summary: dict[str, Any],
+    session_summary: dict[str, Any],
+    evidence_summary: dict[str, int],
+    reconciliation: dict[str, Any],
+) -> bool:
+    return all(
+        (
+            stream_summary["stream_completed"] is True,
+            stream_summary["compile_tool_call_count"] > 0,
+            evidence_summary["model_request_started_count"] > 0,
+            evidence_summary["model_request_completed_count"]
+            == evidence_summary["model_request_started_count"],
+            evidence_summary["compiler_task_terminal_count"] == 1,
+            session_summary["session_count"] == 1,
+            session_summary["status"] == "completed",
+            session_summary["repo_matches"] is True,
+            session_summary["commit_matches"] is True,
+            session_summary["build_system_matches"] is True,
+            session_summary["artifact_count"] > 0,
+            session_summary["verification_status"] == "passed",
+            session_summary["replay_status"] == "passed",
+            session_summary["replay_cleanup_succeeded"] is True,
+            session_summary["finalized"] is True,
+            reconciliation["remaining_count"] == 0,
+            reconciliation["cleanup_succeeded"] is True,
+        )
+    )
+
+
+def _bounded_classification(exc: BaseException) -> str:
+    name = type(exc).__name__
+    return (
+        name if re.fullmatch(r"[A-Za-z][A-Za-z0-9_]{0,63}", name) else "CanaryFailure"
+    )
+
+
+async def _run_agent(model_name: str, thread_id: str) -> dict[str, Any]:
+    from deerflow.client import DeerFlowClient
+
+    client = DeerFlowClient(
+        model_name=model_name,
+        thinking_enabled=False,
+        subagent_enabled=True,
+        plan_mode=False,
+        available_skills=set(),
+    )
+    message = (
+        f"Compile the C/C++ repository at {TARGET_REPOSITORY} using exact commit "
+        f"{TARGET_COMMIT}. The required build system is CMake. Follow the full "
+        "Compile Session workflow, delegate exactly one compiler task, submit "
+        "deterministically verified artifacts, require clean replay, and finalize "
+        "the session. Do not substitute another repository, commit, build system, "
+        "model, or provider."
+    )
+    return await _consume_stream(client, message, thread_id=thread_id)
+
+
+def run_canary(
+    *,
+    model_name: str,
+    output_dir: Path,
+    wall_clock_timeout_seconds: int,
+) -> dict[str, Any]:
+    if model_name not in ALLOWED_MODELS or not _SAFE_MODEL_RE.fullmatch(model_name):
+        raise CanaryError("model_not_allowed")
+    if not 1 <= wall_clock_timeout_seconds <= 1200:
+        raise CanaryError("invalid_wall_clock_timeout")
+
+    launch = forge_benchmark_runner.collect_runtime_launch_preflight(output_dir)
+    if launch["ready"] is not True:
+        return {
+            "status": "rejected",
+            "classification": "runtime_preflight_failed",
+            "model_name": model_name,
+            "provider": ALLOWED_MODELS[model_name]["provider"],
+            "model_call_issued": False,
+            "runtime_preflight": launch,
+        }
+
+    model = ALLOWED_MODELS[model_name]
+    if not os.environ.get(model["credential_env"], "").strip():
+        return {
+            "status": "rejected",
+            "classification": "credential_missing",
+            "model_name": model_name,
+            "provider": model["provider"],
+            "model_call_issued": False,
+            "runtime_preflight": launch,
+        }
+
+    image_id = _inspect_image_id()
+    protocol = _protocol_payload(model_name, image_id)
+    policy = _build_policy(model_name, image_id)
+    experiment_id = new_evidence_id("canary")
+    physical_attempt_id = new_evidence_id("attempt")
+    thread_id = f"provider-canary-{model['provider']}-{uuid.uuid4().hex[:12]}"
+    ledger_path = output_dir / f"{physical_attempt_id}.jsonl"
+    ledger = ExperimentLedger.create(
+        ledger_path,
+        experiment_id=experiment_id,
+        physical_attempt_id=physical_attempt_id,
+        context={
+            "protocol": protocol,
+            "policy": policy.to_payload(),
+            "preflight_ready": True,
+            "formal_pilot": False,
+        },
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=experiment_id,
+        physical_attempt_id=physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+
+    stream_summary: dict[str, Any] = {
+        "stream_completed": False,
+        "event_count": 0,
+        "tool_call_count": 0,
+        "compile_tool_call_count": 0,
+        "usage": {key: 0 for key in _USAGE_KEYS},
+    }
+    classification: str | None = None
+    model_call_issued = False
+    try:
+        model_call_issued = True
+        stream_summary = asyncio.run(
+            asyncio.wait_for(
+                _run_agent(model_name, thread_id),
+                timeout=wall_clock_timeout_seconds,
+            )
+        )
+    except Exception as exc:
+        classification = _bounded_classification(exc)
+        ledger.append(
+            "run.failed",
+            {"classification": classification},
+        )
+    finally:
+        try:
+            finalize_unfinished_thread_sessions_impl(
+                thread_id=thread_id,
+                interrupted_status="failed" if classification else None,
+                error=(
+                    "Provider canary ended before compile-session finalization."
+                    if classification
+                    else None
+                ),
+            )
+        except Exception:
+            classification = classification or "SessionFinalizationError"
+        deactivate_experiment(thread_id)
+
+    try:
+        sessions = sorted(
+            get_compile_services().manager.list_sessions(thread_id),
+            key=lambda session: session.session_id,
+        )
+    except Exception:
+        sessions = []
+        classification = classification or "SessionInspectionError"
+    session_summary = _safe_session_summary(sessions[0] if len(sessions) == 1 else None)
+    session_summary["session_count"] = len(sessions)
+    evidence_summary = _evidence_summary(ledger.read())
+    reconciliation = _reconcile_thread_containers(thread_id)
+    accepted = (
+        len(sessions) == 1
+        and classification is None
+        and _accepted(
+            stream_summary=stream_summary,
+            session_summary=session_summary,
+            evidence_summary=evidence_summary,
+            reconciliation=reconciliation,
+        )
+    )
+    status = "passed" if accepted else "failed"
+    result = {
+        "status": status,
+        "classification": None
+        if accepted
+        else (classification or "acceptance_gate_failed"),
+        "provider": model["provider"],
+        "model_name": model_name,
+        "model_call_issued": model_call_issued,
+        "protocol_sha256": _canonical_sha256(protocol),
+        "ledger_name": ledger_path.name,
+        "thread_id": thread_id,
+        "runtime_preflight": launch,
+        "stream": stream_summary,
+        "evidence": evidence_summary,
+        "session": session_summary,
+        "orphan_reconciliation": reconciliation,
+    }
+    ledger.append(
+        "canary.completed",
+        {
+            "status": status,
+            "classification": result["classification"],
+            "stream_completed": stream_summary["stream_completed"],
+            "compile_tool_call_count": stream_summary["compile_tool_call_count"],
+            "model_request_started_count": evidence_summary[
+                "model_request_started_count"
+            ],
+            "model_request_completed_count": evidence_summary[
+                "model_request_completed_count"
+            ],
+            "compiler_task_terminal_count": evidence_summary[
+                "compiler_task_terminal_count"
+            ],
+            "session_count": session_summary["session_count"],
+            "commit_matches": session_summary["commit_matches"],
+            "build_system_matches": session_summary["build_system_matches"],
+            "verification_status": session_summary["verification_status"],
+            "replay_status": session_summary["replay_status"],
+            "replay_cleanup_succeeded": session_summary["replay_cleanup_succeeded"],
+            "session_finalized": session_summary["finalized"],
+            "remaining_orphan_count": reconciliation["remaining_count"],
+        },
+    )
+    ledger.append("experiment.completed", {"status": status})
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", choices=sorted(ALLOWED_MODELS), required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--wall-clock-timeout", type=int, default=1000)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = run_canary(
+            model_name=args.model,
+            output_dir=args.output_dir,
+            wall_clock_timeout_seconds=args.wall_clock_timeout,
+        )
+    except (CanaryError, OSError, ValueError) as exc:
+        result = {
+            "status": "rejected",
+            "classification": (
+                str(exc)
+                if isinstance(exc, CanaryError)
+                else _bounded_classification(exc)
+            ),
+            "model_name": args.model,
+            "model_call_issued": False,
+        }
+    _emit(result)
+    return 0 if result["status"] == "passed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 关联

关联 #63（本 PR 只交付 canary 入口；两条真实 canary 在合并后串行执行，Issue 将在结果与 v8 决策闭合后关闭。）

## 变更

- 新增独立 `forge-provider-canary-v1` 入口，固定同一 CMake 仓库、完整 commit 与编译镜像；
- RichLab 只允许 `gpt-5.5`，DeepSeek 只允许 `deepseek-v4-flash`，每个条件 1 次且禁止 provider retry/fallback；
- 在首个模型请求前创建独立 append-only evidence，并用 `ExperimentPolicy` 强制 exact commit、CMake identity、同模型 Lead/Compiler 与 clean replay；
- 结果只输出有界状态、计数、usage、身份、哈希与布尔门禁，不输出模型正文、工具参数、命令输出、异常文本、凭据或宿主路径；
- 接受条件要求唯一 Compile Session、恰好一个 terminal compiler task、submit/clean replay/finalize 全部通过且剩余孤儿容器为 0；
- 不修改 v1-v7 manifest、Schema、validator、协议哈希或历史 ledger，不创建 v8 slot。

## 验证

- 新增聚焦测试：`11 passed`
- runner/evidence/compile 聚焦回归：`232 passed`
- 后端主体全量（排除只读 `/repo` 无法执行的配置升级组）：通过
- 可写 `/app/backend` 配置升级组：`4 passed`
- Ruff check/format：通过
- Compose config：通过
- 前端 lint/typecheck/format：串行通过
- 真实 LangGraph Compose/DooD runtime preflight：`ready=true`
- 冻结资产与敏感模式扫描：通过
- 真实 canary 模型调用：`0`（等待本 PR 合并后按 Issue #63 固定顺序执行）