### PR TITLE
研究：新增 formal v3 首批描述性审计报告

### DIFF
--- a/backend/tests/test_forge_formal_collection_v3_report.py
+++ b/backend/tests/test_forge_formal_collection_v3_report.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile.evidence import ExperimentLedger, new_evidence_id
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "forge_formal_collection_v3_report.py"
+SPEC = importlib.util.spec_from_file_location("forge_formal_collection_v3_report", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+reporter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(reporter)
+
+
+def _manifest(*, slots: int = 1, token_limit: int = 1000) -> dict:
+    plan = [
+        {
+            "case_id": f"case-{index}",
+            "condition_id": "richlab-gpt-5.5",
+            "repetition": 1,
+        }
+        for index in range(slots)
+    ]
+    return {
+        "benchmark": {"id": "formal-test"},
+        "scope": {
+            "languages": ["C", "C++"],
+            "phase": "formal",
+            "formal_comparison_enabled": False,
+        },
+        "conditions": [{"id": "richlab-gpt-5.5"}],
+        "cases": [{"id": f"case-{index}"} for index in range(slots)],
+        "collection_plan": plan,
+        "authorization": {
+            "network_observation": {"access_medium": "mobile_hotspot"},
+            "budget_confirmation": {
+                "maximum_recorded_tokens": token_limit,
+                "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+            },
+            "collection_constraints": {
+                "authorized_slot_count": slots,
+                "remaining_slots_require_additional_confirmation": True,
+            },
+        },
+    }
+
+
+def _canary(root: Path, *, passed: bool = True) -> None:
+    path = root / "provider-canaries" / "provider_canary_test.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "document_type": "formal_provider_canary",
+                "manifest_sha256": "1" * 64,
+                "canary_id": "provider_canary_" + "a" * 32,
+                "completed_at": "2000-01-01T00:00:00+00:00",
+                "passed": passed,
+                "conditions": [
+                    {
+                        "id": "richlab-gpt-5.5",
+                        "model": "gpt-5.5",
+                        "duration_ms": 10,
+                        "passed": passed,
+                    }
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _ledger(root: Path, *, index: int = 0, tokens: int = 100) -> Path:
+    case_id = f"case-{index}"
+    path = root / case_id / "richlab-gpt-5.5" / "rep-001" / f"physical_attempt_{index:032d}.jsonl"
+    ledger = ExperimentLedger.create(
+        path,
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={
+            "policy": {
+                "case_id": case_id,
+                "condition": "richlab-gpt-5.5",
+                "repetition": 1,
+                "manifest_sha256": "1" * 64,
+                "model_name": "gpt-5.5",
+            },
+            "preflight_checks": {
+                "network_present": True,
+                "endpoint_reachable": True,
+            },
+        },
+    )
+    ledger.append(
+        "model.request_completed",
+        {
+            "actual_model": "gpt-5.5",
+            "token_usage": {
+                "input_tokens": tokens - 1,
+                "output_tokens": 1,
+                "total_tokens": tokens,
+            },
+        },
+    )
+    ledger.append("oracle.completed", {"passed": True, "classification": None})
+    ledger.append(
+        "orphan.reconciled",
+        {
+            "cleanup_succeeded": True,
+            "orphan_count": 0,
+            "removed_count": 0,
+            "scan_succeeded": True,
+        },
+    )
+    ledger.append(
+        "experiment.completed",
+        {
+            "gate_recomputation_valid": True,
+            "oracle_passed": True,
+            "orphan_cleanup_succeeded": True,
+            "session_finalization_succeeded": True,
+            "status": "passed",
+        },
+    )
+    return path
+
+
+def _build(root: Path, manifest: dict) -> dict:
+    return reporter.build_report(
+        manifest,
+        root,
+        gate_recomputer=lambda _events: {
+            "valid": True,
+            "failure_domains": {
+                "model_endpoint": None,
+                "agent_tool": None,
+                "build": None,
+                "submit_replay": None,
+                "completion": None,
+            },
+        },
+        oracle_runner=lambda _manifest, _events: {
+            "passed": True,
+            "classification": None,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stable_manifest_digest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reporter.protocol, "manifest_sha256", lambda _manifest: "1" * 64)
+
+
+def test_complete_authorized_prefix_builds_report(tmp_path: Path) -> None:
+    manifest = _manifest()
+    _canary(tmp_path)
+    _ledger(tmp_path)
+
+    report = _build(tmp_path, manifest)
+
+    assert report["collection"]["stop_reason"] == "authorized_batch_boundary_reached"
+    assert report["collection"]["analyzed_slots"] == 1
+    assert report["collection"]["recorded_total_tokens"] == 100
+    assert report["canary"]["successful_reports"] == 1
+
+
+def test_short_prefix_requires_recorded_token_boundary(tmp_path: Path) -> None:
+    manifest = _manifest(slots=2, token_limit=101)
+    _canary(tmp_path)
+    _ledger(tmp_path, tokens=100)
+
+    with pytest.raises(reporter.ReportError, match="short authorized prefix"):
+        _build(tmp_path, manifest)
+
+
+def test_short_prefix_at_token_boundary_is_valid(tmp_path: Path) -> None:
+    manifest = _manifest(slots=2, token_limit=100)
+    _canary(tmp_path)
+    _ledger(tmp_path, tokens=100)
+
+    report = _build(tmp_path, manifest)
+
+    assert report["collection"]["stop_reason"] == "recorded_token_boundary_reached"
+    assert report["interpretation"]["slots_8_to_10_not_created"] is True
+
+
+def test_non_contiguous_prefix_is_rejected(tmp_path: Path) -> None:
+    manifest = _manifest(slots=2, token_limit=100)
+    _canary(tmp_path)
+    _ledger(tmp_path, index=1, tokens=100)
+
+    with pytest.raises(reporter.ReportError, match="contiguous frozen schedule prefix"):
+        _build(tmp_path, manifest)
+
+
+def test_successful_canary_is_required(tmp_path: Path) -> None:
+    manifest = _manifest()
+    _canary(tmp_path, passed=False)
+    _ledger(tmp_path)
+
+    with pytest.raises(reporter.ReportError, match="successful dual-provider canary"):
+        _build(tmp_path, manifest)
+
+
+def test_committed_markdown_matches_machine_report() -> None:
+    json_path = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v3-initial-batch.json"
+    markdown_path = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v3-initial-batch.md"
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+
+    assert report["collection"]["analyzed_slots"] == 7
+    assert report["collection"]["oracle_passed"] == 4
+    assert report["collection"]["recorded_total_tokens"] == 1_700_577
+    assert report["collection"]["stop_reason"] == "recorded_token_boundary_reached"
+    assert markdown_path.read_text(encoding="utf-8") == reporter.render_markdown(report)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,23 @@
 # Forge C/C++ benchmark protocols
 
+## Formal v3 initial-batch descriptive audit
+
+Issue #99 adds a deterministic, read-only audit over the authorized formal v3
+schedule prefix. It requires the successful dual-provider canary to precede the
+first ledger, verifies every ledger hash chain and offline gate, rejects a
+non-contiguous or unauthorized slot, and proves that a short prefix stopped at
+the frozen recorded-token boundary:
+
+```bash
+/app/backend/.venv/bin/python /repo/scripts/forge_formal_collection_v3_report.py \
+  --evidence-dir /workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized
+```
+
+The generated JSON and Chinese Markdown reports contain only bounded aggregate
+evidence. They do not include credentials, model text, tool arguments, command
+output, or host-private paths. Generating the report does not authorize another
+slot, retry, replacement, or backfill.
+
 ## Authorized formal collection v3 initial batch
 
 Issue #95 authorizes only the first ten slots of

--- a/benchmarks/reports/cpp-formal-v3-initial-batch.json
+++ b/benchmarks/reports/cpp-formal-v3-initial-batch.json
@@ -1,0 +1,845 @@
+{
+  "attempts": [
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "gpt-5.5"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 250.26,
+      "case_id": "cppitertools",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 6,
+        "successful": 6,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 135.121,
+          "total": 135.121
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "2e8ecb9b984dc81630ad9ed118c70dabeb75dccdd39be452d34782bab9186511",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 9,
+        "completed": 9,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 43.416,
+        "started": 9
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 1,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_eb1d4146bdf048089bdad29d1b042a6a",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 39420,
+        "output_tokens": 1110,
+        "total_tokens": 40530
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "deepseek-v4-flash"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 149.418,
+      "case_id": "cppitertools",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 8,
+        "successful": 8,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 70.136,
+          "total": 70.136
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "2b3d962831597bf0c3d2676d8d24960a88721f13a7eded5175e1922cb0a57697",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 11,
+        "completed": 11,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 17.801,
+        "started": 11
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 2,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_2f404c8227ba48dfbc60c0de5955e5e8",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 60211,
+        "output_tokens": 1370,
+        "total_tokens": 61581
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "deepseek-v4-flash"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 178.666,
+      "case_id": "janet",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 6,
+        "successful": 5,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 105.091,
+          "total": 105.091
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "9e20b06aa46f7282c9fa4806ed94461f82851478e40680041fb193c4c50c660a",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 9,
+        "completed": 9,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 17.801,
+        "started": 9
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 3,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_4af5bab1b56e4366982003802b2434b7",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 55235,
+        "output_tokens": 1199,
+        "total_tokens": 56434
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "gpt-5.5"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 217.886,
+      "case_id": "janet",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 5,
+        "successful": 5,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 110.099,
+          "total": 110.099
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "7783c79b6a93afb4726367ea227418c3da930fd8b3d60fd855dfaf1609809445",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 8,
+        "completed": 8,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 55.25,
+        "started": 8
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 4,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_f039dab2d083489b92ad91567baaac3c",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 36318,
+        "output_tokens": 917,
+        "total_tokens": 37235
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "gpt-5.5"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 1037.118,
+      "case_id": "open62541",
+      "clean_replays": {
+        "completed": 4,
+        "failed": 4,
+        "passed": 0,
+        "reconciled": 1,
+        "started": 4
+      },
+      "commands": {
+        "completed": 12,
+        "successful": 11,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 900.818,
+          "total": 915.828
+        },
+        "failure_classifications": {
+          "compiler_wall_clock_timeout": 1
+        },
+        "invocations": 2,
+        "statuses": {
+          "completed": 1,
+          "timed_out": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 2
+      },
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "deliveries_succeeded": 0,
+      "failure_domains": {
+        "agent_tool": [
+          "compiler_wall_clock_timeout"
+        ],
+        "build": [],
+        "completion": [
+          "experiment_failed"
+        ],
+        "model_endpoint": [],
+        "submit_replay": [
+          "size_mismatch",
+          "size_mismatch",
+          "size_mismatch"
+        ]
+      },
+      "ledger_terminal_sha256": "ebc6cb16b07008a02b5cc735970f75f6be6105725ed37bb5f142abe0fcbe8941",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 19,
+        "completed": 19,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 126.962,
+        "started": 19
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": "oracle_mismatch",
+      "oracle_passed": false,
+      "order": 5,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_9601af7a07554f1c9c77d50d7067c911",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 1
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 1,
+        "completed": 3,
+        "started": 4
+      },
+      "terminal_status": "failed",
+      "token_usage": {
+        "input_tokens": 124633,
+        "output_tokens": 3386,
+        "total_tokens": 128019
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "deepseek-v4-flash"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 1387.455,
+      "case_id": "open62541",
+      "clean_replays": {
+        "completed": 4,
+        "failed": 4,
+        "passed": 0,
+        "reconciled": 0,
+        "started": 4
+      },
+      "commands": {
+        "completed": 45,
+        "successful": 42,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 780.724,
+          "total": 1201.239
+        },
+        "failure_classifications": {
+          "graph_recursion_limit": 1,
+          "post_build_reserve_exhausted": 1
+        },
+        "invocations": 4,
+        "statuses": {
+          "completed": 2,
+          "failed": 1,
+          "timed_out": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 4
+      },
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "deliveries_succeeded": 0,
+      "failure_domains": {
+        "agent_tool": [
+          "graph_recursion_limit",
+          "post_build_reserve_exhausted"
+        ],
+        "build": [],
+        "completion": [
+          "GraphRecursionError",
+          "experiment_failed"
+        ],
+        "model_endpoint": [],
+        "submit_replay": [
+          "size_mismatch",
+          "candidate_verification_failed",
+          "candidate_verification_failed",
+          "candidate_verification_failed",
+          "candidate_verification_failed",
+          "size_mismatch",
+          "size_mismatch",
+          "size_mismatch"
+        ]
+      },
+      "ledger_terminal_sha256": "cc0f4fbea4a1651c6df3b3c7447786250ff5764c858e57e037dd646527fa46f1",
+      "model_requests": {
+        "cancelled": 1,
+        "closed": 67,
+        "completed": 66,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 215.665,
+        "started": 67
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": "oracle_mismatch",
+      "oracle_passed": false,
+      "order": 6,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_9c66a7a06e894e9b92803641a12e3de9",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 1
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 1,
+        "completed": 8,
+        "started": 8
+      },
+      "terminal_status": "failed",
+      "token_usage": {
+        "input_tokens": 741218,
+        "output_tokens": 22830,
+        "total_tokens": 764048
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "deepseek-v4-flash"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 3240.758,
+      "case_id": "powerdns",
+      "clean_replays": {
+        "completed": 0,
+        "failed": 0,
+        "passed": 0,
+        "reconciled": 0,
+        "started": 0
+      },
+      "commands": {
+        "completed": 38,
+        "successful": 35,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 820.859,
+          "total": 1684.413
+        },
+        "failure_classifications": {
+          "post_build_reserve_exhausted": 2
+        },
+        "invocations": 4,
+        "statuses": {
+          "completed": 2,
+          "timed_out": 2
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 4
+      },
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "deliveries_succeeded": 0,
+      "failure_domains": {
+        "agent_tool": [
+          "post_build_reserve_exhausted",
+          "post_build_reserve_exhausted"
+        ],
+        "build": [],
+        "completion": [
+          "GraphRecursionError",
+          "experiment_failed"
+        ],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "f36392088e6061d65165a6bc6e0fc5476084d9c61b0143b0b6488f8d772c4422",
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 72,
+        "completed": 72,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 182.947,
+        "started": 72
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": true,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": "submit_missing",
+      "oracle_passed": false,
+      "order": 7,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_82ec086dfef74164801672d1742e32f4",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": false,
+        "mismatch_count": 0
+      },
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 0,
+        "started": 0
+      },
+      "terminal_status": "failed",
+      "token_usage": {
+        "input_tokens": 597147,
+        "output_tokens": 15583,
+        "total_tokens": 612730
+      }
+    }
+  ],
+  "authorization": {
+    "access_medium": "mobile_hotspot",
+    "authorized_slots": 10,
+    "budget_enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+    "maximum_recorded_tokens": 1633165,
+    "remaining_slots_require_confirmation": true
+  },
+  "benchmark_id": "forge-cpp-formal-v3-authorized-collection",
+  "canary": {
+    "conditions": [
+      {
+        "duration_ms": 4404,
+        "id": "richlab-gpt-5.5",
+        "model": "gpt-5.5",
+        "passed": true
+      },
+      {
+        "duration_ms": 1034,
+        "id": "deepseek-v4-flash",
+        "model": "deepseek-v4-flash",
+        "passed": true
+      }
+    ],
+    "failed_reports": 1,
+    "reports_discovered": 2,
+    "selected_canary_id": "provider_canary_8599bcf904ce4ccb8a6c113f19701ec4",
+    "selected_completed_at": "2026-08-11T07:58:36.955472+00:00",
+    "selected_report_sha256": "e9825db6d36e18f3bd833b74f455b3a1ca9f9e3247b4cf72c57b2041929d07ff",
+    "successful_reports": 1
+  },
+  "collection": {
+    "actual_model_matches": 7,
+    "analyzed_slots": 7,
+    "attempt_duration_seconds": 6461.561,
+    "authorized_slots": 10,
+    "compiler_subagent_invocations": 14,
+    "gate_recomputation_valid": 7,
+    "ledger_hash_chain_valid": 7,
+    "model_requests": {
+      "cancelled": 1,
+      "closed": 195,
+      "completed": 194,
+      "failed": 0,
+      "started": 195
+    },
+    "next_slot_index": 7,
+    "oracle_failed": 3,
+    "oracle_passed": 4,
+    "orphan_cleanup_succeeded": 7,
+    "orphan_count": 0,
+    "recorded_token_limit": 1633165,
+    "recorded_tokens_over_boundary": 67412,
+    "recorded_total_tokens": 1700577,
+    "session_finalization_succeeded": 7,
+    "stop_reason": "recorded_token_boundary_reached",
+    "terminal_completed": 7
+  },
+  "conditions": [
+    {
+      "attempt_duration_seconds": {
+        "maximum": 1037.118,
+        "median": 250.26,
+        "minimum": 217.886,
+        "total": 1505.264
+      },
+      "attempts": 3,
+      "clean_replays": {
+        "completed": 6,
+        "failed": 4,
+        "passed": 2
+      },
+      "commands_completed": 23,
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "failure_event_counts": {
+        "agent_tool:compiler_wall_clock_timeout": 1,
+        "completion:experiment_failed": 1,
+        "submit_replay:size_mismatch": 3
+      },
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 36,
+        "completed": 36,
+        "failed": 0,
+        "started": 36
+      },
+      "oracle_failed": 1,
+      "oracle_passed": 2,
+      "submits_completed": 5,
+      "token_usage": {
+        "input_tokens": 200371,
+        "output_tokens": 5413,
+        "total_tokens": 205784
+      }
+    },
+    {
+      "attempt_duration_seconds": {
+        "maximum": 3240.758,
+        "median": 783.06,
+        "minimum": 149.418,
+        "total": 4956.297
+      },
+      "attempts": 4,
+      "clean_replays": {
+        "completed": 6,
+        "failed": 4,
+        "passed": 2
+      },
+      "commands_completed": 97,
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "failure_event_counts": {
+        "agent_tool:graph_recursion_limit": 1,
+        "agent_tool:post_build_reserve_exhausted": 3,
+        "completion:GraphRecursionError": 2,
+        "completion:experiment_failed": 2,
+        "submit_replay:candidate_verification_failed": 4,
+        "submit_replay:size_mismatch": 4
+      },
+      "model_requests": {
+        "cancelled": 1,
+        "closed": 159,
+        "completed": 158,
+        "failed": 0,
+        "started": 159
+      },
+      "oracle_failed": 2,
+      "oracle_passed": 2,
+      "submits_completed": 10,
+      "token_usage": {
+        "input_tokens": 1453811,
+        "output_tokens": 40982,
+        "total_tokens": 1494793
+      }
+    }
+  ],
+  "failure_event_counts": {
+    "agent_tool:compiler_wall_clock_timeout": 1,
+    "agent_tool:graph_recursion_limit": 1,
+    "agent_tool:post_build_reserve_exhausted": 3,
+    "completion:GraphRecursionError": 2,
+    "completion:experiment_failed": 3,
+    "submit_replay:candidate_verification_failed": 4,
+    "submit_replay:size_mismatch": 7
+  },
+  "interpretation": {
+    "attempt_level_wall_clock_budget_present": false,
+    "compiler_wall_clock_budget_is_per_invocation": true,
+    "historical_ledgers_modified": false,
+    "provider_timeout_observed": false,
+    "retry_replacement_backfill_performed": false,
+    "slots_8_to_10_not_created": true,
+    "valid_outcome_denominator": 7
+  },
+  "limitations": [
+    "The recorded-token boundary stopped collection after seven of ten authorized slots, so provider and case counts are unbalanced.",
+    "Seven one-repetition slots cannot support a population-level model ranking or significance claim.",
+    "The 900-second compiler wall-clock budget applies per compiler invocation, not to the whole physical attempt.",
+    "The mobile-hotspot label records access medium but does not identify the cause of historical endpoint timeouts."
+  ],
+  "manifest_sha256": "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5",
+  "report_version": "formal-v3-initial-batch-report-1.0.0",
+  "scope": {
+    "descriptive_only": true,
+    "formal_comparison_enabled": true,
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v3"
+  }
+}

--- a/benchmarks/reports/cpp-formal-v3-initial-batch.md
+++ b/benchmarks/reports/cpp-formal-v3-initial-batch.md
@@ -1,0 +1,52 @@
+# Forge C/C++ formal v3 首批描述性审计报告
+
+> 状态：预算边界停止后的冻结描述性复核；不是模型总体排名。
+
+## 摘要
+
+- 首批完成 7/10 个授权 slot，停止原因为 `recorded_token_boundary_reached`；slot 8-10 未创建。
+- Oracle 通过 4/7；ledger hash chain、离线 gate、Session finalization 与 cleanup 均为 7/7，orphan=0。
+- 记录 1,700,577 tokens；边界 1,633,165，完成中的 slot 使最终值越界 67,412，随后未创建下一槽。
+- 双 provider canary 选用 `provider_canary_8599bcf904ce4ccb8a6c113f19701ec4`；正式批次请求闭合 195/195，其中完成 194、失败 0、取消 1。
+
+## Condition 汇总
+
+| Condition | Oracle | Attempts | Requests closed/started/failed/cancelled | Tokens | Compiler calls | Wall time (s) |
+|---|---:|---:|---:|---:|---:|---:|
+| `richlab-gpt-5.5` | 2/3 | 3 | 36/36/0/0 | 205,784 | 4 | 1505.264 |
+| `deepseek-v4-flash` | 2/4 | 4 | 159/159/0/1 | 1,494,793 | 10 | 4956.297 |
+
+## 每个 slot
+
+| # | Case | Condition | Oracle | Tokens | Wall time (s) | Compiler calls | Submit | Replay | Failures |
+|---:|---|---|---:|---:|---:|---:|---:|---:|---|
+| 1 | `cppitertools` | `richlab-gpt-5.5` | pass | 40,530 | 250.260 | 1 | 1 | 1/1 | - |
+| 2 | `cppitertools` | `deepseek-v4-flash` | pass | 61,581 | 149.418 | 1 | 1 | 1/1 | - |
+| 3 | `janet` | `deepseek-v4-flash` | pass | 56,434 | 178.666 | 1 | 1 | 1/1 | - |
+| 4 | `janet` | `richlab-gpt-5.5` | pass | 37,235 | 217.886 | 1 | 1 | 1/1 | - |
+| 5 | `open62541` | `richlab-gpt-5.5` | fail | 128,019 | 1037.118 | 2 | 3 | 0/4 | agent_tool:compiler_wall_clock_timeout<br>submit_replay:size_mismatch<br>submit_replay:size_mismatch<br>submit_replay:size_mismatch<br>completion:experiment_failed |
+| 6 | `open62541` | `deepseek-v4-flash` | fail | 764,048 | 1387.455 | 4 | 8 | 0/4 | agent_tool:graph_recursion_limit<br>agent_tool:post_build_reserve_exhausted<br>submit_replay:size_mismatch<br>submit_replay:candidate_verification_failed<br>submit_replay:candidate_verification_failed<br>submit_replay:candidate_verification_failed<br>submit_replay:candidate_verification_failed<br>submit_replay:size_mismatch<br>submit_replay:size_mismatch<br>submit_replay:size_mismatch<br>completion:GraphRecursionError<br>completion:experiment_failed |
+| 7 | `powerdns` | `deepseek-v4-flash` | fail | 612,730 | 3240.758 | 4 | 0 | 0/0 | agent_tool:post_build_reserve_exhausted<br>agent_tool:post_build_reserve_exhausted<br>completion:GraphRecursionError<br>completion:experiment_failed |
+
+## 有效性与预算解释
+
+- 7 个 ledger 均为冻结 schedule 的连续前缀；没有 retry、replacement 或 backfill。
+- Token 边界在创建下一槽前检查，不会中途截断已经创建的 physical attempt。
+- 当前 900 秒 wall-clock 是每次 Compiler 调用的预算。同一 physical attempt 可由 Lead 多次调用 Compiler，因此 attempt 总时长可以超过 900 秒。
+- 下一协议应预注册独立的 physical-attempt 总时限；该建议不改变 v3 结果，也不授权补跑 slot 8-10。
+- 手机热点是已记录的接入分类，不足以把历史 endpoint timeout 归因于热点、WSL、路由或 provider 中任一层。
+
+## 研究边界
+
+- 当前有效分母为实际创建并终结的 7 个 slot，不是计划中的 10，也不是完整 180 槽。
+- Condition 样本不平衡且每个 case 仅一次，不能做显著性检验或总体模型排名。
+- 剩余 170 槽仍需实验所有者再次确认；slot 8-10 也不能在当前 token 授权下继续创建。
+
+## 复算
+
+```bash
+/app/backend/.venv/bin/python /repo/scripts/forge_formal_collection_v3_report.py \
+  --evidence-dir /workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized
+```
+
+JSON 是机器可读来源；Markdown 由同一分析器确定性生成。

--- a/scripts/forge_formal_collection_v3_report.py
+++ b/scripts/forge_formal_collection_v3_report.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Build a deterministic descriptive report for the authorized formal v3 prefix."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(
+    os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])
+).resolve()
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+SCRIPT_ROOT = Path(__file__).resolve().parent
+for import_root in (str(HARNESS_ROOT), str(SCRIPT_ROOT)):
+    if import_root not in sys.path:
+        sys.path.insert(0, import_root)
+
+import forge_benchmark_v8_report as common  # noqa: E402
+import forge_formal_collection_v3_authorized_protocol as protocol  # noqa: E402
+import forge_formal_collection_v3_authorized_runner as runner  # noqa: E402
+
+from deerflow.compile.evidence import EvidenceError, ExperimentLedger  # noqa: E402
+
+REPORT_VERSION = "formal-v3-initial-batch-report-1.0.0"
+DEFAULT_MANIFEST = (
+    REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
+)
+DEFAULT_EVIDENCE_DIR = Path(
+    "/workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized"
+)
+DEFAULT_JSON_REPORT = (
+    REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v3-initial-batch.json"
+)
+DEFAULT_MARKDOWN_REPORT = (
+    REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v3-initial-batch.md"
+)
+
+
+class ReportError(ValueError):
+    """Raised when evidence cannot support the formal v3 report."""
+
+
+def _slot_key(item: dict[str, Any]) -> tuple[str, str, int]:
+    return item["case_id"], item["condition_id"], item["repetition"]
+
+
+def _ledger_slot(events: list[dict[str, Any]]) -> tuple[str, str, int]:
+    started = [
+        event["payload"] for event in events if event["event"] == "experiment.started"
+    ]
+    if len(started) != 1 or not isinstance(started[0].get("policy"), dict):
+        raise ReportError("A formal ledger must contain one experiment.started policy")
+    policy = started[0]["policy"]
+    try:
+        return policy["case_id"], policy["condition"], policy["repetition"]
+    except KeyError as exc:
+        raise ReportError(f"Formal ledger policy is missing {exc.args[0]}") from exc
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_canary_reports(
+    evidence_dir: Path,
+    *,
+    manifest_sha256: str,
+    condition_ids: set[str],
+    first_ledger_time: str,
+) -> dict[str, Any]:
+    reports: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(
+        (evidence_dir / "provider-canaries").glob("provider_canary_*.json")
+    ):
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReportError(f"Invalid provider canary report: {path.name}") from exc
+        if document.get("document_type") != "formal_provider_canary":
+            raise ReportError(
+                f"Unexpected document in provider canary directory: {path.name}"
+            )
+        if document.get("manifest_sha256") != manifest_sha256:
+            raise ReportError(
+                "Provider canary manifest identity does not match formal v3"
+            )
+        reports.append((path, document))
+
+    successful = [(path, item) for path, item in reports if item.get("passed") is True]
+    if not successful:
+        raise ReportError("A successful dual-provider canary is required")
+    path, selected = successful[-1]
+    conditions = selected.get("conditions")
+    if (
+        not isinstance(conditions, list)
+        or {item.get("id") for item in conditions if isinstance(item, dict)}
+        != condition_ids
+    ):
+        raise ReportError(
+            "Successful canary does not cover the frozen provider conditions"
+        )
+    if any(item.get("passed") is not True for item in conditions):
+        raise ReportError("Successful canary contains a failed provider condition")
+    if common._parse_time(selected.get("completed_at")) >= common._parse_time(
+        first_ledger_time
+    ):
+        raise ReportError(
+            "Successful provider canary must precede the first formal ledger"
+        )
+
+    return {
+        "reports_discovered": len(reports),
+        "successful_reports": len(successful),
+        "failed_reports": len(reports) - len(successful),
+        "selected_canary_id": selected.get("canary_id"),
+        "selected_report_sha256": _sha256(path),
+        "selected_completed_at": selected.get("completed_at"),
+        "conditions": [
+            {
+                "id": item.get("id"),
+                "model": item.get("model"),
+                "duration_ms": item.get("duration_ms"),
+                "passed": item.get("passed"),
+            }
+            for item in conditions
+        ],
+    }
+
+
+def _compiler_subagent_metrics(events: list[dict[str, Any]]) -> dict[str, Any]:
+    payloads = [
+        event["payload"]
+        for event in events
+        if event["event"] == "agent.subagent_terminated"
+        and event["payload"].get("role") == "compiler"
+    ]
+    statuses = Counter(payload.get("status", "unknown") for payload in payloads)
+    classifications = Counter(
+        payload["classification"]
+        for payload in payloads
+        if isinstance(payload.get("classification"), str)
+    )
+    elapsed = [
+        payload["budget_snapshot"]["elapsed_seconds"]
+        for payload in payloads
+        if isinstance(payload.get("budget_snapshot"), dict)
+        and isinstance(payload["budget_snapshot"].get("elapsed_seconds"), (int, float))
+    ]
+    limits = sorted(
+        {
+            payload["budget_snapshot"]["wall_clock_limit_seconds"]
+            for payload in payloads
+            if isinstance(payload.get("budget_snapshot"), dict)
+            and isinstance(
+                payload["budget_snapshot"].get("wall_clock_limit_seconds"),
+                (int, float),
+            )
+        }
+    )
+    return {
+        "invocations": len(payloads),
+        "statuses": dict(sorted(statuses.items())),
+        "failure_classifications": dict(sorted(classifications.items())),
+        "worker_stopped": sum(
+            payload.get("worker_stopped") is True for payload in payloads
+        ),
+        "elapsed_seconds": {
+            "total": round(sum(elapsed), 3),
+            "maximum": round(max(elapsed), 3) if elapsed else 0,
+        },
+        "wall_clock_limits_seconds": limits,
+    }
+
+
+def _discover_ledgers(
+    evidence_dir: Path,
+    *,
+    ledger_verifier: Callable[[Path], list[dict[str, Any]]],
+) -> dict[tuple[str, str, int], tuple[Path, list[dict[str, Any]]]]:
+    discovered: dict[tuple[str, str, int], tuple[Path, list[dict[str, Any]]]] = {}
+    for path in sorted(evidence_dir.glob("*/*/rep-*/physical_attempt_*.jsonl")):
+        events = ledger_verifier(path)
+        slot = _ledger_slot(events)
+        if slot in discovered:
+            raise ReportError(f"Formal slot {slot} has multiple ledgers")
+        relative = path.relative_to(evidence_dir)
+        try:
+            path_slot = (
+                relative.parts[0],
+                relative.parts[1],
+                int(relative.parts[2].removeprefix("rep-")),
+            )
+        except (IndexError, ValueError) as exc:
+            raise ReportError(f"Invalid formal ledger path: {relative}") from exc
+        if path_slot != slot:
+            raise ReportError("Formal ledger path does not match its recorded policy")
+        discovered[slot] = path, events
+    return discovered
+
+
+def build_report(
+    manifest: dict[str, Any],
+    evidence_dir: Path,
+    *,
+    ledger_verifier: Callable[
+        [Path], list[dict[str, Any]]
+    ] = ExperimentLedger.verify_path,
+    gate_recomputer: Callable[
+        [list[dict[str, Any]]], dict[str, Any]
+    ] = runner.recompute_gates,
+    oracle_runner: Callable[
+        [dict[str, Any], list[dict[str, Any]]], dict[str, Any]
+    ] = runner.run_oracle,
+) -> dict[str, Any]:
+    authorization = manifest["authorization"]
+    constraints = authorization["collection_constraints"]
+    budget = authorization["budget_confirmation"]
+    authorized_count = int(constraints["authorized_slot_count"])
+    authorized_plan = manifest["collection_plan"][:authorized_count]
+    expected_slots = [_slot_key(slot) for slot in authorized_plan]
+    if len(expected_slots) != len(set(expected_slots)):
+        raise ReportError("Authorized formal v3 prefix contains duplicate slots")
+
+    discovered = _discover_ledgers(
+        evidence_dir,
+        ledger_verifier=ledger_verifier,
+    )
+    if not discovered:
+        raise ReportError("No formal v3 ledgers were discovered")
+    if any(slot not in set(expected_slots) for slot in discovered):
+        raise ReportError(
+            "Evidence contains a slot outside the authorized formal prefix"
+        )
+    observed_count = len(discovered)
+    if set(discovered) != set(expected_slots[:observed_count]):
+        raise ReportError("Formal evidence is not a contiguous frozen schedule prefix")
+
+    manifest_sha256 = protocol.manifest_sha256(manifest)
+    attempts: list[dict[str, Any]] = []
+    first_ledger_time: str | None = None
+    for order, slot in enumerate(expected_slots[:observed_count], start=1):
+        path, events = discovered[slot]
+        if not events or events[-1]["event"] != "experiment.completed":
+            raise ReportError("Every observed formal ledger must be terminal")
+        first_ledger_time = first_ledger_time or events[0]["occurred_at"]
+        metrics = common.extract_attempt_metrics(
+            events,
+            order=order,
+            expected_slot=slot,
+            expected_manifest_sha256=manifest_sha256,
+            gates=gate_recomputer(events),
+            oracle=oracle_runner(manifest, events),
+        )
+        cancelled_requests = sum(
+            event["event"] == "model.request_cancelled" for event in events
+        )
+        metrics["model_requests"].update(
+            {
+                "cancelled": cancelled_requests,
+                "closed": (
+                    metrics["model_requests"]["completed"]
+                    + metrics["model_requests"]["failed"]
+                    + cancelled_requests
+                ),
+            }
+        )
+        metrics.update(
+            {
+                "physical_attempt_id": events[0]["physical_attempt_id"],
+                "ledger_terminal_sha256": events[-1]["event_sha256"],
+                "compiler_subagents": _compiler_subagent_metrics(events),
+            }
+        )
+        attempts.append(metrics)
+
+    recorded_tokens = sum(
+        attempt["token_usage"]["total_tokens"] for attempt in attempts
+    )
+    token_limit = int(budget["maximum_recorded_tokens"])
+    if recorded_tokens >= token_limit:
+        stop_reason = "recorded_token_boundary_reached"
+    elif observed_count == authorized_count:
+        stop_reason = "authorized_batch_boundary_reached"
+    else:
+        raise ReportError(
+            "A short authorized prefix must reach the recorded-token boundary"
+        )
+
+    canary = _load_canary_reports(
+        evidence_dir,
+        manifest_sha256=manifest_sha256,
+        condition_ids={condition["id"] for condition in manifest["conditions"]},
+        first_ledger_time=first_ledger_time,
+    )
+    condition_order = [condition["id"] for condition in manifest["conditions"]]
+    conditions = [
+        common._condition_summary(
+            condition_id,
+            [
+                attempt
+                for attempt in attempts
+                if attempt["condition_id"] == condition_id
+            ],
+        )
+        for condition_id in condition_order
+        if any(attempt["condition_id"] == condition_id for attempt in attempts)
+    ]
+    for condition in conditions:
+        condition_attempts = [
+            attempt
+            for attempt in attempts
+            if attempt["condition_id"] == condition["condition_id"]
+        ]
+        condition["model_requests"].update(
+            {
+                "cancelled": sum(
+                    attempt["model_requests"]["cancelled"]
+                    for attempt in condition_attempts
+                ),
+                "closed": sum(
+                    attempt["model_requests"]["closed"]
+                    for attempt in condition_attempts
+                ),
+            }
+        )
+    failure_events: Counter[str] = Counter()
+    for attempt in attempts:
+        for domain, classifications in attempt["failure_domains"].items():
+            for classification in classifications:
+                failure_events[f"{domain}:{classification}"] += 1
+
+    return {
+        "report_version": REPORT_VERSION,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": manifest_sha256,
+        "scope": {
+            "languages": manifest["scope"]["languages"],
+            "phase": manifest["scope"]["phase"],
+            "formal_comparison_enabled": manifest["scope"]["formal_comparison_enabled"],
+            "descriptive_only": True,
+        },
+        "authorization": {
+            "authorized_slots": authorized_count,
+            "remaining_slots_require_confirmation": constraints[
+                "remaining_slots_require_additional_confirmation"
+            ],
+            "maximum_recorded_tokens": token_limit,
+            "budget_enforcement": budget["enforcement"],
+            "access_medium": authorization["network_observation"]["access_medium"],
+        },
+        "canary": canary,
+        "collection": {
+            "authorized_slots": authorized_count,
+            "analyzed_slots": observed_count,
+            "next_slot_index": observed_count,
+            "stop_reason": stop_reason,
+            "recorded_total_tokens": recorded_tokens,
+            "recorded_token_limit": token_limit,
+            "recorded_tokens_over_boundary": max(0, recorded_tokens - token_limit),
+            "ledger_hash_chain_valid": observed_count,
+            "gate_recomputation_valid": observed_count,
+            "actual_model_matches": sum(
+                attempt["actual_model_match"] is True for attempt in attempts
+            ),
+            "terminal_completed": sum(
+                attempt["terminal_status"] in {"passed", "failed"}
+                for attempt in attempts
+            ),
+            "oracle_passed": sum(attempt["oracle_passed"] for attempt in attempts),
+            "oracle_failed": sum(not attempt["oracle_passed"] for attempt in attempts),
+            "session_finalization_succeeded": sum(
+                attempt["session_finalization_succeeded"] is True
+                for attempt in attempts
+            ),
+            "orphan_cleanup_succeeded": sum(
+                attempt["orphan_cleanup_succeeded"] is True for attempt in attempts
+            ),
+            "orphan_count": sum(attempt["orphan_count"] or 0 for attempt in attempts),
+            "model_requests": {
+                key: sum(attempt["model_requests"][key] for attempt in attempts)
+                for key in ("started", "completed", "failed", "cancelled", "closed")
+            },
+            "compiler_subagent_invocations": sum(
+                attempt["compiler_subagents"]["invocations"] for attempt in attempts
+            ),
+            "attempt_duration_seconds": round(
+                sum(attempt["attempt_duration_seconds"] for attempt in attempts), 3
+            ),
+        },
+        "failure_event_counts": dict(sorted(failure_events.items())),
+        "conditions": conditions,
+        "attempts": attempts,
+        "interpretation": {
+            "valid_outcome_denominator": observed_count,
+            "slots_8_to_10_not_created": observed_count < authorized_count,
+            "provider_timeout_observed": any(
+                attempt["model_requests"]["failed"] > 0 for attempt in attempts
+            ),
+            "attempt_level_wall_clock_budget_present": False,
+            "compiler_wall_clock_budget_is_per_invocation": True,
+            "historical_ledgers_modified": False,
+            "retry_replacement_backfill_performed": False,
+        },
+        "limitations": [
+            "The recorded-token boundary stopped collection after seven of ten authorized slots, so provider and case counts are unbalanced.",
+            "Seven one-repetition slots cannot support a population-level model ranking or significance claim.",
+            "The 900-second compiler wall-clock budget applies per compiler invocation, not to the whole physical attempt.",
+            "The mobile-hotspot label records access medium but does not identify the cause of historical endpoint timeouts.",
+        ],
+    }
+
+
+def _format_failures(attempt: dict[str, Any]) -> str:
+    domains = [
+        *common.FAILURE_DOMAIN_ORDER,
+        *sorted(set(attempt["failure_domains"]) - set(common.FAILURE_DOMAIN_ORDER)),
+    ]
+    values = [
+        f"{domain}:{classification}"
+        for domain in domains
+        for classification in attempt["failure_domains"].get(domain, [])
+    ]
+    return "<br>".join(values) if values else "-"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    collection = report["collection"]
+    lines = [
+        "# Forge C/C++ formal v3 首批描述性审计报告",
+        "",
+        "> 状态：预算边界停止后的冻结描述性复核；不是模型总体排名。",
+        "",
+        "## 摘要",
+        "",
+        f"- 首批完成 {collection['analyzed_slots']}/{collection['authorized_slots']} 个授权 slot，"
+        f"停止原因为 `{collection['stop_reason']}`；slot 8-10 未创建。",
+        f"- Oracle 通过 {collection['oracle_passed']}/{collection['analyzed_slots']}；"
+        f"ledger hash chain、离线 gate、Session finalization 与 cleanup 均为 "
+        f"{collection['analyzed_slots']}/{collection['analyzed_slots']}，orphan={collection['orphan_count']}。",
+        f"- 记录 {collection['recorded_total_tokens']:,} tokens；边界 "
+        f"{collection['recorded_token_limit']:,}，完成中的 slot 使最终值越界 "
+        f"{collection['recorded_tokens_over_boundary']:,}，随后未创建下一槽。",
+        f"- 双 provider canary 选用 `{report['canary']['selected_canary_id']}`；"
+        f"正式批次请求闭合 {collection['model_requests']['closed']}/"
+        f"{collection['model_requests']['started']}，其中完成 "
+        f"{collection['model_requests']['completed']}、失败 "
+        f"{collection['model_requests']['failed']}、取消 "
+        f"{collection['model_requests']['cancelled']}。",
+        "",
+        "## Condition 汇总",
+        "",
+        "| Condition | Oracle | Attempts | Requests closed/started/failed/cancelled | Tokens | Compiler calls | Wall time (s) |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for condition in report["conditions"]:
+        compiler_calls = sum(
+            attempt["compiler_subagents"]["invocations"]
+            for attempt in report["attempts"]
+            if attempt["condition_id"] == condition["condition_id"]
+        )
+        requests = condition["model_requests"]
+        lines.append(
+            f"| `{condition['condition_id']}` | {condition['oracle_passed']}/{condition['attempts']} | "
+            f"{condition['attempts']} | {requests['closed']}/{requests['started']}/"
+            f"{requests['failed']}/{requests['cancelled']} | "
+            f"{condition['token_usage']['total_tokens']:,} | "
+            f"{compiler_calls} | {condition['attempt_duration_seconds']['total']:.3f} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## 每个 slot",
+            "",
+            "| # | Case | Condition | Oracle | Tokens | Wall time (s) | Compiler calls | Submit | Replay | Failures |",
+            "|---:|---|---|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for attempt in report["attempts"]:
+        lines.append(
+            f"| {attempt['order']} | `{attempt['case_id']}` | `{attempt['condition_id']}` | "
+            f"{'pass' if attempt['oracle_passed'] else 'fail'} | "
+            f"{attempt['token_usage']['total_tokens']:,} | {attempt['attempt_duration_seconds']:.3f} | "
+            f"{attempt['compiler_subagents']['invocations']} | {attempt['submits']['completed']} | "
+            f"{attempt['clean_replays']['passed']}/{attempt['clean_replays']['completed']} | "
+            f"{_format_failures(attempt)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## 有效性与预算解释",
+            "",
+            "- 7 个 ledger 均为冻结 schedule 的连续前缀；没有 retry、replacement 或 backfill。",
+            "- Token 边界在创建下一槽前检查，不会中途截断已经创建的 physical attempt。",
+            "- 当前 900 秒 wall-clock 是每次 Compiler 调用的预算。同一 physical attempt 可由 Lead 多次调用 Compiler，因此 attempt 总时长可以超过 900 秒。",
+            "- 下一协议应预注册独立的 physical-attempt 总时限；该建议不改变 v3 结果，也不授权补跑 slot 8-10。",
+            "- 手机热点是已记录的接入分类，不足以把历史 endpoint timeout 归因于热点、WSL、路由或 provider 中任一层。",
+            "",
+            "## 研究边界",
+            "",
+            "- 当前有效分母为实际创建并终结的 7 个 slot，不是计划中的 10，也不是完整 180 槽。",
+            "- Condition 样本不平衡且每个 case 仅一次，不能做显著性检验或总体模型排名。",
+            "- 剩余 170 槽仍需实验所有者再次确认；slot 8-10 也不能在当前 token 授权下继续创建。",
+            "",
+            "## 复算",
+            "",
+            "```bash",
+            "/app/backend/.venv/bin/python /repo/scripts/forge_formal_collection_v3_report.py \\",
+            "  --evidence-dir /workspace/.compile-sessions/benchmark-evidence-formal-v3-authorized",
+            "```",
+            "",
+            "JSON 是机器可读来源；Markdown 由同一分析器确定性生成。",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"Unable to load manifest: {path}") from exc
+    protocol.validate_manifest(document)
+    return document
+
+
+def write_reports(
+    report: dict[str, Any],
+    *,
+    json_path: Path,
+    markdown_path: Path,
+) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument("--json-output", type=Path, default=DEFAULT_JSON_REPORT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_REPORT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = build_report(load_manifest(args.manifest), args.evidence_dir)
+        write_reports(
+            report,
+            json_path=args.json_output,
+            markdown_path=args.markdown_output,
+        )
+    except (EvidenceError, ReportError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report["collection"], ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 formal v3 首批只读描述性审计器，验证 successful canary、授权 schedule 连续前缀、ledger hash chain、离线 gate、oracle 与 token-boundary 停止语义。
- 生成机器可读 JSON 与中文 Markdown 报告，冻结 7/10 槽、4/7 oracle pass、1,700,577 tokens、195/195 请求闭合、14 次 Compiler 调用和 0 orphan。
- 明确 900 秒为每次 Compiler 调用预算；physical attempt 总时限是下一协议设计项，不回写 v3，也不补跑 slot 8-10。
- 添加聚焦测试与 README 复算入口。

## 验证

- `28 passed`
- Ruff check 通过
- `py_compile` 通过
- 7/7 真实 ledger 独立 `verify-ledger` 通过
- 敏感信息与宿主路径扫描通过

Closes #99