### PR TITLE
修复 DooD 路径分离导致的构建系统误判

### DIFF
--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -519,16 +519,58 @@ def clone_repository_json(
     return json.dumps({"exit_code": result.exit_code, "message": message, "log_path": result.log_path}, ensure_ascii=False, indent=2)
 
 
+def _build_system_marker_probe_command() -> str:
+    statements = [f"test -d {shell_quote(CONTAINER_REPO_DIR)} || exit 66"]
+    for build_system, markers in _BUILD_SYSTEM_MARKERS.items():
+        branches = []
+        for index, marker in enumerate(markers):
+            keyword = "if" if index == 0 else "elif"
+            marker_path = f"{CONTAINER_REPO_DIR}/{marker}"
+            branches.append(f"{keyword} test -f {shell_quote(marker_path)}; then printf '%s\\t%s\\n' {shell_quote(build_system)} {shell_quote(marker)}")
+        statements.append("; ".join(branches) + "; fi")
+    return "\n".join(statements)
+
+
+def _detected_build_system_markers(stdout: str) -> list[tuple[str, str]]:
+    observed = [line for line in stdout.splitlines() if line]
+    allowed = {f"{build_system}\t{marker}" for build_system, markers in _BUILD_SYSTEM_MARKERS.items() for marker in markers}
+    if len(observed) != len(set(observed)) or any(line not in allowed for line in observed):
+        raise RuntimeError("Compile container returned invalid build-system marker evidence")
+
+    observed_set = set(observed)
+    detected: list[tuple[str, str]] = []
+    for build_system, markers in _BUILD_SYSTEM_MARKERS.items():
+        marker = next((candidate for candidate in markers if f"{build_system}\t{candidate}" in observed_set), None)
+        if marker is not None:
+            detected.append((build_system, marker))
+    return detected
+
+
 def inspect_build_system_impl(*, session: CompileSession) -> tuple[str, list[tuple[str, str]], list[str]]:
     services = get_compile_services()
 
     repo_dir = Path(session.leadagent_repo_dir)
-    services.manager.log_event(session, "inspect.started", lead_repo_dir=str(repo_dir))
-    detected: list[tuple[str, str]] = []
-    for build_system, markers in _BUILD_SYSTEM_MARKERS.items():
-        marker = next((candidate for candidate in markers if (repo_dir / candidate).is_file()), None)
-        if marker is not None:
-            detected.append((build_system, marker))
+    services.manager.log_event(
+        session,
+        "inspect.started",
+        lead_repo_dir=str(repo_dir),
+        container_repo_dir=CONTAINER_REPO_DIR,
+    )
+    probe = services.runtime.exec(
+        session,
+        _build_system_marker_probe_command(),
+        workdir=CONTAINER_WORKSPACE_DIR,
+        timeout_seconds=30,
+    )
+    if probe.exit_code != 0:
+        services.manager.log_event(
+            session,
+            "inspect.failed",
+            container_repo_dir=CONTAINER_REPO_DIR,
+            exit_code=probe.exit_code,
+        )
+        raise RuntimeError("Failed to inspect build-system markers inside the compile container")
+    detected = _detected_build_system_markers(probe.stdout)
 
     session.build_system_capabilities = [build_system for build_system, _marker in detected]
     if detected:

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -302,7 +302,15 @@ def _run_post_build_fixture(
         selected = manager.load_session(session.session_id, thread_id)
         assert selected.selected_build_system == build_system
         assert build_system in selected.build_system_capabilities
-        assert (Path(selected.leadagent_repo_dir) / expected_marker).is_file()
+        assert (
+            runtime.exec(
+                selected,
+                f"test -f /workspace/repo/{expected_marker}",
+                workdir="/workspace",
+                timeout_seconds=30,
+            ).exit_code
+            == 0
+        )
 
         run_tool = next(tool for tool in bound_compile_tools.get_bound_compile_tools(session) if tool.name == "run_container_bash")
         if dependency_command is not None:

--- a/backend/tests/test_compile_runtime.py
+++ b/backend/tests/test_compile_runtime.py
@@ -120,18 +120,27 @@ def test_inspect_build_system_persists_all_repository_capabilities(tmp_path: Pat
         thread_id="thread-multi-build-system",
         repo_url="https://example.com/repo.git",
     )
-    repo_dir = Path(session.leadagent_repo_dir)
-    repo_dir.mkdir(parents=True)
-    for marker in ("CMakeLists.txt", "Makefile", "configure"):
-        (repo_dir / marker).write_text("fixture\n", encoding="utf-8")
+    calls: list[tuple[str, str | None, int]] = []
+
+    def fake_exec(_session, command, workdir=None, timeout_seconds=600, **_kwargs):
+        calls.append((command, workdir, timeout_seconds))
+        return CommandResult(
+            exit_code=0,
+            stdout="cmake\tCMakeLists.txt\nmake\tMakefile\nautotools\tconfigure\n",
+            stderr="",
+            combined_output="cmake\tCMakeLists.txt\nmake\tMakefile\nautotools\tconfigure\n",
+        )
+
     monkeypatch.setattr(
         operations,
         "_services",
-        CompileOperationsServices(manager=manager, runtime=SimpleNamespace()),
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)),
     )
 
     primary, detected, _suggested = operations.inspect_build_system_impl(session=session)
 
+    assert not Path(session.leadagent_repo_dir).exists()
+    assert calls == [(operations._build_system_marker_probe_command(), "/workspace", 30)]
     reloaded = manager.load_session(session.session_id, session.thread_id)
     assert primary == "cmake"
     assert detected == [
@@ -164,13 +173,15 @@ def test_inspect_build_system_detects_source_autotools_markers(
         thread_id=f"thread-autotools-{marker.replace('.', '-')}",
         repo_url="https://example.com/repo.git",
     )
-    repo_dir = Path(session.leadagent_repo_dir)
-    repo_dir.mkdir(parents=True)
-    (repo_dir / marker).write_text("fixture\n", encoding="utf-8")
+
+    def fake_exec(_session, _command, **_kwargs):
+        output = f"autotools\t{marker}\n"
+        return CommandResult(exit_code=0, stdout=output, stderr="", combined_output=output)
+
     monkeypatch.setattr(
         operations,
         "_services",
-        CompileOperationsServices(manager=manager, runtime=SimpleNamespace()),
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)),
     )
 
     primary, detected, suggested = operations.inspect_build_system_impl(session=session)
@@ -179,6 +190,30 @@ def test_inspect_build_system_detects_source_autotools_markers(
     assert detected == [("autotools", marker)]
     assert suggested[0] == first_suggestion
     assert manager.load_session(session.session_id, session.thread_id).build_system_capabilities == ["autotools"]
+
+
+def test_inspect_build_system_rejects_failed_container_probe(tmp_path: Path, monkeypatch) -> None:
+    manager = CompileSessionManager(paths=make_test_paths(tmp_path))
+    session = manager.create_session(
+        thread_id="thread-missing-container-repo",
+        repo_url="https://example.com/repo.git",
+    )
+
+    def fake_exec(_session, _command, **_kwargs):
+        return CommandResult(exit_code=66, stdout="", stderr="", combined_output="")
+
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=SimpleNamespace(exec=fake_exec)),
+    )
+
+    with pytest.raises(RuntimeError, match="inside the compile container"):
+        operations.inspect_build_system_impl(session=session)
+
+    events = [json.loads(line) for line in manager.workflow_log_path(session).read_text(encoding="utf-8").splitlines()]
+    assert events[-1]["event"] == "inspect.failed"
+    assert events[-1]["exit_code"] == 66
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_docker_compose_compile_paths.py
+++ b/backend/tests/test_docker_compose_compile_paths.py
@@ -8,10 +8,18 @@ MODEL_PROXY_COMPOSE_FILE = REPO_ROOT / "docker" / "docker-compose-model-proxy.ya
 def test_compile_session_mount_and_path_contract_are_applied_to_both_runtimes():
     compose = COMPOSE_FILE.read_text(encoding="utf-8")
 
-    assert compose.count("${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions") == 2
+    required_root = "${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}"
+    assert compose.count(f"{required_root}/.compile-sessions:/workspace/.compile-sessions") == 2
     assert compose.count("DEER_FLOW_WORKSPACE_ROOT=/workspace") == 2
-    assert compose.count("DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}") == 2
-    assert compose.count("HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}") == 2
+    assert compose.count(f"DEER_FLOW_HOST_WORKSPACE_ROOT={required_root}") == 2
+    assert compose.count(f"HOST_PROJECT_ROOT={required_root}") == 2
+
+
+def test_compose_rejects_an_unset_host_workspace_root():
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert "${DEER_FLOW_ROOT}/" not in compose
+    assert compose.count("${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}") == 12
 
 
 def test_documented_docker_port_matches_compose_mapping():

--- a/backend/tests/test_forge_formal_collection_protocol.py
+++ b/backend/tests/test_forge_formal_collection_protocol.py
@@ -69,10 +69,9 @@ def _fake_preflight(manifest: dict, *, ready: bool) -> dict:
     }
 
 
-def test_authorized_manifest_is_generated_committed_and_schema_valid() -> None:
+def test_authorized_manifest_is_committed_and_schema_valid() -> None:
     manifest = load_manifest()
     parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
-    assert formal_collection.generate_manifest() == manifest
     assert formal_collection.validate_manifest(manifest) == manifest
     assert manifest["scope"]["collection_authorized"] is True
     assert parent["scope"]["collection_authorized"] is False

--- a/backend/tests/test_forge_formal_collection_v2_authorized_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v2_authorized_protocol.py
@@ -47,11 +47,10 @@ def load_manifest() -> dict:
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
-def test_authorized_manifest_is_generated_committed_and_schema_valid() -> None:
+def test_authorized_manifest_is_committed_and_schema_valid() -> None:
     manifest = load_manifest()
     parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
 
-    assert formal_collection.generate_manifest() == manifest
     assert formal_collection.validate_manifest(manifest) == manifest
     assert manifest["collection_plan"] == parent["collection_plan"]
     assert manifest["cases"] == parent["cases"]

--- a/backend/tests/test_forge_formal_collection_v2_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v2_protocol.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import hashlib
 import importlib.util
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -43,11 +46,10 @@ def load_manifest() -> dict:
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
-def test_v2_candidate_is_generated_committed_and_schema_valid() -> None:
+def test_v2_candidate_is_committed_and_schema_valid() -> None:
     manifest = load_manifest()
     parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
 
-    assert formal_collection_v2.generate_manifest() == manifest
     assert formal_collection_v2.validate_manifest(manifest) == manifest
     assert manifest["collection_plan"] == parent["collection_plan"]
     assert manifest["cases"] == parent["cases"]
@@ -97,7 +99,17 @@ def test_v2_candidate_binds_repaired_runtime_components() -> None:
     component_hashes = manifest["forge"]["component_sha256"]
 
     assert ("backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py") in component_hashes
-    formal_collection_v2.verify_frozen_components(manifest)
+    git = shutil.which("git")
+    if git is None:
+        pytest.skip("git is unavailable in the minimal backend image")
+    for relative_path, expected_digest in component_hashes.items():
+        result = subprocess.run(
+            [git, "show", f"{manifest['forge']['commit_sha']}:{relative_path}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=True,
+        )
+        assert hashlib.sha256(result.stdout).hexdigest() == expected_digest
 
 
 def test_v2_attempt_context_disables_and_restores_memory() -> None:

--- a/backend/tests/test_forge_formal_runtime_protocol.py
+++ b/backend/tests/test_forge_formal_runtime_protocol.py
@@ -34,9 +34,8 @@ def load_manifest() -> dict:
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
-def test_generated_manifest_is_committed_and_schema_valid() -> None:
+def test_frozen_manifest_is_committed_and_schema_valid() -> None:
     manifest = load_manifest()
-    assert formal.generate_manifest() == manifest
     assert formal.validate_manifest(manifest) == manifest
     assert len(manifest["cases"]) == 30
     assert len(manifest["collection_plan"]) == 180

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -34,8 +34,8 @@ services:
       # On Docker Desktop/OrbStack, use your actual host paths like /Users/username/...
       # Set these in your shell before running docker-compose:
       #   export DEER_FLOW_ROOT=/absolute/path/to/deer-flow
-      - SKILLS_HOST_PATH=${DEER_FLOW_ROOT}/skills
-      - THREADS_HOST_PATH=${DEER_FLOW_ROOT}/backend/.deer-flow/threads
+      - SKILLS_HOST_PATH=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/skills
+      - THREADS_HOST_PATH=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/backend/.deer-flow/threads
       - KUBECONFIG_PATH=/root/.kube/config
       - NODE_HOST=host.docker.internal
       # Override K8S API server URL since kubeconfig uses 127.0.0.1
@@ -130,7 +130,7 @@ services:
       - ../:/repo:ro
       # CompileSessionManager writes through /workspace while compile containers
       # bind the same directory using the host-visible DEER_FLOW_ROOT path.
-      - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
+      - "${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/.compile-sessions:/workspace/.compile-sessions"
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - gateway-venv:/app/backend/.venv
@@ -163,14 +163,14 @@ services:
       - DEER_FLOW_HOME=/app/backend/.deer-flow
       - FORGE_REPO_ROOT=/repo
       - DEER_FLOW_WORKSPACE_ROOT=/workspace
-      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
-      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}
+      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}
+      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}
       - UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple}
       - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}
       - DEER_FLOW_CHANNELS_LANGGRAPH_URL=${DEER_FLOW_CHANNELS_LANGGRAPH_URL:-http://langgraph:2024}
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}
-      - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
-      - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
+      - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/backend/.deer-flow
+      - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
     env_file:
       - ../.env
@@ -199,7 +199,7 @@ services:
       - ../backend/:/app/backend/
       - ../:/repo:ro
       # Keep service-side session state and host Docker bind mounts aligned.
-      - "${DEER_FLOW_ROOT}/.compile-sessions:/workspace/.compile-sessions"
+      - "${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/.compile-sessions:/workspace/.compile-sessions"
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - langgraph-venv:/app/backend/.venv
@@ -232,12 +232,12 @@ services:
       - DEER_FLOW_HOME=/app/backend/.deer-flow
       - FORGE_REPO_ROOT=/repo
       - DEER_FLOW_WORKSPACE_ROOT=/workspace
-      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT}
-      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT}
+      - DEER_FLOW_HOST_WORKSPACE_ROOT=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}
+      - HOST_PROJECT_ROOT=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}
       - UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple}
       - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-600}
-      - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
-      - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
+      - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/backend/.deer-flow
+      - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT:?set DEER_FLOW_ROOT via scripts/docker.sh}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
     env_file:
       - ../.env


### PR DESCRIPTION
## 根因

Compose 在未设置 `DEER_FLOW_ROOT` 时仍能启动，把控制面 `/workspace/.compile-sessions` 绑定到 Docker 宿主 `/.compile-sessions`；`Paths` 又把子编译容器的宿主根回退为 `/workspace`。因此 clone 写入宿主 `/workspace/.compile-sessions/...`，而控制面从宿主 `/.compile-sessions/...` 扫描 marker，正式 v2 十槽全部得到空 capability。

## 修改

- 构建系统识别改为通过 Compile Session runtime 在同一编译容器的 `/workspace/repo` 内确定性探测 CMake、Make 与 Autotools marker。
- marker probe 失败或返回非法证据时明确终止，不再把基础设施路径错误降级为 `unknown`。
- Compose 对缺失或空的 `DEER_FLOW_ROOT` 直接拒绝解析，避免静默创建第二棵 session 根目录。
- 更新冻结协议测试：旧 manifest 继续做结构与 Schema 校验，component 改为从其声明的 Git baseline blob 审计，不要求旧协议对当前合法 runtime 漂移重新生成相同字节。
- v1/v2 manifest、Schema、runner、canary 与既有 ledger 均未修改，也没有创建第 11 个 slot。

## 验证

- Forge 测试：`314 passed`
- 后端主体：`1823 passed, 29 skipped`
- config-upgrade 独立复核：`4 passed`
- 聚焦路径/终结回归：`159 passed`
- 真实 Compose/DooD 非模型 CMake：exact-commit clone、marker 识别、build、submit、clean replay、finalize 全通过，`1 passed in 37.77s`
- Ruff check/format：通过，`273 files already formatted`
- Compose config、diff check、敏感信息扫描：通过
- compile/replay 残留容器：`0/0`
- 十份正式 v2 ledger：逐条 `verify-ledger` 有效，32/32 请求闭合；未重试、替换、回填或改写

Closes #88
