### PR TITLE
修复：分离候选构建与干净重放的离线门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,12 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- Issue #69 — 分离 `candidate_only` 与 `clean_replay` 的离线 gate 重算语义
-  - 来源: v8 `sysstat-nondeterministic / richlab-gpt-5.5` 的两个 SHA-256 mismatch submit；ledger hash chain 有效，但在线 `candidate_only=true` 被离线错误重算为 `false`。
-  - 边界: 只修未来离线审计并增加 candidate-pass + replay-mismatch 回归；不得改写、回填或 replacement 任一 v8 ledger，也不创建新实验 slot。
-
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-29 — 修复 candidate-only 与 clean-replay 离线 gate 重算
+  - 根因: `recompute_gates()` 把 submit checks 中的 `clean_replay` 也计入 `candidate_only`，使候选构建已通过但干净重放 SHA-256 mismatch 的 submit 被离线错误重算为 candidate failure。
+  - 修复: candidate-only 只聚合候选产物检查，clean replay 继续由独立 replay 事件与 gate 复核；新增 candidate-pass/replay-fail 与真实 candidate-check-fail 两个回归。
+  - 冻结边界: 不改写、回填、retry 或 replacement 任一 v8 ledger，也不创建实验 slot；旧 v8 current-tree gate 继续拒绝合法 runner 漂移，并从 `c7977ab7` 读取历史协议 blob 复核原 SHA-256。
+  - 证据: 聚焦协议/evidence `255 passed`，后端全量 `1742 passed, 29 skipped`，Ruff/format/内存语法编译通过；15 条现存 v8 ledger 均为 hash chain、gate 重算、终态和清理 15/15 有效，0 遗留编译容器，原 oracle 仍为 6/15 passed。
+  - 下一入口: 基于冻结 v8 形成描述性研究报告，明确小样本边界与失败分层，再预注册扩大后的正式分层实验。
 
 - 2026-07-29 — 完成双提供商 C/C++ pilot v8 十槽采集
   - GitHub: Issue #68 已完成审计并关闭；10 个 slot 严格按 manifest 交错顺序串行执行，无 retry、fallback、replacement 或 backfill。离线 gate 缺陷转入 Issue #69。
@@ -184,7 +187,7 @@
 
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
-- 完成 Issue #69 的 candidate-only/clean-replay 离线重算修复；修复后形成 v8 描述性报告，再预注册约 30 个分层 C/C++ 项目、每 condition 至少 3 次的正式实验。
+- 基于冻结 v8 形成描述性报告，再预注册约 30 个分层 C/C++ 项目、每 condition 至少 3 次的正式实验。
 - 当前 `backend/packages/harness/deerflow/compile/manager.py` 的 lifecycle lock 是进程内锁；部署多个后端进程前，需要改为文件锁/数据库事务或带版本号的 CAS，并增加跨进程竞态测试。
 
 ## 已知问题 (Known Issues / Pitfalls)

--- a/backend/tests/test_forge_benchmark_runner.py
+++ b/backend/tests/test_forge_benchmark_runner.py
@@ -1419,6 +1419,107 @@ def test_gate_recomputation_detects_tampering_and_oracle_is_independent() -> Non
     assert oracle["replay_artifact_diff"]["available"] is False
 
 
+def test_gate_recomputation_keeps_candidate_independent_from_failed_clean_replay() -> None:
+    events = [
+        {"event": "experiment.started", "payload": {"policy": {"case_id": "sysstat-nondeterministic"}}},
+        {
+            "event": "command.completed",
+            "payload": {
+                "command_id": "command-1",
+                "role": "build",
+                "exit_code": 0,
+                "timed_out": False,
+            },
+        },
+        {
+            "event": "replay.completed",
+            "payload": {
+                "replay_attempt_id": "replay-1",
+                "status": "failed",
+                "cleanup_succeeded": True,
+                "primary_failure_classification": "sha256_mismatch",
+            },
+        },
+        {
+            "event": "submit.completed",
+            "payload": {
+                "submit_attempt_id": "submit-1",
+                "supporting_command_id": "command-1",
+                "candidate_status": "passed",
+                "artifacts": [{"path": "sar", "artifact_type": "executable"}],
+                "checks": [
+                    {"name": "sar_exists", "passed": True},
+                    {"name": "repro_bundle", "passed": True},
+                    {"name": "clean_replay", "passed": False},
+                ],
+                "recipe_sha256": "2" * 64,
+                "replay": {
+                    "replay_attempt_id": "replay-1",
+                    "status": "failed",
+                    "primary_failure_classification": "sha256_mismatch",
+                },
+                "gates": {
+                    "exit_code": True,
+                    "candidate_only": True,
+                    "replay_ready": True,
+                    "clean_replay": False,
+                    "delivered": None,
+                },
+            },
+        },
+    ]
+
+    gates = forge_benchmark_runner.recompute_gates(events)
+
+    assert gates["valid"] is True
+    assert gates["mismatches"] == []
+    assert gates["submits"][0]["gates"]["candidate_only"] is True
+    assert gates["submits"][0]["gates"]["clean_replay"] is False
+
+
+def test_gate_recomputation_rejects_failed_candidate_check() -> None:
+    events = [
+        {"event": "experiment.started", "payload": {"policy": {"case_id": "fmt"}}},
+        {
+            "event": "command.completed",
+            "payload": {
+                "command_id": "command-1",
+                "role": "build",
+                "exit_code": 0,
+                "timed_out": False,
+            },
+        },
+        {
+            "event": "submit.completed",
+            "payload": {
+                "submit_attempt_id": "submit-1",
+                "supporting_command_id": "command-1",
+                "candidate_status": "passed",
+                "artifacts": [{"path": "libfmt.a", "artifact_type": "static_library"}],
+                "checks": [
+                    {"name": "libfmt.a_exists", "passed": False},
+                    {"name": "repro_bundle", "passed": True},
+                ],
+                "recipe_sha256": None,
+                "replay": None,
+                "gates": {
+                    "exit_code": True,
+                    "candidate_only": False,
+                    "replay_ready": False,
+                    "clean_replay": False,
+                    "delivered": None,
+                },
+            },
+        },
+    ]
+
+    gates = forge_benchmark_runner.recompute_gates(events)
+
+    assert gates["valid"] is True
+    assert gates["mismatches"] == []
+    assert gates["submits"][0]["gates"]["candidate_only"] is False
+
+
 def _oracle_events(
     *,
     artifacts: list[dict],

--- a/backend/tests/test_forge_benchmark_v8.py
+++ b/backend/tests/test_forge_benchmark_v8.py
@@ -15,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v8.json"
 SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-benchmark-v8.schema.json"
 VALIDATOR_PATH = REPO_ROOT / "scripts" / "forge_benchmark_v8.py"
+V8_PROTOCOL_COMMIT = "c7977ab7d72f5060d14bfd22754363052a687b0f"
 
 SPEC = importlib.util.spec_from_file_location("forge_benchmark_v8", VALIDATOR_PATH)
 assert SPEC is not None and SPEC.loader is not None
@@ -99,17 +100,14 @@ def test_v8_validator_rejects_budget_drift(
         forge_benchmark_v8.validate_manifest(drifted)
 
 
-def test_v8_current_tree_gate_accepts_frozen_assets_and_rejects_drift() -> None:
+def test_v8_current_tree_gate_rejects_post_collection_runner_drift() -> None:
     manifest = load_manifest()
-    forge_benchmark_v8.verify_frozen_components(manifest, REPO_ROOT)
 
-    drifted = copy.deepcopy(manifest)
-    drifted["protocol_artifact_sha256"]["scripts/forge_benchmark_runner.py"] = "0" * 64
     with pytest.raises(
         forge_benchmark_v8.BenchmarkError,
         match="scripts/forge_benchmark_runner.py",
     ):
-        forge_benchmark_v8.verify_frozen_components(drifted, REPO_ROOT)
+        forge_benchmark_v8.verify_frozen_components(manifest, REPO_ROOT)
 
 
 def test_v8_runtime_components_match_the_declared_baseline() -> None:
@@ -121,6 +119,22 @@ def test_v8_runtime_components_match_the_declared_baseline() -> None:
     for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
         result = subprocess.run(
             [git, "show", f"{manifest['forge']['commit_sha']}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
+
+
+def test_v8_protocol_artifacts_match_the_frozen_protocol_commit() -> None:
+    manifest = load_manifest()
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+
+    for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
+        result = subprocess.run(
+            [git, "show", f"{V8_PROTOCOL_COMMIT}:{relative_path}"],
             cwd=REPO_ROOT,
             capture_output=True,
             check=True,

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -944,9 +944,10 @@ def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
         replay_snapshot = submit.get("replay") or {}
         replay = replays.get(replay_snapshot.get("replay_attempt_id"))
         checks = submit.get("checks") or []
+        candidate_checks = [check for check in checks if check.get("name") != "clean_replay"]
         recomputed = {
             "exit_code": supporting is not None and supporting.get("role") == "build" and supporting.get("exit_code") == 0 and supporting.get("timed_out") is False,
-            "candidate_only": submit.get("candidate_status") == "passed" and bool(submit.get("artifacts")) and all(check.get("passed") is True for check in checks),
+            "candidate_only": submit.get("candidate_status") == "passed" and bool(submit.get("artifacts")) and all(check.get("passed") is True for check in candidate_checks),
             "replay_ready": bool(submit.get("recipe_sha256")) and bool(replay_snapshot.get("replay_attempt_id")),
             "clean_replay": replay is not None and replay.get("status") == "passed" and replay.get("cleanup_succeeded") is True and replay.get("primary_failure_classification") is None,
             "delivered": bool(deliveries.get(submit["submit_attempt_id"], {}).get("delivered")),


### PR DESCRIPTION
## 背景

v8 `sysstat-nondeterministic / richlab-gpt-5.5` 的两个 submit 已在线记录 `candidate_only=true`、`clean_replay=false`，但离线 `recompute_gates()` 把 `clean_replay` check 也纳入 candidate-only 聚合，产生错误 mismatch。

## 修改

- candidate-only 只聚合候选产物检查，clean replay 保持独立 gate
- 增加 candidate 通过但 clean replay SHA-256 mismatch 的回归
- 增加真实 candidate check 失败的反向回归
- 保留 v8 current-tree 漂移拒绝，并从冻结提交 `c7977ab7` 审计历史协议 blob
- 更新项目状态快照

## 验证

- 聚焦协议/evidence：`255 passed`
- 后端全量：`1742 passed, 29 skipped`
- Ruff、format、内存语法编译、`git diff --check` 通过
- 15 条现存 v8 ledger：hash chain、gate 重算、终态、清理均为 15/15 有效
- 0 个遗留 compile/replay/physical-attempt 容器
- 原 oracle 结果保持 6/15 passed，没有改写实验结论

## 边界

没有调用模型，没有 retry、replacement、backfill 或创建新实验 slot；没有修改 v1-v8 manifest、Schema、validator 或任一冻结 ledger。

Closes #69