### PR TITLE
实验：授权 formal v3 首批十槽并迁移 RichLab 端点

### DIFF
--- a/backend/tests/test_forge_formal_collection_v3_authorized_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v3_authorized_protocol.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v3_authorized_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v3_authorized_runner.py"
+PARENT_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-collection.json"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v3-authorized.schema.json"
+PARENT_CANONICAL_SHA256 = "9777816f157078ae555969c6c77ca8734ca4e1417235f57c98a628c384031b5d"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+formal_collection = _load_module(
+    "forge_formal_collection_v3_authorized_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_formal_collection_v3_authorized_runner_test",
+    RUNNER_PATH,
+)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _evidence_mount(source: str) -> list[dict]:
+    return [
+        {
+            "Type": "bind",
+            "Source": source,
+            "Destination": "/workspace/.compile-sessions",
+            "RW": True,
+        }
+    ]
+
+
+def test_authorized_v3_manifest_is_committed_and_schema_valid() -> None:
+    manifest = load_manifest()
+    parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert formal_collection.validate_manifest(manifest) == manifest
+    assert manifest["collection_plan"] == parent["collection_plan"]
+    assert manifest["cases"] == parent["cases"]
+    assert manifest["conditions"] == parent["conditions"]
+    assert manifest["scope"]["collection_authorized"] is True
+    assert parent["scope"]["collection_authorized"] is False
+    assert manifest["model_profiles"]["richlab-gpt-5.5"]["endpoint"] == ("https://rich-api.choosefire.com/v1")
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_authorization_binds_owner_budget_network_and_boundaries() -> None:
+    authorization = load_manifest()["authorization"]
+
+    assert authorization["authorized_on"] == "2026-08-11"
+    assert authorization["issue_url"].endswith("/issues/95")
+    assert authorization["parent_manifest"]["canonical_sha256"] == (PARENT_CANONICAL_SHA256)
+    assert authorization["network_observation"] == {
+        "access_medium": "mobile_hotspot",
+        "browser_ui_required": False,
+    }
+    assert authorization["budget_confirmation"]["maximum_recorded_tokens"] == 1_633_165
+    constraints = authorization["collection_constraints"]
+    assert constraints["authorized_slot_count"] == 10
+    assert constraints["remaining_slot_count"] == 170
+    assert constraints["remaining_slots_require_additional_confirmation"] is True
+    assert constraints["evidence_directory"].endswith("benchmark-evidence-formal-v3-authorized")
+    assert constraints["required_runtime_launch_checks"] == ["evidence_mount_source_matches_host_workspace"]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["scope"].update(collection_authorized=False),
+        lambda value: value["authorization"]["budget_confirmation"].update(maximum_recorded_tokens=1_633_166),
+        lambda value: value["authorization"]["network_observation"].update(access_medium="wifi"),
+        lambda value: value["authorization"]["collection_constraints"].update(authorized_slot_count=11),
+        lambda value: value["model_profiles"]["richlab-gpt-5.5"].update(endpoint="https://example.invalid/v1"),
+        lambda value: value["collection_plan"].reverse(),
+    ],
+)
+def test_authorized_v3_rejects_identity_or_parent_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(formal_collection.BenchmarkError):
+        formal_collection.validate_manifest(manifest)
+
+
+def test_runner_loads_authorized_policy_and_real_execution_methods() -> None:
+    manifest = runner._load_manifest(MANIFEST_PATH)
+    first_slot = manifest["collection_plan"][0]
+    policy = runner.build_policy(
+        manifest,
+        case_id=first_slot["case_id"],
+        condition_id=first_slot["condition_id"],
+        repetition=first_slot["repetition"],
+    )
+
+    assert policy.benchmark_id == "forge-cpp-formal-v3-authorized-collection"
+    assert policy.endpoint == "https://rich-api.choosefire.com/v1"
+    assert policy.memory_enabled is False
+    assert policy.artifact_instructions
+    assert runner._original_collect_provider_canary.__module__.endswith("_base")
+    assert runner._original_create_attempt.__module__.endswith("_base")
+    assert runner._original_run_attempt.__module__.endswith("_base")
+
+
+def test_default_cli_manifest_is_the_authorized_v3_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    def fake_main(arguments: list[str]) -> int:
+        captured.extend(arguments)
+        return 0
+
+    monkeypatch.setattr(runner._runner, "main", fake_main)
+
+    assert runner.main(["preflight", "--output-dir", "/tmp/evidence"]) == 0
+    assert captured[:3] == ["preflight", "--manifest", str(MANIFEST_PATH)]
+
+
+def test_evidence_mount_source_gate_is_retained() -> None:
+    assert runner._evidence_mount_source_matches_host_workspace(
+        _evidence_mount("/mnt/c/work/Forge-AutoCompiler/.compile-sessions"),
+        host_workspace_root="/mnt/c/work/Forge-AutoCompiler",
+    )
+    assert not runner._evidence_mount_source_matches_host_workspace(
+        _evidence_mount("/.compile-sessions"),
+        host_workspace_root="/mnt/c/work/Forge-AutoCompiler",
+    )
+
+
+def test_attempt_after_authorized_boundary_is_rejected_without_ledger(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    slot = manifest["collection_plan"][10]
+
+    with pytest.raises(runner.RunnerError, match="initial authorization"):
+        runner.create_attempt(
+            manifest,
+            case_id=slot["case_id"],
+            condition_id=slot["condition_id"],
+            repetition=slot["repetition"],
+            output_dir=tmp_path,
+            manifest_path=MANIFEST_PATH,
+            check_endpoint=False,
+        )
+
+    assert list(tmp_path.rglob("*.jsonl")) == []
+
+
+def test_wrong_evidence_directory_is_rejected_before_canary(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(runner.RunnerError, match="evidence directory"):
+        runner.collect_provider_canary(
+            load_manifest(),
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+        )
+
+
+def test_recorded_token_boundary_blocks_next_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    slot = manifest["collection_plan"][0]
+    observed = [
+        (
+            {
+                "case_id": slot["case_id"],
+                "condition_id": slot["condition_id"],
+                "repetition": slot["repetition"],
+            },
+            [
+                {
+                    "event": "model.request_completed",
+                    "payload": {"token_usage": {"total_tokens": 1_633_165}},
+                }
+            ],
+        )
+    ]
+    monkeypatch.setattr(
+        runner._runner,
+        "_observed_collection_ledgers",
+        lambda *args, **kwargs: observed,
+    )
+
+    with pytest.raises(runner.RunnerError, match="recorded-token boundary"):
+        runner.create_attempt(
+            manifest,
+            case_id=slot["case_id"],
+            condition_id=slot["condition_id"],
+            repetition=slot["repetition"],
+            output_dir=Path(manifest["authorization"]["collection_constraints"]["evidence_directory"]),
+            manifest_path=MANIFEST_PATH,
+            check_endpoint=False,
+        )

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,43 @@
 # Forge C/C++ benchmark protocols
 
+## Authorized formal collection v3 initial batch
+
+Issue #95 authorizes only the first ten slots of
+`cpp-formal-v3-authorized-collection.json`. The authorized identity preserves
+the reviewed 180-slot C/C++ schedule, changes only the RichLab endpoint to
+`https://rich-api.choosefire.com/v1`, records `mobile_hotspot` as the access
+medium, and keeps RichLab `gpt-5.5` and DeepSeek `deepseek-v4-flash` as separate
+conditions. Memory and Skills remain disabled; retries, fallback, replacement,
+and backfill remain forbidden.
+
+Run the adapter from the `deer-flow-dev` LangGraph container with the backend
+virtual-environment interpreter. Its CLI defaults to the authorized v3
+manifest, so omitting `--manifest` cannot select an older pilot manifest:
+
+```bash
+output=/workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized
+
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v3_authorized_runner.py preflight \
+  --output-dir "$output" --skip-endpoint-check
+
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v3_authorized_runner.py \
+  provider-canary --output-dir "$output"
+
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v3_authorized_runner.py run-batch \
+  --output-dir "$output" --max-attempts 10
+```
+
+The runner rejects every other evidence directory, requires the Compose/DooD
+host bind source to match `DEER_FLOW_HOST_WORKSPACE_ROOT`, and requires a
+successful dual-provider canary before the first ledger. It stops before slot
+11 and before any next slot once completed provider responses record at least
+1,633,165 total tokens. The remaining 170 slots require a separate owner
+confirmation. Historical pilot-v3 evidence in other directories is immutable
+and must not be moved into this collection.
+
 ## Formal per-case build protocol
 
 Issue #78 turns the 30-project preregistration into a result-blind,

--- a/benchmarks/manifests/cpp-formal-v3-authorized-collection.json
+++ b/benchmarks/manifests/cpp-formal-v3-authorized-collection.json
@@ -1,0 +1,2805 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+  "schema_version": "formal-collection-3.1.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v3-authorized-collection",
+    "name": "Forge C/C++ repaired formal collection v3",
+    "purpose": "authorized append-only initial-batch evidence collection",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v3",
+    "formal_comparison_enabled": true,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "0b3f0b209afa7e59dd409d383db87ab6ed393c80",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "d574d26b001473b7a95b4e4258b912d133789baf1908fa76a1ef33a448d7dfcd",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "1acc6992c5e97c496fe4b59e69c8dbef0c00a3689cad417fa3c637c9f3cd77a1",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "35f6b23ebbbb1e7bc5b540a0b9bfd627d23b75957095922aa79c2db396b64c4b",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v3-authorized-collection",
+    "status": "authorized_initial_batch",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/95",
+    "network_observation": {
+      "access_medium": "mobile_hotspot",
+      "browser_ui_required": false
+    },
+    "budget_confirmation": {
+      "confirmed": true,
+      "initial_batch_projected_tokens": 1306532,
+      "maximum_recorded_tokens": 1633165,
+      "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+      "remaining_tokens_ceiling_before_batch": 29172532
+    },
+    "collection_constraints": {
+      "planned_attempts": 180,
+      "initial_batch_size": 10,
+      "authorized_slot_count": 10,
+      "remaining_slot_count": 170,
+      "remaining_slots_require_additional_confirmation": true,
+      "provider_canary_required_before_first_ledger": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "excluded_v2_launch_is_not_part_of_v3_analysis": true,
+      "required_runtime_launch_checks": [
+        "evidence_mount_source_matches_host_workspace"
+      ],
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized"
+    },
+    "excluded_v2_launch": {
+      "benchmark_id": "forge-cpp-formal-v2-authorized-collection",
+      "status": "excluded_infrastructure_launch",
+      "exclusion_reason": "build_system_mismatch_from_evidence_bind_source_split",
+      "canary_sha256": "8ba42a5ed465f78196405b4673620bdeeb1af4d9f890c52eb645e2e5a3d4b16e",
+      "ledger_sha256": {
+        "slot-000": "7eba5023cf7f695f30cd81c491131e50a9955ce444982a737bdacbe91ef2340d",
+        "slot-001": "e31cc7c73ed16df812b3b45a1388fab9acde7ca6efb0c46d2185f8a8f15d91db",
+        "slot-002": "96bef8012ebebe8cdd29ed2488cd56c73a1bb52a0b90c2f87f9401b78d37f241",
+        "slot-003": "64dc624bf30ea90ffba5248ebadca9a1b79028f8213358364410c0116027ddd4",
+        "slot-004": "ec988f7e97276fe6851bc5989baf1df0739eb5213507f0535567468d6f01e0dd",
+        "slot-005": "f1004b4a56e9575e243614a08e1b4c01c82bed5b2734fe496483ece9279c3164",
+        "slot-006": "644adf29081250e59d76a43fc75ca6b8ac22f11f96579f91e2f867e962e39ec9",
+        "slot-007": "f92512b1d2d714bace641fee748e32ce26e0d16ba61b4e89c33738edc54e7ee9",
+        "slot-008": "6191d9cf555d17f07e10771013fd1eeef54bda171f343584f2ffcf604ab9a32c",
+        "slot-009": "227b332f9d2f4119e2f96d4edbc4f9fb30b1521471faf6e99f518465305af35c"
+      },
+      "attempts": 10,
+      "model_requests_started": 32,
+      "model_requests_completed": 32,
+      "recorded_tokens": 143286,
+      "ledger_elapsed_seconds": 697.972,
+      "oracle_passes": 0,
+      "build_system_mismatch_attempts": 10,
+      "residual_containers": 0
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v3-collection",
+      "path": "benchmarks/manifests/cpp-formal-v3-collection.json",
+      "canonical_sha256": "9777816f157078ae555969c6c77ca8734ca4e1417235f57c98a628c384031b5d"
+    }
+  }
+}

--- a/benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+  "title": "Forge C/C++ authorized formal collection v3",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "authorization"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-3.1.0"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "type": "object",
+      "required": [
+        "collection_authorized",
+        "formal_comparison_enabled"
+      ],
+      "properties": {
+        "collection_authorized": {
+          "const": true
+        },
+        "formal_comparison_enabled": {
+          "const": true
+        }
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "0b3f0b209afa7e59dd409d383db87ab6ed393c80"
+        },
+        "component_sha256": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "authorized_by",
+        "authorized_on",
+        "issue_url",
+        "network_observation",
+        "budget_confirmation",
+        "collection_constraints",
+        "excluded_v2_launch",
+        "parent_manifest"
+      ],
+      "properties": {
+        "status": {
+          "const": "authorized_initial_batch"
+        },
+        "network_observation": {
+          "type": "object",
+          "required": [
+            "access_medium",
+            "browser_ui_required"
+          ],
+          "properties": {
+            "access_medium": {
+              "const": "mobile_hotspot"
+            },
+            "browser_ui_required": {
+              "const": false
+            }
+          }
+        },
+        "budget_confirmation": {
+          "type": "object",
+          "required": [
+            "confirmed",
+            "maximum_recorded_tokens",
+            "enforcement"
+          ],
+          "properties": {
+            "confirmed": {
+              "const": true
+            },
+            "maximum_recorded_tokens": {
+              "const": 1633165
+            },
+            "enforcement": {
+              "const": "stop_before_next_slot_when_recorded_total_reaches_limit"
+            }
+          }
+        },
+        "collection_constraints": {
+          "type": "object",
+          "required": [
+            "initial_batch_size",
+            "authorized_slot_count",
+            "remaining_slots_require_additional_confirmation",
+            "evidence_directory"
+          ],
+          "properties": {
+            "initial_batch_size": {
+              "const": 10
+            },
+            "authorized_slot_count": {
+              "const": 10
+            },
+            "remaining_slots_require_additional_confirmation": {
+              "const": true
+            },
+            "evidence_directory": {
+              "const": "/workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized"
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/forge_formal_collection_v3_authorized_protocol.py
+++ b/scripts/forge_formal_collection_v3_authorized_protocol.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Generate and validate the authorized Forge formal-collection v3 protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v3_protocol as parent_protocol  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-3.1.0"
+BASELINE_COMMIT = "0b3f0b209afa7e59dd409d383db87ab6ed393c80"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-collection.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v3-authorized.schema.json"
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_collection_v3_authorized_runner.py",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+}
+RICHLAB_ENDPOINT = "https://rich-api.choosefire.com/v1"
+AUTHORIZED_EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized"
+BATCH_TOKEN_LIMIT = 1_633_165
+AUTHORIZATION = {
+    "id": "forge-cpp-formal-v3-authorized-collection",
+    "status": "authorized_initial_batch",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/95",
+    "network_observation": {
+        "access_medium": "mobile_hotspot",
+        "browser_ui_required": False,
+    },
+    "budget_confirmation": {
+        "confirmed": True,
+        "initial_batch_projected_tokens": 1_306_532,
+        "maximum_recorded_tokens": BATCH_TOKEN_LIMIT,
+        "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+        "remaining_tokens_ceiling_before_batch": 29_172_532,
+    },
+    "collection_constraints": {
+        "planned_attempts": 180,
+        "initial_batch_size": 10,
+        "authorized_slot_count": 10,
+        "remaining_slot_count": 170,
+        "remaining_slots_require_additional_confirmation": True,
+        "provider_canary_required_before_first_ledger": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+        "excluded_v2_launch_is_not_part_of_v3_analysis": True,
+        "required_runtime_launch_checks": ["evidence_mount_source_matches_host_workspace"],
+        "evidence_directory": AUTHORIZED_EVIDENCE_DIRECTORY,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    return parent_protocol.validate_manifest(parent)
+
+
+def _authorized_model_profiles(parent: dict[str, Any]) -> dict[str, Any]:
+    profiles = copy.deepcopy(parent["model_profiles"])
+    profiles["richlab-gpt-5.5"]["endpoint"] = RICHLAB_ENDPOINT
+    return profiles
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION),
+        "excluded_v2_launch": copy.deepcopy(parent["authorization"]["excluded_v2_launch"]),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v3-collection.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parent = _parent_manifest(parent)
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v3-authorized.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v3-authorized-collection",
+        "name": "Forge C/C++ repaired formal collection v3",
+        "purpose": "authorized append-only initial-batch evidence collection",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection_v3",
+        "formal_comparison_enabled": True,
+        "collection_authorized": True,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": parent_protocol.parent_protocol.candidate_protocol.parent_protocol._hash_paths(
+            repo_root,
+            COMPONENT_PATHS,
+        ),
+    }
+    manifest["protocol_artifact_sha256"] = parent_protocol.parent_protocol.candidate_protocol.parent_protocol._hash_paths(
+        repo_root,
+        PROTOCOL_ARTIFACT_PATHS,
+    )
+    manifest["model_profiles"] = _authorized_model_profiles(parent)
+    manifest["authorization"] = _authorization(parent)
+    return validate_manifest(manifest, parent=parent)
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected_root = {
+            "$schema",
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+            "authorization",
+        }
+        if set(manifest) != expected_root:
+            v1._fail(
+                "manifest",
+                "must contain exactly the authorized formal collection v3 fields",
+            )
+        if manifest["$schema"] != ("../schemas/forge-cpp-formal-collection-v3-authorized.schema.json"):
+            v1._fail(
+                "manifest.$schema",
+                "must reference the authorized v3 collection schema",
+            )
+        if manifest["schema_version"] != SCHEMA_VERSION:
+            v1._fail("manifest.schema_version", f"must be {SCHEMA_VERSION!r}")
+        if manifest["document_type"] != "manifest":
+            v1._fail("manifest.document_type", "must be 'manifest'")
+        v1._scan_for_unsafe_values(manifest)
+        parent = _parent_manifest(parent)
+        if manifest["benchmark"] != {
+            "id": "forge-cpp-formal-v3-authorized-collection",
+            "name": "Forge C/C++ repaired formal collection v3",
+            "purpose": "authorized append-only initial-batch evidence collection",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }:
+            v1._fail(
+                "manifest.benchmark",
+                "must identify the authorized formal collection v3",
+            )
+        if manifest["scope"] != {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection_v3",
+            "formal_comparison_enabled": True,
+            "collection_authorized": True,
+            "instrumentation_blocker": False,
+        }:
+            v1._fail(
+                "manifest.scope",
+                "must authorize only the frozen formal collection v3 initial batch",
+            )
+        immutable_fields = (
+            "source_protocols",
+            "prompt_sha256",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+        )
+        for field in immutable_fields:
+            if manifest[field] != parent[field]:
+                v1._fail(
+                    f"manifest.{field}",
+                    "must remain identical to the reviewed v3 candidate",
+                )
+        if manifest["model_profiles"] != _authorized_model_profiles(parent):
+            v1._fail(
+                "manifest.model_profiles",
+                "may change only the authorized RichLab endpoint",
+            )
+        forge = v1._as_object(manifest["forge"], "manifest.forge")
+        if set(forge) != set(parent["forge"]):
+            v1._fail(
+                "manifest.forge",
+                "must contain exactly the inherited Forge identity fields",
+            )
+        if forge["repository_url"] != parent["forge"]["repository_url"]:
+            v1._fail("manifest.forge.repository_url", "must preserve the repository")
+        if forge["commit_sha"] != BASELINE_COMMIT or forge["revision_policy"] != REVISION_POLICY:
+            v1._fail("manifest.forge", "must bind the Issue #94 repair baseline")
+        validator = parent_protocol.parent_protocol.candidate_protocol.parent_protocol
+        validator._validate_hash_map(
+            forge["component_sha256"],
+            expected_paths=COMPONENT_PATHS,
+            path="manifest.forge.component_sha256",
+        )
+        validator._validate_hash_map(
+            manifest["protocol_artifact_sha256"],
+            expected_paths=PROTOCOL_ARTIFACT_PATHS,
+            path="manifest.protocol_artifact_sha256",
+        )
+        if manifest["authorization"] != _authorization(parent):
+            v1._fail(
+                "manifest.authorization",
+                "must bind the Issue #95 initial-batch authorization",
+            )
+        if len(manifest["collection_plan"]) != 180:
+            v1._fail("manifest.collection_plan", "must retain all 180 frozen slots")
+        return manifest
+    except BenchmarkError:
+        raise
+    except (
+        AttributeError,
+        KeyError,
+        OverflowError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise BenchmarkError("manifest: contains a malformed authorized collection v3 value") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(validate_manifest(manifest))
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest)
+    parent_path = repo_root / manifest["authorization"]["parent_manifest"]["path"]
+    parent = _parent_manifest(load_json_document(parent_path))
+    if parent_protocol.manifest_sha256(parent) != (manifest["authorization"]["parent_manifest"]["canonical_sha256"]):
+        v1._fail(
+            "manifest.authorization.parent_manifest",
+            "does not match the reviewed v3 candidate",
+        )
+    hasher = parent_protocol.parent_protocol.candidate_protocol.parent_protocol
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        (
+            "manifest.protocol_artifact_sha256",
+            manifest["protocol_artifact_sha256"],
+        ),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            actual = hasher._file_sha256(repo_root / relative_path)
+            if actual != expected:
+                v1._fail(
+                    f"{path_prefix}.{relative_path}",
+                    "does not match the current repository file",
+                )
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    schema["$id"] = "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json"
+    schema["title"] = "Forge C/C++ authorized formal collection v3"
+    properties = schema["properties"]
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["scope"]["properties"] = {
+        "collection_authorized": {"const": True},
+        "formal_comparison_enabled": {"const": True},
+    }
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["authorization"] = {
+        "type": "object",
+        "required": [
+            "id",
+            "status",
+            "authorized_by",
+            "authorized_on",
+            "issue_url",
+            "network_observation",
+            "budget_confirmation",
+            "collection_constraints",
+            "excluded_v2_launch",
+            "parent_manifest",
+        ],
+        "properties": {
+            "status": {"const": "authorized_initial_batch"},
+            "network_observation": {
+                "type": "object",
+                "required": ["access_medium", "browser_ui_required"],
+                "properties": {
+                    "access_medium": {"const": "mobile_hotspot"},
+                    "browser_ui_required": {"const": False},
+                },
+            },
+            "budget_confirmation": {
+                "type": "object",
+                "required": [
+                    "confirmed",
+                    "maximum_recorded_tokens",
+                    "enforcement",
+                ],
+                "properties": {
+                    "confirmed": {"const": True},
+                    "maximum_recorded_tokens": {"const": BATCH_TOKEN_LIMIT},
+                    "enforcement": {"const": "stop_before_next_slot_when_recorded_total_reaches_limit"},
+                },
+            },
+            "collection_constraints": {
+                "type": "object",
+                "required": [
+                    "initial_batch_size",
+                    "authorized_slot_count",
+                    "remaining_slots_require_additional_confirmation",
+                    "evidence_directory",
+                ],
+                "properties": {
+                    "initial_batch_size": {"const": 10},
+                    "authorized_slot_count": {"const": 10},
+                    "remaining_slots_require_additional_confirmation": {"const": True},
+                    "evidence_directory": {"const": AUTHORIZED_EVIDENCE_DIRECTORY},
+                },
+            },
+        },
+    }
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorization_status": manifest["authorization"]["status"],
+                    "authorized_slot_count": manifest["authorization"]["collection_constraints"]["authorized_slot_count"],
+                    "maximum_recorded_tokens": manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"],
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "cases": len(manifest["cases"]),
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "slots": len(manifest["collection_plan"]),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v3_authorized_runner.py
+++ b/scripts/forge_formal_collection_v3_authorized_runner.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Authorized initial-batch adapter for the Forge formal-collection v3 runner."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import posixpath
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_collection_v3_authorized_protocol as protocol  # noqa: E402
+
+
+def _load_private_base_runner():
+    module_name = f"{__name__}_base"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_formal_collection_v2_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the formal collection base runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_runner = _load_private_base_runner()
+
+_original_manifest_protocol = _runner._manifest_protocol
+_original_build_policy = _runner.build_policy
+_original_collect_runtime_launch_preflight = _runner.collect_runtime_launch_preflight
+_original_collect_provider_canary = _runner.collect_provider_canary
+_original_create_attempt = _runner.create_attempt
+_original_run_attempt = _runner.run_attempt
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+_EVIDENCE_MOUNT_ROOT = Path("/workspace/.compile-sessions")
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+):
+    policy = _original_build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        return policy
+    case = _runner._manifest_case(manifest, case_id)
+    artifacts = tuple(
+        (
+            artifact["relative_path"],
+            artifact.get("build_output_path", artifact["relative_path"]),
+            artifact["artifact_type"],
+        )
+        for artifact in case["oracle"]["required_artifacts"]
+    )
+    return replace(policy, artifact_instructions=artifacts)
+
+
+def _evidence_mount_source_matches_host_workspace(
+    mounts: list[dict[str, Any]] | None,
+    *,
+    host_workspace_root: str | None = None,
+) -> bool:
+    root = host_workspace_root if host_workspace_root is not None else os.environ.get("DEER_FLOW_HOST_WORKSPACE_ROOT")
+    if not isinstance(root, str) or not root.strip():
+        return False
+    normalized_root = posixpath.normpath(root.strip())
+    if not PurePosixPath(normalized_root).is_absolute() or normalized_root == "/":
+        return False
+    expected_source = posixpath.join(normalized_root, ".compile-sessions")
+    evidence_mounts = [mount for mount in mounts or [] if mount.get("Type") == "bind" and mount.get("Destination") == _EVIDENCE_MOUNT_ROOT.as_posix() and mount.get("RW") is True]
+    if len(evidence_mounts) != 1:
+        return False
+    source = evidence_mounts[0].get("Source")
+    return isinstance(source, str) and PurePosixPath(posixpath.normpath(source)).is_absolute() and posixpath.normpath(source) == expected_source
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    result = _original_collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+    _labels, mounts = _runner._current_container_metadata(repo_root)
+    source_matches = _evidence_mount_source_matches_host_workspace(mounts)
+    checks = {
+        **result["checks"],
+        "evidence_mount_source_matches_host_workspace": source_matches,
+    }
+    return {
+        **result,
+        "ready": result["ready"] is True and source_matches,
+        "checks": checks,
+    }
+
+
+def _authorized_slot_count(manifest: dict[str, Any]) -> int:
+    return int(manifest["authorization"]["collection_constraints"]["authorized_slot_count"])
+
+
+def _authorized_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["collection_constraints"]["evidence_directory"])
+
+
+def _require_authorized_output_dir(
+    manifest: dict[str, Any],
+    output_dir: Path,
+) -> None:
+    expected = _authorized_output_dir(manifest)
+    if output_dir.resolve(strict=False) != expected.resolve(strict=False):
+        raise RunnerError("Formal v3 evidence must use the frozen authorized evidence directory")
+
+
+def _slot_index(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+) -> int:
+    target = {
+        "case_id": case_id,
+        "condition_id": condition_id,
+        "repetition": repetition,
+    }
+    for index, slot in enumerate(manifest["collection_plan"]):
+        if {
+            "case_id": slot["case_id"],
+            "condition_id": slot["condition_id"],
+            "repetition": slot["repetition"],
+        } == target:
+            return index
+    raise RunnerError("The requested slot is not part of the frozen collection")
+
+
+def _recorded_total_tokens(
+    observed: list[tuple[dict[str, Any], list[dict[str, Any]]]],
+) -> int:
+    total = 0
+    for _slot, events in observed:
+        for event in events:
+            if event.get("event") != "model.request_completed":
+                continue
+            payload = event.get("payload")
+            usage = payload.get("token_usage") if isinstance(payload, dict) else None
+            value = usage.get("total_tokens") if isinstance(usage, dict) else None
+            if type(value) is int and value >= 0:
+                total += value
+    return total
+
+
+def _token_limit(manifest: dict[str, Any]) -> int:
+    return int(manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"])
+
+
+def _observed_authorized_ledgers(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    return _runner._observed_collection_ledgers(
+        manifest,
+        output_dir=output_dir,
+    )
+
+
+def _ensure_token_budget_remaining(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> int:
+    observed = _observed_authorized_ledgers(manifest, output_dir=output_dir)
+    recorded = _recorded_total_tokens(observed)
+    if recorded >= _token_limit(manifest):
+        raise RunnerError("The authorized recorded-token boundary has already been reached")
+    return recorded
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        _require_authorized_output_dir(manifest, output_dir)
+    return _original_collect_provider_canary(
+        manifest,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        repo_root=repo_root,
+    )
+
+
+def create_attempt(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+    **kwargs: Any,
+):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        index = _slot_index(
+            manifest,
+            case_id=case_id,
+            condition_id=condition_id,
+            repetition=repetition,
+        )
+        if index >= _authorized_slot_count(manifest):
+            raise RunnerError("The initial authorization stops before this frozen slot")
+        _require_authorized_output_dir(manifest, output_dir)
+        _ensure_token_budget_remaining(manifest, output_dir=output_dir)
+    return _original_create_attempt(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        output_dir=output_dir,
+        **kwargs,
+    )
+
+
+def run_attempt(
+    manifest: dict[str, Any],
+    ledger_path: Path,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        expected = _authorized_output_dir(manifest).resolve(strict=False)
+        try:
+            ledger_path.resolve(strict=False).relative_to(expected)
+        except ValueError as exc:
+            raise RunnerError("Formal v3 ledger is outside the authorized evidence directory") from exc
+        _ensure_token_budget_remaining(manifest, output_dir=expected)
+    return _original_run_attempt(manifest, ledger_path, **kwargs)
+
+
+def run_formal_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Batch execution is only valid for the authorized formal v3 collection")
+    _require_authorized_output_dir(manifest, output_dir)
+    authorized_slots = _authorized_slot_count(manifest)
+    if max_attempts < 1 or max_attempts > authorized_slots:
+        raise RunnerError(f"Batch execution must request between 1 and {authorized_slots} attempts")
+    observed = _observed_authorized_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    planned_slots = [
+        {
+            "case_id": slot["case_id"],
+            "condition_id": slot["condition_id"],
+            "repetition": slot["repetition"],
+        }
+        for slot in manifest["collection_plan"]
+    ]
+    if observed_slots != planned_slots[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the frozen collection prefix")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous frozen slot must complete before batch execution resumes")
+    start_index = len(observed_slots)
+    if start_index >= authorized_slots:
+        raise RunnerError("The authorized ten-slot boundary has already been reached")
+    if max_attempts > authorized_slots - start_index:
+        raise RunnerError("The requested batch would cross the authorized ten-slot boundary")
+
+    results: list[dict[str, Any]] = []
+    stop_reason = "authorized_batch_boundary_reached"
+    with asyncio.Runner() as async_runner:
+        for slot_index in range(start_index, start_index + max_attempts):
+            recorded_before = _ensure_token_budget_remaining(
+                manifest,
+                output_dir=output_dir,
+            )
+            slot = manifest["collection_plan"][slot_index]
+            ledger, _preflight = create_attempt(
+                manifest,
+                case_id=slot["case_id"],
+                condition_id=slot["condition_id"],
+                repetition=slot["repetition"],
+                output_dir=output_dir,
+                manifest_path=manifest_path,
+                check_endpoint=check_endpoint,
+            )
+            result = run_attempt(
+                manifest,
+                ledger.path,
+                async_runner=async_runner,
+            )
+            observed_after = _observed_authorized_ledgers(
+                manifest,
+                output_dir=output_dir,
+            )
+            recorded_after = _recorded_total_tokens(observed_after)
+            results.append(
+                {
+                    "slot_index": slot_index,
+                    "case_id": slot["case_id"],
+                    "condition_id": slot["condition_id"],
+                    "repetition": slot["repetition"],
+                    "physical_attempt_id": ledger.physical_attempt_id,
+                    "ledger": str(ledger.path),
+                    "status": result["status"],
+                    "recorded_tokens_before": recorded_before,
+                    "recorded_tokens_after": recorded_after,
+                }
+            )
+            if recorded_after >= _token_limit(manifest):
+                stop_reason = "recorded_token_boundary_reached"
+                break
+    return {
+        "status": stop_reason,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "start_slot_index": start_index,
+        "next_slot_index": start_index + len(results),
+        "authorized_end_slot_index": authorized_slots,
+        "attempts_completed": len(results),
+        "recorded_total_tokens": (results[-1]["recorded_tokens_after"] if results else _recorded_total_tokens(observed)),
+        "recorded_token_limit": _token_limit(manifest),
+        "results": results,
+    }
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.build_policy = build_policy
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_formal_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_provider_canary.py
+++ b/scripts/forge_provider_canary.py
@@ -45,7 +45,7 @@ COMPILE_IMAGE = "autocompiler:gcc13"
 ALLOWED_MODELS = {
     "gpt-5.5": {
         "provider": "richlab",
-        "endpoint": "https://richlab-api-x.choosefire.com/v1",
+        "endpoint": "https://rich-api.choosefire.com/v1",
         "credential_env": "OpenAI_AK",
     },
     "deepseek-v4-flash": {

--- a/scripts/model_provider_preflight.py
+++ b/scripts/model_provider_preflight.py
@@ -24,7 +24,7 @@ class Provider:
 
 PROVIDERS = {
     "richlab": Provider(
-        endpoint="https://richlab-api-x.choosefire.com/v1",
+        endpoint="https://rich-api.choosefire.com/v1",
         credential_env="OpenAI_AK",
         models=("gpt-5.5", "gpt-5.4"),
     ),


### PR DESCRIPTION
## 变更说明

- 将当前 RichLab 连通性预检和完整 provider canary 迁移到新的 OpenAI 兼容地址。
- 新增 formal v3 已授权协议、清单、Schema 与隔离 runner，保留未授权 v3 和历史 evidence 不变。
- 固定 2026-08-11 实验所有者授权、手机热点网络分类、首批 10 slot、1,633,165 recorded-token 边界及独立 evidence 目录。
- 强制首条 ledger 前完成双 provider canary，保留 DooD evidence bind-source gate，并禁止 retry、fallback、replacement 与 backfill。
- CLI 未显式传入 `--manifest` 时默认使用已授权 v3 清单，避免误落到旧 pilot manifest。

## 验证

- 协议、runner 与 provider 聚焦回归：`66 passed`。
- Ruff 格式与聚焦静态检查通过。
- staged secret scan 通过，`.env` 未纳入 Git。
- LangGraph Compose/DooD 非模型 preflight：`ready=true`，包含 `evidence_mount_source_matches_host_workspace=true`。
- authorized manifest canonical SHA-256：`87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5`。

本 PR 不调用模型、不创建 formal physical-attempt ledger，也不授权剩余 170 slot。

Closes #95
