### PR TITLE
修复：固定 GitHub 写入与 WSL 推送通道

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-07-30 — 固定 GitHub 写入与 WSL Git 网络通道
+  - 文件: `AGENTS.md`, `scripts/push-via-wsl.ps1`, `.claude/memory/project.md`
+  - 动机: GitHub App 对仓库写操作稳定返回 403；Windows Git 未使用当前可用代理，直连 `github.com:443` 超时，而 `api.github.com` 与带代理环境的 WSL Git 正常。
+  - 实现: GitHub Issue/PR/评论等写操作直接使用已认证 Windows `gh`；push 统一通过 WSL Git 与 Windows `gh auth git-credential`，包含 URL/分支/remote 校验、有界超时和重试，不输出 token、代理值或认证头。
+  - 验证: Issue #93 已用 Windows `gh` 创建并回读；PowerShell 语法、WSL dry-run、三类错误参数拒绝和真实测试分支 push 均通过。
+
 - 2026-07-30 — 冻结未授权 formal v3 与 DooD evidence source 门禁
   - GitHub: Issue #90 / PR #91 已 squash 合并为 `main@96445f68`，Issue 自动关闭；PR 与主干 Unit Tests、后端 lint、前端 format/lint/typecheck/build 全绿。
   - 协议: v3 继承 v2 authorized 的双 provider、30 个 C/C++ exact-commit case、180-slot schedule、三次重复、Compose/DooD、Compile Session、clean replay 与零 fallback；canonical SHA-256 为 `9777816f157078ae555969c6c77ca8734ca4e1417235f57c98a628c384031b5d`。
@@ -239,6 +245,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- GitHub 的 API 与 Git HTTPS 是独立网络通道：`api.github.com` 正常不代表 Windows Git 能访问 `github.com:443`。本机 Windows Git 未使用 WSL 的代理环境，push/ls-remote 会超时或连接重置；仓库 push 应直接运行 `pwsh -NoProfile -File scripts/push-via-wsl.ps1`，不要先重复 Windows `git push`。GitHub App 写权限 403 也属于独立权限边界，Issue/PR/评论等写入直接使用已认证 Windows `gh`。
 - DooD preflight 只验证 mount destination、bind 类型和可写性仍不够；错误启动可能把 `/.compile-sessions` 挂到正确的容器 destination。必须同时验证 mount `Source == DEER_FLOW_HOST_WORKSPACE_ROOT/.compile-sessions`，并拒绝缺失、相对路径、根目录和重复 evidence mount。
 - 多版本 runner adapter 在同一 Python 进程中共享底层模块；直接覆写 `protocol_formal_collection` 会让测试收集顺序改变旧 schema 的可识别性。新版本应增加 schema dispatch，并只适配新增 policy 字段，不能替换冻结版本的全局协议身份。
 - PowerShell 调用 `gh` 时，正文中的 `\n` 不会自动变成换行，可能把字面反斜杠写进 squash/PR body。所有 GitHub 多行正文使用 PowerShell here-string 或 `--body-file`，提交后再读取远端正文确认。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Agent Instructions
+
+Read and follow `CLAUDE.md` before changing this repository. Files below
+`backend/` and `frontend/` may have additional local instructions.
+
+## GitHub Workflow
+
+- Write GitHub Issue, Pull Request, review, comment, and commit text in Chinese.
+  Keep branch names, code identifiers, commands, and required closing keywords
+  such as `Closes #93` in their native form.
+- The GitHub App available in the current Codex environment has a known
+  read-only permission boundary for this repository. Do not attempt Issue, PR,
+  comment, merge, branch, or other GitHub writes through the App first. Use the
+  authenticated Windows `gh` CLI directly.
+- Use a PowerShell here-string or `--body-file` for multiline GitHub text.
+  Read the created Issue or PR back after writing it so literal `\n` sequences
+  and field drift are detected immediately.
+- Open or confirm the tracking Issue before modifying code. Link the PR with an
+  English closing keyword when automatic closure is intended.
+
+## Git Network Path
+
+- Local, non-network Git commands may use Windows Git. For pushes from this
+  Windows workspace, use:
+
+  ```powershell
+  pwsh -NoProfile -File scripts/push-via-wsl.ps1
+  ```
+
+- The helper deliberately uses WSL Git, the WSL network/proxy environment, and
+  the authenticated Windows `gh auth git-credential` helper. It must not print
+  credential values, proxy values, authorization headers, or tokens.
+- Do not first retry Windows `git push` when `github.com:443` is known to be
+  unhealthy. The Windows path can time out while `api.github.com` and WSL Git
+  remain healthy.
+- If the WSL helper exhausts its bounded retries, report the failure. Git Data
+  API publication is an explicit fallback, not an automatic side effect.

--- a/scripts/push-via-wsl.ps1
+++ b/scripts/push-via-wsl.ps1
@@ -1,0 +1,149 @@
+[CmdletBinding()]
+param(
+    [string]$Remote = "origin",
+    [string]$Branch,
+    [string]$Distro = "Ubuntu",
+    [ValidateRange(1, 5)]
+    [int]$Attempts = 3,
+    [ValidateRange(10, 300)]
+    [int]$TimeoutSeconds = 90,
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$traceVariables = @(
+    "GH_DEBUG",
+    "GIT_CURL_VERBOSE",
+    "GIT_TRACE",
+    "GIT_TRACE_CURL",
+    "GIT_TRACE_PACKET",
+    "GIT_TRACE_PERFORMANCE",
+    "GIT_TRACE_SETUP",
+    "GIT_TRACE_SHALLOW",
+    "GIT_TRACE2",
+    "GIT_TRACE2_EVENT",
+    "GIT_TRACE2_PERF"
+)
+foreach ($variable in $traceVariables) {
+    [Environment]::SetEnvironmentVariable($variable, $null, "Process")
+}
+
+function ConvertTo-BashSingleQuoted {
+    param([Parameter(Mandatory)][string]$Value)
+
+    return "'" + $Value.Replace("'", "'`"`"'`"`'") + "'"
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    $output = & $Executable @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Executable failed with exit code $LASTEXITCODE"
+    }
+    return ($output | Out-String).Trim()
+}
+
+if (-not $IsWindows) {
+    throw "This helper must run from Windows PowerShell or PowerShell 7."
+}
+
+$git = (Get-Command git -ErrorAction Stop).Source
+$gh = (Get-Command gh -ErrorAction Stop).Source
+$wsl = (Get-Command wsl.exe -ErrorAction Stop).Source
+
+$repoRoot = Invoke-CheckedCommand $git @("rev-parse", "--show-toplevel")
+if (-not $Branch) {
+    $Branch = Invoke-CheckedCommand $git @("branch", "--show-current")
+}
+if (-not $Branch) {
+    throw "Detached HEAD is not supported; pass -Branch explicitly."
+}
+& $git check-ref-format --branch $Branch *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw "Invalid Git branch name."
+}
+if ($Remote -notmatch "^[A-Za-z0-9._-]+$") {
+    throw "Remote must contain only letters, numbers, dot, underscore, or hyphen."
+}
+
+$remoteUrl = Invoke-CheckedCommand $git @("remote", "get-url", $Remote)
+if ($remoteUrl -notmatch "^https://github\.com/[^/]+/[^/]+(?:\.git)?$") {
+    throw "Remote must be a credential-free GitHub HTTPS URL."
+}
+
+& $gh auth status --hostname github.com *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows gh is not authenticated for github.com."
+}
+
+$wslRepo = Invoke-CheckedCommand $wsl @(
+    "-d",
+    $Distro,
+    "--",
+    "wslpath",
+    "-a",
+    $repoRoot
+)
+$wslGh = Invoke-CheckedCommand $wsl @(
+    "-d",
+    $Distro,
+    "--",
+    "wslpath",
+    "-a",
+    $gh
+)
+
+$credentialHelper = "!`"$wslGh`" auth git-credential"
+$pushArguments = @(
+    "git",
+    "-c",
+    "credential.helper=",
+    "-c",
+    "credential.helper=$credentialHelper",
+    "push"
+)
+if ($DryRun) {
+    $pushArguments += "--dry-run"
+}
+$pushArguments += @(
+    "--set-upstream",
+    $Remote,
+    "HEAD:refs/heads/$Branch"
+)
+
+$quotedArguments = $pushArguments | ForEach-Object {
+    ConvertTo-BashSingleQuoted $_
+}
+$unsetTrace = "unset " + ($traceVariables -join " ")
+$bashCommand = "$unsetTrace; cd $(ConvertTo-BashSingleQuoted $wslRepo) && " +
+    "timeout --foreground ${TimeoutSeconds}s " +
+    ($quotedArguments -join " ")
+
+for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+    $output = & $wsl -d $Distro -- bash -lc $bashCommand 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        if ($output) {
+            $output | Write-Output
+        }
+        $mode = if ($DryRun) { "dry-run" } else { "push" }
+        Write-Output "WSL Git $mode succeeded on attempt $attempt/$Attempts."
+        exit 0
+    }
+
+    Write-Warning "WSL Git attempt $attempt/$Attempts failed with exit code $LASTEXITCODE."
+    if ($attempt -lt $Attempts) {
+        Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 6))
+    }
+}
+
+throw (
+    "WSL Git exhausted $Attempts attempts. " +
+    "Do not retry Windows Git automatically; diagnose the WSL route or use " +
+    "the explicit Git Data API fallback."
+)


### PR DESCRIPTION
## 根因

GitHub 的元数据 API 与 Git HTTPS 是两条独立通道：GitHub App 对本仓库写入稳定返回 403；Windows Git 未使用当前可用代理，直连 `github.com:443` 会超时或连接重置，而 Windows `gh` 与 WSL Git 均可用。

## 修改

- 增加仓库级 `AGENTS.md`，固定中文 GitHub 工作流、Windows `gh` 写入通道和回读要求。
- 增加 `scripts/push-via-wsl.ps1`，通过 WSL Git 与 Windows `gh auth git-credential` 推送。
- 对 branch、remote、无凭据 GitHub HTTPS URL 和认证状态做前置校验。
- 使用有界 timeout/重试，清除调试输出变量并重置 credential helper 链；失败后不自动执行 Git Data API 写入。
- 更新项目状态快照与 Obsidian 开发记录。

## 验证

- PowerShell parser 通过。
- WSL Git dry-run 与真实分支 push 通过。
- 非法 branch、非法 remote 和不存在 remote 均在网络写入前拒绝。
- 注入 Git/gh 调试变量后，输出未包含 token、代理值、认证头或凭据。
- `git diff --cached --check` 通过。

Closes #93