### PR TITLE
研究：冻结正式实验运行协议与非模型预检

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,18 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-29 — Issue #78 正在冻结正式实验逐项目构建路径与 artifact oracle
-  - 文件: `benchmarks/preregistrations/cpp-formal-v1-cases.json`, `benchmarks/preregistrations/cpp-formal-v1-cases.md`, `scripts/forge_formal_case_protocol.py`, `backend/tests/test_forge_formal_case_protocol.py`
-  - 当前结果: 30/30 case 与 Issue #76 预注册 identity/分层一致，冻结 30 个精确 artifact oracle 与 77 条 exact-commit/OSS-Fuzz 证据；validator 与 18 个回归、协议/evidence 261 个回归、后端全量 `1798 passed, 28 skipped`，前端 lint/typecheck/build、Compose 与 0 orphan 通过。
-  - 审计修正: `jpegoptim` 固定提交使用 `configure.in + Makefile.in`；FreeRADIUS archive 位于 `build/lib/.libs`；uWebSockets 的 Linux 入口是 `GNUmakefile` 且 `capi` 为空操作，现固定 `examples -> HelloWorld`；`cppitertools` 固定独立 `examples/CMakeLists.txt -> accumulate_examples`。
-  - 边界: 0 模型请求、0 formal ledger，v1-v8 冻结资产不变；下一步为中文提交/PR、CI/合并和知识库同步，仍不授权 180-slot 采集。
+- 2026-07-30 — Issue #80 正在冻结正式实验运行协议与非模型 preflight
+  - 文件: `benchmarks/manifests/cpp-formal-v1.json`, `benchmarks/schemas/forge-cpp-formal-v1.schema.json`, `scripts/forge_formal_runtime_protocol.py`, `scripts/forge_benchmark_runner.py`, `backend/packages/harness/deerflow/compile/evidence.py`
+  - 当前结果: 已从 Issue #76/#78 冻结资产机械生成 30-case、180-slot manifest，并绑定 component/prompt/image/budget/source-protocol 摘要；逐项目 source/bootstrap/target/artifact 指令进入 runtime policy 与 compiler prompt，未授权 create/run 在 ledger 前硬拒绝。聚焦回归 `123 passed`，后端全量除隔离容器首次依赖下载超时外为 `1806 passed, 28 skipped`，该配置升级组在缓存环境单独 `4 passed`；Ruff、前端 lint/typecheck/隔离生产 build 通过。
+  - 边界: `collection_authorized=false`，本阶段只允许静态与 Compose/DooD 非模型 preflight，不调用模型、不创建 formal ledger、不修改 v1-v8。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-07-29 — 冻结正式实验逐项目构建路径与 artifact oracle
+  - GitHub: Issue #78 / PR #79 已 squash 合并为 `main@09012ff6`。
+  - 结果: 30/30 case 与预注册 identity/分层一致，冻结 30 个精确 artifact oracle 与 77 条 exact-commit/OSS-Fuzz 证据；本地新增 `18 passed`、协议/evidence `261 passed`、后端全量 `1798 passed, 28 skipped`，前端与主干 CI 全绿。
+  - 边界: 没有模型请求、formal ledger、replacement、backfill 或 v1-v8 改写。
 
 - 2026-07-29 — 预注册 C/C++ 正式分层实验 v1
   - GitHub: Issue #76 / PR #77；本阶段只冻结研究设计，不调用模型、不创建 formal ledger，也不授权 v9/正式采集。
@@ -217,6 +221,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 只读一次性后端测试容器必须把 `PYTHONPATH` 指向 `/repo/backend/packages/harness`，否则会导入镜像内旧源码；`config-upgrade` 还要把 `UV_CACHE_DIR`/`UV_PROJECT_ENVIRONMENT` 指向可写路径。冷缓存首次同步依赖可能超过该测试固定的 60 秒，应在缓存环境单独复核，不能误判为业务回归。
 - 手机热点下 `github.com` 网页/Git 通道可能在 8 路并发时 76/76 请求均连接超时，而 `api.github.com` 串行请求仍可稳定核验 77 条证据；网络诊断必须区分主机、通道和并发度，证据 000/timeout 不能直接当作文件 404。
 - 后端全量测试从只读 `/repo` 运行时，`config-upgrade` 需要单独挂载有效 `/repo/backend/.venv`，live upload 需要 tmpfs `/repo/backend/.deer-flow`；否则会在业务断言前产生只读文件系统伪失败。
 - uWebSockets 同时存在 Windows NMake `Makefile` 和 Linux/macOS `GNUmakefile`；Linux C/C++ 协议不能只凭文件名优先级选择 `Makefile`，且该提交的 `capi`/`all` 分支明确为空操作，必须使用有实际产物的 GNU Make `examples` 路径。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -7,7 +7,7 @@
 
 - 2026-07-30 — Issue #80 正在冻结正式实验运行协议与非模型 preflight
   - 文件: `benchmarks/manifests/cpp-formal-v1.json`, `benchmarks/schemas/forge-cpp-formal-v1.schema.json`, `scripts/forge_formal_runtime_protocol.py`, `scripts/forge_benchmark_runner.py`, `backend/packages/harness/deerflow/compile/evidence.py`
-  - 当前结果: 已从 Issue #76/#78 冻结资产机械生成 30-case、180-slot manifest，并绑定 component/prompt/image/budget/source-protocol 摘要；逐项目 source/bootstrap/target/artifact 指令进入 runtime policy 与 compiler prompt，未授权 create/run 在 ledger 前硬拒绝。聚焦回归 `123 passed`，后端全量除隔离容器首次依赖下载超时外为 `1806 passed, 28 skipped`，该配置升级组在缓存环境单独 `4 passed`；Ruff、前端 lint/typecheck/隔离生产 build 通过。
+  - 当前结果: 已从 Issue #76/#78 冻结资产机械生成 30-case、180-slot manifest，并绑定 component/prompt/image/budget/source-protocol 摘要；逐项目 source/bootstrap/target/artifact 指令进入 runtime policy 与 compiler prompt，未授权 create/run 在 ledger 前硬拒绝。manifest SHA-256 为 `50ee3b447648d3149789a4b72bdab7a58c067b68f9cbca2a993e7843cd3889b1`；真实 Compose/DooD 非模型 preflight `ready=true`，实际未授权 create-attempt 后 ledger 数保持 `17 -> 17`。聚焦回归 `123 passed`，后端全量除隔离容器首次依赖下载超时外为 `1806 passed, 28 skipped`，该配置升级组在缓存环境单独 `4 passed`；Ruff、前端 lint/typecheck/隔离生产 build 通过。
   - 边界: `collection_authorized=false`，本阶段只允许静态与 Compose/DooD 非模型 preflight，不调用模型、不创建 formal ledger、不修改 v1-v8。
 
 ## 最近变更 (Recent Changes)

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -11,7 +11,7 @@ import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -364,6 +364,10 @@ class ExperimentPolicy:
     compiler_graph_recursion_limit: int | None = None
     compiler_wall_clock_seconds: int | None = None
     compiler_post_build_reserve_seconds: int = 0
+    source_subdir: str = "."
+    bootstrap_commands: tuple[str, ...] = ()
+    build_targets: tuple[str, ...] = ()
+    artifact_instructions: tuple[tuple[str, str, str], ...] = ()
 
     def __post_init__(self) -> None:
         _validate_sha256(self.manifest_sha256, "manifest_sha256")
@@ -392,6 +396,25 @@ class ExperimentPolicy:
             raise EvidenceError("cmake_arguments require expected_build_system=cmake")
         if self.expected_build_system != "autotools" and self.configure_arguments:
             raise EvidenceError("configure_arguments require expected_build_system=autotools")
+        source_path = PurePosixPath(self.source_subdir)
+        if source_path.is_absolute() or ".." in source_path.parts or "\\" in self.source_subdir:
+            raise EvidenceError("source_subdir must be a safe repository-relative path")
+        for label, values in (
+            ("bootstrap_commands", self.bootstrap_commands),
+            ("build_targets", self.build_targets),
+        ):
+            if len(values) > 32 or any(not value or len(value) > 512 or any(character in value for character in ("\0", "\r", "\n")) for value in values):
+                raise EvidenceError(f"{label} must contain bounded single-line values")
+        for staged_path, build_path, artifact_type in self.artifact_instructions:
+            for label, value in (
+                ("staged artifact path", staged_path),
+                ("build output path", build_path),
+            ):
+                path = PurePosixPath(value)
+                if not value or path.is_absolute() or ".." in path.parts or "\\" in value:
+                    raise EvidenceError(f"{label} must be a safe relative path")
+            if artifact_type not in {"executable", "shared_library", "static_library", "object"}:
+                raise EvidenceError("artifact instruction type is unsupported")
         _validate_endpoint(self.endpoint)
         _validate_safe_value(self.to_payload())
 
@@ -444,6 +467,22 @@ class ExperimentPolicy:
                     "compiler_graph_recursion_limit": self.compiler_graph_recursion_limit,
                     "compiler_wall_clock_seconds": self.compiler_wall_clock_seconds,
                     "compiler_post_build_reserve_seconds": self.compiler_post_build_reserve_seconds,
+                }
+            )
+        if self.source_subdir != "." or self.bootstrap_commands or self.build_targets or self.artifact_instructions:
+            payload.update(
+                {
+                    "source_subdir": self.source_subdir,
+                    "bootstrap_commands": list(self.bootstrap_commands),
+                    "build_targets": list(self.build_targets),
+                    "artifact_instructions": [
+                        {
+                            "staged_relative_path": staged_path,
+                            "build_output_path": build_path,
+                            "artifact_type": artifact_type,
+                        }
+                        for staged_path, build_path, artifact_type in self.artifact_instructions
+                    ],
                 }
             )
         return payload

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -120,6 +120,22 @@ def _with_benchmark_constraints(prompt: str, policy: ExperimentPolicy) -> str:
         requirements.append(f"- Every relevant CMake configure command must include these exact argument tokens in this order: {json.dumps(list(policy.cmake_arguments), ensure_ascii=True)}.")
     if policy.configure_arguments:
         requirements.append(f"- Every relevant Autotools configure command must include these exact argument tokens in this order: {json.dumps(list(policy.configure_arguments), ensure_ascii=True)}.")
+    if policy.source_subdir != ".":
+        requirements.append(f"- Run the frozen build path from repository-relative source directory {json.dumps(policy.source_subdir, ensure_ascii=True)}.")
+    if policy.bootstrap_commands:
+        requirements.append(f"- Run these bootstrap commands in order before configure/build: {json.dumps(list(policy.bootstrap_commands), ensure_ascii=True)}.")
+    if policy.build_targets:
+        requirements.append(f"- Build only the reviewed target path needed for acceptance: {json.dumps(list(policy.build_targets), ensure_ascii=True)}.")
+    if policy.artifact_instructions:
+        artifacts = [
+            {
+                "build_output_path": build_path,
+                "staged_relative_path": staged_path,
+                "artifact_type": artifact_type,
+            }
+            for staged_path, build_path, artifact_type in policy.artifact_instructions
+        ]
+        requirements.append(f"- Stage exactly these reviewed outputs into /artifacts using the declared relative names: {json.dumps(artifacts, ensure_ascii=True)}.")
     requirements.extend(
         [
             "- Set command_role on every run_container_bash call; use configure for configuration and build for the successful command that supports final acceptance.",

--- a/backend/tests/test_forge_benchmark_v7.py
+++ b/backend/tests/test_forge_benchmark_v7.py
@@ -61,7 +61,7 @@ def test_v7_current_tree_gate_rejects_post_collection_runner_drift() -> None:
 
     with pytest.raises(
         forge_benchmark_v7.BenchmarkError,
-        match="scripts/forge_benchmark_runner.py",
+        match="does not match the current repository file",
     ):
         forge_benchmark_v7.verify_frozen_components(manifest, REPO_ROOT)
 

--- a/backend/tests/test_forge_benchmark_v8.py
+++ b/backend/tests/test_forge_benchmark_v8.py
@@ -105,7 +105,7 @@ def test_v8_current_tree_gate_rejects_post_collection_runner_drift() -> None:
 
     with pytest.raises(
         forge_benchmark_v8.BenchmarkError,
-        match="scripts/forge_benchmark_runner.py",
+        match="does not match the current repository file",
     ):
         forge_benchmark_v8.verify_frozen_components(manifest, REPO_ROOT)
 

--- a/backend/tests/test_forge_formal_runtime_protocol.py
+++ b/backend/tests/test_forge_formal_runtime_protocol.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from deerflow.tools.builtins.task_tool import _with_benchmark_constraints
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_runtime_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_benchmark_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-v1.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+formal = _load_module("forge_formal_runtime_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_benchmark_runner_formal_test", RUNNER_PATH)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_generated_manifest_is_committed_and_schema_valid() -> None:
+    manifest = load_manifest()
+    assert formal.generate_manifest() == manifest
+    assert formal.validate_manifest(manifest) == manifest
+    assert len(manifest["cases"]) == 30
+    assert len(manifest["collection_plan"]) == 180
+    assert manifest["scope"]["collection_authorized"] is False
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_formal_manifest_binds_source_protocols_budget_and_prompts() -> None:
+    manifest = load_manifest()
+    assert set(manifest["prompt_sha256"]) == formal.PROMPT_PATHS
+    assert manifest["budget"]["budget_sha256"] == formal.canonical_sha256(manifest["budget"]["policy"])
+    assert manifest["schedule_sha256"] == ("9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469")
+    assert manifest["source_protocols"]["case_protocol"]["sha256"] == ("ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["scope"].update(collection_authorized=True),
+        lambda value: value["cases"][0]["protocol"].update(source_subdir="../escape"),
+        lambda value: value["collection_plan"].reverse(),
+        lambda value: value["budget"].update(budget_sha256="0" * 64),
+    ],
+)
+def test_formal_manifest_rejects_protocol_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+    with pytest.raises(formal.BenchmarkError):
+        formal.validate_manifest(manifest)
+
+
+def test_runner_loads_formal_policy_and_injects_case_protocol() -> None:
+    manifest = runner._load_manifest(MANIFEST_PATH)
+    case = manifest["cases"][0]
+    policy = runner.build_policy(
+        manifest,
+        case_id=case["id"],
+        condition_id="richlab-gpt-5.5",
+        repetition=1,
+    )
+    prompt = _with_benchmark_constraints("compile", policy)
+    assert policy.source_subdir == case["protocol"]["source_subdir"]
+    assert list(policy.bootstrap_commands) == case["protocol"]["bootstrap_commands"]
+    assert list(policy.build_targets) == case["protocol"]["build_targets"]
+    assert case["oracle"]["required_artifacts"][0]["build_output_path"] in prompt
+    assert case["oracle"]["required_artifacts"][0]["relative_path"] in prompt
+
+
+def test_unauthorized_formal_protocol_cannot_create_ledger_or_run(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    with pytest.raises(runner.RunnerError, match="not authorized"):
+        runner.create_attempt(
+            manifest,
+            case_id=manifest["cases"][0]["id"],
+            condition_id=manifest["conditions"][0]["id"],
+            repetition=1,
+            output_dir=tmp_path,
+            check_endpoint=False,
+        )
+    assert list(tmp_path.rglob("*.jsonl")) == []
+    with pytest.raises(runner.RunnerError, match="not authorized"):
+        runner.run_attempt(manifest, tmp_path / "missing.jsonl")
+
+
+def test_existing_pilot_manifest_remains_supported() -> None:
+    manifest = runner._load_manifest(REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v8.json")
+    policy = runner.build_policy(
+        manifest,
+        case_id="fmt",
+        condition_id="richlab-gpt-5.5",
+        repetition=1,
+    )
+    assert policy.source_subdir == "."
+    assert policy.bootstrap_commands == ()
+    assert policy.build_targets == ()
+    assert policy.artifact_instructions == ()
+    assert "source_subdir" not in policy.to_payload()

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -418,3 +418,24 @@ python scripts/forge_benchmark.py record `
 ```
 
 `record` prints the same canonical normalized object to stdout and appends it once. Treat a validation, identity, secret-scan, missing-evidence, or duplicate-slot error as a stopped run; do not hand-edit JSONL around the failure.
+
+## Formal runtime protocol v1
+
+`benchmarks/manifests/cpp-formal-v1.json` is generated from the frozen
+preregistration and case protocol. It binds all 30 exact commits, the 180-slot
+schedule, case-specific source/bootstrap/configure/build/artifact instructions,
+runtime components, prompt files, immutable compile image, and the reviewed
+budget projection. Regenerate and validate it with:
+
+```bash
+python scripts/forge_formal_runtime_protocol.py generate
+python scripts/forge_formal_runtime_protocol.py validate-manifest \
+  benchmarks/manifests/cpp-formal-v1.json
+```
+
+The authoritative validator checks cross-document identity and deterministic
+derivation in addition to the Draft 2020-12 Schema. The committed protocol has
+`collection_authorized=false`: runner `preflight` is allowed, but
+`create-attempt` and `run` fail before ledger creation or model execution.
+Collection requires a separate reviewed protocol identity and explicit human
+budget authorization; never toggle the frozen manifest in place.

--- a/benchmarks/manifests/cpp-formal-v1.json
+++ b/benchmarks/manifests/cpp-formal-v1.json
@@ -1,0 +1,2726 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-v1.schema.json",
+  "schema_version": "formal-1.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v1",
+    "name": "Forge C/C++ dual-provider stratified formal experiment",
+    "purpose": "pre-collection frozen runtime protocol",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_pre_collection",
+    "formal_comparison_enabled": true,
+    "collection_authorized": false,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "09012ff6bf908094d8127bee441b99730cdcc0f4",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "d574d26b001473b7a95b4e4258b912d133789baf1908fa76a1ef33a448d7dfcd",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "41832b10c93a13a0955d0342f4fbed45cca729769f86e521628db4f04faf417b",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "c1d7bbd83e5fc5b4616c9758eee4e3b9ff00eef69935787d13a52b5277c81af5"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://richlab-api-x.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ]
+}

--- a/benchmarks/schemas/forge-cpp-formal-v1.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+  "title": "Forge C/C++ formal runtime protocol",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-1.0.0"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "type": "object",
+      "required": [
+        "collection_authorized"
+      ],
+      "properties": {
+        "collection_authorized": {
+          "const": false
+        }
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "component_sha256": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/forge_benchmark_runner.py
+++ b/scripts/forge_benchmark_runner.py
@@ -36,6 +36,7 @@ import forge_benchmark_v5 as protocol_v5  # noqa: E402
 import forge_benchmark_v6 as protocol_v6  # noqa: E402
 import forge_benchmark_v7 as protocol_v7  # noqa: E402
 import forge_benchmark_v8 as protocol_v8  # noqa: E402
+import forge_formal_runtime_protocol as protocol_formal  # noqa: E402
 
 from deerflow.compile.evidence import (  # noqa: E402
     EvidenceError,
@@ -150,6 +151,8 @@ def _manifest_protocol(manifest: dict[str, Any]):
         return protocol_v7
     if schema_version == protocol_v8.SCHEMA_VERSION:
         return protocol_v8
+    if schema_version == protocol_formal.SCHEMA_VERSION:
+        return protocol_formal
     raise RunnerError(f"Unsupported benchmark schema version: {schema_version}")
 
 
@@ -350,7 +353,7 @@ def _condition_model(
     manifest: dict[str, Any],
     condition: dict[str, Any],
 ) -> dict[str, Any]:
-    if manifest.get("schema_version") == protocol_v8.SCHEMA_VERSION:
+    if "model_profiles" in manifest:
         profile_name = condition["model_profile"]
         try:
             return manifest["model_profiles"][profile_name]
@@ -360,7 +363,7 @@ def _condition_model(
 
 
 def _manifest_models(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    if manifest.get("schema_version") == protocol_v8.SCHEMA_VERSION:
+    if "model_profiles" in manifest:
         return manifest["model_profiles"]
     return {"default": manifest["model"]}
 
@@ -392,6 +395,8 @@ def build_policy(
     model = _condition_model(manifest, condition)
     runtime = manifest["runtime"]
     constraints = case["constraints"]
+    case_protocol = case.get("protocol", {})
+    oracle_artifacts = case["oracle"]["required_artifacts"]
     build_arguments = constraints["build_arguments"]
     lead_model = model["roles"]["lead"]
     compiler_model = model["roles"]["compiler"]
@@ -431,6 +436,19 @@ def build_policy(
             "post_build_reserve_seconds",
             0,
         ),
+        source_subdir=case_protocol.get("source_subdir", "."),
+        bootstrap_commands=tuple(case_protocol.get("bootstrap_commands", [])),
+        build_targets=tuple(case_protocol.get("build_targets", [])),
+        artifact_instructions=tuple(
+            (
+                artifact["relative_path"],
+                artifact.get("build_output_path", artifact["relative_path"]),
+                artifact["artifact_type"],
+            )
+            for artifact in oracle_artifacts
+        )
+        if manifest.get("schema_version") == protocol_formal.SCHEMA_VERSION
+        else (),
     )
 
 
@@ -500,6 +518,7 @@ def collect_preflight(
         protocol_v6.REVISION_POLICY,
         protocol_v7.REVISION_POLICY,
         protocol_v8.REVISION_POLICY,
+        protocol_formal.REVISION_POLICY,
     }
     baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy in runnable_revision_policies else False
     component_results: dict[str, dict[str, Any]] = {}
@@ -546,7 +565,7 @@ def collect_preflight(
         profile_name: {
             "credential_present": _credential_present(model["credential_env"]),
             "endpoint_reachable": (_endpoint_reachable(model["endpoint"]) if check_endpoint else None),
-            "configuration_matches": (_model_config_matches(model) if manifest["schema_version"] == protocol_v8.SCHEMA_VERSION else True),
+            "configuration_matches": (_model_config_matches(model) if "model_profiles" in manifest else True),
         }
         for profile_name, model in models.items()
     }
@@ -563,6 +582,7 @@ def collect_preflight(
         protocol_v6.CONTROL_PLANE_TOPOLOGY,
         protocol_v7.CONTROL_PLANE_TOPOLOGY,
         protocol_v8.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal.CONTROL_PLANE_TOPOLOGY,
     }
     topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
     if runtime_launch is None:
@@ -628,6 +648,7 @@ def collect_preflight(
                 protocol_v6.SCHEMA_VERSION: "cpp-pilot-v6.json",
                 protocol_v7.SCHEMA_VERSION: "cpp-pilot-v7.json",
                 protocol_v8.SCHEMA_VERSION: "cpp-pilot-v8.json",
+                protocol_formal.SCHEMA_VERSION: "cpp-formal-v1.json",
             }[manifest["schema_version"]]
         ),
         "forge": {
@@ -756,6 +777,8 @@ def create_attempt(
     repo_root: Path = REPO_ROOT,
     manifest_path: Path | None = None,
 ) -> tuple[ExperimentLedger, dict[str, Any]]:
+    if manifest.get("scope", {}).get("collection_authorized") is False:
+        raise RunnerError("Formal collection is not authorized; preflight may run but no ledger may be created")
     if manifest.get("schema_version") == protocol_v8.SCHEMA_VERSION:
         if replacement_for is not None:
             raise RunnerError("v8 forbids replacement physical attempts")
@@ -1336,6 +1359,8 @@ def run_attempt(
     manifest: dict[str, Any],
     ledger_path: Path,
 ) -> dict[str, Any]:
+    if manifest.get("scope", {}).get("collection_authorized") is False:
+        raise RunnerError("Formal collection is not authorized; model execution is forbidden")
     ledger = ExperimentLedger.open(ledger_path)
     events = ledger.read()
     context = events[0]["payload"]
@@ -1352,6 +1377,7 @@ def run_attempt(
         protocol_v6.CONTROL_PLANE_TOPOLOGY,
         protocol_v7.CONTROL_PLANE_TOPOLOGY,
         protocol_v8.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal.CONTROL_PLANE_TOPOLOGY,
     }:
         if not _running_inside_compose_dood(REPO_ROOT):
             ledger.append(

--- a/scripts/forge_formal_runtime_protocol.py
+++ b/scripts/forge_formal_runtime_protocol.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Generate and validate the pre-collection Forge C/C++ formal runtime protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_benchmark_v8 as v8  # noqa: E402
+import forge_formal_case_protocol as case_protocol  # noqa: E402
+import forge_formal_preregistration as preregistration  # noqa: E402
+
+SCHEMA_VERSION = "formal-1.0.0"
+BASELINE_COMMIT = "09012ff6bf908094d8127bee441b99730cdcc0f4"
+REVISION_POLICY = "baseline_ancestor_with_frozen_components"
+CONTROL_PLANE_TOPOLOGY = "compose-dood"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-v1.schema.json"
+COMPONENT_PATHS = v8.COMPONENT_PATHS
+PROMPT_PATHS = {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+}
+PROTOCOL_ARTIFACT_PATHS = {
+    "backend/Dockerfile",
+    "scripts/forge_benchmark.py",
+    "scripts/forge_benchmark_runner.py",
+    "scripts/forge_formal_case_protocol.py",
+    "scripts/forge_formal_preregistration.py",
+    "scripts/forge_formal_runtime_protocol.py",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+}
+SOURCE_PROTOCOL_PATHS = {
+    "preregistration": "benchmarks/preregistrations/cpp-formal-v1.json",
+    "case_protocol": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+}
+RUNTIME_BUDGETS = copy.deepcopy(v8.RUNTIME_BUDGETS)
+MODEL_PROFILES = copy.deepcopy(v8.MODEL_PROFILES)
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise BenchmarkError("document cannot be represented as canonical JSON") from exc
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    if not path.is_file() or path.is_symlink():
+        raise BenchmarkError(f"frozen artifact is not an ordinary file: {path}")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    return {relative_path: _file_sha256(repo_root / relative_path) for relative_path in sorted(paths)}
+
+
+def _source_protocols(
+    prereg: dict[str, Any],
+    cases: dict[str, Any],
+) -> dict[str, dict[str, str]]:
+    return {
+        "preregistration": {
+            "id": prereg["preregistration"]["id"],
+            "path": SOURCE_PROTOCOL_PATHS["preregistration"],
+            "sha256": preregistration.canonical_sha256(prereg),
+        },
+        "case_protocol": {
+            "id": cases["protocolization"]["id"],
+            "path": SOURCE_PROTOCOL_PATHS["case_protocol"],
+            "sha256": case_protocol.canonical_sha256(cases),
+        },
+    }
+
+
+def _runtime_case(
+    selected: dict[str, Any],
+    reviewed: dict[str, Any],
+) -> dict[str, Any]:
+    recipe = reviewed["recipe"]
+    required_artifacts = [
+        {
+            "relative_path": artifact["staged_relative_path"],
+            "build_output_path": artifact["build_output_path"],
+            "artifact_type": artifact["artifact_type"],
+            "producing_target": artifact["producing_target"],
+        }
+        for artifact in reviewed["artifact_oracle"]["required_artifacts"]
+    ]
+    build_system = selected["build_system"]
+    return {
+        "id": selected["id"],
+        "repository_url": selected["repository_url"],
+        "commit_sha": selected["commit"],
+        "languages": [selected["language"]],
+        "build_system": build_system,
+        "license": selected["license_spdx"],
+        "protocol": {
+            "source_subdir": recipe["source_subdir"],
+            "bootstrap_commands": copy.deepcopy(recipe["bootstrap_commands"]),
+            "configure_arguments": copy.deepcopy(recipe["configure_arguments"]),
+            "build_targets": copy.deepcopy(recipe["build_targets"]),
+        },
+        "oracle": {
+            "expected_candidate_status": "pass",
+            "expected_clean_replay_status": "pass",
+            "required_artifacts": required_artifacts,
+        },
+        "constraints": {
+            "required_system_packages": copy.deepcopy(recipe["required_system_packages"]),
+            "build_arguments": {
+                "cmake": (copy.deepcopy(recipe["configure_arguments"]) if build_system == "cmake" else []),
+                "configure": (copy.deepcopy(recipe["configure_arguments"]) if build_system == "autotools" else []),
+            },
+            "environment": {},
+            "minimum_replay_delay_seconds": 0,
+        },
+    }
+
+
+def _runtime_cases(
+    prereg: dict[str, Any],
+    protocol: dict[str, Any],
+) -> list[dict[str, Any]]:
+    reviewed_by_id = {case["id"]: case for case in protocol["cases"]}
+    return [_runtime_case(selected, reviewed_by_id[selected["id"]]) for selected in prereg["cases"]]
+
+
+def _budget(prereg: dict[str, Any]) -> dict[str, Any]:
+    projection = copy.deepcopy(prereg["resource_projection_from_v8"])
+    policy = {
+        "planned_attempts": projection["planned_attempts"],
+        "linear_projected_tokens": projection["linear_projected_tokens"],
+        "linear_projected_serial_hours": projection["linear_projected_serial_hours"],
+        "planning_contingency_multiplier": projection["planning_contingency_multiplier"],
+        "contingency_tokens": projection["contingency_tokens"],
+        "contingency_serial_hours": projection["contingency_serial_hours"],
+        "human_confirmation_required_before_collection": True,
+    }
+    return {"policy": policy, "budget_sha256": canonical_sha256(policy)}
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    prereg: dict[str, Any] | None = None,
+    case_document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    prereg = prereg or preregistration.load_preregistration()
+    case_document = case_document or case_protocol.load_protocol()
+    preregistration.validate_preregistration(prereg)
+    case_protocol.validate_protocol(case_document, preregistration=prereg)
+    schedule = preregistration.build_schedule(prereg)
+    manifest = {
+        "$schema": "../schemas/forge-cpp-formal-v1.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": "manifest",
+        "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+        "benchmark": {
+            "id": "forge-cpp-formal-v1",
+            "name": "Forge C/C++ dual-provider stratified formal experiment",
+            "purpose": "pre-collection frozen runtime protocol",
+            "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc",
+        },
+        "scope": {
+            "languages": ["C", "C++"],
+            "phase": "formal_pre_collection",
+            "formal_comparison_enabled": True,
+            "collection_authorized": False,
+            "instrumentation_blocker": False,
+        },
+        "source_protocols": _source_protocols(prereg, case_document),
+        "forge": {
+            "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+            "commit_sha": BASELINE_COMMIT,
+            "revision_policy": REVISION_POLICY,
+            "component_sha256": _hash_paths(repo_root, COMPONENT_PATHS),
+        },
+        "protocol_artifact_sha256": _hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS),
+        "prompt_sha256": _hash_paths(repo_root, PROMPT_PATHS),
+        "model_profiles": MODEL_PROFILES,
+        "runtime": {
+            "compile_image": "autocompiler:gcc13",
+            "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+            "control_plane_topology": CONTROL_PLANE_TOPOLOGY,
+            "replay_timeout_seconds": 1200,
+            "cleanup_timeout_seconds": 20,
+            "docker_control_timeout_seconds": 30,
+            **RUNTIME_BUDGETS,
+            "max_parallel_runs": 1,
+            "backend_processes": 1,
+            "network_policy": {
+                "network_name": "compile_network_wwf_v1",
+                "egress": "enabled_for_clone_and_dependencies",
+            },
+            "host": {
+                "wsl_distribution": "Ubuntu",
+                "cpu_count": 32,
+                "memory_kib": 7723024,
+                "kernel": "6.6.114.1-microsoft-standard-WSL2",
+                "architecture": "x86_64",
+                "docker_server_version": "29.5.3",
+            },
+        },
+        "budget": _budget(prereg),
+        "conditions": [
+            {
+                "id": condition["id"],
+                "model_profile": condition["id"],
+                "memory_enabled": False,
+                "skills_enabled": False,
+                "repetitions": prereg["design"]["repetitions_per_project_condition"],
+                "acceptance_gate": "clean_replay",
+            }
+            for condition in prereg["conditions"]
+        ],
+        "collection_plan": schedule,
+        "schedule_sha256": prereg["design"]["schedule_sha256"],
+        "cases": _runtime_cases(prereg, case_document),
+    }
+    return validate_manifest(
+        manifest,
+        prereg=prereg,
+        case_document=case_document,
+    )
+
+
+def _validate_hash_map(
+    value: Any,
+    *,
+    expected_paths: set[str],
+    path: str,
+) -> dict[str, str]:
+    hashes = v1._as_object(value, path)
+    if set(hashes) != expected_paths:
+        v1._fail(path, "must contain exactly the required frozen paths")
+    for relative_path, digest in hashes.items():
+        pure_path = PurePosixPath(relative_path)
+        if pure_path.is_absolute() or ".." in pure_path.parts or "\\" in relative_path:
+            v1._fail(f"{path}.{relative_path}", "must stay inside the repository")
+        v1._validate_sha256(digest, f"{path}.{relative_path}")
+    return hashes
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    prereg: dict[str, Any] | None = None,
+    case_document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected_root = {
+            "$schema",
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+        }
+        if set(manifest) != expected_root:
+            v1._fail("manifest", "must contain exactly the formal protocol fields")
+        if manifest["schema_version"] != SCHEMA_VERSION:
+            v1._fail("manifest.schema_version", f"must be {SCHEMA_VERSION!r}")
+        if manifest["document_type"] != "manifest":
+            v1._fail("manifest.document_type", "must be 'manifest'")
+        v1._scan_for_unsafe_values(manifest)
+        prereg = prereg or preregistration.load_preregistration()
+        case_document = case_document or case_protocol.load_protocol()
+        preregistration.validate_preregistration(prereg)
+        case_protocol.validate_protocol(case_document, preregistration=prereg)
+        if manifest["source_protocols"] != _source_protocols(prereg, case_document):
+            v1._fail(
+                "manifest.source_protocols",
+                "must bind the frozen preregistration and case protocol",
+            )
+        scope = manifest["scope"]
+        if scope != {
+            "languages": ["C", "C++"],
+            "phase": "formal_pre_collection",
+            "formal_comparison_enabled": True,
+            "collection_authorized": False,
+            "instrumentation_blocker": False,
+        }:
+            v1._fail(
+                "manifest.scope",
+                "must remain pre-collection and collection_authorized=false",
+            )
+        forge = v1._as_object(manifest["forge"], "manifest.forge")
+        if forge.get("commit_sha") != BASELINE_COMMIT or forge.get("revision_policy") != REVISION_POLICY:
+            v1._fail("manifest.forge", "must bind the reviewed Issue #78 baseline")
+        _validate_hash_map(
+            forge["component_sha256"],
+            expected_paths=COMPONENT_PATHS,
+            path="manifest.forge.component_sha256",
+        )
+        _validate_hash_map(
+            manifest["protocol_artifact_sha256"],
+            expected_paths=PROTOCOL_ARTIFACT_PATHS,
+            path="manifest.protocol_artifact_sha256",
+        )
+        _validate_hash_map(
+            manifest["prompt_sha256"],
+            expected_paths=PROMPT_PATHS,
+            path="manifest.prompt_sha256",
+        )
+        if manifest["model_profiles"] != MODEL_PROFILES:
+            v1._fail(
+                "manifest.model_profiles",
+                "must freeze the preregistered provider profiles",
+            )
+        runtime = manifest["runtime"]
+        if runtime.get("control_plane_topology") != CONTROL_PLANE_TOPOLOGY or runtime.get("max_parallel_runs") != 1 or runtime.get("backend_processes") != 1:
+            v1._fail(
+                "manifest.runtime",
+                "must freeze serial Compose/DooD execution",
+            )
+        for key, expected in RUNTIME_BUDGETS.items():
+            if runtime.get(key) != expected:
+                v1._fail(f"manifest.runtime.{key}", f"must be {expected}")
+        expected_budget = _budget(prereg)
+        if manifest["budget"] != expected_budget:
+            v1._fail(
+                "manifest.budget",
+                "must bind the preregistered projection and confirmation gate",
+            )
+        expected_conditions = [
+            {
+                "id": condition["id"],
+                "model_profile": condition["id"],
+                "memory_enabled": False,
+                "skills_enabled": False,
+                "repetitions": 3,
+                "acceptance_gate": "clean_replay",
+            }
+            for condition in prereg["conditions"]
+        ]
+        if manifest["conditions"] != expected_conditions:
+            v1._fail(
+                "manifest.conditions",
+                "must freeze both preregistered conditions with three repetitions",
+            )
+        schedule = preregistration.build_schedule(prereg)
+        if manifest["collection_plan"] != schedule or len(schedule) != 180 or manifest["schedule_sha256"] != prereg["design"]["schedule_sha256"]:
+            v1._fail(
+                "manifest.collection_plan",
+                "must equal the frozen 180-slot schedule",
+            )
+        expected_cases = _runtime_cases(prereg, case_document)
+        if manifest["cases"] != expected_cases:
+            v1._fail(
+                "manifest.cases",
+                "must be mechanically derived from both frozen source protocols",
+            )
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: contains a malformed value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(validate_manifest(manifest))
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest)
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            actual = _file_sha256(repo_root / relative_path)
+            if actual != expected:
+                v1._fail(
+                    f"{path_prefix}.{relative_path}",
+                    "does not match the current repository file",
+                )
+
+
+def schema_document() -> dict[str, Any]:
+    hash_map = {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+        "title": "Forge C/C++ formal runtime protocol",
+        "type": "object",
+        "required": [
+            "$schema",
+            "schema_version",
+            "document_type",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+        ],
+        "properties": {
+            "schema_version": {"const": SCHEMA_VERSION},
+            "document_type": {"const": "manifest"},
+            "scope": {
+                "type": "object",
+                "required": ["collection_authorized"],
+                "properties": {"collection_authorized": {"const": False}},
+            },
+            "source_protocols": {"type": "object"},
+            "forge": {
+                "type": "object",
+                "required": ["commit_sha", "component_sha256"],
+                "properties": {
+                    "commit_sha": {"pattern": "^[0-9a-f]{40}$"},
+                    "component_sha256": hash_map,
+                },
+            },
+            "protocol_artifact_sha256": hash_map,
+            "prompt_sha256": hash_map,
+            "runtime": {
+                "type": "object",
+                "required": [
+                    "image_id",
+                    "control_plane_topology",
+                    "max_parallel_runs",
+                ],
+                "properties": {
+                    "image_id": {"pattern": "^sha256:[0-9a-f]{64}$"},
+                    "control_plane_topology": {"const": CONTROL_PLANE_TOPOLOGY},
+                    "max_parallel_runs": {"const": 1},
+                },
+            },
+            "budget": {"type": "object"},
+            "conditions": {"type": "array", "minItems": 2, "maxItems": 2},
+            "collection_plan": {
+                "type": "array",
+                "minItems": 180,
+                "maxItems": 180,
+            },
+            "schedule_sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+            },
+            "cases": {"type": "array", "minItems": 30, "maxItems": 30},
+        },
+        "additionalProperties": True,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "slots": len(manifest["collection_plan"]),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从 Issue #76 的正式预注册与 Issue #78 的逐项目协议机械生成 30-case、180-slot 正式 manifest。
- 新增 Draft 2020-12 Schema、权威 validator、确定性生成器以及 source/component/prompt/image/budget/schedule 摘要。
- 将 source subdir、bootstrap、configure 参数、build target 和 artifact staging 约束注入 ExperimentPolicy 与 compiler prompt。
- runner 支持正式协议静态/Compose/DooD preflight；`collection_authorized=false` 时在 ledger 创建和模型执行前硬拒绝。
- 保留 v1-v8 冻结 manifest、Schema、ledger 与结果不变。

## 验证

- 正式协议聚焦回归：`9 passed`；相关协议/runner/evidence：`123 passed`。
- 后端全量：`1806 passed, 28 skipped`；唯一冷缓存依赖下载超时的配置升级组单独 `4 passed`。
- Ruff、Schema、diff、Compose config 通过。
- 前端 lint、typecheck、隔离 production build（44 页）通过。
- 真实 WSL2 Compose/DooD 非模型 preflight：`ready=true`。
- 未授权 create-attempt 被拒绝，ledger 数量保持 `17 -> 17`。
- 未调用模型、未创建 formal ledger、未使用或输出密钥值。

Closes #80
