### PR TITLE
研究：授权正式采集并增加双提供商 canary

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,10 +5,10 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-07-30 — Issue #80 正在冻结正式实验运行协议与非模型 preflight
-  - 文件: `benchmarks/manifests/cpp-formal-v1.json`, `benchmarks/schemas/forge-cpp-formal-v1.schema.json`, `scripts/forge_formal_runtime_protocol.py`, `scripts/forge_benchmark_runner.py`, `backend/packages/harness/deerflow/compile/evidence.py`
-  - 当前结果: 已从 Issue #76/#78 冻结资产机械生成 30-case、180-slot manifest，并绑定 component/prompt/image/budget/source-protocol 摘要；逐项目 source/bootstrap/target/artifact 指令进入 runtime policy 与 compiler prompt，未授权 create/run 在 ledger 前硬拒绝。manifest SHA-256 为 `50ee3b447648d3149789a4b72bdab7a58c067b68f9cbca2a993e7843cd3889b1`；真实 Compose/DooD 非模型 preflight `ready=true`，实际未授权 create-attempt 后 ledger 数保持 `17 -> 17`。聚焦回归 `123 passed`，后端全量除隔离容器首次依赖下载超时外为 `1806 passed, 28 skipped`，该配置升级组在缓存环境单独 `4 passed`；Ruff、前端 lint/typecheck/隔离生产 build 通过。
-  - 边界: `collection_authorized=false`，本阶段只允许静态与 Compose/DooD 非模型 preflight，不调用模型、不创建 formal ledger、不修改 v1-v8。
+- 2026-07-30 — Issue #82 正在授权正式实验并准备首批 10 个 slot
+  - 文件: `benchmarks/manifests/cpp-formal-v1-collection.json`, `benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json`, `scripts/forge_formal_collection_protocol.py`, `scripts/forge_formal_collection_runner.py`, `backend/tests/test_forge_formal_collection_protocol.py`
+  - 当前结果: 已新增独立 `formal-collection-1.0.0` identity，绑定父 manifest canonical SHA、Issue #82、2,939.7 万 token / 31.301 小时上限、双 provider canary 和 10-slot 批次边界；旧 `cpp-formal-v1`、原 runner 与 v1-v8 证据保持逐字不变。授权 manifest SHA-256 为 `8cfd909724a540a87fee9d68f7dafc0095964dd61150083a76f2ffdadc533aeb`。协议/evidence `305 passed`；后端全量主体 `1814 passed, 28 skipped`，配置升级冷缓存组在 `UV_NO_SYNC=1` 下单独 `4 passed`；Ruff、Schema、Compose、前端 lint/typecheck 通过。
+  - 边界: 尚未提交/合并，尚未执行 provider canary 或创建 formal ledger；本机 7.7 GiB WSL 下隔离 Next.js production build 两次被 OOM 终止，等待 GitHub CI 独立环境复核。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
@@ -221,6 +221,8 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- `config-upgrade` 集成测试会在每个 case 内调用 `uv run`；仅迁移 `UV_CACHE_DIR` 仍可能因冷同步超过固定 60 秒，复用已同步 `.venv` 时还需设置 `UV_NO_SYNC=1`。本次由权限错误转为冷下载超时后，以该变量单独复核为 `4 passed`。
+- 当前 WSL2 仅约 7.7 GiB 内存时，Next.js 16/Turbopack 的无缓存 production build 即使停止全部开发服务、给 Node 4 GiB 上限，仍可能把 WSL 推到约 7 GiB 后被 OOM kill；不要把无错误栈的 `ELIFECYCLE` 直接归因于前端代码，优先用 GitHub CI 或提高 WSL 内存后复核。
 - 只读一次性后端测试容器必须把 `PYTHONPATH` 指向 `/repo/backend/packages/harness`，否则会导入镜像内旧源码；`config-upgrade` 还要把 `UV_CACHE_DIR`/`UV_PROJECT_ENVIRONMENT` 指向可写路径。冷缓存首次同步依赖可能超过该测试固定的 60 秒，应在缓存环境单独复核，不能误判为业务回归。
 - 手机热点下 `github.com` 网页/Git 通道可能在 8 路并发时 76/76 请求均连接超时，而 `api.github.com` 串行请求仍可稳定核验 77 条证据；网络诊断必须区分主机、通道和并发度，证据 000/timeout 不能直接当作文件 404。
 - 后端全量测试从只读 `/repo` 运行时，`config-upgrade` 需要单独挂载有效 `/repo/backend/.venv`，live upload 需要 tmpfs `/repo/backend/.deer-flow`；否则会在业务断言前产生只读文件系统伪失败。

--- a/backend/tests/test_forge_formal_collection_protocol.py
+++ b/backend/tests/test_forge_formal_collection_protocol.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import jsonschema
+import pytest
+
+from deerflow.models import factory as model_factory
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_runner.py"
+PARENT_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1.json"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1-collection.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v1.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+formal_collection = _load_module("forge_formal_collection_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_benchmark_runner_formal_collection_test", RUNNER_PATH)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _successful_canary_report(manifest: dict, output_dir: Path) -> Path:
+    report = {
+        "schema_version": "formal-provider-canary-1.0.0",
+        "document_type": "formal_provider_canary",
+        "canary_id": "provider_canary_" + "1" * 32,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": formal_collection.manifest_sha256(manifest),
+        "control_plane_topology": formal_collection.CONTROL_PLANE_TOPOLOGY,
+        "conditions": [{"id": condition["id"], "passed": True} for condition in manifest["conditions"]],
+        "passed": True,
+    }
+    path = output_dir / runner._PROVIDER_CANARY_DIRNAME / "provider_canary_test.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(report), encoding="utf-8")
+    return path
+
+
+def _fake_runtime_preflight() -> dict:
+    return {"ready": True, "checks": {"runtime": True}}
+
+
+def _fake_preflight(manifest: dict, *, ready: bool) -> dict:
+    return {
+        "ready": ready,
+        "manifest_sha256": formal_collection.manifest_sha256(manifest),
+        "manifest_file_sha256": "1" * 64,
+        "forge": {},
+        "protocol": {},
+        "runtime": {},
+        "checks": {"ready": ready},
+    }
+
+
+def test_authorized_manifest_is_generated_committed_and_schema_valid() -> None:
+    manifest = load_manifest()
+    parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert formal_collection.generate_manifest() == manifest
+    assert formal_collection.validate_manifest(manifest) == manifest
+    assert manifest["scope"]["collection_authorized"] is True
+    assert parent["scope"]["collection_authorized"] is False
+    assert manifest["collection_plan"] == parent["collection_plan"]
+    assert manifest["cases"] == parent["cases"]
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_authorization_binds_parent_budget_issue_and_batch_limit() -> None:
+    manifest = load_manifest()
+    authorization = manifest["authorization"]
+    assert authorization["parent_manifest"]["canonical_sha256"] == ("50ee3b447648d3149789a4b72bdab7a58c067b68f9cbca2a993e7843cd3889b1")
+    assert authorization["issue_url"].endswith("/issues/82")
+    assert authorization["budget_confirmation"] == {
+        "confirmed": True,
+        "maximum_tokens": 29396970,
+        "maximum_serial_hours": 31.301,
+    }
+    assert authorization["collection_constraints"]["initial_batch_size"] == 10
+    assert authorization["collection_constraints"]["provider_canary_required_before_first_ledger"] is True
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["authorization"]["budget_confirmation"].update(confirmed=False),
+        lambda value: value["scope"].update(collection_authorized=False),
+        lambda value: value["collection_plan"].reverse(),
+        lambda value: value["cases"][0]["protocol"].update(source_subdir="../escape"),
+    ],
+)
+def test_authorized_manifest_rejects_identity_or_parent_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+    with pytest.raises(formal_collection.BenchmarkError):
+        formal_collection.validate_manifest(manifest)
+
+
+def test_runner_loads_authorized_policy_with_formal_artifact_contract() -> None:
+    manifest = runner._load_manifest(MANIFEST_PATH)
+    first_slot = manifest["collection_plan"][0]
+    policy = runner.build_policy(
+        manifest,
+        case_id=first_slot["case_id"],
+        condition_id=first_slot["condition_id"],
+        repetition=first_slot["repetition"],
+    )
+    case = next(case for case in manifest["cases"] if case["id"] == first_slot["case_id"])
+    assert policy.benchmark_id == "forge-cpp-formal-v1-collection"
+    assert policy.artifact_instructions
+    assert policy.source_subdir == case["protocol"]["source_subdir"]
+
+
+def test_formal_attempt_requires_successful_canary_before_ledger(tmp_path: Path) -> None:
+    manifest = load_manifest()
+    first_slot = manifest["collection_plan"][0]
+    with pytest.raises(runner.RunnerError, match="canary"):
+        runner.create_attempt(
+            manifest,
+            case_id=first_slot["case_id"],
+            condition_id=first_slot["condition_id"],
+            repetition=first_slot["repetition"],
+            output_dir=tmp_path,
+            check_endpoint=False,
+        )
+    assert list(tmp_path.rglob("*.jsonl")) == []
+
+
+def test_formal_preflight_failure_does_not_create_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    first_slot = manifest["collection_plan"][0]
+    _successful_canary_report(manifest, tmp_path)
+    monkeypatch.setattr(
+        runner,
+        "collect_runtime_launch_preflight",
+        lambda *args, **kwargs: _fake_runtime_preflight(),
+    )
+    monkeypatch.setattr(
+        runner,
+        "collect_preflight",
+        lambda *args, **kwargs: _fake_preflight(manifest, ready=False),
+    )
+    with pytest.raises(runner.RunnerError, match="before physical-attempt ledger"):
+        runner.create_attempt(
+            manifest,
+            case_id=first_slot["case_id"],
+            condition_id=first_slot["condition_id"],
+            repetition=first_slot["repetition"],
+            output_dir=tmp_path,
+            check_endpoint=False,
+        )
+    assert list(tmp_path.rglob("*.jsonl")) == []
+
+
+def test_dual_provider_canary_writes_sanitized_append_only_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+
+    class FakeModel:
+        def invoke(self, _message: str):
+            return SimpleNamespace(content="CANARY_OK")
+
+    monkeypatch.setattr(runner, "_running_inside_compose_dood", lambda _repo_root: True)
+    monkeypatch.setattr(
+        runner,
+        "collect_preflight",
+        lambda *args, **kwargs: _fake_preflight(manifest, ready=True),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "create_chat_model",
+        lambda **kwargs: FakeModel(),
+    )
+    result = runner.collect_provider_canary(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        repo_root=tmp_path,
+    )
+    assert result["passed"] is True
+    assert len(result["conditions"]) == 2
+    report_path = Path(result["report_path"])
+    report_text = report_path.read_text(encoding="utf-8")
+    assert "CANARY_OK" not in report_text
+    assert "api_key" not in report_text
+    assert runner._successful_provider_canary(manifest, output_dir=tmp_path) == report_path
+
+
+def test_formal_batch_stops_at_the_ten_slot_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    created_slots: list[tuple[str, str, int]] = []
+
+    def fake_create_attempt(
+        _manifest: dict,
+        *,
+        case_id: str,
+        condition_id: str,
+        repetition: int,
+        **_kwargs,
+    ):
+        created_slots.append((case_id, condition_id, repetition))
+        index = len(created_slots)
+        ledger = SimpleNamespace(
+            path=tmp_path / f"ledger-{index}.jsonl",
+            physical_attempt_id=f"physical_attempt_{index:032x}",
+        )
+        return ledger, {}
+
+    monkeypatch.setattr(runner, "_observed_collection_ledgers", lambda *args, **kwargs: [])
+    monkeypatch.setattr(runner, "create_attempt", fake_create_attempt)
+    monkeypatch.setattr(runner, "run_attempt", lambda *args, **kwargs: {"status": "failed"})
+    result = runner.run_formal_batch(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        max_attempts=10,
+    )
+    expected = [(slot["case_id"], slot["condition_id"], slot["repetition"]) for slot in manifest["collection_plan"][:10]]
+    assert created_slots == expected
+    assert result["start_slot_index"] == 0
+    assert result["next_slot_index"] == 10
+    assert result["batch_end_slot_index"] == 10
+    assert result["attempts_completed"] == 10
+    with pytest.raises(runner.RunnerError, match="between 1 and 10"):
+        runner.run_formal_batch(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+            max_attempts=11,
+        )

--- a/benchmarks/manifests/cpp-formal-v1-collection.json
+++ b/benchmarks/manifests/cpp-formal-v1-collection.json
@@ -1,0 +1,2753 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v1.schema.json",
+  "schema_version": "formal-collection-1.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v1-collection",
+    "name": "Forge C/C++ dual-provider stratified formal collection",
+    "purpose": "authorized append-only formal evidence collection",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection",
+    "formal_comparison_enabled": true,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "d70f97ddf8bfcda073b5060bcf3790d769607b48",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "d574d26b001473b7a95b4e4258b912d133789baf1908fa76a1ef33a448d7dfcd",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "41832b10c93a13a0955d0342f4fbed45cca729769f86e521628db4f04faf417b",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "c1d7bbd83e5fc5b4616c9758eee4e3b9ff00eef69935787d13a52b5277c81af5"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json": "055a158b7831774cb84c2adda8deeeb740517881609ce190cce2fd7bff4c98af",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_protocol.py": "7b33315a0444235125bb7a82afa65ebf0a98a3532cd26d0b18790ae524709b96",
+    "scripts/forge_formal_collection_runner.py": "cb83f3a30bbf63fea7456e5c7e73549f58865a400e674de6a5d0f58189470fbe",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://richlab-api-x.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v1-collection-authorization",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-07-30",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/82",
+    "budget_confirmation": {
+      "confirmed": true,
+      "maximum_tokens": 29396970,
+      "maximum_serial_hours": 31.301
+    },
+    "collection_constraints": {
+      "planned_attempts": 180,
+      "initial_batch_size": 10,
+      "provider_canary_required_before_first_ledger": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/manifests/cpp-formal-v1.json",
+      "canonical_sha256": "50ee3b447648d3149789a4b72bdab7a58c067b68f9cbca2a993e7843cd3889b1"
+    }
+  }
+}

--- a/benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json",
+  "title": "Forge C/C++ authorized formal collection protocol",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "authorization"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-1.0.0"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "type": "object",
+      "required": [
+        "collection_authorized"
+      ],
+      "properties": {
+        "collection_authorized": {
+          "const": true
+        }
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "d70f97ddf8bfcda073b5060bcf3790d769607b48"
+        },
+        "component_sha256": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "type": "object",
+      "required": [
+        "id",
+        "authorized_by",
+        "authorized_on",
+        "issue_url",
+        "budget_confirmation",
+        "collection_constraints",
+        "parent_manifest"
+      ]
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/forge_formal_collection_protocol.py
+++ b/scripts/forge_formal_collection_protocol.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Generate and validate the authorized Forge C/C++ formal collection protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_runtime_protocol as parent_protocol  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-1.0.0"
+BASELINE_COMMIT = "d70f97ddf8bfcda073b5060bcf3790d769607b48"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v1-collection.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v1.schema.json"
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_collection_runner.py",
+    "scripts/forge_formal_collection_protocol.py",
+    "benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json",
+}
+AUTHORIZATION = {
+    "id": "forge-cpp-formal-v1-collection-authorization",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-07-30",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/82",
+    "budget_confirmation": {
+        "confirmed": True,
+        "maximum_tokens": 29396970,
+        "maximum_serial_hours": 31.301,
+    },
+    "collection_constraints": {
+        "planned_attempts": 180,
+        "initial_batch_size": 10,
+        "provider_canary_required_before_first_ledger": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "backfill_forbidden": True,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+canonical_sha256 = parent_protocol.canonical_sha256
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    return parent_protocol.validate_manifest(parent)
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v1.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parent = _parent_manifest(parent)
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v1.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v1-collection",
+        "name": "Forge C/C++ dual-provider stratified formal collection",
+        "purpose": "authorized append-only formal evidence collection",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection",
+        "formal_comparison_enabled": True,
+        "collection_authorized": True,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": parent_protocol._hash_paths(
+            repo_root,
+            parent_protocol.COMPONENT_PATHS,
+        ),
+    }
+    manifest["protocol_artifact_sha256"] = parent_protocol._hash_paths(
+        repo_root,
+        PROTOCOL_ARTIFACT_PATHS,
+    )
+    manifest["authorization"] = _authorization(parent)
+    return validate_manifest(manifest, parent=parent)
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected_root = {
+            "$schema",
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+            "authorization",
+        }
+        if set(manifest) != expected_root:
+            v1._fail(
+                "manifest",
+                "must contain exactly the authorized formal collection fields",
+            )
+        if manifest["$schema"] != "../schemas/forge-cpp-formal-collection-v1.schema.json":
+            v1._fail("manifest.$schema", "must reference the authorized collection schema")
+        if manifest["schema_version"] != SCHEMA_VERSION:
+            v1._fail("manifest.schema_version", f"must be {SCHEMA_VERSION!r}")
+        if manifest["document_type"] != "manifest":
+            v1._fail("manifest.document_type", "must be 'manifest'")
+        v1._scan_for_unsafe_values(manifest)
+        parent = _parent_manifest(parent)
+        if manifest["benchmark"] != {
+            "id": "forge-cpp-formal-v1-collection",
+            "name": "Forge C/C++ dual-provider stratified formal collection",
+            "purpose": "authorized append-only formal evidence collection",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }:
+            v1._fail("manifest.benchmark", "must identify the authorized formal collection")
+        if manifest["scope"] != {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection",
+            "formal_comparison_enabled": True,
+            "collection_authorized": True,
+            "instrumentation_blocker": False,
+        }:
+            v1._fail("manifest.scope", "must authorize only the frozen formal collection")
+        immutable_fields = (
+            "source_protocols",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+        )
+        for field in immutable_fields:
+            if manifest[field] != parent[field]:
+                v1._fail(
+                    f"manifest.{field}",
+                    "must remain identical to the frozen parent manifest",
+                )
+        forge = v1._as_object(manifest["forge"], "manifest.forge")
+        if set(forge) != set(parent["forge"]):
+            v1._fail(
+                "manifest.forge",
+                "must contain exactly the parent Forge identity fields",
+            )
+        if forge["repository_url"] != parent["forge"]["repository_url"]:
+            v1._fail("manifest.forge.repository_url", "must preserve the frozen repository")
+        if forge["commit_sha"] != BASELINE_COMMIT or forge["revision_policy"] != REVISION_POLICY:
+            v1._fail("manifest.forge", "must bind the reviewed Issue #80 baseline")
+        if forge["component_sha256"] != parent["forge"]["component_sha256"]:
+            v1._fail(
+                "manifest.forge.component_sha256",
+                "must preserve the frozen runtime components",
+            )
+        parent_protocol._validate_hash_map(
+            manifest["protocol_artifact_sha256"],
+            expected_paths=PROTOCOL_ARTIFACT_PATHS,
+            path="manifest.protocol_artifact_sha256",
+        )
+        if manifest["authorization"] != _authorization(parent):
+            v1._fail(
+                "manifest.authorization",
+                "must match the approved Issue #82 authorization",
+            )
+        if len(manifest["collection_plan"]) != AUTHORIZATION["collection_constraints"]["planned_attempts"]:
+            v1._fail("manifest.collection_plan", "must retain all 180 frozen slots")
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError("manifest: contains a malformed authorized collection value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(validate_manifest(manifest))
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest)
+    parent_path = repo_root / manifest["authorization"]["parent_manifest"]["path"]
+    parent = _parent_manifest(load_json_document(parent_path))
+    if parent_protocol.manifest_sha256(parent) != manifest["authorization"]["parent_manifest"]["canonical_sha256"]:
+        v1._fail(
+            "manifest.authorization.parent_manifest",
+            "does not match the frozen parent manifest",
+        )
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            actual = parent_protocol._file_sha256(repo_root / relative_path)
+            if actual != expected:
+                v1._fail(
+                    f"{path_prefix}.{relative_path}",
+                    "does not match the current repository file",
+                )
+
+
+def schema_document() -> dict[str, Any]:
+    hash_map = {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+        },
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v1.schema.json",
+        "title": "Forge C/C++ authorized formal collection protocol",
+        "type": "object",
+        "required": [
+            "$schema",
+            "schema_version",
+            "document_type",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+            "authorization",
+        ],
+        "properties": {
+            "schema_version": {"const": SCHEMA_VERSION},
+            "document_type": {"const": "manifest"},
+            "scope": {
+                "type": "object",
+                "required": ["collection_authorized"],
+                "properties": {"collection_authorized": {"const": True}},
+            },
+            "source_protocols": {"type": "object"},
+            "forge": {
+                "type": "object",
+                "required": ["commit_sha", "component_sha256"],
+                "properties": {
+                    "commit_sha": {"const": BASELINE_COMMIT},
+                    "component_sha256": hash_map,
+                },
+            },
+            "protocol_artifact_sha256": hash_map,
+            "prompt_sha256": hash_map,
+            "runtime": {
+                "type": "object",
+                "required": ["image_id", "control_plane_topology", "max_parallel_runs"],
+                "properties": {
+                    "image_id": {"pattern": "^sha256:[0-9a-f]{64}$"},
+                    "control_plane_topology": {"const": CONTROL_PLANE_TOPOLOGY},
+                    "max_parallel_runs": {"const": 1},
+                },
+            },
+            "budget": {"type": "object"},
+            "conditions": {"type": "array", "minItems": 2, "maxItems": 2},
+            "collection_plan": {"type": "array", "minItems": 180, "maxItems": 180},
+            "schedule_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+            "cases": {"type": "array", "minItems": 30, "maxItems": 30},
+            "authorization": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "authorized_by",
+                    "authorized_on",
+                    "issue_url",
+                    "budget_confirmation",
+                    "collection_constraints",
+                    "parent_manifest",
+                ],
+            },
+        },
+        "additionalProperties": True,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "initial_batch_size": manifest["authorization"]["collection_constraints"]["initial_batch_size"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "slots": len(manifest["collection_plan"]),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_runner.py
+++ b/scripts/forge_formal_collection_runner.py
@@ -1,0 +1,1867 @@
+#!/usr/bin/env python3
+"""Evidence-first runner for the Forge C/C++ benchmark protocol.
+
+The runner deliberately separates attempt creation from model execution. A
+physical-attempt ledger must exist before ``run`` can issue a provider call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+for import_root in (str(HARNESS_ROOT), str(Path(__file__).resolve().parent)):
+    if import_root not in sys.path:
+        sys.path.insert(0, import_root)
+
+import forge_benchmark as protocol  # noqa: E402
+import forge_benchmark_v2 as protocol_v2  # noqa: E402
+import forge_benchmark_v3 as protocol_v3  # noqa: E402
+import forge_benchmark_v4 as protocol_v4  # noqa: E402
+import forge_benchmark_v5 as protocol_v5  # noqa: E402
+import forge_benchmark_v6 as protocol_v6  # noqa: E402
+import forge_benchmark_v7 as protocol_v7  # noqa: E402
+import forge_benchmark_v8 as protocol_v8  # noqa: E402
+import forge_formal_collection_protocol as protocol_formal_collection  # noqa: E402
+import forge_formal_runtime_protocol as protocol_formal  # noqa: E402
+
+from deerflow.compile.evidence import (  # noqa: E402
+    EvidenceError,
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+
+
+class RunnerError(ValueError):
+    pass
+
+
+_COMPILE_ACTION_TOOL_NAMES = frozenset(
+    {
+        "prepare_compile_session",
+        "clone_repository",
+        "identify_build_system",
+        "task",
+        "run_container_bash",
+        "submit_build_result",
+        "finalize_session",
+    }
+)
+_FAILURE_DOMAIN_NAMES = (
+    "model_endpoint",
+    "agent_tool",
+    "build",
+    "submit_replay",
+    "completion",
+)
+_MAX_ARTIFACT_DIFF_ENTRIES = 64
+_REPLAY_ARTIFACT_MISMATCH_ORDER = (
+    "unexpected_artifact",
+    "missing_artifact",
+    "type",
+    "size",
+    "sha256",
+    "smoke",
+)
+_BACKEND_VENV_ROOT = Path("/app/backend/.venv")
+_EVIDENCE_MOUNT_ROOT = Path("/workspace/.compile-sessions")
+_DEFAULT_EVIDENCE_DIR = _EVIDENCE_MOUNT_ROOT / "benchmark-evidence"
+_REQUIRED_RUNTIME_IMPORTS = ("deerflow.client",)
+_PROVIDER_CANARY_DIRNAME = "provider-canaries"
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _run_command(arguments: list[str], *, cwd: Path = REPO_ROOT) -> tuple[int, str]:
+    try:
+        result = subprocess.run(
+            arguments,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 1, ""
+    return result.returncode, result.stdout.strip()
+
+
+def _git_state(repo_root: Path) -> dict[str, Any]:
+    safe_directory = f"safe.directory={repo_root}"
+    revision_code, revision = _run_command(
+        ["git", "-c", safe_directory, "rev-parse", "HEAD"],
+        cwd=repo_root,
+    )
+    dirty_code, dirty_output = _run_command(
+        [
+            "git",
+            "-c",
+            safe_directory,
+            "status",
+            "--porcelain",
+            "--untracked-files=normal",
+        ],
+        cwd=repo_root,
+    )
+    return {
+        "revision": revision if revision_code == 0 else None,
+        "dirty": bool(dirty_output) if dirty_code == 0 else None,
+    }
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    schema_version = manifest.get("schema_version")
+    if schema_version == protocol.SCHEMA_VERSION:
+        return protocol
+    if schema_version == protocol_v2.SCHEMA_VERSION:
+        return protocol_v2
+    if schema_version == protocol_v3.SCHEMA_VERSION:
+        return protocol_v3
+    if schema_version == protocol_v4.SCHEMA_VERSION:
+        return protocol_v4
+    if schema_version == protocol_v5.SCHEMA_VERSION:
+        return protocol_v5
+    if schema_version == protocol_v6.SCHEMA_VERSION:
+        return protocol_v6
+    if schema_version == protocol_v7.SCHEMA_VERSION:
+        return protocol_v7
+    if schema_version == protocol_v8.SCHEMA_VERSION:
+        return protocol_v8
+    if schema_version == protocol_formal.SCHEMA_VERSION:
+        return protocol_formal
+    if schema_version == protocol_formal_collection.SCHEMA_VERSION:
+        return protocol_formal_collection
+    raise RunnerError(f"Unsupported benchmark schema version: {schema_version}")
+
+
+def _manifest_sha256(manifest: dict[str, Any]) -> str:
+    return _manifest_protocol(manifest).manifest_sha256(manifest)
+
+
+def _baseline_is_ancestor(repo_root: Path, baseline_revision: str) -> bool:
+    code, _ = _run_command(
+        [
+            "git",
+            "-c",
+            f"safe.directory={repo_root}",
+            "merge-base",
+            "--is-ancestor",
+            baseline_revision,
+            "HEAD",
+        ],
+        cwd=repo_root,
+    )
+    return code == 0
+
+
+def _compose_dood_present(repo_root: Path) -> bool:
+    code, container_ids = _run_command(
+        [
+            "docker",
+            "ps",
+            "-q",
+            "--filter",
+            "label=com.docker.compose.project=deer-flow-dev",
+            "--filter",
+            "label=com.docker.compose.service=langgraph",
+        ],
+        cwd=repo_root,
+    )
+    if code != 0:
+        return False
+    for container_id in container_ids.splitlines():
+        inspect_code, mounts_json = _run_command(
+            ["docker", "inspect", "--format", "{{json .Mounts}}", container_id],
+            cwd=repo_root,
+        )
+        if inspect_code != 0:
+            continue
+        try:
+            mounts = json.loads(mounts_json)
+        except (TypeError, ValueError):
+            continue
+        if any(isinstance(mount, dict) and mount.get("Type") == "bind" and mount.get("Destination") == "/var/run/docker.sock" for mount in mounts):
+            return True
+    return False
+
+
+def _current_container_metadata(
+    repo_root: Path,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]] | None]:
+    if not Path("/.dockerenv").is_file():
+        return None, None
+    container_id = os.environ.get("HOSTNAME", "").strip()
+    if not container_id:
+        return None, None
+    labels_code, labels_json = _run_command(
+        ["docker", "inspect", "--format", "{{json .Config.Labels}}", container_id],
+        cwd=repo_root,
+    )
+    mounts_code, mounts_json = _run_command(
+        ["docker", "inspect", "--format", "{{json .Mounts}}", container_id],
+        cwd=repo_root,
+    )
+    if labels_code != 0 or mounts_code != 0:
+        return None, None
+    try:
+        labels = json.loads(labels_json)
+        mounts = json.loads(mounts_json)
+    except (TypeError, ValueError):
+        return None, None
+    return (
+        labels if isinstance(labels, dict) else None,
+        mounts if isinstance(mounts, list) and all(isinstance(mount, dict) for mount in mounts) else None,
+    )
+
+
+def _running_inside_compose_dood(repo_root: Path) -> bool:
+    labels, mounts = _current_container_metadata(repo_root)
+    return (
+        isinstance(labels, dict)
+        and isinstance(mounts, list)
+        and labels.get("com.docker.compose.project") == "deer-flow-dev"
+        and labels.get("com.docker.compose.service") == "langgraph"
+        and any(isinstance(mount, dict) and mount.get("Destination") == "/var/run/docker.sock" and mount.get("RW") is True for mount in mounts)
+    )
+
+
+def _runner_interpreter_matches() -> bool:
+    return sys.prefix != sys.base_prefix and Path(sys.prefix) == _BACKEND_VENV_ROOT and Path(sys.executable).parent == _BACKEND_VENV_ROOT / "bin"
+
+
+def _runtime_imports_available() -> bool:
+    try:
+        for module_name in _REQUIRED_RUNTIME_IMPORTS:
+            importlib.import_module(module_name)
+    except Exception:
+        return False
+    return True
+
+
+def _evidence_mount_is_bind_rw(mounts: list[dict[str, Any]] | None) -> bool:
+    return bool(mounts and any(mount.get("Type") == "bind" and mount.get("Destination") == _EVIDENCE_MOUNT_ROOT.as_posix() and mount.get("RW") is True for mount in mounts))
+
+
+def _docker_socket_is_bind_rw(mounts: list[dict[str, Any]] | None) -> bool:
+    return bool(mounts and any(mount.get("Type") == "bind" and mount.get("Destination") == "/var/run/docker.sock" and mount.get("RW") is True for mount in mounts))
+
+
+def _evidence_output_checks(
+    output_dir: Path,
+    *,
+    mount_root: Path = _EVIDENCE_MOUNT_ROOT,
+) -> tuple[bool, bool]:
+    if not output_dir.is_absolute():
+        return False, False
+    try:
+        resolved_mount = mount_root.resolve(strict=True)
+        if resolved_mount != mount_root or mount_root.is_symlink():
+            return False, False
+        resolved_output = output_dir.resolve(strict=False)
+        relative_output = resolved_output.relative_to(resolved_mount)
+    except (OSError, ValueError):
+        return False, False
+    if not relative_output.parts:
+        return False, False
+
+    candidate = resolved_mount
+    for part in relative_output.parts:
+        candidate /= part
+        if candidate.is_symlink():
+            return False, False
+
+    temporary_path: Path | None = None
+    try:
+        resolved_output.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".forge-runtime-preflight-",
+            dir=resolved_output,
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(b"forge-runtime-preflight\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.unlink()
+    except OSError:
+        return True, False
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return True, True
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    labels, mounts = _current_container_metadata(repo_root)
+    compose_process = bool(labels and labels.get("com.docker.compose.project") == "deer-flow-dev" and labels.get("com.docker.compose.service") == "langgraph")
+    evidence_mount = _evidence_mount_is_bind_rw(mounts)
+    output_within_mount, output_writable = _evidence_output_checks(output_dir) if evidence_mount else (False, False)
+    checks = {
+        "runtime_process_is_langgraph_compose": compose_process,
+        "docker_socket_is_bind_rw": _docker_socket_is_bind_rw(mounts),
+        "runner_interpreter_matches": _runner_interpreter_matches(),
+        "runtime_imports_available": _runtime_imports_available(),
+        "evidence_mount_is_bind_rw": evidence_mount,
+        "evidence_output_within_mount": output_within_mount,
+        "evidence_output_writable": output_writable,
+    }
+    return {"ready": all(checks.values()), "checks": checks}
+
+
+def _manifest_case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
+    for case in manifest["cases"]:
+        if case["id"] == case_id:
+            return case
+    raise RunnerError(f"Unknown benchmark case: {case_id}")
+
+
+def _manifest_condition(
+    manifest: dict[str, Any],
+    condition_id: str,
+) -> dict[str, Any]:
+    for condition in manifest["conditions"]:
+        if condition["id"] == condition_id:
+            return condition
+    raise RunnerError(f"Unknown benchmark condition: {condition_id}")
+
+
+def _condition_model(
+    manifest: dict[str, Any],
+    condition: dict[str, Any],
+) -> dict[str, Any]:
+    if "model_profiles" in manifest:
+        profile_name = condition["model_profile"]
+        try:
+            return manifest["model_profiles"][profile_name]
+        except KeyError as exc:
+            raise RunnerError(f"Unknown model profile for condition {condition['id']}: {profile_name}") from exc
+    return manifest["model"]
+
+
+def _manifest_models(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if "model_profiles" in manifest:
+        return manifest["model_profiles"]
+    return {"default": manifest["model"]}
+
+
+def _model_config_matches(model: dict[str, Any]) -> bool:
+    try:
+        from deerflow.config import get_app_config
+
+        model_name = model["roles"]["lead"]
+        configured = get_app_config().get_model_config(model_name)
+        if configured is None or configured.model != model_name:
+            return False
+        settings = configured.model_dump(exclude_none=True)
+        endpoint = settings.get("base_url", settings.get("openai_api_base"))
+        return endpoint is not None and str(endpoint).rstrip("/") == model["endpoint"].rstrip("/")
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return False
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+) -> ExperimentPolicy:
+    case = _manifest_case(manifest, case_id)
+    condition = _manifest_condition(manifest, condition_id)
+    model = _condition_model(manifest, condition)
+    runtime = manifest["runtime"]
+    constraints = case["constraints"]
+    case_protocol = case.get("protocol", {})
+    oracle_artifacts = case["oracle"]["required_artifacts"]
+    build_arguments = constraints["build_arguments"]
+    lead_model = model["roles"]["lead"]
+    compiler_model = model["roles"]["compiler"]
+    if lead_model != compiler_model:
+        raise RunnerError("The benchmark runner requires one frozen model for both roles")
+    if repetition > condition["repetitions"]:
+        raise RunnerError("Repetition exceeds the manifest condition")
+    return ExperimentPolicy(
+        benchmark_id=manifest["benchmark"]["id"],
+        manifest_sha256=_manifest_sha256(manifest),
+        case_id=case_id,
+        condition=condition_id,
+        repetition=repetition,
+        expected_repo_url=case["repository_url"],
+        expected_commit_sha=case["commit_sha"],
+        expected_build_system=case["build_system"],
+        compile_image=runtime["compile_image"],
+        image_id=runtime["image_id"],
+        model_name=lead_model,
+        endpoint=model["endpoint"].rstrip("/"),
+        credential_env=model["credential_env"],
+        request_timeout_seconds=model["request_timeout_seconds"],
+        model_max_retries=model["max_retries"],
+        compiler_max_turns=(runtime["compiler_max_turns"] if "compiler_max_turns" in runtime else runtime["model_turn_limit"]),
+        subagent_timeout_seconds=(runtime["subagent_timeout_seconds"] if "subagent_timeout_seconds" in runtime else runtime["wall_clock_timeout_seconds"]),
+        memory_enabled=condition["memory_enabled"],
+        skills_enabled=condition["skills_enabled"],
+        required_system_packages=tuple(constraints["required_system_packages"]),
+        cmake_arguments=tuple(build_arguments["cmake"]),
+        configure_arguments=tuple(build_arguments["configure"]),
+        environment=tuple(constraints["environment"].items()),
+        minimum_replay_delay_seconds=constraints["minimum_replay_delay_seconds"],
+        compiler_model_turn_limit=runtime.get("model_turn_limit"),
+        compiler_graph_recursion_limit=runtime.get("graph_recursion_limit"),
+        compiler_wall_clock_seconds=runtime.get("wall_clock_timeout_seconds"),
+        compiler_post_build_reserve_seconds=runtime.get(
+            "post_build_reserve_seconds",
+            0,
+        ),
+        source_subdir=case_protocol.get("source_subdir", "."),
+        bootstrap_commands=tuple(case_protocol.get("bootstrap_commands", [])),
+        build_targets=tuple(case_protocol.get("build_targets", [])),
+        artifact_instructions=tuple(
+            (
+                artifact["relative_path"],
+                artifact.get("build_output_path", artifact["relative_path"]),
+                artifact["artifact_type"],
+            )
+            for artifact in oracle_artifacts
+        )
+        if manifest.get("schema_version")
+        in {
+            protocol_formal.SCHEMA_VERSION,
+            protocol_formal_collection.SCHEMA_VERSION,
+        }
+        else (),
+    )
+
+
+def _endpoint_reachable(endpoint: str) -> bool:
+    request = urllib.request.Request(
+        f"{endpoint.rstrip('/')}/models",
+        method="GET",
+        headers={"User-Agent": "forge-benchmark-preflight/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except urllib.error.HTTPError as exc:
+        return 100 <= exc.code <= 599
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def _credential_present(variable_name: str) -> bool:
+    if variable_name in os.environ:
+        return True
+    code, container_ids = _run_command(
+        [
+            "docker",
+            "ps",
+            "-q",
+            "--filter",
+            "label=com.docker.compose.service=langgraph",
+        ]
+    )
+    if code != 0:
+        return False
+    for container_id in container_ids.splitlines():
+        exists_code, _ = _run_command(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "sh",
+                "-c",
+                f'test "${{{variable_name}+x}}" = x',
+            ]
+        )
+        if exists_code == 0:
+            return True
+    return False
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path = REPO_ROOT,
+    manifest_path: Path | None = None,
+    output_dir: Path = _DEFAULT_EVIDENCE_DIR,
+    runtime_launch: dict[str, Any] | None = None,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    forge_state = _git_state(repo_root)
+    forge_baseline = manifest["forge"]["commit_sha"]
+    revision_policy = manifest["forge"].get("revision_policy", "exact")
+    baseline_is_ancestor = _baseline_is_ancestor(repo_root, forge_baseline)
+    runnable_revision_policies = {
+        protocol_v2.REVISION_POLICY,
+        protocol_v3.REVISION_POLICY,
+        protocol_v4.REVISION_POLICY,
+        protocol_v5.REVISION_POLICY,
+        protocol_v6.REVISION_POLICY,
+        protocol_v7.REVISION_POLICY,
+        protocol_v8.REVISION_POLICY,
+        protocol_formal.REVISION_POLICY,
+        protocol_formal_collection.REVISION_POLICY,
+    }
+    baseline_satisfied = forge_state["revision"] == forge_baseline if revision_policy == "exact" else baseline_is_ancestor if revision_policy in runnable_revision_policies else False
+    component_results: dict[str, dict[str, Any]] = {}
+    for relative_path, expected_digest in manifest["forge"]["component_sha256"].items():
+        actual_digest = _sha256_file(repo_root / relative_path)
+        component_results[relative_path] = {
+            "expected": expected_digest,
+            "actual": actual_digest,
+            "matches": actual_digest == expected_digest,
+        }
+
+    protocol_results: dict[str, dict[str, Any]] = {}
+    for relative_path, expected_digest in manifest["protocol_artifact_sha256"].items():
+        actual_digest = _sha256_file(repo_root / relative_path)
+        protocol_results[relative_path] = {
+            "expected": expected_digest,
+            "actual": actual_digest,
+            "matches": actual_digest == expected_digest,
+        }
+
+    runtime = manifest["runtime"]
+    image_code, image_id = _run_command(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}",
+            runtime["compile_image"],
+        ],
+        cwd=repo_root,
+    )
+    network_code, _ = _run_command(
+        ["docker", "network", "inspect", runtime["network_policy"]["network_name"]],
+        cwd=repo_root,
+    )
+    docker_version_code, docker_version = _run_command(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        cwd=repo_root,
+    )
+    models = _manifest_models(manifest)
+    condition_baseline = all(not condition["memory_enabled"] and not condition["skills_enabled"] for condition in manifest["conditions"])
+    model_checks = {
+        profile_name: {
+            "credential_present": _credential_present(model["credential_env"]),
+            "endpoint_reachable": (_endpoint_reachable(model["endpoint"]) if check_endpoint else None),
+            "configuration_matches": (_model_config_matches(model) if "model_profiles" in manifest else True),
+        }
+        for profile_name, model in models.items()
+    }
+    credential_present = all(result["credential_present"] for result in model_checks.values())
+    model_configuration_matches = all(result["configuration_matches"] for result in model_checks.values())
+    endpoint_reachable = all(result["endpoint_reachable"] is True for result in model_checks.values()) if check_endpoint else None
+    expected_topology = runtime.get("control_plane_topology")
+    compose_dood_present = _compose_dood_present(repo_root)
+    compose_dood_topologies = {
+        protocol_v2.CONTROL_PLANE_TOPOLOGY,
+        protocol_v3.CONTROL_PLANE_TOPOLOGY,
+        protocol_v4.CONTROL_PLANE_TOPOLOGY,
+        protocol_v5.CONTROL_PLANE_TOPOLOGY,
+        protocol_v6.CONTROL_PLANE_TOPOLOGY,
+        protocol_v7.CONTROL_PLANE_TOPOLOGY,
+        protocol_v8.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal_collection.CONTROL_PLANE_TOPOLOGY,
+    }
+    topology_matches = expected_topology is None or (expected_topology in compose_dood_topologies and compose_dood_present)
+    if runtime_launch is None:
+        runtime_launch = collect_runtime_launch_preflight(
+            output_dir,
+            repo_root=repo_root,
+        )
+    checks = {
+        "credential_present": credential_present,
+        "model_configuration_matches": model_configuration_matches,
+        "endpoint_reachable": endpoint_reachable,
+        "forge_head_equals_baseline": forge_state["revision"] == manifest["forge"]["commit_sha"],
+        "forge_revision_matches": baseline_satisfied,
+        "forge_baseline_is_ancestor": baseline_is_ancestor,
+        "forge_baseline_satisfied": baseline_satisfied,
+        "forge_clean": forge_state["dirty"] is False,
+        "forge_components_match": all(result["matches"] for result in component_results.values()),
+        "protocol_artifacts_match": all(result["matches"] for result in protocol_results.values()),
+        "image_present": image_code == 0,
+        "image_id_matches": image_code == 0 and image_id == runtime["image_id"],
+        "network_present": network_code == 0,
+        "docker_server_matches": (docker_version_code == 0 and docker_version == runtime["host"]["docker_server_version"]),
+        "single_process_serial": runtime["backend_processes"] == 1 and runtime["max_parallel_runs"] == 1,
+        "fallback_forbidden": all(model["fallback_policy"] == "forbidden" for model in models.values()),
+        "memory_skills_disabled": condition_baseline,
+        "instrumentation_unblocked": not manifest["scope"]["instrumentation_blocker"],
+        "control_plane_topology_matches": topology_matches,
+        **runtime_launch["checks"],
+    }
+    required_checks = [
+        checks["credential_present"],
+        checks["model_configuration_matches"],
+        checks["forge_revision_matches"],
+        checks["forge_clean"],
+        checks["forge_components_match"],
+        checks["protocol_artifacts_match"],
+        checks["image_id_matches"],
+        checks["network_present"],
+        checks["single_process_serial"],
+        checks["fallback_forbidden"],
+        checks["memory_skills_disabled"],
+        checks["instrumentation_unblocked"],
+        checks["control_plane_topology_matches"],
+        runtime_launch["ready"],
+    ]
+    if check_endpoint:
+        required_checks.append(checks["endpoint_reachable"] is True)
+    return {
+        "ready": all(required_checks),
+        "launch_ready": runtime_launch["ready"],
+        "manifest_sha256": _manifest_sha256(manifest),
+        "manifest_file_sha256": _sha256_file(
+            manifest_path
+            or repo_root
+            / "benchmarks"
+            / "manifests"
+            / {
+                protocol.SCHEMA_VERSION: "cpp-pilot-v1.json",
+                protocol_v2.SCHEMA_VERSION: "cpp-pilot-v2.json",
+                protocol_v3.SCHEMA_VERSION: "cpp-pilot-v3.json",
+                protocol_v4.SCHEMA_VERSION: "cpp-pilot-v4.json",
+                protocol_v5.SCHEMA_VERSION: "cpp-pilot-v5.json",
+                protocol_v6.SCHEMA_VERSION: "cpp-pilot-v6.json",
+                protocol_v7.SCHEMA_VERSION: "cpp-pilot-v7.json",
+                protocol_v8.SCHEMA_VERSION: "cpp-pilot-v8.json",
+                protocol_formal.SCHEMA_VERSION: "cpp-formal-v1.json",
+                protocol_formal_collection.SCHEMA_VERSION: "cpp-formal-v1-collection.json",
+            }[manifest["schema_version"]]
+        ),
+        "forge": {
+            **forge_state,
+            "expected_revision": manifest["forge"]["commit_sha"],
+            "revision_policy": revision_policy,
+            "components": component_results,
+        },
+        "protocol": protocol_results,
+        "models": model_checks,
+        "runtime": {
+            "image_id": image_id if image_code == 0 else None,
+            "docker_server_version": (docker_version if docker_version_code == 0 else None),
+            "platform_system": platform.system(),
+            "platform_machine": platform.machine(),
+            "control_plane_topology": (expected_topology if compose_dood_present else None),
+        },
+        "checks": checks,
+    }
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    document = protocol.load_json_document(path)
+    return _manifest_protocol(document).validate_manifest(document)
+
+
+def _slot_matches(
+    events: list[dict[str, Any]],
+    policy: ExperimentPolicy,
+) -> bool:
+    if not events:
+        return False
+    recorded = events[0]["payload"].get("policy")
+    if not isinstance(recorded, dict):
+        return False
+    return all(
+        recorded.get(key) == value
+        for key, value in {
+            "benchmark_id": policy.benchmark_id,
+            "case_id": policy.case_id,
+            "condition": policy.condition,
+            "repetition": policy.repetition,
+        }.items()
+    )
+
+
+def find_slot_ledgers(
+    output_dir: Path,
+    policy: ExperimentPolicy,
+) -> list[tuple[Path, list[dict[str, Any]]]]:
+    matches: list[tuple[Path, list[dict[str, Any]]]] = []
+    if not output_dir.exists():
+        return matches
+    for ledger_path in sorted(output_dir.rglob("*.jsonl")):
+        try:
+            events = ExperimentLedger.verify_path(ledger_path)
+        except EvidenceError:
+            continue
+        if _slot_matches(events, policy):
+            matches.append((ledger_path, events))
+    return matches
+
+
+def _observed_collection_ledgers(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    observed: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+    if output_dir.exists():
+        for ledger_path in output_dir.rglob("*.jsonl"):
+            try:
+                events = ExperimentLedger.verify_path(ledger_path)
+            except EvidenceError as exc:
+                raise RunnerError("Existing evidence contains an invalid ledger; frozen collection is blocked") from exc
+            if not events:
+                continue
+            policy = events[0]["payload"].get("policy")
+            if not isinstance(policy, dict) or policy.get("benchmark_id") != manifest["benchmark"]["id"] or policy.get("manifest_sha256") != _manifest_sha256(manifest):
+                continue
+            observed.append(
+                (
+                    {
+                        "case_id": policy.get("case_id"),
+                        "condition_id": policy.get("condition"),
+                        "repetition": policy.get("repetition"),
+                    },
+                    events,
+                )
+            )
+    observed.sort(
+        key=lambda item: (
+            item[1][0].get("occurred_at", ""),
+            item[1][0].get("physical_attempt_id", ""),
+        )
+    )
+    return observed
+
+
+def _enforce_frozen_collection_order(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+) -> int:
+    requested = {
+        "case_id": case_id,
+        "condition_id": condition_id,
+        "repetition": repetition,
+    }
+    plan = [
+        {
+            "case_id": slot["case_id"],
+            "condition_id": slot["condition_id"],
+            "repetition": slot["repetition"],
+        }
+        for slot in manifest["collection_plan"]
+    ]
+    observed = _observed_collection_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    if observed_slots != plan[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the frozen collection prefix")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous frozen slot must complete before the next slot is created")
+    if len(observed_slots) >= len(plan):
+        raise RunnerError("All frozen collection slots already have physical evidence")
+    if requested != plan[len(observed_slots)]:
+        raise RunnerError("The requested slot is not next in the frozen collection order")
+    return len(observed_slots)
+
+
+def _model_response_text(response: Any) -> str:
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    return "".join(parts)
+
+
+def _successful_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> Path | None:
+    expected_conditions = {condition["id"] for condition in manifest["conditions"]}
+    canary_dir = output_dir / _PROVIDER_CANARY_DIRNAME
+    if not canary_dir.exists():
+        return None
+    for report_path in sorted(canary_dir.glob("*.json"), reverse=True):
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, ValueError):
+            continue
+        conditions = report.get("conditions")
+        if (
+            report.get("document_type") == "formal_provider_canary"
+            and report.get("benchmark_id") == manifest["benchmark"]["id"]
+            and report.get("manifest_sha256") == _manifest_sha256(manifest)
+            and report.get("passed") is True
+            and report.get("control_plane_topology") == protocol_formal_collection.CONTROL_PLANE_TOPOLOGY
+            and isinstance(conditions, list)
+            and {condition.get("id") for condition in conditions if isinstance(condition, dict)} == expected_conditions
+            and all(isinstance(condition, dict) and condition.get("passed") is True for condition in conditions)
+        ):
+            return report_path
+    return None
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol_formal_collection.SCHEMA_VERSION:
+        raise RunnerError("Provider canary is only valid for the authorized formal collection")
+    if manifest.get("scope", {}).get("collection_authorized") is not True:
+        raise RunnerError("Formal collection is not authorized")
+    if _observed_collection_ledgers(manifest, output_dir=output_dir):
+        raise RunnerError("Provider canary must complete before the first formal ledger is created")
+    if not _running_inside_compose_dood(repo_root):
+        raise RunnerError("Provider canary must run inside the frozen Compose/DooD control plane")
+    preflight = collect_preflight(
+        manifest,
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        check_endpoint=True,
+    )
+    if preflight["ready"] is not True:
+        raise RunnerError("Provider canary preflight is not ready")
+
+    from deerflow.models.factory import create_chat_model
+
+    condition_results: list[dict[str, Any]] = []
+    for condition in manifest["conditions"]:
+        profile = _condition_model(manifest, condition)
+        started = time.perf_counter()
+        error_class: str | None = None
+        response_text = ""
+        try:
+            model = create_chat_model(
+                name=profile["roles"]["lead"],
+                thinking_enabled=False,
+            )
+            response = model.invoke("Reply with exactly CANARY_OK and nothing else.")
+            response_text = _model_response_text(response)
+        except Exception as exc:
+            error_class = type(exc).__name__
+        duration_ms = round((time.perf_counter() - started) * 1000)
+        passed = error_class is None and bool(response_text.strip())
+        condition_results.append(
+            {
+                "id": condition["id"],
+                "model": profile["roles"]["lead"],
+                "endpoint": profile["endpoint"].rstrip("/"),
+                "credential_env": profile["credential_env"],
+                "duration_ms": duration_ms,
+                "response_nonempty": bool(response_text.strip()),
+                "response_sha256": (hashlib.sha256(response_text.encode("utf-8")).hexdigest() if response_text else None),
+                "error_class": error_class,
+                "passed": passed,
+            }
+        )
+
+    canary_id = new_evidence_id("provider_canary")
+    report = {
+        "schema_version": "formal-provider-canary-1.0.0",
+        "document_type": "formal_provider_canary",
+        "canary_id": canary_id,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": _manifest_sha256(manifest),
+        "manifest_file_sha256": _sha256_file(manifest_path),
+        "completed_at": datetime.now(UTC).isoformat(),
+        "control_plane_topology": protocol_formal_collection.CONTROL_PLANE_TOPOLOGY,
+        "preflight_ready": preflight["ready"],
+        "conditions": condition_results,
+        "passed": all(result["passed"] for result in condition_results),
+    }
+    report_path = output_dir / _PROVIDER_CANARY_DIRNAME / f"{canary_id}.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("x", encoding="utf-8", newline="\n") as stream:
+        json.dump(report, stream, ensure_ascii=False, indent=2, sort_keys=True)
+        stream.write("\n")
+    return {**report, "report_path": str(report_path)}
+
+
+def create_attempt(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+    replacement_for: str | None = None,
+    check_endpoint: bool = True,
+    repo_root: Path = REPO_ROOT,
+    manifest_path: Path | None = None,
+) -> tuple[ExperimentLedger, dict[str, Any]]:
+    if manifest.get("scope", {}).get("collection_authorized") is False:
+        raise RunnerError("Formal collection is not authorized; preflight may run but no ledger may be created")
+    ordered_schema_versions = {
+        protocol_v8.SCHEMA_VERSION,
+        protocol_formal_collection.SCHEMA_VERSION,
+    }
+    if manifest.get("schema_version") in ordered_schema_versions:
+        if replacement_for is not None:
+            raise RunnerError("The frozen collection forbids replacement physical attempts")
+        _enforce_frozen_collection_order(
+            manifest,
+            case_id=case_id,
+            condition_id=condition_id,
+            repetition=repetition,
+            output_dir=output_dir,
+        )
+    if manifest.get("schema_version") == protocol_formal_collection.SCHEMA_VERSION:
+        if _successful_provider_canary(manifest, output_dir=output_dir) is None:
+            raise RunnerError("A successful dual-provider canary is required before formal ledger creation")
+    policy = build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+    runtime_launch = collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+    if runtime_launch["ready"] is not True:
+        raise RunnerError("Runtime launch preflight failed before physical-attempt ledger creation")
+    existing = find_slot_ledgers(output_dir, policy)
+    if existing and replacement_for is None:
+        raise RunnerError("This benchmark slot already has physical evidence; create an explicit replacement attempt")
+    replacement_event: dict[str, Any] | None = None
+    if replacement_for is not None:
+        replacement_event = next(
+            (events[0] for _path, events in existing if events[0]["physical_attempt_id"] == replacement_for),
+            None,
+        )
+        if replacement_event is None:
+            raise RunnerError("The replacement attempt does not belong to this slot")
+
+    preflight = collect_preflight(
+        manifest,
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        runtime_launch=runtime_launch,
+        check_endpoint=check_endpoint,
+    )
+    if manifest.get("schema_version") == protocol_formal_collection.SCHEMA_VERSION and preflight["ready"] is not True:
+        raise RunnerError("Formal preflight failed before physical-attempt ledger creation")
+    experiment_id = replacement_event["experiment_id"] if replacement_event is not None else new_evidence_id("experiment")
+    physical_attempt_id = new_evidence_id("physical_attempt")
+    thread_id = new_evidence_id("thread")
+    ledger_path = output_dir / policy.case_id / policy.condition / f"rep-{policy.repetition:03d}" / f"{physical_attempt_id}.jsonl"
+    context = {
+        "thread_id": thread_id,
+        "replacement_for_physical_attempt_id": replacement_for,
+        "policy": policy.to_payload(),
+        "forge": preflight["forge"],
+        "protocol": {
+            "manifest_sha256": preflight["manifest_sha256"],
+            "manifest_file_sha256": preflight["manifest_file_sha256"],
+            "artifacts": preflight["protocol"],
+        },
+        "runtime": preflight["runtime"],
+        "preflight_checks": preflight["checks"],
+        "preflight_ready": preflight["ready"],
+    }
+    ledger = ExperimentLedger.create(
+        ledger_path,
+        experiment_id=experiment_id,
+        physical_attempt_id=physical_attempt_id,
+        context=context,
+    )
+    ledger.append(
+        "preflight.completed",
+        {
+            "ready": preflight["ready"],
+            "checks": preflight["checks"],
+        },
+    )
+    return ledger, preflight
+
+
+def recompute_failure_domains(
+    events: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]] | None]:
+    domains: dict[str, list[dict[str, Any]]] = {name: [] for name in _FAILURE_DOMAIN_NAMES}
+    recorded_domain_map = {
+        "model_endpoint": "model_endpoint",
+        "agent_tool": "agent_tool",
+        "build": "build",
+        "verification": "submit_replay",
+        "submit": "submit_replay",
+        "replay": "submit_replay",
+    }
+    for event in events:
+        event_name = event["event"]
+        payload = event["payload"]
+        if event_name == "failure.recorded":
+            domain = recorded_domain_map.get(payload.get("domain"))
+            if domain is not None:
+                domains[domain].append(
+                    {
+                        "event": event_name,
+                        "classification": payload.get("classification"),
+                    }
+                )
+        elif event_name == "agent.tool_failed":
+            domains["agent_tool"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("exception_class"),
+                    "tool_name": payload.get("tool_name"),
+                    "terminal": payload.get("terminal"),
+                }
+            )
+        elif event_name == "agent.no_compile_progress":
+            domains["agent_tool"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("classification"),
+                    "terminal": payload.get("terminal"),
+                }
+            )
+        elif event_name == "run.failed":
+            domains["completion"].append(
+                {
+                    "event": event_name,
+                    "classification": payload.get("classification"),
+                }
+            )
+        elif event_name == "experiment.completed" and payload.get("status") != "passed":
+            domains["completion"].append(
+                {
+                    "event": event_name,
+                    "classification": "experiment_failed",
+                }
+            )
+    return {name: values or None for name, values in domains.items()}
+
+
+def recompute_build_identity(events: list[dict[str, Any]]) -> dict[str, Any]:
+    started = next((event for event in events if event["event"] == "experiment.started"), None)
+    policy = started["payload"].get("policy", {}) if started is not None else {}
+    expected = policy.get("expected_build_system")
+    benchmark_id = policy.get("benchmark_id")
+    snapshots = [event["payload"] for event in events if event["event"] == "build.identity_snapshot"]
+    attempt_executed = any(event["event"].startswith("model.") or event["event"] in {"runtime.topology_verified", "run.failed", "orphan.reconciled"} for event in events)
+    identity_contract = benchmark_id in {
+        "forge-cpp-clean-replay-pilot-v5",
+        "forge-cpp-clean-replay-pilot-v6",
+        "forge-cpp-clean-replay-pilot-v7",
+        "forge-cpp-clean-replay-pilot-v8",
+        "forge-cpp-formal-v1-collection",
+    }
+    snapshot_required = identity_contract and attempt_executed
+    submits = [event for event in events if event["event"] == "submit.completed"]
+    snapshots_by_session = {snapshot["session_id"]: snapshot for snapshot in snapshots if snapshot.get("session_id") is not None}
+    submit_identity_proven = not identity_contract or all(
+        (snapshot := snapshots_by_session.get(submit["payload"].get("session_id"))) is not None and snapshot.get("selected_build_system") == expected and snapshot.get("executed_build_system") == expected for submit in submits
+    )
+    snapshot_present = bool(snapshots)
+    return {
+        "valid": (not snapshot_required or snapshot_present) and submit_identity_proven,
+        "snapshot_required": snapshot_required,
+        "snapshot_present": snapshot_present,
+        "expected_build_system": expected,
+        "session_count": sum(snapshot.get("session_id") is not None for snapshot in snapshots),
+        "submit_identity_proven": submit_identity_proven,
+        "snapshots": snapshots,
+    }
+
+
+def recompute_gates(events: list[dict[str, Any]]) -> dict[str, Any]:
+    commands: dict[str, dict[str, Any]] = {}
+    replays: dict[str, dict[str, Any]] = {}
+    deliveries: dict[str, dict[str, Any]] = {}
+    submits: list[dict[str, Any]] = []
+    for event in events:
+        payload = event["payload"]
+        if event["event"] == "command.completed":
+            commands[payload["command_id"]] = payload
+        elif event["event"] == "replay.completed":
+            replays[payload["replay_attempt_id"]] = payload
+        elif event["event"] == "delivery.completed":
+            submit_id = payload.get("submit_attempt_id")
+            if submit_id:
+                deliveries[submit_id] = payload
+        elif event["event"] == "submit.completed":
+            submits.append(payload)
+
+    results: list[dict[str, Any]] = []
+    mismatches: list[dict[str, Any]] = []
+    for submit in submits:
+        supporting = commands.get(submit.get("supporting_command_id"))
+        replay_snapshot = submit.get("replay") or {}
+        replay = replays.get(replay_snapshot.get("replay_attempt_id"))
+        checks = submit.get("checks") or []
+        candidate_checks = [check for check in checks if check.get("name") != "clean_replay"]
+        recomputed = {
+            "exit_code": supporting is not None and supporting.get("role") == "build" and supporting.get("exit_code") == 0 and supporting.get("timed_out") is False,
+            "candidate_only": submit.get("candidate_status") == "passed" and bool(submit.get("artifacts")) and all(check.get("passed") is True for check in candidate_checks),
+            "replay_ready": bool(submit.get("recipe_sha256")) and bool(replay_snapshot.get("replay_attempt_id")),
+            "clean_replay": replay is not None and replay.get("status") == "passed" and replay.get("cleanup_succeeded") is True and replay.get("primary_failure_classification") is None,
+            "delivered": bool(deliveries.get(submit["submit_attempt_id"], {}).get("delivered")),
+        }
+        recorded = submit.get("gates") or {}
+        for gate in ("exit_code", "candidate_only", "replay_ready", "clean_replay"):
+            if recorded.get(gate) != recomputed[gate]:
+                mismatches.append(
+                    {
+                        "submit_attempt_id": submit["submit_attempt_id"],
+                        "gate": gate,
+                        "recorded": recorded.get(gate),
+                        "recomputed": recomputed[gate],
+                    }
+                )
+        delivery = deliveries.get(submit["submit_attempt_id"])
+        if delivery is not None and delivery.get("delivered") != recomputed["delivered"]:
+            mismatches.append(
+                {
+                    "submit_attempt_id": submit["submit_attempt_id"],
+                    "gate": "delivered",
+                    "recorded": delivery.get("delivered"),
+                    "recomputed": recomputed["delivered"],
+                }
+            )
+        results.append(
+            {
+                "submit_attempt_id": submit["submit_attempt_id"],
+                "gates": recomputed,
+            }
+        )
+    build_identity = recompute_build_identity(events)
+    if not build_identity["valid"]:
+        mismatches.append(
+            {
+                "gate": "build_identity",
+                "recorded": build_identity["snapshot_present"],
+                "recomputed": False,
+            }
+        )
+    return {
+        "valid": not mismatches,
+        "submits": results,
+        "mismatches": mismatches,
+        "build_identity": build_identity,
+        "failure_domains": recompute_failure_domains(events),
+    }
+
+
+def _safe_artifact_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 512 or ".compile-sessions" in value or any(character in value for character in ("\\", ":", "\0", "\r", "\n")):
+        return None
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return value
+
+
+def _safe_artifact_type(value: Any) -> str | None:
+    if isinstance(value, str) and value in {
+        "static_library",
+        "shared_library",
+        "executable",
+    }:
+        return value
+    return None
+
+
+def _safe_nonnegative_int(value: Any) -> int | None:
+    if type(value) is int and value >= 0:
+        return value
+    return None
+
+
+def _safe_int(value: Any) -> int | None:
+    if type(value) is int:
+        return value
+    return None
+
+
+def _safe_sha256(value: Any) -> str | None:
+    if isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value):
+        return value
+    return None
+
+
+def _bounded_artifact_observation(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Return only stable, non-sensitive artifact identity evidence."""
+    return {
+        "path": _safe_artifact_path(artifact.get("path")),
+        "artifact_type": _safe_artifact_type(artifact.get("artifact_type")),
+        "size_bytes": _safe_nonnegative_int(artifact.get("size_bytes")),
+        "sha256": _safe_sha256(artifact.get("sha256")),
+        "smoke_exit_code": _safe_int(artifact.get("smoke_exit_code")),
+        "smoke_output_sha256": _safe_sha256(artifact.get("smoke_output_sha256")),
+    }
+
+
+def _artifact_identity_diff(
+    expected_artifacts: set[tuple[str, str]],
+    actual_artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    observations_by_identity: dict[tuple[str | None, str | None], dict[str, Any]] = {}
+    for artifact in actual_artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        observation = _bounded_artifact_observation(artifact)
+        identity = (observation["path"], observation["artifact_type"])
+        observations_by_identity.setdefault(identity, observation)
+
+    observed_identities = set(observations_by_identity)
+    expected_only_identities = sorted(
+        expected_artifacts - observed_identities,
+        key=lambda value: (value[0], value[1]),
+    )
+    observed_only_identities = sorted(
+        observed_identities - expected_artifacts,
+        key=lambda value: (value[0] or "", value[1] or ""),
+    )
+    matched_identities = sorted(
+        expected_artifacts & observed_identities,
+        key=lambda value: (value[0], value[1]),
+    )
+
+    expected_types_by_path: dict[str, set[str]] = {}
+    for path, artifact_type in expected_only_identities:
+        expected_types_by_path.setdefault(path, set()).add(artifact_type)
+    observed_types_by_path: dict[str, list[dict[str, Any]]] = {}
+    for identity in observed_only_identities:
+        path = identity[0]
+        if path is not None:
+            observed_types_by_path.setdefault(path, []).append(observations_by_identity[identity])
+    type_mismatches = [
+        {
+            "path": path,
+            "expected_artifact_types": sorted(expected_types),
+            "observed_artifact_types": sorted({value["artifact_type"] for value in observed_types_by_path[path] if value["artifact_type"] is not None}),
+        }
+        for path, expected_types in sorted(expected_types_by_path.items())
+        if path in observed_types_by_path
+    ]
+
+    expected_only = [{"path": path, "artifact_type": artifact_type} for path, artifact_type in expected_only_identities]
+    observed_only = [observations_by_identity[identity] for identity in observed_only_identities]
+    return {
+        "expected_count": len(expected_artifacts),
+        "observed_count": len(observed_identities),
+        "matched_count": len(matched_identities),
+        "expected_only_count": len(expected_only),
+        "observed_only_count": len(observed_only),
+        "type_mismatch_count": len(type_mismatches),
+        "expected_only": expected_only[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "observed_only": observed_only[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "type_mismatches": type_mismatches[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "truncated": any(len(values) > _MAX_ARTIFACT_DIFF_ENTRIES for values in (expected_only, observed_only, type_mismatches)),
+    }
+
+
+def _replay_artifact_diff(
+    events: list[dict[str, Any]],
+    replay_attempt_id: str | None,
+) -> dict[str, Any]:
+    replay = next(
+        (event["payload"] for event in reversed(events) if event["event"] == "replay.completed" and event["payload"].get("replay_attempt_id") == replay_attempt_id),
+        None,
+    )
+    if replay is None or not isinstance(replay.get("artifacts"), list):
+        return {
+            "available": False,
+            "mismatch_count": 0,
+            "mismatches": [],
+            "truncated": False,
+        }
+
+    differences: list[dict[str, Any]] = []
+    mismatch_rank = {value: index for index, value in enumerate(_REPLAY_ARTIFACT_MISMATCH_ORDER)}
+    for artifact in replay["artifacts"]:
+        if not isinstance(artifact, dict):
+            continue
+        raw_mismatches = artifact.get("mismatches") or []
+        mismatches = sorted(
+            {value for value in raw_mismatches if value in _REPLAY_ARTIFACT_MISMATCH_ORDER},
+            key=mismatch_rank.__getitem__,
+        )
+        if artifact.get("passed") is True and not mismatches:
+            continue
+        differences.append(
+            {
+                "path": _safe_artifact_path(artifact.get("path")),
+                "expected_artifact_type": _safe_artifact_type(artifact.get("expected_type")),
+                "observed_artifact_type": _safe_artifact_type(artifact.get("actual_type")),
+                "expected_size_bytes": _safe_nonnegative_int(artifact.get("expected_size_bytes")),
+                "observed_size_bytes": _safe_nonnegative_int(artifact.get("actual_size_bytes")),
+                "expected_sha256": _safe_sha256(artifact.get("expected_sha256")),
+                "observed_sha256": _safe_sha256(artifact.get("actual_sha256")),
+                "expected_smoke_exit_code": _safe_int(artifact.get("expected_smoke_exit_code")),
+                "observed_smoke_exit_code": _safe_int(artifact.get("actual_smoke_exit_code")),
+                "expected_smoke_output_sha256": _safe_sha256(artifact.get("expected_smoke_output_sha256")),
+                "observed_smoke_output_sha256": _safe_sha256(artifact.get("actual_smoke_output_sha256")),
+                "mismatches": mismatches,
+            }
+        )
+    differences.sort(
+        key=lambda value: (
+            value["path"] or "",
+            value["expected_artifact_type"] or "",
+            value["observed_artifact_type"] or "",
+        )
+    )
+    return {
+        "available": True,
+        "mismatch_count": len(differences),
+        "mismatches": differences[:_MAX_ARTIFACT_DIFF_ENTRIES],
+        "truncated": len(differences) > _MAX_ARTIFACT_DIFF_ENTRIES,
+    }
+
+
+def run_oracle(
+    manifest: dict[str, Any],
+    events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    started = events[0]["payload"]
+    case = _manifest_case(manifest, started["policy"]["case_id"])
+    submits = [event["payload"] for event in events if event["event"] == "submit.completed"]
+    if not submits:
+        return {"passed": False, "classification": "submit_missing"}
+    submit = submits[-1]
+    expected_artifacts = {(artifact["relative_path"], artifact["artifact_type"]) for artifact in case["oracle"]["required_artifacts"]}
+    submitted_artifacts = submit.get("artifacts", [])
+    actual_artifacts = {(artifact.get("path"), artifact.get("artifact_type")) for artifact in submitted_artifacts if isinstance(artifact, dict)}
+    artifact_identity_diff = _artifact_identity_diff(
+        expected_artifacts,
+        submitted_artifacts,
+    )
+    replay = submit.get("replay") or {}
+    expected_candidate_pass = case["oracle"]["expected_candidate_status"] == "pass"
+    expected_replay_pass = case["oracle"]["expected_clean_replay_status"] == "pass"
+    candidate_pass = submit.get("candidate_status") == "passed"
+    replay_pass = replay.get("status") == "passed"
+    expected_failure = case["oracle"].get("expected_replay_failure_classification")
+    actual_failure = replay.get("primary_failure_classification")
+    failure_matches = expected_failure is None or actual_failure == expected_failure
+    passed = expected_artifacts.issubset(actual_artifacts) and candidate_pass == expected_candidate_pass and replay_pass == expected_replay_pass and failure_matches
+    return {
+        "passed": passed,
+        "classification": None if passed else "oracle_mismatch",
+        "submit_attempt_id": submit["submit_attempt_id"],
+        "artifact_oracle_passed": expected_artifacts.issubset(actual_artifacts),
+        "artifact_identity_diff": artifact_identity_diff,
+        "replay_artifact_diff": _replay_artifact_diff(
+            events,
+            replay.get("replay_attempt_id"),
+        ),
+        "candidate_expectation_passed": candidate_pass == expected_candidate_pass,
+        "replay_expectation_passed": replay_pass == expected_replay_pass,
+        "failure_classification_expectation_passed": failure_matches,
+    }
+
+
+def reconcile_orphans(physical_attempt_id: str) -> dict[str, Any]:
+    code, output = _run_command(
+        [
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+            (f"label=deerflow.compile.physical_attempt_id={physical_attempt_id}"),
+        ]
+    )
+    identifiers = output.splitlines() if code == 0 and output else []
+    removed = 0
+    for identifier in identifiers:
+        remove_code, _ = _run_command(["docker", "rm", "-f", identifier])
+        if remove_code == 0:
+            removed += 1
+    return {
+        "scan_succeeded": code == 0,
+        "orphan_count": len(identifiers),
+        "removed_count": removed,
+        "cleanup_succeeded": code == 0 and removed == len(identifiers),
+    }
+
+
+def _finalize_attempt_sessions(
+    thread_id: str,
+    *,
+    interrupted_status: str | None,
+    error: str | None,
+) -> bool:
+    try:
+        from deerflow.compile.operations import finalize_unfinished_thread_sessions_impl
+
+        sessions = finalize_unfinished_thread_sessions_impl(
+            thread_id=thread_id,
+            interrupted_status=interrupted_status,
+            error=error,
+        )
+    except Exception:
+        return False
+    return all(session.finalized_at is not None for session in sessions)
+
+
+def _record_attempt_build_identity(thread_id: str, ledger: ExperimentLedger) -> bool:
+    try:
+        from deerflow.compile.operations import get_compile_services
+
+        sessions = sorted(
+            get_compile_services().manager.list_sessions(thread_id),
+            key=lambda session: session.session_id,
+        )
+    except Exception:
+        ledger.append(
+            "failure.recorded",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "domain": "build",
+                "classification": "identity_snapshot_unavailable",
+                "primary": True,
+            },
+        )
+        return False
+
+    snapshots = sessions or [None]
+    try:
+        for session in snapshots:
+            ledger.append(
+                "build.identity_snapshot",
+                {
+                    "session_id": session.session_id if session is not None else None,
+                    "build_system_capabilities": list(session.build_system_capabilities) if session is not None else [],
+                    "selected_build_system": session.selected_build_system if session is not None else None,
+                    "executed_build_system": session.executed_build_system if session is not None else None,
+                },
+            )
+    except EvidenceError:
+        ledger.append(
+            "failure.recorded",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "domain": "build",
+                "classification": "identity_snapshot_invalid",
+                "primary": True,
+            },
+        )
+        return False
+    return True
+
+
+async def _consume_client_stream(
+    client: Any,
+    message: str,
+    *,
+    thread_id: str,
+) -> dict[str, int | bool]:
+    tool_call_count = 0
+    compile_tool_call_count = 0
+    stream_completed = False
+    async for event in client.astream(message, thread_id=thread_id):
+        if event.type == "end":
+            stream_completed = True
+            continue
+        if event.type != "messages-tuple" or not isinstance(event.data, dict):
+            continue
+        if event.data.get("type") != "ai":
+            continue
+        tool_calls = event.data.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            tool_name = tool_call.get("name")
+            if not isinstance(tool_name, str):
+                continue
+            tool_call_count += 1
+            if tool_name in _COMPILE_ACTION_TOOL_NAMES:
+                compile_tool_call_count += 1
+    return {
+        "tool_call_count": tool_call_count,
+        "compile_tool_call_count": compile_tool_call_count,
+        "stream_completed": stream_completed,
+    }
+
+
+def run_attempt(
+    manifest: dict[str, Any],
+    ledger_path: Path,
+) -> dict[str, Any]:
+    if manifest.get("scope", {}).get("collection_authorized") is False:
+        raise RunnerError("Formal collection is not authorized; model execution is forbidden")
+    ledger = ExperimentLedger.open(ledger_path)
+    events = ledger.read()
+    context = events[0]["payload"]
+    if context.get("preflight_ready") is not True:
+        raise RunnerError("The physical attempt did not pass preflight")
+    if any(event["event"].startswith("model.") for event in events):
+        raise RunnerError("A physical attempt cannot issue model calls twice")
+    expected_topology = manifest["runtime"].get("control_plane_topology")
+    if expected_topology in {
+        protocol_v2.CONTROL_PLANE_TOPOLOGY,
+        protocol_v3.CONTROL_PLANE_TOPOLOGY,
+        protocol_v4.CONTROL_PLANE_TOPOLOGY,
+        protocol_v5.CONTROL_PLANE_TOPOLOGY,
+        protocol_v6.CONTROL_PLANE_TOPOLOGY,
+        protocol_v7.CONTROL_PLANE_TOPOLOGY,
+        protocol_v8.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal.CONTROL_PLANE_TOPOLOGY,
+        protocol_formal_collection.CONTROL_PLANE_TOPOLOGY,
+    }:
+        if not _running_inside_compose_dood(REPO_ROOT):
+            ledger.append(
+                "runtime.topology_rejected",
+                {"control_plane_topology": expected_topology},
+            )
+            raise RunnerError("The physical attempt must run inside the frozen Compose/DooD control plane")
+        ledger.append(
+            "runtime.topology_verified",
+            {"control_plane_topology": expected_topology},
+        )
+    policy_data = context["policy"]
+    policy = build_policy(
+        manifest,
+        case_id=policy_data["case_id"],
+        condition_id=policy_data["condition"],
+        repetition=policy_data["repetition"],
+    )
+    if policy.to_payload() != policy_data:
+        raise RunnerError("The ledger policy no longer matches the manifest")
+    thread_id = context["thread_id"]
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+    )
+    run_status = "failed"
+    session_finalization_succeeded = False
+    build_identity_snapshot_recorded = manifest["schema_version"] not in {
+        protocol_v5.SCHEMA_VERSION,
+        protocol_v6.SCHEMA_VERSION,
+        protocol_v7.SCHEMA_VERSION,
+        protocol_v8.SCHEMA_VERSION,
+        protocol_formal_collection.SCHEMA_VERSION,
+    }
+    try:
+        from deerflow.client import DeerFlowClient
+
+        client = DeerFlowClient(
+            model_name=policy.model_name,
+            thinking_enabled=False,
+            subagent_enabled=True,
+            plan_mode=False,
+            available_skills=set(),
+        )
+        message = f"Compile the C/C++ repository at {policy.expected_repo_url} using exact commit {policy.expected_commit_sha}. Use the compiler subagent and finish only after deterministic artifact submission and session finalization."
+        stream_summary = asyncio.run(_consume_client_stream(client, message, thread_id=thread_id))
+        completed_model_request_count = sum(event["event"] == "model.request_completed" for event in ledger.read())
+        if completed_model_request_count > 0 and stream_summary["stream_completed"] and stream_summary["compile_tool_call_count"] == 0:
+            ledger.append(
+                "agent.no_compile_progress",
+                {
+                    "failure_id": new_evidence_id("failure"),
+                    "classification": "no_compile_tool_call",
+                    "completed_model_request_count": completed_model_request_count,
+                    "tool_call_count": stream_summary["tool_call_count"],
+                    "compile_tool_call_count": 0,
+                    "stream_completed": stream_summary["stream_completed"],
+                    "terminal": True,
+                },
+            )
+        run_status = "completed"
+    except BaseException as exc:
+        ledger.append(
+            "run.failed",
+            {
+                "failure_id": new_evidence_id("failure"),
+                "classification": type(exc).__name__,
+            },
+        )
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
+    finally:
+        interrupted_status = "failed" if run_status == "failed" else None
+        termination_error = "Benchmark run ended before compile session finalization." if interrupted_status is not None else None
+        session_finalization_succeeded = _finalize_attempt_sessions(
+            thread_id,
+            interrupted_status=interrupted_status,
+            error=termination_error,
+        )
+        deactivate_experiment(thread_id)
+        reconciliation = reconcile_orphans(ledger.physical_attempt_id)
+        if not session_finalization_succeeded and reconciliation["cleanup_succeeded"]:
+            session_finalization_succeeded = _finalize_attempt_sessions(
+                thread_id,
+                interrupted_status=interrupted_status,
+                error=termination_error,
+            )
+        if manifest["schema_version"] in {
+            protocol_v5.SCHEMA_VERSION,
+            protocol_v6.SCHEMA_VERSION,
+            protocol_v7.SCHEMA_VERSION,
+            protocol_v8.SCHEMA_VERSION,
+            protocol_formal_collection.SCHEMA_VERSION,
+        }:
+            build_identity_snapshot_recorded = _record_attempt_build_identity(thread_id, ledger)
+        ledger.append("orphan.reconciled", reconciliation)
+
+    events = ledger.read()
+    gates = recompute_gates(events)
+    oracle = run_oracle(manifest, events)
+    ledger.append("oracle.completed", oracle)
+    final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] and session_finalization_succeeded and build_identity_snapshot_recorded else "failed"
+    ledger.append(
+        "experiment.completed",
+        {
+            "status": final_status,
+            "gate_recomputation_valid": gates["valid"],
+            "oracle_passed": oracle["passed"],
+            "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
+            "session_finalization_succeeded": session_finalization_succeeded,
+            "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
+        },
+    )
+    return {
+        "status": final_status,
+        "gate_recomputation": gates,
+        "oracle": oracle,
+        "orphan_reconciliation": reconciliation,
+        "session_finalization_succeeded": session_finalization_succeeded,
+        "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
+    }
+
+
+def run_formal_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol_formal_collection.SCHEMA_VERSION:
+        raise RunnerError("Batch execution is only valid for the authorized formal collection")
+    batch_size = manifest["authorization"]["collection_constraints"]["initial_batch_size"]
+    if max_attempts < 1 or max_attempts > batch_size:
+        raise RunnerError(f"Batch execution must request between 1 and {batch_size} attempts")
+    observed = _observed_collection_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    planned_slots = [
+        {
+            "case_id": slot["case_id"],
+            "condition_id": slot["condition_id"],
+            "repetition": slot["repetition"],
+        }
+        for slot in manifest["collection_plan"]
+    ]
+    if observed_slots != planned_slots[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the frozen collection prefix")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous frozen slot must complete before batch execution resumes")
+    start_index = len(observed_slots)
+    if start_index >= len(manifest["collection_plan"]):
+        raise RunnerError("All frozen collection slots already have physical evidence")
+    batch_end_index = min(
+        ((start_index // batch_size) + 1) * batch_size,
+        len(manifest["collection_plan"]),
+    )
+    attempts_to_run = min(max_attempts, batch_end_index - start_index)
+    results: list[dict[str, Any]] = []
+    for slot_index in range(start_index, start_index + attempts_to_run):
+        slot = manifest["collection_plan"][slot_index]
+        ledger, _preflight = create_attempt(
+            manifest,
+            case_id=slot["case_id"],
+            condition_id=slot["condition_id"],
+            repetition=slot["repetition"],
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            check_endpoint=check_endpoint,
+        )
+        result = run_attempt(manifest, ledger.path)
+        results.append(
+            {
+                "slot_index": slot_index,
+                "case_id": slot["case_id"],
+                "condition_id": slot["condition_id"],
+                "repetition": slot["repetition"],
+                "physical_attempt_id": ledger.physical_attempt_id,
+                "ledger": str(ledger.path),
+                "status": result["status"],
+            }
+        )
+    return {
+        "status": "batch_boundary_reached",
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": _manifest_sha256(manifest),
+        "start_slot_index": start_index,
+        "next_slot_index": start_index + len(results),
+        "batch_end_slot_index": batch_end_index,
+        "attempts_completed": len(results),
+        "results": results,
+    }
+
+
+def _json_print(value: Any) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--manifest",
+        type=Path,
+        default=REPO_ROOT / "benchmarks" / "manifests" / "cpp-pilot-v8.json",
+    )
+    common.add_argument("--skip-endpoint-check", action="store_true")
+
+    runtime_preflight = subparsers.add_parser("runtime-preflight")
+    runtime_preflight.add_argument("--output-dir", type=Path, required=True)
+    preflight = subparsers.add_parser("preflight", parents=[common])
+    preflight.add_argument("--output-dir", type=Path, required=True)
+    canary = subparsers.add_parser("provider-canary")
+    canary.add_argument("--manifest", type=Path, required=True)
+    canary.add_argument("--output-dir", type=Path, required=True)
+    create = subparsers.add_parser("create-attempt", parents=[common])
+    create.add_argument("--case", required=True)
+    create.add_argument("--condition", default="baseline")
+    create.add_argument("--repetition", type=int, default=1)
+    create.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+    )
+    create.add_argument("--replacement-for")
+
+    verify = subparsers.add_parser("verify-ledger", parents=[common])
+    verify.add_argument("--ledger", type=Path, required=True)
+    run = subparsers.add_parser("run", parents=[common])
+    run.add_argument("--ledger", type=Path, required=True)
+    batch = subparsers.add_parser("run-batch", parents=[common])
+    batch.add_argument("--output-dir", type=Path, required=True)
+    batch.add_argument("--max-attempts", type=int, default=10)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "runtime-preflight":
+            result = collect_runtime_launch_preflight(args.output_dir)
+            _json_print(result)
+            return 0 if result["ready"] else 2
+        manifest = _load_manifest(args.manifest)
+        if args.command == "preflight":
+            result = collect_preflight(
+                manifest,
+                manifest_path=args.manifest,
+                output_dir=args.output_dir,
+                check_endpoint=not args.skip_endpoint_check,
+            )
+            _json_print(result)
+            return 0 if result["ready"] else 2
+        if args.command == "provider-canary":
+            result = collect_provider_canary(
+                manifest,
+                manifest_path=args.manifest,
+                output_dir=args.output_dir,
+            )
+            _json_print(result)
+            return 0 if result["passed"] else 2
+        if args.command == "create-attempt":
+            ledger, preflight = create_attempt(
+                manifest,
+                case_id=args.case,
+                condition_id=args.condition,
+                repetition=args.repetition,
+                output_dir=args.output_dir,
+                replacement_for=args.replacement_for,
+                manifest_path=args.manifest,
+                check_endpoint=not args.skip_endpoint_check,
+            )
+            _json_print(
+                {
+                    "created": True,
+                    "ledger": str(ledger.path),
+                    "physical_attempt_id": ledger.physical_attempt_id,
+                    "preflight_ready": preflight["ready"],
+                }
+            )
+            return 0
+        if args.command == "verify-ledger":
+            events = ExperimentLedger.verify_path(args.ledger)
+            gates = recompute_gates(events)
+            oracle = run_oracle(manifest, events)
+            result = {
+                "ledger_valid": True,
+                "gate_recomputation": gates,
+                "oracle": oracle,
+            }
+            _json_print(result)
+            return 0 if gates["valid"] else 2
+        if args.command == "run":
+            result = run_attempt(manifest, args.ledger)
+            _json_print(result)
+            return 0 if result["status"] == "passed" else 2
+        if args.command == "run-batch":
+            result = run_formal_batch(
+                manifest,
+                manifest_path=args.manifest,
+                output_dir=args.output_dir,
+                max_attempts=args.max_attempts,
+                check_endpoint=not args.skip_endpoint_check,
+            )
+            _json_print(result)
+            return 0
+    except (EvidenceError, RunnerError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 目标

为 Issue #82 增加独立的正式采集授权身份，在不改写已冻结父协议的前提下，提供双提供商 canary、账本前置门禁和首批 10 个 slot 的不可替换批次边界。

关联 #82

## 主要变更

- 新增 `formal-collection-1.0.0` manifest 与 Schema，绑定父 manifest canonical SHA、授权预算及 Issue #82。
- 新增独立 collection runner；原 `cpp-formal-v1` manifest、旧 runner 与 v1-v8 证据保持逐字不变。
- 首条正式账本前强制 RichLab 与 DeepSeek 双提供商真实 canary，报告不记录响应正文或密钥。
- 冻结 180-slot 顺序，禁止 retry、fallback、replacement 和 backfill；单批最多推进 10 个 slot。
- 对 create/run/submit 增加授权、canary、批次边界与 build identity 复核。

## 验证

- 协议与 evidence 聚焦回归：305 passed
- 后端全量主体：1814 passed, 28 skipped
- config-upgrade 隔离复核：4 passed
- Ruff、Schema/manifest、py_compile、Compose config、前端 lint/typecheck：通过
- 旧正式 runner：与主干逐字一致

## 环境说明

本机 WSL2 约 7.7 GiB 内存；Next.js 16/Turbopack 无缓存 production build 在 2 GiB 与 4 GiB Node 上限下均被 OOM 终止，未出现前端代码错误栈。本 PR 不修改前端，交由 GitHub CI 的独立环境复核。

## 合并后执行

合并并在实际 LangGraph Compose/DooD 环境复核后，先运行双提供商 canary；仅在 canary 成功时创建并执行首批 10 个正式 slot。Issue #82 将在采集与审计完成后关闭。