### PR TITLE
研究：冻结 formal v4 attempt 预算与宿主资源门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -271,6 +271,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 后端 CI 从 `backend/` 运行 `uvx ruff` 并加载 `backend/ruff.toml`（当前行宽 240）。对 `backend/tests/` 显式传 `backend/pyproject.toml` 会使用不同格式规则，可能出现本地 format check 通过但 CI 要求反向格式化；本地复核必须使用 `backend/ruff.toml` 或从 `backend/` 工作目录运行与 CI 相同的命令。
 - 修改 `.env` 后仅 `docker compose restart` 不会重新加载环境，必须 recreate Gateway/LangGraph。直接调用开发 Compose 还必须显式提供 `DEER_FLOW_ROOT`；否则在配置插值阶段退出。优先使用 `scripts/docker.sh`，定向 recreate 时传完整 WSL 绝对路径，避免 PowerShell 提前展开 `$repo`。
 - formal canary 的 endpoint preflight 失败发生在模型调用和报告创建之前；真实 provider 请求超时则会留下不可变 canary 报告。恢复前必须分别核对 report 数、formal JSONL 数和 orphan 数，不能把“没有报告”误写成模型失败。
 - 单次成功或超时不能证明某个 RichLab 模型稳定可用。本次同一路径中 `gpt-5.5` 可在 3.8–5.4 秒完成原始文本/工具请求，也可在 LangChain canary 中 121 秒超时；`gpt-5.4` 同样出现一次 120 秒文本超时后 3 秒工具成功。保持模型身份冻结并按请求级 endpoint failure 记录。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -9,7 +9,7 @@
 <!-- 倒序，最新在上。 -->
 
 - 2026-08-11 — 冻结未授权 formal v4 attempt 级预算与宿主资源门禁
-  - GitHub: Issue #103 记录 formal v3 长尾根因、v4 设计目标和禁止模型采集边界；候选协议 canonical SHA-256 为 `bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720`。
+  - GitHub: Issue #103 / PR #104 记录 formal v3 长尾根因、v4 设计目标和禁止模型采集边界；候选协议 canonical SHA-256 为 `bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720`。
   - 协议: v4 保持 C/C++、180-slot schedule、双 provider、Compose/DooD、Compile Session、clean replay 与 artifact oracle 不变，并重新锁定 `collection_authorized=false`；v1-v3 manifest、Schema、runner、报告和历史 evidence 未修改。
   - 预算: 每个 physical attempt 总墙钟 1,800 秒，其中 120 秒保留给收口；最多 2 次 Compiler 调用和 48 次模型请求。provider、Compiler 与 submit/replay 在达到工作/调用边界后硬拒绝新工作，finalize/cleanup 即使超限仍必须执行并记录 overrun。
   - 资源: 新 attempt 前要求 WSL2 Linux 可见 `MemAvailable >= 2 GiB`，`docker info` 在 10 秒内成功且 daemon 延迟不高于 5 秒；preflight 不记录 IP、SSID、代理、凭据、server version 或其他宿主标识。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,15 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-11 — 冻结未授权 formal v4 attempt 级预算与宿主资源门禁
+  - GitHub: Issue #103 记录 formal v3 长尾根因、v4 设计目标和禁止模型采集边界；候选协议 canonical SHA-256 为 `bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720`。
+  - 协议: v4 保持 C/C++、180-slot schedule、双 provider、Compose/DooD、Compile Session、clean replay 与 artifact oracle 不变，并重新锁定 `collection_authorized=false`；v1-v3 manifest、Schema、runner、报告和历史 evidence 未修改。
+  - 预算: 每个 physical attempt 总墙钟 1,800 秒，其中 120 秒保留给收口；最多 2 次 Compiler 调用和 48 次模型请求。provider、Compiler 与 submit/replay 在达到工作/调用边界后硬拒绝新工作，finalize/cleanup 即使超限仍必须执行并记录 overrun。
+  - 资源: 新 attempt 前要求 WSL2 Linux 可见 `MemAvailable >= 2 GiB`，`docker info` 在 10 秒内成功且 daemon 延迟不高于 5 秒；preflight 不记录 IP、SSID、代理、凭据、server version 或其他宿主标识。
+  - 分析: v3 的 7 个 slot 保留为独立描述性 protocol stratum，不与 v4 primary estimand 池化；v4 primary 只纳入同协议完整 project block，不完整 block 从 paired primary estimate 排除但保留在端到端描述性失败分母。
+  - 文件: `scripts/forge_formal_collection_v4_protocol.py`, `scripts/forge_formal_collection_v4_runner.py`, `benchmarks/manifests/cpp-formal-v4-collection.json`, `benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json`, `benchmarks/preregistrations/cpp-formal-v4-amendment.md`, `backend/tests/test_forge_formal_collection_v4_protocol.py`, `benchmarks/README.md`
+  - 验证: 聚焦 v4 `18 passed`，v3/v4 扩大回归 `54 passed`；真实 Compose/DooD 非模型 preflight 11/11 checks 通过，可用内存约 5.64 GB、daemon 响应约 0.032 秒；真实 `provider-canary` 入口以退出码 2 拒绝且 0 evidence 文件。Ruff、格式、Schema、确定性再生成、`py_compile`、diff 和敏感信息扫描通过。
+
 - 2026-08-11 — 审计 formal v3 首批预算边界结果并停止后续 slot
   - GitHub: Issue #97 的双 provider canary 阻塞已在成功 canary 后解除并关闭；Issue #99 / PR #100 已完成描述性报告并 squash 合并为 `main@3ee28e8d`，三项 CI 全绿。
   - 采集: authorized preflight 为 `ready=true`，RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` canary 分别约 4.404 秒和 1.034 秒通过；7/10 个授权 slot 执行后以 `recorded_token_boundary_reached` 停止，slot 8-10 未创建。
@@ -253,7 +262,7 @@
 ## 待办 (TODOs)
 <!-- 发现但未做的事。带 file:line 指针。 -->
 
-- 基于 `scripts/forge_formal_collection_v3_authorized_runner.py:309` 设计下一版协议：增加 physical-attempt 总墙钟、总模型请求或 Compiler 调用上限，以及宿主内存、WSL/Docker daemon 响应资源门禁；同时预注册 token 停止造成不平衡样本时的分析处理。新协议、token 预算和采集范围重新确认前，只允许设计、测试和非模型 preflight。
+- 若后续授权 formal v4，必须把 `scripts/forge_formal_collection_v4_runner.py:244` 的 attempt checkpoint 接入真实 provider、Compiler、submit/replay、finalize 和 cleanup 路径，并增加总墙钟取消、Session finalization、orphan reconciliation 的真实 Docker 回归；不能只把 manifest 的授权位改为 `true`。
 - 清理与当前源码不一致的后端测试模块引用，例如 `backend/tests/test_aio_sandbox_local_backend.py:1` 和 `backend/tests/test_channels.py:14`。
 - 统一 `backend/tests/test_subagent_timeout_config.py:261` 对 `max_turns` 的期望值与当前实现默认值。
 - Issue #78 的 30 项目文档级构建路径与 artifact oracle 已实现并通过本地验证；待中文 PR/CI/合并后，再冻结 formal manifest/Schema/runner/image/prompt。任何采集仍须单独 Issue 和用户预算确认。

--- a/backend/tests/test_forge_formal_collection_v4_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_protocol.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_runner.py"
+PARENT_MANIFEST_PATH = (
+    REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
+)
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json"
+SCHEMA_PATH = (
+    REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4.schema.json"
+)
+PARENT_CANONICAL_SHA256 = (
+    "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5"
+)
+PARENT_FILE_SHA256 = {
+    "benchmarks/manifests/cpp-formal-v3-authorized-collection.json": (
+        "3c88c86fc2bba43fcbde1706e500a8cd41547d6481ae02dfa493b55c55c90045"
+    ),
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": (
+        "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d"
+    ),
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": (
+        "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868"
+    ),
+    "scripts/forge_formal_collection_v3_authorized_runner.py": (
+        "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158"
+    ),
+    "benchmarks/reports/cpp-formal-v3-initial-batch.json": (
+        "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f"
+    ),
+    "benchmarks/reports/cpp-formal-v3-initial-batch.md": (
+        "c7e5ff42ae26871d18032e9efa6a919b0a46d334c97a0487eb7e716e393d74c9"
+    ),
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+formal_collection = _load_module(
+    "forge_formal_collection_v4_protocol_test", PROTOCOL_PATH
+)
+runner = _load_module("forge_formal_collection_v4_runner_test", RUNNER_PATH)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _evidence_mount(source: str) -> list[dict]:
+    return [
+        {
+            "Type": "bind",
+            "Source": source,
+            "Destination": "/workspace/.compile-sessions",
+            "RW": True,
+        }
+    ]
+
+
+def test_v4_manifest_is_committed_schema_valid_and_deterministic() -> None:
+    manifest = load_manifest()
+    parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert formal_collection.validate_manifest(manifest) == manifest
+    assert formal_collection.generate_manifest() == manifest
+    assert manifest["collection_plan"] == parent["collection_plan"]
+    assert manifest["cases"] == parent["cases"]
+    assert manifest["conditions"] == parent["conditions"]
+    assert manifest["scope"]["collection_authorized"] is False
+    assert manifest["scope"]["formal_comparison_enabled"] is False
+    assert parent["scope"]["collection_authorized"] is True
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_v4_binds_attempt_resource_and_analysis_boundaries() -> None:
+    manifest = load_manifest()
+
+    assert manifest["attempt_budget"] == formal_collection.ATTEMPT_BUDGET
+    assert manifest["resource_preflight"] == formal_collection.RESOURCE_PREFLIGHT
+    assert manifest["analysis_plan"] == formal_collection.ANALYSIS_PLAN
+    assert manifest["authorization"]["issue_url"].endswith("/issues/103")
+    assert (
+        manifest["authorization"]["parent_manifest"]["canonical_sha256"]
+        == PARENT_CANONICAL_SHA256
+    )
+    assert manifest["authorization"]["v3_initial_batch"]["analyzed_slots"] == 7
+    assert manifest["attempt_budget"]["total_wall_clock_seconds"] == 1800
+    assert manifest["attempt_budget"]["cleanup_reserve_seconds"] == 120
+    assert manifest["attempt_budget"]["max_compiler_invocations"] == 2
+    assert manifest["attempt_budget"]["max_model_requests"] == 48
+    assert (
+        manifest["resource_preflight"]["minimum_available_memory_bytes"] == 2 * 1024**3
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["scope"].update(collection_authorized=True),
+        lambda value: value["attempt_budget"].update(total_wall_clock_seconds=1801),
+        lambda value: value["attempt_budget"].update(max_compiler_invocations=3),
+        lambda value: value["resource_preflight"].update(
+            minimum_available_memory_bytes=1
+        ),
+        lambda value: value["analysis_plan"].update(protocol_version_pooling="allowed"),
+        lambda value: value["authorization"]["collection_constraints"].update(
+            model_execution_forbidden=False
+        ),
+        lambda value: value["collection_plan"].reverse(),
+    ],
+)
+def test_v4_rejects_authorization_budget_resource_or_analysis_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(formal_collection.BenchmarkError):
+        formal_collection.validate_manifest(manifest)
+
+
+def test_v3_parent_and_report_files_remain_byte_identical() -> None:
+    for relative_path, expected in PARENT_FILE_SHA256.items():
+        assert (
+            hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest()
+            == expected
+        )
+
+
+def test_v4_runner_loads_policy_without_authorizing_collection() -> None:
+    manifest = runner._load_manifest(MANIFEST_PATH)
+    first_slot = manifest["collection_plan"][0]
+    policy = runner.build_policy(
+        manifest,
+        case_id=first_slot["case_id"],
+        condition_id=first_slot["condition_id"],
+        repetition=first_slot["repetition"],
+    )
+
+    assert policy.benchmark_id == "forge-cpp-formal-v4-collection"
+    assert policy.memory_enabled is False
+    assert policy.artifact_instructions
+    assert runner.protocol.SCHEMA_VERSION == formal_collection.SCHEMA_VERSION
+
+
+def test_runtime_preflight_requires_memory_daemon_and_mount_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_original_collect_runtime_launch_preflight",
+        lambda *args, **kwargs: {"ready": True, "checks": {"base": True}},
+    )
+    monkeypatch.setattr(
+        runner._runner,
+        "_current_container_metadata",
+        lambda *args, **kwargs: (
+            {},
+            _evidence_mount("/mnt/c/work/Forge-AutoCompiler/.compile-sessions"),
+        ),
+    )
+    monkeypatch.setattr(runner, "_available_memory_bytes", lambda: 3 * 1024**3)
+    monkeypatch.setattr(
+        runner,
+        "_docker_daemon_probe",
+        lambda timeout: {"responded": True, "latency_seconds": 0.25},
+    )
+
+    result = runner.collect_runtime_launch_preflight(tmp_path)
+
+    assert result["ready"] is True
+    assert all(result["checks"].values())
+    assert result["observations"]["available_memory_bytes"] == 3 * 1024**3
+    assert "server_version" not in result["observations"]
+
+
+@pytest.mark.parametrize(
+    ("memory", "daemon", "failed_check"),
+    [
+        (
+            1024**3,
+            {"responded": True, "latency_seconds": 0.25},
+            "host_available_memory_at_least_minimum",
+        ),
+        (
+            3 * 1024**3,
+            {"responded": False, "latency_seconds": 10.0},
+            "docker_daemon_responded",
+        ),
+        (
+            3 * 1024**3,
+            {"responded": True, "latency_seconds": 5.1},
+            "docker_daemon_latency_within_limit",
+        ),
+    ],
+)
+def test_runtime_preflight_rejects_each_resource_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    memory: int,
+    daemon: dict,
+    failed_check: str,
+) -> None:
+    monkeypatch.setenv(
+        "DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_original_collect_runtime_launch_preflight",
+        lambda *args, **kwargs: {"ready": True, "checks": {"base": True}},
+    )
+    monkeypatch.setattr(
+        runner._runner,
+        "_current_container_metadata",
+        lambda *args, **kwargs: (
+            {},
+            _evidence_mount("/mnt/c/work/Forge-AutoCompiler/.compile-sessions"),
+        ),
+    )
+    monkeypatch.setattr(runner, "_available_memory_bytes", lambda: memory)
+    monkeypatch.setattr(runner, "_docker_daemon_probe", lambda timeout: daemon)
+
+    result = runner.collect_runtime_launch_preflight(tmp_path)
+
+    assert result["ready"] is False
+    assert result["checks"][failed_check] is False
+
+
+def test_attempt_budget_state_blocks_new_work_at_each_boundary() -> None:
+    manifest = load_manifest()
+    events = [
+        *[
+            {"event": "model.request_started", "payload": {}}
+            for _ in range(manifest["attempt_budget"]["max_model_requests"])
+        ],
+        *[
+            {"event": "agent.subagent_terminated", "payload": {"role": "compiler"}}
+            for _ in range(manifest["attempt_budget"]["max_compiler_invocations"])
+        ],
+    ]
+
+    state = runner.attempt_budget_state(manifest, events, elapsed_seconds=100)
+    assert state["allow_new_model_request"] is False
+    assert state["allow_new_compiler_invocation"] is False
+    assert state["cleanup_required"] is True
+    assert state["within_total_wall_clock"] is True
+
+    deadline = runner.attempt_budget_state(manifest, [], elapsed_seconds=1680)
+    assert deadline["allow_new_work"] is False
+    assert deadline["cleanup_required"] is True
+
+    overrun = runner.attempt_budget_state(manifest, [], elapsed_seconds=1800.001)
+    assert overrun["within_total_wall_clock"] is False
+
+
+def test_attempt_budget_checkpoints_reject_new_work_but_allow_cleanup() -> None:
+    manifest = load_manifest()
+    events = [
+        {"event": "model.request_started", "payload": {}}
+        for _ in range(manifest["attempt_budget"]["max_model_requests"])
+    ]
+
+    with pytest.raises(runner.RunnerError, match="model-request budget"):
+        runner.require_attempt_budget_checkpoint(
+            manifest,
+            events,
+            elapsed_seconds=100,
+            checkpoint="before_provider_request",
+        )
+    with pytest.raises(runner.RunnerError, match="work deadline"):
+        runner.require_attempt_budget_checkpoint(
+            manifest,
+            [],
+            elapsed_seconds=1680,
+            checkpoint="before_submit_or_replay",
+        )
+
+    finalize = runner.require_attempt_budget_checkpoint(
+        manifest,
+        events,
+        elapsed_seconds=1801,
+        checkpoint="before_finalize",
+    )
+    cleanup = runner.require_attempt_budget_checkpoint(
+        manifest,
+        events,
+        elapsed_seconds=1801,
+        checkpoint="before_cleanup",
+    )
+    assert finalize["within_total_wall_clock"] is False
+    assert cleanup["cleanup_required"] is True
+
+
+def test_all_unapproved_cli_actions_are_rejected_without_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    first_slot = manifest["collection_plan"][0]
+    common = ["--manifest", str(MANIFEST_PATH)]
+    commands = [
+        ["provider-canary", *common, "--output-dir", str(tmp_path)],
+        [
+            "create-attempt",
+            *common,
+            "--case",
+            first_slot["case_id"],
+            "--condition",
+            first_slot["condition_id"],
+            "--repetition",
+            str(first_slot["repetition"]),
+            "--output-dir",
+            str(tmp_path),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run",
+            *common,
+            "--ledger",
+            str(tmp_path / "missing.jsonl"),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run-batch",
+            *common,
+            "--output-dir",
+            str(tmp_path),
+            "--max-attempts",
+            "1",
+            "--skip-endpoint-check",
+        ],
+    ]
+
+    for command in commands:
+        assert runner.main(command) == 2
+
+    assert list(tmp_path.rglob("*.jsonl")) == []
+    assert list(tmp_path.rglob("*.json")) == []

--- a/backend/tests/test_forge_formal_collection_v4_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_protocol.py
@@ -12,35 +12,17 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_protocol.py"
 RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_runner.py"
-PARENT_MANIFEST_PATH = (
-    REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
-)
+PARENT_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v3-authorized-collection.json"
 MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json"
-SCHEMA_PATH = (
-    REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4.schema.json"
-)
-PARENT_CANONICAL_SHA256 = (
-    "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5"
-)
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4.schema.json"
+PARENT_CANONICAL_SHA256 = "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5"
 PARENT_FILE_SHA256 = {
-    "benchmarks/manifests/cpp-formal-v3-authorized-collection.json": (
-        "3c88c86fc2bba43fcbde1706e500a8cd41547d6481ae02dfa493b55c55c90045"
-    ),
-    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": (
-        "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d"
-    ),
-    "scripts/forge_formal_collection_v3_authorized_protocol.py": (
-        "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868"
-    ),
-    "scripts/forge_formal_collection_v3_authorized_runner.py": (
-        "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158"
-    ),
-    "benchmarks/reports/cpp-formal-v3-initial-batch.json": (
-        "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f"
-    ),
-    "benchmarks/reports/cpp-formal-v3-initial-batch.md": (
-        "c7e5ff42ae26871d18032e9efa6a919b0a46d334c97a0487eb7e716e393d74c9"
-    ),
+    "benchmarks/manifests/cpp-formal-v3-authorized-collection.json": ("3c88c86fc2bba43fcbde1706e500a8cd41547d6481ae02dfa493b55c55c90045"),
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": ("30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d"),
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": ("148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868"),
+    "scripts/forge_formal_collection_v3_authorized_runner.py": ("88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158"),
+    "benchmarks/reports/cpp-formal-v3-initial-batch.json": ("1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f"),
+    "benchmarks/reports/cpp-formal-v3-initial-batch.md": ("c7e5ff42ae26871d18032e9efa6a919b0a46d334c97a0487eb7e716e393d74c9"),
 }
 
 
@@ -53,9 +35,7 @@ def _load_module(name: str, path: Path):
     return module
 
 
-formal_collection = _load_module(
-    "forge_formal_collection_v4_protocol_test", PROTOCOL_PATH
-)
+formal_collection = _load_module("forge_formal_collection_v4_protocol_test", PROTOCOL_PATH)
 runner = _load_module("forge_formal_collection_v4_runner_test", RUNNER_PATH)
 
 
@@ -99,18 +79,13 @@ def test_v4_binds_attempt_resource_and_analysis_boundaries() -> None:
     assert manifest["resource_preflight"] == formal_collection.RESOURCE_PREFLIGHT
     assert manifest["analysis_plan"] == formal_collection.ANALYSIS_PLAN
     assert manifest["authorization"]["issue_url"].endswith("/issues/103")
-    assert (
-        manifest["authorization"]["parent_manifest"]["canonical_sha256"]
-        == PARENT_CANONICAL_SHA256
-    )
+    assert manifest["authorization"]["parent_manifest"]["canonical_sha256"] == PARENT_CANONICAL_SHA256
     assert manifest["authorization"]["v3_initial_batch"]["analyzed_slots"] == 7
     assert manifest["attempt_budget"]["total_wall_clock_seconds"] == 1800
     assert manifest["attempt_budget"]["cleanup_reserve_seconds"] == 120
     assert manifest["attempt_budget"]["max_compiler_invocations"] == 2
     assert manifest["attempt_budget"]["max_model_requests"] == 48
-    assert (
-        manifest["resource_preflight"]["minimum_available_memory_bytes"] == 2 * 1024**3
-    )
+    assert manifest["resource_preflight"]["minimum_available_memory_bytes"] == 2 * 1024**3
 
 
 @pytest.mark.parametrize(
@@ -119,13 +94,9 @@ def test_v4_binds_attempt_resource_and_analysis_boundaries() -> None:
         lambda value: value["scope"].update(collection_authorized=True),
         lambda value: value["attempt_budget"].update(total_wall_clock_seconds=1801),
         lambda value: value["attempt_budget"].update(max_compiler_invocations=3),
-        lambda value: value["resource_preflight"].update(
-            minimum_available_memory_bytes=1
-        ),
+        lambda value: value["resource_preflight"].update(minimum_available_memory_bytes=1),
         lambda value: value["analysis_plan"].update(protocol_version_pooling="allowed"),
-        lambda value: value["authorization"]["collection_constraints"].update(
-            model_execution_forbidden=False
-        ),
+        lambda value: value["authorization"]["collection_constraints"].update(model_execution_forbidden=False),
         lambda value: value["collection_plan"].reverse(),
     ],
 )
@@ -139,10 +110,7 @@ def test_v4_rejects_authorization_budget_resource_or_analysis_drift(mutation) ->
 
 def test_v3_parent_and_report_files_remain_byte_identical() -> None:
     for relative_path, expected in PARENT_FILE_SHA256.items():
-        assert (
-            hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest()
-            == expected
-        )
+        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected
 
 
 def test_v4_runner_loads_policy_without_authorizing_collection() -> None:
@@ -165,9 +133,7 @@ def test_runtime_preflight_requires_memory_daemon_and_mount_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(
-        "DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler"
-    )
+    monkeypatch.setenv("DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler")
     monkeypatch.setattr(
         runner,
         "_original_collect_runtime_launch_preflight",
@@ -223,9 +189,7 @@ def test_runtime_preflight_rejects_each_resource_failure(
     daemon: dict,
     failed_check: str,
 ) -> None:
-    monkeypatch.setenv(
-        "DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler"
-    )
+    monkeypatch.setenv("DEER_FLOW_HOST_WORKSPACE_ROOT", "/mnt/c/work/Forge-AutoCompiler")
     monkeypatch.setattr(
         runner,
         "_original_collect_runtime_launch_preflight",
@@ -251,14 +215,8 @@ def test_runtime_preflight_rejects_each_resource_failure(
 def test_attempt_budget_state_blocks_new_work_at_each_boundary() -> None:
     manifest = load_manifest()
     events = [
-        *[
-            {"event": "model.request_started", "payload": {}}
-            for _ in range(manifest["attempt_budget"]["max_model_requests"])
-        ],
-        *[
-            {"event": "agent.subagent_terminated", "payload": {"role": "compiler"}}
-            for _ in range(manifest["attempt_budget"]["max_compiler_invocations"])
-        ],
+        *[{"event": "model.request_started", "payload": {}} for _ in range(manifest["attempt_budget"]["max_model_requests"])],
+        *[{"event": "agent.subagent_terminated", "payload": {"role": "compiler"}} for _ in range(manifest["attempt_budget"]["max_compiler_invocations"])],
     ]
 
     state = runner.attempt_budget_state(manifest, events, elapsed_seconds=100)
@@ -277,10 +235,7 @@ def test_attempt_budget_state_blocks_new_work_at_each_boundary() -> None:
 
 def test_attempt_budget_checkpoints_reject_new_work_but_allow_cleanup() -> None:
     manifest = load_manifest()
-    events = [
-        {"event": "model.request_started", "payload": {}}
-        for _ in range(manifest["attempt_budget"]["max_model_requests"])
-    ]
+    events = [{"event": "model.request_started", "payload": {}} for _ in range(manifest["attempt_budget"]["max_model_requests"])]
 
     with pytest.raises(runner.RunnerError, match="model-request budget"):
         runner.require_attempt_budget_checkpoint(

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,28 @@
 # Forge C/C++ benchmark protocols
 
+## Formal v4 unapproved protocol amendment
+
+Issue #103 freezes an unapproved v4 candidate after the formal v3 initial batch
+showed that the 900-second compiler budget applies to each Compiler invocation,
+not to the whole physical attempt. The candidate adds a 1,800-second attempt
+budget with a 120-second cleanup reserve, at most two Compiler invocations, at
+most 48 model requests, a 2 GiB host-memory gate, and bounded Docker daemon
+health checks. The rationale and incomplete-block analysis rules are
+preregistered in `preregistrations/cpp-formal-v4-amendment.md`.
+
+Only this non-model runtime preflight is allowed:
+
+```bash
+/app/backend/.venv/bin/python /repo/scripts/forge_formal_collection_v4_runner.py \
+  runtime-preflight \
+  --output-dir /workspace/.compile-sessions/benchmark-evidence-formal-v4-preflight
+```
+
+The v4 manifest keeps `collection_authorized=false`. Provider canary, ledger
+creation, model execution, retry, replacement, fallback, and backfill are all
+forbidden until a separate Issue records a new collection and token-budget
+authorization.
+
 ## Formal v3 initial-batch descriptive audit
 
 Issue #99 adds a deterministic, read-only audit over the authorized formal v3

--- a/benchmarks/manifests/cpp-formal-v4-collection.json
+++ b/benchmarks/manifests/cpp-formal-v4-collection.json
@@ -1,0 +1,2820 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v4.schema.json",
+  "schema_version": "formal-collection-4.0.0",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v4-collection",
+    "name": "Forge C/C++ attempt-bounded formal collection v4 candidate",
+    "purpose": "unapproved protocol amendment with attempt-level and host-resource gates",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v4_candidate",
+    "formal_comparison_enabled": false,
+    "collection_authorized": false,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "7d5ad0d294e1cc28a29f92a71264e79df1121ef2",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "b42750116bf36e872cf9515cbd3d3828c52447db290d8fc212101fc8bd1b54ef",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "d574d26b001473b7a95b4e4258b912d133789baf1908fa76a1ef33a448d7dfcd",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "1acc6992c5e97c496fe4b59e69c8dbef0c00a3689cad417fa3c637c9f3cd77a1",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": "90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": "6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "35f6b23ebbbb1e7bc5b540a0b9bfd627d23b75957095922aa79c2db396b64c4b",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
+    "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "2096af2033194bcb4b65b490ad45267c17f1dd87d67665d888cad86452a5ee2c"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v4-collection-authorization-request",
+    "status": "pending_experiment_owner_confirmation",
+    "requested_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/103",
+    "collection_constraints": {
+      "planned_attempts": 180,
+      "collection_authorized": false,
+      "provider_canary_forbidden": true,
+      "physical_attempt_creation_forbidden": true,
+      "model_execution_forbidden": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "new_collection_budget_requires_confirmation": true,
+      "required_runtime_launch_checks": [
+        "evidence_mount_source_matches_host_workspace",
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit"
+      ]
+    },
+    "v3_initial_batch": {
+      "report_path": "benchmarks/reports/cpp-formal-v3-initial-batch.json",
+      "report_sha256": "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f",
+      "analyzed_slots": 7,
+      "authorized_slots": 10,
+      "recorded_usage_units": 1700577,
+      "recorded_budget_units": 1633165,
+      "recorded_overage_units": 67412,
+      "oracle_passed": 4,
+      "stop_reason": "recorded_token_boundary_reached",
+      "slots_8_to_10_not_created": true
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v3-authorized-collection",
+      "path": "benchmarks/manifests/cpp-formal-v3-authorized-collection.json",
+      "canonical_sha256": "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5"
+    }
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit"
+    ],
+    "sensitive_host_identifiers_forbidden": true
+  },
+  "analysis_plan": {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": true,
+    "retry_replacement_backfill_forbidden": true
+  }
+}

--- a/benchmarks/preregistrations/cpp-formal-v4-amendment.md
+++ b/benchmarks/preregistrations/cpp-formal-v4-amendment.md
@@ -1,0 +1,43 @@
+# C/C++ formal v4 协议修订预注册
+
+状态：未授权采集。Issue #103 只冻结协议、实现门禁、运行测试和非模型 preflight；不得执行 provider canary、创建 physical-attempt ledger 或调用模型。
+
+## 修订依据
+
+formal v3 首批在 7/10 个授权 slot 后达到 recorded-token 边界。7 个 slot 共调用 Compiler 14 次；其中 PowerDNS 单槽调用 4 次 Compiler，总历时 3,240.758 秒。现有 900 秒限制作用于每次 Compiler 调用，不能限制整个 physical attempt 的时间和请求尾部。
+
+## Attempt 级预算
+
+| 门禁 | v4 冻结值 | 依据 |
+| --- | ---: | --- |
+| physical attempt 总墙钟 | 1,800 秒 | v3 正常成功槽约 149-250 秒，失败槽约 1,037-3,241 秒；保留复杂 case 空间并截断极端尾部 |
+| cleanup reserve | 120 秒 | 从总墙钟中预留，达到 1,680 秒后不得开始新的 provider、Compiler、submit 或 replay 工作 |
+| Compiler 调用总数 | 2 次 | v3 正常成功槽为 1 次；4 次调用造成单槽长尾，2 次允许一次受控恢复 |
+| 模型请求总数 | 48 次 | v3 正常成功槽为 8-11 次；失败长尾为 67-72 次 |
+
+预算必须在 provider 请求、Compiler 调用、submit/replay、finalize 和 cleanup 前复算。新工作超限时终态分类固定为 `attempt_budget_exhausted`；finalize 和 cleanup 不因超限而跳过，超出总墙钟必须记录为 overrun。
+
+当前 v4 runner 只开放预算状态复算与 checkpoint 拒绝函数。由于 `collection_authorized=false`，所有真实执行入口都在 ledger 和 provider 调用前拒绝。后续若创建 authorized v4，必须把同一 checkpoint 函数接入实际执行路径并增加取消、finalization 和 orphan reconciliation 的真实 Docker 回归，不能仅解除授权位。
+
+## 宿主资源门禁
+
+创建新 attempt 前必须同时满足：
+
+- `/proc/meminfo` 的 `MemAvailable` 不低于 2 GiB；该值代表 LangGraph 所在 WSL2 Linux 环境可见的宿主内存余量。
+- `docker info` 在 10 秒命令时限内成功。
+- Docker daemon 响应延迟不高于 5 秒。
+- 既有 Compose/DooD、Docker socket、解释器、runtime import、evidence bind source 与可写目录门禁继续通过。
+
+preflight 只记录可用内存字节数、阈值和 daemon 延迟，不记录 IP、SSID、代理、凭据、Docker server 版本或其他宿主标识。
+
+## 不平衡样本处理
+
+- formal v3 的 7 个 slot 保持独立描述性 protocol stratum，不删除、不回填，也不与 v4 primary estimand 池化。
+- v4 primary estimand 只使用 v4 下完成的完整 project block。
+- token 或资源停止造成的不完整 block 不进入 paired primary estimate，但保留在端到端描述性失败分母和 provider/case imbalance 报告中。
+- 禁止 retry、fallback、replacement 和 backfill。
+- v4 的采集范围、批次 token 上限和启动时间必须在独立 Issue 中重新获得实验负责人确认。
+
+## 研究边界
+
+本修订针对的是实验运行控制与删失机制，不改变 C/C++ 样本框、exact commit、构建路径、模型条件、Compile Session、clean replay 或 artifact oracle。阈值来自 formal v3 的小样本运行证据，属于预注册工程参数，不应被解释为总体最优值；后续论文应将阈值敏感性列为限制或消融项。

--- a/benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json
@@ -1,0 +1,258 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+  "title": "Forge C/C++ unapproved formal collection v4",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "manifest_canonicalization",
+    "benchmark",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "model_profiles",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "attempt_budget",
+    "resource_preflight",
+    "analysis_plan",
+    "authorization"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-4.0.0"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "type": "object",
+      "required": [
+        "collection_authorized",
+        "formal_comparison_enabled"
+      ],
+      "properties": {
+        "collection_authorized": {
+          "const": false
+        },
+        "formal_comparison_enabled": {
+          "const": false
+        }
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "7d5ad0d294e1cc28a29f92a71264e79df1121ef2"
+        },
+        "component_sha256": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "const": {
+        "id": "forge-cpp-formal-v4-collection-authorization-request",
+        "status": "pending_experiment_owner_confirmation",
+        "requested_on": "2026-08-11",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/103",
+        "collection_constraints": {
+          "planned_attempts": 180,
+          "collection_authorized": false,
+          "provider_canary_forbidden": true,
+          "physical_attempt_creation_forbidden": true,
+          "model_execution_forbidden": true,
+          "replacement_forbidden": true,
+          "fallback_forbidden": true,
+          "retry_forbidden": true,
+          "backfill_forbidden": true,
+          "new_collection_budget_requires_confirmation": true,
+          "required_runtime_launch_checks": [
+            "evidence_mount_source_matches_host_workspace",
+            "host_available_memory_at_least_minimum",
+            "docker_daemon_responded",
+            "docker_daemon_latency_within_limit"
+          ]
+        },
+        "v3_initial_batch": {
+          "report_path": "benchmarks/reports/cpp-formal-v3-initial-batch.json",
+          "report_sha256": "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f",
+          "analyzed_slots": 7,
+          "authorized_slots": 10,
+          "recorded_usage_units": 1700577,
+          "recorded_budget_units": 1633165,
+          "recorded_overage_units": 67412,
+          "oracle_passed": 4,
+          "stop_reason": "recorded_token_boundary_reached",
+          "slots_8_to_10_not_created": true
+        },
+        "parent_manifest": {
+          "id": "forge-cpp-formal-v3-authorized-collection",
+          "path": "benchmarks/manifests/cpp-formal-v3-authorized-collection.json",
+          "canonical_sha256": "87968a3a1dc858c5eb2881e32711da0e2912b90a50437d9534babc37bef67cb5"
+        }
+      }
+    },
+    "$schema": {
+      "const": "../schemas/forge-cpp-formal-collection-v4.schema.json"
+    },
+    "manifest_canonicalization": {
+      "const": "UTF-8 JSON, sorted object keys, compact separators, no NaN"
+    },
+    "benchmark": {
+      "const": {
+        "id": "forge-cpp-formal-v4-collection",
+        "name": "Forge C/C++ attempt-bounded formal collection v4 candidate",
+        "purpose": "unapproved protocol amendment with attempt-level and host-resource gates",
+        "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+      }
+    },
+    "model_profiles": {
+      "const": {
+        "richlab-gpt-5.5": {
+          "endpoint": "https://rich-api.choosefire.com/v1",
+          "credential_env": "OpenAI_AK",
+          "roles": {
+            "lead": "gpt-5.5",
+            "compiler": "gpt-5.5"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        },
+        "deepseek-v4-flash": {
+          "endpoint": "https://api.deepseek.com",
+          "credential_env": "DEEPSEEK_API_KEY",
+          "roles": {
+            "lead": "deepseek-v4-flash",
+            "compiler": "deepseek-v4-flash"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        }
+      }
+    },
+    "attempt_budget": {
+      "const": {
+        "total_wall_clock_seconds": 1800,
+        "cleanup_reserve_seconds": 120,
+        "max_compiler_invocations": 2,
+        "max_model_requests": 48,
+        "enforcement_checkpoints": [
+          "before_provider_request",
+          "before_compiler_invocation",
+          "before_submit_or_replay",
+          "before_finalize",
+          "before_cleanup"
+        ],
+        "new_work_forbidden_after_limit": true,
+        "cleanup_mandatory_after_limit": true,
+        "terminal_classification": "attempt_budget_exhausted"
+      }
+    },
+    "resource_preflight": {
+      "const": {
+        "minimum_available_memory_bytes": 2147483648,
+        "docker_daemon_timeout_seconds": 10,
+        "maximum_docker_daemon_latency_seconds": 5,
+        "required_checks": [
+          "host_available_memory_at_least_minimum",
+          "docker_daemon_responded",
+          "docker_daemon_latency_within_limit"
+        ],
+        "sensitive_host_identifiers_forbidden": true
+      }
+    },
+    "analysis_plan": {
+      "const": {
+        "protocol_version_pooling": "forbidden",
+        "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+        "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+        "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+        "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+        "provider_and_case_imbalance_must_be_reported": true,
+        "retry_replacement_backfill_forbidden": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/forge_formal_collection_v4_protocol.py
+++ b/scripts/forge_formal_collection_v4_protocol.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Generate and validate the unapproved Forge formal-collection v4 protocol."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v3_authorized_protocol as parent_protocol  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-4.0.0"
+BASELINE_COMMIT = "7d5ad0d294e1cc28a29f92a71264e79df1121ef2"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PARENT_MANIFEST = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "manifests"
+    / "cpp-formal-v3-authorized-collection.json"
+)
+DEFAULT_MANIFEST = (
+    REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json"
+)
+DEFAULT_SCHEMA = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "schemas"
+    / "forge-cpp-formal-collection-v4.schema.json"
+)
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_collection_v4_runner.py",
+    "scripts/forge_formal_collection_v4_protocol.py",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+}
+
+V3_REPORT_PATH = "benchmarks/reports/cpp-formal-v3-initial-batch.json"
+V3_REPORT_SHA256 = "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f"
+ATTEMPT_BUDGET = {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+        "before_provider_request",
+        "before_compiler_invocation",
+        "before_submit_or_replay",
+        "before_finalize",
+        "before_cleanup",
+    ],
+    "new_work_forbidden_after_limit": True,
+    "cleanup_mandatory_after_limit": True,
+    "terminal_classification": "attempt_budget_exhausted",
+}
+RESOURCE_PREFLIGHT = {
+    "minimum_available_memory_bytes": 2_147_483_648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit",
+    ],
+    "sensitive_host_identifiers_forbidden": True,
+}
+ANALYSIS_PLAN = {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": True,
+    "retry_replacement_backfill_forbidden": True,
+}
+AUTHORIZATION_REQUEST = {
+    "id": "forge-cpp-formal-v4-collection-authorization-request",
+    "status": "pending_experiment_owner_confirmation",
+    "requested_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/103",
+    "collection_constraints": {
+        "planned_attempts": 180,
+        "collection_authorized": False,
+        "provider_canary_forbidden": True,
+        "physical_attempt_creation_forbidden": True,
+        "model_execution_forbidden": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+        "new_collection_budget_requires_confirmation": True,
+        "required_runtime_launch_checks": [
+            "evidence_mount_source_matches_host_workspace",
+            *RESOURCE_PREFLIGHT["required_checks"],
+        ],
+    },
+    "v3_initial_batch": {
+        "report_path": V3_REPORT_PATH,
+        "report_sha256": V3_REPORT_SHA256,
+        "analyzed_slots": 7,
+        "authorized_slots": 10,
+        "recorded_usage_units": 1_700_577,
+        "recorded_budget_units": 1_633_165,
+        "recorded_overage_units": 67_412,
+        "oracle_passed": 4,
+        "stop_reason": "recorded_token_boundary_reached",
+        "slots_8_to_10_not_created": True,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    return parent_protocol.validate_manifest(parent)
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION_REQUEST),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v3-authorized-collection.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parent = _parent_manifest(parent)
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v4.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v4-collection",
+        "name": "Forge C/C++ attempt-bounded formal collection v4 candidate",
+        "purpose": "unapproved protocol amendment with attempt-level and host-resource gates",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection_v4_candidate",
+        "formal_comparison_enabled": False,
+        "collection_authorized": False,
+        "instrumentation_blocker": False,
+    }
+    hasher = parent_protocol.parent_protocol.parent_protocol.candidate_protocol.parent_protocol
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": hasher._hash_paths(repo_root, COMPONENT_PATHS),
+    }
+    manifest["protocol_artifact_sha256"] = hasher._hash_paths(
+        repo_root, PROTOCOL_ARTIFACT_PATHS
+    )
+    manifest["attempt_budget"] = copy.deepcopy(ATTEMPT_BUDGET)
+    manifest["resource_preflight"] = copy.deepcopy(RESOURCE_PREFLIGHT)
+    manifest["analysis_plan"] = copy.deepcopy(ANALYSIS_PLAN)
+    manifest["authorization"] = _authorization(parent)
+    return validate_manifest(manifest, parent=parent)
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected_root = {
+            "$schema",
+            "schema_version",
+            "document_type",
+            "manifest_canonicalization",
+            "benchmark",
+            "scope",
+            "source_protocols",
+            "forge",
+            "protocol_artifact_sha256",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+            "attempt_budget",
+            "resource_preflight",
+            "analysis_plan",
+            "authorization",
+        }
+        if set(manifest) != expected_root:
+            v1._fail("manifest", "must contain exactly the formal collection v4 fields")
+        if (
+            manifest["$schema"]
+            != "../schemas/forge-cpp-formal-collection-v4.schema.json"
+        ):
+            v1._fail(
+                "manifest.$schema", "must reference the formal collection v4 schema"
+            )
+        if manifest["schema_version"] != SCHEMA_VERSION:
+            v1._fail("manifest.schema_version", f"must be {SCHEMA_VERSION!r}")
+        if manifest["document_type"] != "manifest":
+            v1._fail("manifest.document_type", "must be 'manifest'")
+        v1._scan_for_unsafe_values(manifest)
+        parent = _parent_manifest(parent)
+        expected_benchmark = {
+            "id": "forge-cpp-formal-v4-collection",
+            "name": "Forge C/C++ attempt-bounded formal collection v4 candidate",
+            "purpose": "unapproved protocol amendment with attempt-level and host-resource gates",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }
+        if manifest["benchmark"] != expected_benchmark:
+            v1._fail("manifest.benchmark", "must identify the v4 candidate")
+        if manifest["scope"] != {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection_v4_candidate",
+            "formal_comparison_enabled": False,
+            "collection_authorized": False,
+            "instrumentation_blocker": False,
+        }:
+            v1._fail("manifest.scope", "must keep v4 model execution disabled")
+        immutable_fields = (
+            "source_protocols",
+            "prompt_sha256",
+            "model_profiles",
+            "runtime",
+            "budget",
+            "conditions",
+            "collection_plan",
+            "schedule_sha256",
+            "cases",
+        )
+        for field in immutable_fields:
+            if manifest[field] != parent[field]:
+                v1._fail(
+                    f"manifest.{field}", "must remain identical to formal collection v3"
+                )
+        if manifest["attempt_budget"] != ATTEMPT_BUDGET:
+            v1._fail(
+                "manifest.attempt_budget",
+                "must preserve the reviewed attempt-level limits",
+            )
+        if manifest["resource_preflight"] != RESOURCE_PREFLIGHT:
+            v1._fail(
+                "manifest.resource_preflight",
+                "must preserve the reviewed host-resource gates",
+            )
+        if manifest["analysis_plan"] != ANALYSIS_PLAN:
+            v1._fail(
+                "manifest.analysis_plan",
+                "must preserve the preregistered imbalance handling",
+            )
+        if (
+            ATTEMPT_BUDGET["cleanup_reserve_seconds"]
+            >= ATTEMPT_BUDGET["total_wall_clock_seconds"]
+        ):
+            v1._fail(
+                "manifest.attempt_budget.cleanup_reserve_seconds",
+                "must be smaller than the total wall clock",
+            )
+        forge = v1._as_object(manifest["forge"], "manifest.forge")
+        if set(forge) != set(parent["forge"]):
+            v1._fail(
+                "manifest.forge",
+                "must contain exactly the inherited Forge identity fields",
+            )
+        if forge["repository_url"] != parent["forge"]["repository_url"]:
+            v1._fail("manifest.forge.repository_url", "must preserve the repository")
+        if (
+            forge["commit_sha"] != BASELINE_COMMIT
+            or forge["revision_policy"] != REVISION_POLICY
+        ):
+            v1._fail("manifest.forge", "must bind the Issue #101 snapshot baseline")
+        hasher = parent_protocol.parent_protocol.parent_protocol.candidate_protocol.parent_protocol
+        hasher._validate_hash_map(
+            forge["component_sha256"],
+            expected_paths=COMPONENT_PATHS,
+            path="manifest.forge.component_sha256",
+        )
+        hasher._validate_hash_map(
+            manifest["protocol_artifact_sha256"],
+            expected_paths=PROTOCOL_ARTIFACT_PATHS,
+            path="manifest.protocol_artifact_sha256",
+        )
+        if manifest["authorization"] != _authorization(parent):
+            v1._fail(
+                "manifest.authorization",
+                "must bind the pending Issue #103 authorization",
+            )
+        if len(manifest["collection_plan"]) != 180:
+            v1._fail("manifest.collection_plan", "must retain all 180 frozen slots")
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OverflowError, TypeError, ValueError) as exc:
+        raise BenchmarkError(
+            "manifest: contains a malformed formal collection v4 value"
+        ) from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(validate_manifest(manifest))
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest)
+    parent_path = repo_root / manifest["authorization"]["parent_manifest"]["path"]
+    parent = _parent_manifest(load_json_document(parent_path))
+    if (
+        parent_protocol.manifest_sha256(parent)
+        != manifest["authorization"]["parent_manifest"]["canonical_sha256"]
+    ):
+        v1._fail(
+            "manifest.authorization.parent_manifest",
+            "does not match formal collection v3",
+        )
+    report_path = (
+        repo_root / manifest["authorization"]["v3_initial_batch"]["report_path"]
+    )
+    if hashlib.sha256(report_path.read_bytes()).hexdigest() != V3_REPORT_SHA256:
+        v1._fail(
+            "manifest.authorization.v3_initial_batch.report_sha256",
+            "does not match the audited v3 report",
+        )
+    hasher = parent_protocol.parent_protocol.parent_protocol.candidate_protocol.parent_protocol
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            actual = hasher._file_sha256(repo_root / relative_path)
+            if actual != expected:
+                v1._fail(
+                    f"{path_prefix}.{relative_path}",
+                    "does not match the current repository file",
+                )
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    parent = _parent_manifest()
+    schema["$id"] = (
+        "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json"
+    )
+    schema["title"] = "Forge C/C++ unapproved formal collection v4"
+    schema["additionalProperties"] = False
+    schema["required"] = [
+        "$schema",
+        "schema_version",
+        "document_type",
+        "manifest_canonicalization",
+        "benchmark",
+        "scope",
+        "source_protocols",
+        "forge",
+        "protocol_artifact_sha256",
+        "prompt_sha256",
+        "model_profiles",
+        "runtime",
+        "budget",
+        "conditions",
+        "collection_plan",
+        "schedule_sha256",
+        "cases",
+        "attempt_budget",
+        "resource_preflight",
+        "analysis_plan",
+        "authorization",
+    ]
+    properties = schema["properties"]
+    properties["$schema"] = {
+        "const": "../schemas/forge-cpp-formal-collection-v4.schema.json"
+    }
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["manifest_canonicalization"] = {
+        "const": parent["manifest_canonicalization"]
+    }
+    properties["benchmark"] = {
+        "const": {
+            "id": "forge-cpp-formal-v4-collection",
+            "name": "Forge C/C++ attempt-bounded formal collection v4 candidate",
+            "purpose": "unapproved protocol amendment with attempt-level and host-resource gates",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }
+    }
+    properties["scope"]["properties"] = {
+        "collection_authorized": {"const": False},
+        "formal_comparison_enabled": {"const": False},
+    }
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["model_profiles"] = {"const": parent["model_profiles"]}
+    properties["attempt_budget"] = {"const": copy.deepcopy(ATTEMPT_BUDGET)}
+    properties["resource_preflight"] = {"const": copy.deepcopy(RESOURCE_PREFLIGHT)}
+    properties["analysis_plan"] = {"const": copy.deepcopy(ANALYSIS_PLAN)}
+    properties["authorization"] = {"const": _authorization(parent)}
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorization_status": manifest["authorization"]["status"],
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "maximum_compiler_invocations": manifest["attempt_budget"][
+                        "max_compiler_invocations"
+                    ],
+                    "maximum_model_requests": manifest["attempt_budget"][
+                        "max_model_requests"
+                    ],
+                    "physical_attempt_wall_clock_seconds": manifest["attempt_budget"][
+                        "total_wall_clock_seconds"
+                    ],
+                    "slots": len(manifest["collection_plan"]),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_runner.py
+++ b/scripts/forge_formal_collection_v4_runner.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Unapproved formal-v4 adapter with attempt-budget and resource gates."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import posixpath
+import subprocess
+import sys
+import time
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_collection_v4_protocol as protocol  # noqa: E402
+
+
+def _load_private_base_runner():
+    module_name = f"{__name__}_base"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_formal_collection_v2_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the formal collection base runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_runner = _load_private_base_runner()
+_original_manifest_protocol = _runner._manifest_protocol
+_original_build_policy = _runner.build_policy
+_original_collect_runtime_launch_preflight = _runner.collect_runtime_launch_preflight
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+_EVIDENCE_MOUNT_ROOT = Path("/workspace/.compile-sessions")
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+):
+    policy = _original_build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        return policy
+    case = _runner._manifest_case(manifest, case_id)
+    artifacts = tuple(
+        (
+            artifact["relative_path"],
+            artifact.get("build_output_path", artifact["relative_path"]),
+            artifact["artifact_type"],
+        )
+        for artifact in case["oracle"]["required_artifacts"]
+    )
+    return replace(policy, artifact_instructions=artifacts)
+
+
+def _evidence_mount_source_matches_host_workspace(
+    mounts: list[dict[str, Any]] | None,
+    *,
+    host_workspace_root: str | None = None,
+) -> bool:
+    root = (
+        host_workspace_root
+        if host_workspace_root is not None
+        else os.environ.get("DEER_FLOW_HOST_WORKSPACE_ROOT")
+    )
+    if not isinstance(root, str) or not root.strip():
+        return False
+    normalized_root = posixpath.normpath(root.strip())
+    if not PurePosixPath(normalized_root).is_absolute() or normalized_root == "/":
+        return False
+    expected_source = posixpath.join(normalized_root, ".compile-sessions")
+    evidence_mounts = [
+        mount
+        for mount in mounts or []
+        if mount.get("Type") == "bind"
+        and mount.get("Destination") == _EVIDENCE_MOUNT_ROOT.as_posix()
+        and mount.get("RW") is True
+    ]
+    if len(evidence_mounts) != 1:
+        return False
+    source = evidence_mounts[0].get("Source")
+    return (
+        isinstance(source, str)
+        and PurePosixPath(posixpath.normpath(source)).is_absolute()
+        and posixpath.normpath(source) == expected_source
+    )
+
+
+def _available_memory_bytes(meminfo_path: Path = Path("/proc/meminfo")) -> int | None:
+    try:
+        for line in meminfo_path.read_text(encoding="ascii").splitlines():
+            if not line.startswith("MemAvailable:"):
+                continue
+            fields = line.split()
+            if len(fields) != 3 or fields[2] != "kB":
+                return None
+            return int(fields[1]) * 1024
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return None
+
+
+def _docker_daemon_probe(timeout_seconds: int) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{json .ServerVersion}}"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {
+            "responded": False,
+            "latency_seconds": round(time.monotonic() - started, 6),
+        }
+    return {
+        "responded": result.returncode == 0 and bool(result.stdout.strip()),
+        "latency_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    result = _original_collect_runtime_launch_preflight(output_dir, repo_root=repo_root)
+    _labels, mounts = _runner._current_container_metadata(repo_root)
+    source_matches = _evidence_mount_source_matches_host_workspace(mounts)
+    available_memory = _available_memory_bytes()
+    resource_policy = protocol.RESOURCE_PREFLIGHT
+    daemon = _docker_daemon_probe(resource_policy["docker_daemon_timeout_seconds"])
+    memory_ready = (
+        available_memory is not None
+        and available_memory >= resource_policy["minimum_available_memory_bytes"]
+    )
+    daemon_responded = daemon["responded"] is True
+    daemon_latency_ready = (
+        daemon_responded
+        and daemon["latency_seconds"]
+        <= resource_policy["maximum_docker_daemon_latency_seconds"]
+    )
+    checks = {
+        **result["checks"],
+        "evidence_mount_source_matches_host_workspace": source_matches,
+        "host_available_memory_at_least_minimum": memory_ready,
+        "docker_daemon_responded": daemon_responded,
+        "docker_daemon_latency_within_limit": daemon_latency_ready,
+    }
+    observations = {
+        **result.get("observations", {}),
+        "available_memory_bytes": available_memory,
+        "minimum_available_memory_bytes": resource_policy[
+            "minimum_available_memory_bytes"
+        ],
+        "docker_daemon_latency_seconds": daemon["latency_seconds"],
+        "maximum_docker_daemon_latency_seconds": resource_policy[
+            "maximum_docker_daemon_latency_seconds"
+        ],
+    }
+    return {
+        **result,
+        "ready": all(checks.values()),
+        "checks": checks,
+        "observations": observations,
+    }
+
+
+def attempt_budget_state(
+    manifest: dict[str, Any],
+    events: list[dict[str, Any]],
+    *,
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    if elapsed_seconds < 0:
+        raise RunnerError("Attempt elapsed time cannot be negative")
+    budget = manifest["attempt_budget"]
+    compiler_invocations = sum(
+        event.get("event") == "agent.subagent_terminated"
+        and event.get("payload", {}).get("role") == "compiler"
+        for event in events
+    )
+    model_requests = sum(
+        event.get("event") == "model.request_started" for event in events
+    )
+    work_deadline = (
+        budget["total_wall_clock_seconds"] - budget["cleanup_reserve_seconds"]
+    )
+    return {
+        "elapsed_seconds": round(elapsed_seconds, 6),
+        "work_deadline_seconds": work_deadline,
+        "total_wall_clock_seconds": budget["total_wall_clock_seconds"],
+        "compiler_invocations": compiler_invocations,
+        "model_requests": model_requests,
+        "allow_new_work": elapsed_seconds < work_deadline,
+        "allow_new_compiler_invocation": (
+            elapsed_seconds < work_deadline
+            and compiler_invocations < budget["max_compiler_invocations"]
+        ),
+        "allow_new_model_request": (
+            elapsed_seconds < work_deadline
+            and model_requests < budget["max_model_requests"]
+        ),
+        "within_total_wall_clock": elapsed_seconds
+        <= budget["total_wall_clock_seconds"],
+        "cleanup_required": (
+            elapsed_seconds >= work_deadline
+            or compiler_invocations >= budget["max_compiler_invocations"]
+            or model_requests >= budget["max_model_requests"]
+        ),
+    }
+
+
+def require_attempt_budget_checkpoint(
+    manifest: dict[str, Any],
+    events: list[dict[str, Any]],
+    *,
+    elapsed_seconds: float,
+    checkpoint: str,
+) -> dict[str, Any]:
+    budget = manifest["attempt_budget"]
+    if checkpoint not in budget["enforcement_checkpoints"]:
+        raise RunnerError(f"Unknown attempt-budget checkpoint: {checkpoint}")
+    state = attempt_budget_state(manifest, events, elapsed_seconds=elapsed_seconds)
+    if checkpoint == "before_provider_request" and not state["allow_new_model_request"]:
+        raise RunnerError("The physical-attempt model-request budget is exhausted")
+    if (
+        checkpoint == "before_compiler_invocation"
+        and not state["allow_new_compiler_invocation"]
+    ):
+        raise RunnerError(
+            "The physical-attempt Compiler invocation budget is exhausted"
+        )
+    if checkpoint == "before_submit_or_replay" and not state["allow_new_work"]:
+        raise RunnerError("The physical-attempt work deadline is exhausted")
+    return state
+
+
+def _reject_unapproved_action(action: str) -> None:
+    raise RunnerError(f"Formal collection v4 is not authorized; {action} is forbidden")
+
+
+def collect_provider_canary(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("provider canary")
+
+
+def create_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("physical-attempt ledger creation")
+
+
+def run_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("model execution")
+
+
+def run_formal_batch(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("batch execution")
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.build_policy = build_policy
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_formal_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

formal v3 首批审计确认：900 秒是每次 Compiler 调用预算，不是 physical attempt 总预算。7 个 slot 共调用 Compiler 14 次，PowerDNS 单槽 4 次调用并持续约 3,240.758 秒；协议还缺少总模型请求、总 Compiler 调用和宿主资源门禁。

## 变更内容

- 新增独立 `formal-collection-4.0.0` manifest、Schema、protocol 与 runner，保持 C/C++、180-slot schedule、双 provider、Compose/DooD、Compile Session、clean replay 与 artifact oracle 不变。
- 冻结每个 physical attempt 总墙钟 1,800 秒、cleanup reserve 120 秒、最多 2 次 Compiler 调用和 48 次模型请求。
- 新增预算状态复算与 checkpoint 拒绝；provider、Compiler、submit/replay 超限后禁止新工作，finalize/cleanup 仍必须执行。
- 新增宿主资源 preflight：`MemAvailable >= 2 GiB`、`docker info` 10 秒命令时限和不高于 5 秒的 daemon 延迟。
- 预注册跨协议与不完整 block 处理：v3 7-slot 独立描述，不与 v4 primary 池化；不完整 block 不进入 paired primary estimate，但保留在端到端描述性分母。
- v4 继续固定 `collection_authorized=false`，所有 canary、ledger 创建、模型运行和 batch 入口硬拒绝。

## 验证

- v4 聚焦回归：`18 passed`
- v3/v4 扩大回归：`54 passed`
- 真实 Compose/DooD 非模型 preflight：11/11 checks 通过；可用内存约 5.64 GB，Docker daemon 响应约 0.032 秒
- 真实 `provider-canary` 入口：退出码 2，0 evidence 文件，未调用模型
- Ruff check/format、JSON Schema、确定性再生成、`py_compile`、`git diff --check`、敏感信息扫描通过

## 边界

本 PR 不授权任何模型采集，不创建 physical-attempt ledger，不修改 v1-v3 manifest、Schema、runner、报告或历史 evidence。后续 authorized v4 必须另开 Issue，重新确认采集范围和 token 预算，并把 checkpoint 接入真实执行路径及 Docker 生命周期回归。

Closes #103