### PR TITLE
文档：归档 v8 协议完成状态

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,15 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-29 — Issue #65 冻结双提供商 C/C++ pilot v8 协议
-  - 分支: `research/issue-65-v8-protocol`，基于 `main@54fdf418`。v8 计划保留 v7 的 5 个 exact-commit C/C++ case、镜像、Compose/DooD、Compile Session、clean replay 与 compiler 预算。
-  - 条件: RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 是两个独立 condition；每个 case × provider 1 个不可替换 slot，共 10 个，严格串行并在 manifest 冻结交错顺序。禁止 retry、fallback、replacement、补跑、跨 provider 池化和非 C/C++ 扩展。
-  - 实现: 新增独立 v8 manifest/Schema/validator，runner 按 condition 解析 provider profile，同时预检两套 credential-env、endpoint 和实际 model config；乱序、未完成前推进、replacement 与损坏 ledger 均在新 ledger 前拒绝。Compose backend dev 镜像补齐 Git，并只信任固定只读 `/repo`，Dockerfile 本身进入 v8 协议哈希。
-  - 验证: v1-v8/evidence 聚焦 `215 passed, 25 skipped`，最终后端全量 `1739 passed, 29 skipped`；Ruff、Schema、Compose、前端 lint/typecheck/build 与真实 WSL2 Compose runtime gate 通过。真实乱序负例保持 0 v8 ledger，最终 0 compile/replay/physical-attempt 容器；未调用模型。
-  - 阶段边界: 当前只设计独立 v8 manifest/Schema/validator、condition→provider/model policy 与 preflight；协议 PR 合并前后都不得创建或执行 v8 physical slot，采集需作为后续单独阶段明确启动。
-
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-29 — 双提供商 C/C++ pilot v8 协议进入主干
+  - GitHub: Issue #65 已关闭，PR #66 已 squash 合并为 `main@c7977ab7`；协议分支已删除，主干 Unit Tests 与 Lint Check 全绿。
+  - 设计: 保留 v7 的 5 个 exact-commit C/C++ case、镜像、Compose/DooD、Compile Session、clean replay 与 compiler 预算；RichLab `gpt-5.5` 和 DeepSeek `deepseek-v4-flash` 分为两个 condition，共 10 个不可替换、严格串行的交错 slot。
+  - 实现: 独立 v8 manifest/Schema/validator；runner 预检两套 credential-env、endpoint 和实际 model config，乱序、前槽未完成、replacement 与损坏 ledger 均在新 ledger 前拒绝。Compose backend dev 镜像补齐 Git，只信任固定只读 `/repo`，Dockerfile 纳入 v8 协议哈希。
+  - 证据: 后端全量 `1739 passed, 29 skipped`，Ruff、Schema、Compose、前端 lint/typecheck/build 和真实 WSL2 Compose gate 通过；最终 preflight `ready=true`，0 v8 ledger、0 compile/replay/physical-attempt 容器，未调用模型。
+  - 下一入口: v8 采集必须新建独立 Issue 并由用户明确启动；不得把协议合并视为采集授权，也不得 retry、fallback、replacement、补跑或跨提供商池化。
 
 - 2026-07-29 — 双提供商非 pilot 端到端 canary 完成
   - Issue #63 已关闭；入口 PR #64 squash 合并为 `main@54fdf418`。两条件严格各执行 1 次，无 retry/replacement/fallback，两个本地 append-only ledger 的 hash chain 均有效且最终 0 compile/replay orphan。
@@ -173,7 +173,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #65 的 v8 manifest、Schema、validator、runner 路由、10-slot 交错采集顺序及历史兼容测试；协议 PR 只做冻结与验证，不调用模型或创建 physical slot。
+- 等待用户明确授权后，为 v8 十槽采集新建独立 Issue；开始前再次要求主干 clean preflight `ready=true`，采集严格按 manifest 顺序且不得 retry、fallback、replacement 或补跑。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)


### PR DESCRIPTION
## 关联

关联 #65（仅归档完成状态，不重新开启）。

## 变更

- 将 v8 协议从项目快照的“进行中”移到“最近变更”；
- 记录 PR #66、主干提交、验证结果与零 ledger/零遗留容器边界；
- 下一入口改为等待用户明确授权后新建独立 v8 采集 Issue。

本 PR 只更新项目状态快照，不修改协议、runner、manifest、Schema、validator 或实验 ledger。