### PR TITLE
研究：接通 formal v4 physical-attempt 生命周期预算

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,8 +8,9 @@
 - 2026-08-11 — Issue #105 正在接通 formal v4 physical-attempt 生命周期预算
   - 已实现: experiment evidence 保存单调时钟与原子 claim；provider、Compiler、submit/replay、finalize、cleanup 使用同一预算上下文，基础 runner 在工作 deadline 主动取消 async agent stream，并在强制收口后记录 overrun 快照。
   - 已验证: 聚焦/扩大单元回归 `227 passed`；真实 WSL/DooD Docker Session 在 submit 被截止拒绝后仍完成 `timed_out` finalization、容器删除和 0 orphan。
-  - 协议候选: 实现基线已提交为 `3ac49b92eedecf4932a829e75465dd7ddd16b97e`；未授权 `formal-collection-4.1.0-runtime-candidate` 已派生，canonical SHA-256 为 `5e3675f2c07c665d672bd1eb07c328c27d8fead922754f96b9189384b71ee9f4`，旧 v4 父文件保持逐字不变。
-  - 待完成: 提交 runtime candidate；完成扩大回归、真实 Compose preflight、PR/CI 和知识库同步。任何 provider canary、模型执行、v4 ledger 与正式采集仍禁止。
+  - 协议候选: 实现基线已提交为 `3ac49b92eedecf4932a829e75465dd7ddd16b97e`；未授权 `formal-collection-4.1.0-runtime-candidate` 已派生，canonical SHA-256 为 `d1c211e638ee2fd71c5c2f9e70f250306a131f9ae8759c9bd064e48a96252473`，旧 v4 父文件保持逐字不变。
+  - 已验证: 最终候选聚焦测试 `12 passed`，扩大回归 `227 passed`，真实 Docker 生命周期 `1 passed`；Compose/DooD preflight 11/11 通过，未授权 provider canary 明确拒绝且 0 evidence。Ruff、Schema、冻结父文件、diff 与敏感信息检查通过。
+  - 待完成: 提交并推送容器路径修复，创建 PR、等待 CI/合并并同步知识库。任何真实 provider canary、模型执行、v4 ledger 与正式采集仍禁止。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
@@ -277,6 +278,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- Compose 同时把脚本挂到 `/app/scripts`、完整仓库挂到 `/repo`；仅设置 `FORGE_REPO_ROOT=/repo` 不足以修复版本化协议链，因为先导入的父 runner 会把 `/app` 根协议放入 `sys.modules`。runtime adapter 必须先从 `/repo/scripts` 导入协议链，再导入父 runner；preflight 还必须使用 `/app/backend/.venv/bin/python` 和 `/workspace/.compile-sessions` 子目录，否则解释器、runtime import 与 evidence 持久化 gate 会按设计拒绝。
 - 后端 CI 从 `backend/` 运行 `uvx ruff` 并加载 `backend/ruff.toml`（当前行宽 240）。对 `backend/tests/` 显式传 `backend/pyproject.toml` 会使用不同格式规则，可能出现本地 format check 通过但 CI 要求反向格式化；本地复核必须使用 `backend/ruff.toml` 或从 `backend/` 工作目录运行与 CI 相同的命令。
 - 修改 `.env` 后仅 `docker compose restart` 不会重新加载环境，必须 recreate Gateway/LangGraph。直接调用开发 Compose 还必须显式提供 `DEER_FLOW_ROOT`；否则在配置插值阶段退出。优先使用 `scripts/docker.sh`，定向 recreate 时传完整 WSL 绝对路径，避免 PowerShell 提前展开 `$repo`。
 - formal canary 的 endpoint preflight 失败发生在模型调用和报告创建之前；真实 provider 请求超时则会留下不可变 canary 报告。恢复前必须分别核对 report 数、formal JSONL 数和 orphan 数，不能把“没有报告”误写成模型失败。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,11 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-11 — Issue #105 正在接通 formal v4 physical-attempt 生命周期预算
+  - 已实现: experiment evidence 保存单调时钟与原子 claim；provider、Compiler、submit/replay、finalize、cleanup 使用同一预算上下文，基础 runner 在工作 deadline 主动取消 async agent stream，并在强制收口后记录 overrun 快照。
+  - 已验证: 聚焦/扩大单元回归 `227 passed`；真实 WSL/DooD Docker Session 在 submit 被截止拒绝后仍完成 `timed_out` finalization、容器删除和 0 orphan。
+  - 待完成: 提交实现基线；以该 SHA 派生未授权 `formal-collection-4.1.0` runtime candidate；完成扩大回归、PR/CI 和知识库同步。任何 provider canary、模型执行、v4 ledger 与正式采集仍禁止。
+
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -279,6 +279,7 @@
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
 - Compose 同时把脚本挂到 `/app/scripts`、完整仓库挂到 `/repo`；仅设置 `FORGE_REPO_ROOT=/repo` 不足以修复版本化协议链，因为先导入的父 runner 会把 `/app` 根协议放入 `sys.modules`。runtime adapter 必须先从 `/repo/scripts` 导入协议链，再导入父 runner；preflight 还必须使用 `/app/backend/.venv/bin/python` 和 `/workspace/.compile-sessions` 子目录，否则解释器、runtime import 与 evidence 持久化 gate 会按设计拒绝。
+- 历史 formal manifest 应冻结当时的 runner SHA，但共享基础 runner 会由后续版本继续演进；回归测试应直接断言历史 manifest 中的旧 identity 保持不变，并由新版本 manifest 绑定当前 runtime，不能要求工作树中的共享 runner 永远等于最早候选字节。旧协议遇到 current-tree runtime 漂移时拒绝执行是预期 gate。
 - 后端 CI 从 `backend/` 运行 `uvx ruff` 并加载 `backend/ruff.toml`（当前行宽 240）。对 `backend/tests/` 显式传 `backend/pyproject.toml` 会使用不同格式规则，可能出现本地 format check 通过但 CI 要求反向格式化；本地复核必须使用 `backend/ruff.toml` 或从 `backend/` 工作目录运行与 CI 相同的命令。
 - 修改 `.env` 后仅 `docker compose restart` 不会重新加载环境，必须 recreate Gateway/LangGraph。直接调用开发 Compose 还必须显式提供 `DEER_FLOW_ROOT`；否则在配置插值阶段退出。优先使用 `scripts/docker.sh`，定向 recreate 时传完整 WSL 绝对路径，避免 PowerShell 提前展开 `$repo`。
 - formal canary 的 endpoint preflight 失败发生在模型调用和报告创建之前；真实 provider 请求超时则会留下不可变 canary 报告。恢复前必须分别核对 report 数、formal JSONL 数和 orphan 数，不能把“没有报告”误写成模型失败。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,7 +8,8 @@
 - 2026-08-11 — Issue #105 正在接通 formal v4 physical-attempt 生命周期预算
   - 已实现: experiment evidence 保存单调时钟与原子 claim；provider、Compiler、submit/replay、finalize、cleanup 使用同一预算上下文，基础 runner 在工作 deadline 主动取消 async agent stream，并在强制收口后记录 overrun 快照。
   - 已验证: 聚焦/扩大单元回归 `227 passed`；真实 WSL/DooD Docker Session 在 submit 被截止拒绝后仍完成 `timed_out` finalization、容器删除和 0 orphan。
-  - 待完成: 提交实现基线；以该 SHA 派生未授权 `formal-collection-4.1.0` runtime candidate；完成扩大回归、PR/CI 和知识库同步。任何 provider canary、模型执行、v4 ledger 与正式采集仍禁止。
+  - 协议候选: 实现基线已提交为 `3ac49b92eedecf4932a829e75465dd7ddd16b97e`；未授权 `formal-collection-4.1.0-runtime-candidate` 已派生，canonical SHA-256 为 `5e3675f2c07c665d672bd1eb07c328c27d8fead922754f96b9189384b71ee9f4`，旧 v4 父文件保持逐字不变。
+  - 待完成: 提交 runtime candidate；完成扩大回归、真实 Compose preflight、PR/CI 和知识库同步。任何 provider canary、模型执行、v4 ledger 与正式采集仍禁止。
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->

--- a/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
@@ -20,6 +20,7 @@ from langchain_core.messages import AIMessage
 from langgraph.errors import GraphBubbleUp
 
 from deerflow.compile.evidence import (
+    enforce_experiment_attempt_budget,
     get_active_experiment,
     model_response_metadata,
     new_evidence_id,
@@ -171,6 +172,7 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
             request,
             active.policy.model_name if active is not None else "unknown",
         )
+        enforce_experiment_attempt_budget(thread_id, "before_provider_request")
         record_experiment_event(
             thread_id,
             "model.request_started",

--- a/backend/packages/harness/deerflow/compile/evidence.py
+++ b/backend/packages/harness/deerflow/compile/evidence.py
@@ -7,10 +7,11 @@ import os
 import re
 import tempfile
 import threading
+import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlsplit
@@ -85,10 +86,72 @@ _ALLOWED_SUBAGENT_FAILURE_CLASSIFICATIONS = {
     "subagent_timeout",
     "tracking_lost",
 }
+_ATTEMPT_BUDGET_CHECKPOINTS = {
+    "before_provider_request",
+    "before_compiler_invocation",
+    "before_submit_or_replay",
+    "before_finalize",
+    "before_cleanup",
+}
 
 
 class EvidenceError(ValueError):
     pass
+
+
+class AttemptBudgetExceeded(RuntimeError):
+    """Raised before new experiment work would exceed its frozen attempt budget."""
+
+    def __init__(self, checkpoint: str, classification: str):
+        self.checkpoint = checkpoint
+        self.classification = classification
+        super().__init__(f"Physical-attempt budget rejected {checkpoint}: {classification}")
+
+
+@dataclass(frozen=True)
+class ExperimentAttemptBudget:
+    total_wall_clock_seconds: int
+    cleanup_reserve_seconds: int
+    max_compiler_invocations: int
+    max_model_requests: int
+    terminal_classification: str = "attempt_budget_exhausted"
+
+    def __post_init__(self) -> None:
+        for name in (
+            "total_wall_clock_seconds",
+            "max_compiler_invocations",
+            "max_model_requests",
+        ):
+            if type(getattr(self, name)) is not int or getattr(self, name) < 1:
+                raise EvidenceError(f"{name} must be a positive integer")
+        if type(self.cleanup_reserve_seconds) is not int or self.cleanup_reserve_seconds < 0 or self.cleanup_reserve_seconds >= self.total_wall_clock_seconds:
+            raise EvidenceError("cleanup_reserve_seconds must be non-negative and smaller than the total wall clock")
+        if not isinstance(self.terminal_classification, str) or not _BOUNDED_IDENTIFIER_RE.fullmatch(self.terminal_classification):
+            raise EvidenceError("terminal_classification must be a bounded identifier")
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> ExperimentAttemptBudget:
+        return cls(
+            total_wall_clock_seconds=value["total_wall_clock_seconds"],
+            cleanup_reserve_seconds=value["cleanup_reserve_seconds"],
+            max_compiler_invocations=value["max_compiler_invocations"],
+            max_model_requests=value["max_model_requests"],
+            terminal_classification=value.get("terminal_classification", "attempt_budget_exhausted"),
+        )
+
+    @property
+    def work_deadline_seconds(self) -> int:
+        return self.total_wall_clock_seconds - self.cleanup_reserve_seconds
+
+
+@dataclass
+class _ExperimentAttemptBudgetRuntime:
+    policy: ExperimentAttemptBudget
+    clock: Callable[[], float]
+    started_monotonic: float
+    model_requests_claimed: int = 0
+    compiler_invocations_claimed: int = 0
+    lock: threading.RLock = field(default_factory=threading.RLock)
 
 
 def new_evidence_id(prefix: str) -> str:
@@ -160,7 +223,88 @@ def _validate_safe_value(value: Any, path: str = "payload") -> None:
     raise EvidenceError(f"{path} contains unsupported value type {type(value).__name__}")
 
 
+def _validate_attempt_budget_snapshot(value: Any, path: str) -> None:
+    required = {
+        "elapsed_seconds",
+        "work_deadline_seconds",
+        "total_wall_clock_seconds",
+        "cleanup_reserve_seconds",
+        "model_requests_claimed",
+        "maximum_model_requests",
+        "compiler_invocations_claimed",
+        "compiler_invocations_completed",
+        "maximum_compiler_invocations",
+        "work_deadline_reached",
+        "model_request_limit_reached",
+        "compiler_invocation_limit_reached",
+        "within_total_wall_clock",
+        "cleanup_required",
+        "terminal_classification",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise EvidenceError(f"{path} has an invalid attempt-budget snapshot schema")
+    elapsed = value["elapsed_seconds"]
+    if type(elapsed) not in (int, float) or not math.isfinite(elapsed) or elapsed < 0:
+        raise EvidenceError(f"{path}.elapsed_seconds must be finite and non-negative")
+    for key in (
+        "work_deadline_seconds",
+        "total_wall_clock_seconds",
+        "maximum_model_requests",
+        "maximum_compiler_invocations",
+    ):
+        if type(value[key]) is not int or value[key] < 1:
+            raise EvidenceError(f"{path}.{key} must be positive")
+    for key in (
+        "cleanup_reserve_seconds",
+        "model_requests_claimed",
+        "compiler_invocations_claimed",
+        "compiler_invocations_completed",
+    ):
+        if type(value[key]) is not int or value[key] < 0:
+            raise EvidenceError(f"{path}.{key} must be non-negative")
+    for key in (
+        "work_deadline_reached",
+        "model_request_limit_reached",
+        "compiler_invocation_limit_reached",
+        "within_total_wall_clock",
+        "cleanup_required",
+    ):
+        if type(value[key]) is not bool:
+            raise EvidenceError(f"{path}.{key} must be boolean")
+    if not isinstance(value["terminal_classification"], str) or not _BOUNDED_IDENTIFIER_RE.fullmatch(value["terminal_classification"]):
+        raise EvidenceError(f"{path}.terminal_classification is invalid")
+
+
 def _validate_agent_event_payload(event: str, payload: dict[str, Any], path: str = "payload") -> None:
+    if event == "attempt.budget_checkpoint":
+        if set(payload) != {
+            "checkpoint",
+            "allowed",
+            "rejection_classification",
+            "snapshot",
+        }:
+            raise EvidenceError(f"{path} has an invalid attempt.budget_checkpoint schema")
+        if payload["checkpoint"] not in _ATTEMPT_BUDGET_CHECKPOINTS:
+            raise EvidenceError(f"{path}.checkpoint is invalid")
+        if type(payload["allowed"]) is not bool:
+            raise EvidenceError(f"{path}.allowed must be boolean")
+        classification = payload["rejection_classification"]
+        if payload["allowed"]:
+            if classification is not None:
+                raise EvidenceError(f"{path}.rejection_classification must be null when allowed")
+        elif classification not in {
+            "work_deadline_reached",
+            "model_request_limit_reached",
+            "compiler_invocation_limit_reached",
+        }:
+            raise EvidenceError(f"{path}.rejection_classification is invalid")
+        _validate_attempt_budget_snapshot(payload["snapshot"], f"{path}.snapshot")
+        return
+
+    if event == "attempt.budget_completed":
+        _validate_attempt_budget_snapshot(payload, path)
+        return
+
     if event == "build.identity_snapshot":
         required = {
             "session_id",
@@ -495,6 +639,7 @@ class ActiveExperiment:
     physical_attempt_id: str
     ledger: ExperimentLedger
     policy: ExperimentPolicy
+    attempt_budget: _ExperimentAttemptBudgetRuntime | None = None
 
 
 _PATH_LOCKS: dict[Path, threading.RLock] = {}
@@ -692,6 +837,8 @@ def activate_experiment(
     physical_attempt_id: str,
     ledger: ExperimentLedger,
     policy: ExperimentPolicy,
+    attempt_budget: ExperimentAttemptBudget | None = None,
+    monotonic_clock: Callable[[], float] = time.monotonic,
 ) -> ActiveExperiment:
     if not thread_id or any(character in thread_id for character in ("\0", "\r", "\n")):
         raise EvidenceError("A safe thread_id is required to activate experiment evidence")
@@ -701,6 +848,15 @@ def activate_experiment(
         physical_attempt_id=_validate_id(physical_attempt_id, "physical_attempt_id"),
         ledger=ledger,
         policy=policy,
+        attempt_budget=(
+            _ExperimentAttemptBudgetRuntime(
+                policy=attempt_budget,
+                clock=monotonic_clock,
+                started_monotonic=monotonic_clock(),
+            )
+            if attempt_budget is not None
+            else None
+        ),
     )
     if ledger.experiment_id != active.experiment_id or ledger.physical_attempt_id != active.physical_attempt_id:
         raise EvidenceError("Active experiment identity does not match its ledger")
@@ -721,6 +877,118 @@ def get_active_experiment(thread_id: str | None) -> ActiveExperiment | None:
         return None
     with _ACTIVE_EXPERIMENTS_GUARD:
         return _ACTIVE_EXPERIMENTS.get(thread_id)
+
+
+def _attempt_budget_snapshot_locked(active: ActiveExperiment) -> dict[str, Any]:
+    runtime = active.attempt_budget
+    if runtime is None:
+        raise EvidenceError("The active experiment has no attempt budget")
+    elapsed_seconds = max(0.0, runtime.clock() - runtime.started_monotonic)
+    events = active.ledger.read()
+    compiler_invocations_completed = sum(event["event"] == "agent.subagent_terminated" and event["payload"].get("role") == "compiler" for event in events)
+    policy = runtime.policy
+    work_deadline_reached = elapsed_seconds >= policy.work_deadline_seconds
+    model_request_limit_reached = runtime.model_requests_claimed >= policy.max_model_requests
+    compiler_invocation_limit_reached = compiler_invocations_completed >= policy.max_compiler_invocations
+    return {
+        "elapsed_seconds": round(elapsed_seconds, 6),
+        "work_deadline_seconds": policy.work_deadline_seconds,
+        "total_wall_clock_seconds": policy.total_wall_clock_seconds,
+        "cleanup_reserve_seconds": policy.cleanup_reserve_seconds,
+        "model_requests_claimed": runtime.model_requests_claimed,
+        "maximum_model_requests": policy.max_model_requests,
+        "compiler_invocations_claimed": runtime.compiler_invocations_claimed,
+        "compiler_invocations_completed": compiler_invocations_completed,
+        "maximum_compiler_invocations": policy.max_compiler_invocations,
+        "work_deadline_reached": work_deadline_reached,
+        "model_request_limit_reached": model_request_limit_reached,
+        "compiler_invocation_limit_reached": compiler_invocation_limit_reached,
+        "within_total_wall_clock": (elapsed_seconds <= policy.total_wall_clock_seconds),
+        "cleanup_required": (work_deadline_reached or model_request_limit_reached or compiler_invocation_limit_reached),
+        "terminal_classification": policy.terminal_classification,
+    }
+
+
+def experiment_attempt_budget_snapshot(
+    thread_id: str | None,
+) -> dict[str, Any] | None:
+    active = get_active_experiment(thread_id)
+    if active is None or active.attempt_budget is None:
+        return None
+    with active.attempt_budget.lock:
+        return _attempt_budget_snapshot_locked(active)
+
+
+def remaining_experiment_work_seconds(thread_id: str | None) -> float | None:
+    snapshot = experiment_attempt_budget_snapshot(thread_id)
+    if snapshot is None:
+        return None
+    return max(
+        0.0,
+        snapshot["work_deadline_seconds"] - snapshot["elapsed_seconds"],
+    )
+
+
+def enforce_experiment_attempt_budget(
+    thread_id: str | None,
+    checkpoint: str,
+) -> dict[str, Any] | None:
+    if checkpoint not in _ATTEMPT_BUDGET_CHECKPOINTS:
+        raise EvidenceError(f"Unknown attempt-budget checkpoint: {checkpoint}")
+    active = get_active_experiment(thread_id)
+    if active is None or active.attempt_budget is None:
+        return None
+    runtime = active.attempt_budget
+    with runtime.lock:
+        before = _attempt_budget_snapshot_locked(active)
+        cleanup_checkpoint = checkpoint in {"before_finalize", "before_cleanup"}
+        allowed = cleanup_checkpoint
+        classification: str | None = None
+        if not cleanup_checkpoint:
+            if before["work_deadline_reached"]:
+                classification = "work_deadline_reached"
+            elif before["model_request_limit_reached"]:
+                classification = "model_request_limit_reached"
+            elif before["compiler_invocation_limit_reached"]:
+                classification = "compiler_invocation_limit_reached"
+            elif checkpoint == "before_compiler_invocation" and runtime.compiler_invocations_claimed >= runtime.policy.max_compiler_invocations:
+                classification = "compiler_invocation_limit_reached"
+            else:
+                allowed = True
+
+        if allowed and checkpoint == "before_provider_request":
+            runtime.model_requests_claimed += 1
+        elif allowed and checkpoint == "before_compiler_invocation":
+            runtime.compiler_invocations_claimed += 1
+
+        snapshot = _attempt_budget_snapshot_locked(active)
+        active.ledger.append(
+            "attempt.budget_checkpoint",
+            {
+                "checkpoint": checkpoint,
+                "allowed": allowed,
+                "rejection_classification": classification,
+                "snapshot": snapshot,
+            },
+        )
+        if not allowed:
+            raise AttemptBudgetExceeded(
+                checkpoint,
+                runtime.policy.terminal_classification,
+            )
+        return snapshot
+
+
+def record_experiment_attempt_budget_completion(
+    thread_id: str | None,
+) -> dict[str, Any] | None:
+    active = get_active_experiment(thread_id)
+    if active is None or active.attempt_budget is None:
+        return None
+    with active.attempt_budget.lock:
+        snapshot = _attempt_budget_snapshot_locked(active)
+        active.ledger.append("attempt.budget_completed", snapshot)
+        return snapshot
 
 
 def record_experiment_event(thread_id: str | None, event: str, **payload: Any) -> dict[str, Any] | None:

--- a/backend/packages/harness/deerflow/compile/operations.py
+++ b/backend/packages/harness/deerflow/compile/operations.py
@@ -20,6 +20,7 @@ from deerflow.compile.docker_runtime import CONTAINER_REPO_DIR, CONTAINER_WORKSP
 from deerflow.compile.evidence import (
     EvidenceError,
     allowed_command_role,
+    enforce_experiment_attempt_budget,
     get_active_experiment,
     new_evidence_id,
     record_experiment_event,
@@ -1452,6 +1453,10 @@ def submit_build_result_impl(
     session: CompileSession,
     supporting_command_id: str | None = None,
 ) -> str:
+    enforce_experiment_attempt_budget(
+        session.thread_id,
+        "before_submit_or_replay",
+    )
     services = get_compile_services()
     submit_attempt_id = new_evidence_id("submit")
     with services.manager.session_lock(session.thread_id, session.session_id):
@@ -2252,6 +2257,10 @@ def verify_clean_replay_impl(
     submit_attempt_id: str | None = None,
     timeout_seconds: int | None = None,
 ) -> ReplayVerificationResult:
+    enforce_experiment_attempt_budget(
+        session.thread_id,
+        "before_submit_or_replay",
+    )
     services = get_compile_services()
     configured_timeout = getattr(getattr(services.runtime, "config", None), "replay_timeout_seconds", 1200)
     effective_timeout = max(1, timeout_seconds or configured_timeout)
@@ -2632,6 +2641,7 @@ def finalize_compile_session_impl(
     error: str | None = None,
     generate_repro_bundle: bool = True,
 ) -> CompileSession:
+    enforce_experiment_attempt_budget(session.thread_id, "before_finalize")
     services = get_compile_services()
     with services.manager.session_lock(session.thread_id, session.session_id):
         try:
@@ -2809,6 +2819,7 @@ def cleanup_and_finalize_compile_session_impl(
     error: str | None = None,
 ) -> tuple[CompileSession, ContainerCleanupResult]:
     """Clean a session container and persist a terminal result only after cleanup succeeds."""
+    enforce_experiment_attempt_budget(session.thread_id, "before_cleanup")
     services = get_compile_services()
     with services.manager.session_lock(session.thread_id, session.session_id):
         try:
@@ -2916,6 +2927,7 @@ def cleanup_compile_session_container_impl(
     error: str | None = None,
 ) -> tuple[CompileSession, ContainerCleanupResult]:
     """Reload and clean a session container under the session lifecycle lock."""
+    enforce_experiment_attempt_budget(session.thread_id, "before_cleanup")
     services = get_compile_services()
     with services.manager.session_lock(session.thread_id, session.session_id):
         try:

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -15,7 +15,12 @@ from langgraph.typing import ContextT
 
 from deerflow.agents.lead_agent.prompt import get_skills_prompt_section
 from deerflow.agents.thread_state import ThreadState
-from deerflow.compile.evidence import ExperimentPolicy, new_evidence_id, record_experiment_event
+from deerflow.compile.evidence import (
+    ExperimentPolicy,
+    enforce_experiment_attempt_budget,
+    new_evidence_id,
+    record_experiment_event,
+)
 from deerflow.subagents import SubagentExecutor, get_available_subagent_names, get_subagent_config
 from deerflow.subagents.executor import (
     SubagentStatus,
@@ -358,6 +363,12 @@ async def task_tool(
         trace_id=trace_id,
         initial_state=compile_state,
     )
+
+    if subagent_type == "compiler":
+        enforce_experiment_attempt_budget(
+            thread_id,
+            "before_compiler_invocation",
+        )
 
     task_started_at = monotonic()
     task_id = executor.execute_async(prompt, task_id=tool_call_id)

--- a/backend/tests/test_compile_replay_docker.py
+++ b/backend/tests/test_compile_replay_docker.py
@@ -21,7 +21,16 @@ import pytest
 
 from deerflow.compile import operations
 from deerflow.compile.docker_runtime import CompileDockerRuntime
-from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
+from deerflow.compile.evidence import (
+    AttemptBudgetExceeded,
+    ExperimentAttemptBudget,
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+    record_experiment_attempt_budget_completion,
+)
 from deerflow.compile.manager import CompileSessionManager
 from deerflow.compile.operations import (
     CompileOperationsServices,
@@ -31,6 +40,7 @@ from deerflow.compile.operations import (
     clone_repository_impl,
     finalize_unfinished_thread_sessions_impl,
     inspect_build_system_impl,
+    submit_build_result_impl,
     verify_clean_replay_impl,
 )
 from deerflow.compile.schemas import BuildArtifact, BuildCommandRecord, CommandResult, CompileSession, VerificationResult
@@ -990,3 +1000,116 @@ def test_clean_replay_rejects_success_recipe_dependent_on_failed_configure_side_
     assert attempt.failure_classification == "recipe_execution_failed"
     assert attempt.exit_code not in {None, 0}
     assert not any(check.name == "artifact_set" for check in attempt.checks)
+
+
+def test_attempt_budget_rejects_submit_but_finalizes_and_leaves_no_orphan(
+    monkeypatch,
+):
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    thread_id = f"docker-attempt-budget-{uuid.uuid4().hex[:12]}"
+    session = manager.create_session(
+        thread_id=thread_id,
+        repo_url=REPO_URL,
+        image=COMPILE_IMAGE,
+    )
+    runtime = CompileDockerRuntime(manager=manager)
+    ledger = ExperimentLedger.create(
+        Path(session.metadata_path).parent / "attempt-budget.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-attempt-budget-integration",
+        manifest_sha256="5" * 64,
+        case_id="cmake-hello-world",
+        condition="non-model-integration",
+        repetition=1,
+        expected_repo_url=REPO_URL,
+        expected_commit_sha=COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=COMPILE_IMAGE,
+        image_id=COMPILE_IMAGE_ID,
+        model_name="deterministic-tools",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=300,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    now = [100.0]
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+        attempt_budget=ExperimentAttemptBudget(
+            total_wall_clock_seconds=20,
+            cleanup_reserve_seconds=5,
+            max_compiler_invocations=2,
+            max_model_requests=48,
+        ),
+        monotonic_clock=lambda: now[0],
+    )
+    try:
+        runtime.create_container(session)
+        manager.save_session(session)
+
+        now[0] = 115.0
+        with pytest.raises(AttemptBudgetExceeded):
+            submit_build_result_impl(session=session)
+
+        now[0] = 121.0
+        finalized, cleanup = cleanup_and_finalize_compile_session_impl(
+            session=session,
+            interrupted_status="timed_out",
+            error="Physical-attempt budget exhausted.",
+        )
+        completion = record_experiment_attempt_budget_completion(thread_id)
+
+        assert cleanup.succeeded is True
+        assert cleanup.removed is True
+        assert finalized.status == "timed_out"
+        assert finalized.finalized_at is not None
+        assert completion is not None
+        assert completion["within_total_wall_clock"] is False
+
+        orphans = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-aq",
+                "--filter",
+                (f"label=deerflow.compile.physical_attempt_id={ledger.physical_attempt_id}"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert orphans.returncode == 0, orphans.stderr
+        assert orphans.stdout.strip() == ""
+
+        checkpoints = [event["payload"] for event in ledger.read() if event["event"] == "attempt.budget_checkpoint"]
+        assert any(payload["checkpoint"] == "before_submit_or_replay" and payload["allowed"] is False for payload in checkpoints)
+        assert any(payload["checkpoint"] == "before_cleanup" and payload["allowed"] is True for payload in checkpoints)
+        assert any(payload["checkpoint"] == "before_finalize" and payload["allowed"] is True for payload in checkpoints)
+    finally:
+        assert deactivate_experiment(thread_id) is active
+        runtime.stop_and_remove_container(session)
+        shutil.rmtree(Path(session.metadata_path).parent.parent, ignore_errors=True)

--- a/backend/tests/test_experiment_evidence.py
+++ b/backend/tests/test_experiment_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,17 +10,22 @@ from types import SimpleNamespace
 import pytest
 
 from deerflow.compile.evidence import (
+    AttemptBudgetExceeded,
     EvidenceError,
+    ExperimentAttemptBudget,
     ExperimentLedger,
     ExperimentPolicy,
     activate_experiment,
     canonical_json_bytes,
     claim_experiment_clarification_auto_answer,
     deactivate_experiment,
+    enforce_experiment_attempt_budget,
+    experiment_attempt_budget_snapshot,
     get_active_experiment,
     model_response_metadata,
     new_evidence_id,
     record_agent_tool_failure,
+    record_experiment_attempt_budget_completion,
     record_experiment_event,
 )
 from deerflow.tools.builtins.task_tool import _record_subagent_terminal_evidence
@@ -162,6 +168,167 @@ def test_active_experiment_registry_routes_events_to_one_thread(tmp_path: Path) 
     events = ledger.read()
     assert [event["event"] for event in events] == ["experiment.started", "model.request_started"]
     assert get_active_experiment(thread_id) is None
+
+
+def test_attempt_budget_claims_are_atomic_and_hash_chained(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    budget = ExperimentAttemptBudget(
+        total_wall_clock_seconds=60,
+        cleanup_reserve_seconds=10,
+        max_compiler_invocations=2,
+        max_model_requests=2,
+    )
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+        attempt_budget=budget,
+    )
+
+    def claim_provider() -> bool:
+        try:
+            enforce_experiment_attempt_budget(
+                thread_id,
+                "before_provider_request",
+            )
+        except AttemptBudgetExceeded:
+            return False
+        return True
+
+    try:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            allowed = list(pool.map(lambda _index: claim_provider(), range(8)))
+        snapshot = experiment_attempt_budget_snapshot(thread_id)
+        assert snapshot is not None
+        assert sum(allowed) == 2
+        assert snapshot["model_requests_claimed"] == 2
+        assert snapshot["model_request_limit_reached"] is True
+        completion = record_experiment_attempt_budget_completion(thread_id)
+        assert completion is not None
+        assert completion["model_requests_claimed"] == 2
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+    events = ExperimentLedger.verify_path(ledger.path)
+    checkpoints = [event for event in events if event["event"] == "attempt.budget_checkpoint"]
+    assert len(checkpoints) == 8
+    assert sum(event["payload"]["allowed"] for event in checkpoints) == 2
+    assert events[-1]["event"] == "attempt.budget_completed"
+
+
+def test_attempt_budget_rejects_third_compiler_claim_atomically(
+    tmp_path: Path,
+) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+        attempt_budget=ExperimentAttemptBudget(
+            total_wall_clock_seconds=60,
+            cleanup_reserve_seconds=10,
+            max_compiler_invocations=2,
+            max_model_requests=48,
+        ),
+    )
+
+    def claim_compiler() -> bool:
+        try:
+            enforce_experiment_attempt_budget(
+                thread_id,
+                "before_compiler_invocation",
+            )
+        except AttemptBudgetExceeded:
+            return False
+        return True
+
+    try:
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            allowed = list(pool.map(lambda _index: claim_compiler(), range(6)))
+        snapshot = experiment_attempt_budget_snapshot(thread_id)
+        assert snapshot is not None
+        assert sum(allowed) == 2
+        assert snapshot["compiler_invocations_claimed"] == 2
+        assert snapshot["compiler_invocations_completed"] == 0
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+
+def test_attempt_budget_rejects_new_work_but_never_cleanup(tmp_path: Path) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    now = [100.0]
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+        attempt_budget=ExperimentAttemptBudget(
+            total_wall_clock_seconds=20,
+            cleanup_reserve_seconds=5,
+            max_compiler_invocations=2,
+            max_model_requests=48,
+        ),
+        monotonic_clock=lambda: now[0],
+    )
+    try:
+        now[0] = 115.0
+        with pytest.raises(AttemptBudgetExceeded) as rejected:
+            enforce_experiment_attempt_budget(
+                thread_id,
+                "before_submit_or_replay",
+            )
+        assert rejected.value.classification == "attempt_budget_exhausted"
+
+        now[0] = 121.0
+        finalize = enforce_experiment_attempt_budget(
+            thread_id,
+            "before_finalize",
+        )
+        cleanup = enforce_experiment_attempt_budget(
+            thread_id,
+            "before_cleanup",
+        )
+        assert finalize is not None
+        assert cleanup is not None
+        assert finalize["within_total_wall_clock"] is False
+        assert cleanup["cleanup_required"] is True
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+
+def test_experiment_without_attempt_budget_preserves_legacy_behavior(
+    tmp_path: Path,
+) -> None:
+    ledger = create_ledger(tmp_path)
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    active = activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=make_policy(),
+    )
+    try:
+        assert (
+            enforce_experiment_attempt_budget(
+                thread_id,
+                "before_provider_request",
+            )
+            is None
+        )
+        assert experiment_attempt_budget_snapshot(thread_id) is None
+    finally:
+        assert deactivate_experiment(thread_id) is active
+
+    assert [event["event"] for event in ledger.read()] == ["experiment.started"]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_forge_formal_collection_v2_authorized_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v2_authorized_protocol.py
@@ -20,8 +20,8 @@ CANDIDATE_FILE_SHA256 = {
     "benchmarks/manifests/cpp-formal-v2-collection.json": ("e2537295a33ab52c136121ad02dc1034040bc95d52253944433884f10f629002"),
     "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": ("aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30"),
     "scripts/forge_formal_collection_v2_protocol.py": ("f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499"),
-    "scripts/forge_formal_collection_v2_runner.py": ("35f6b23ebbbb1e7bc5b540a0b9bfd627d23b75957095922aa79c2db396b64c4b"),
 }
+FROZEN_CANDIDATE_RUNNER_SHA256 = "35f6b23ebbbb1e7bc5b540a0b9bfd627d23b75957095922aa79c2db396b64c4b"
 
 
 def _load_module(name: str, path: Path):
@@ -98,6 +98,12 @@ def test_candidate_protocol_files_remain_byte_identical() -> None:
     for relative_path, expected in CANDIDATE_FILE_SHA256.items():
         actual = hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest()
         assert actual == expected
+
+
+def test_historical_manifests_keep_the_frozen_candidate_runner_identity() -> None:
+    for manifest_path in (PARENT_MANIFEST_PATH, MANIFEST_PATH):
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["protocol_artifact_sha256"]["scripts/forge_formal_collection_v2_runner.py"] == FROZEN_CANDIDATE_RUNNER_SHA256
 
 
 def test_runner_loads_authorized_policy_and_shared_v2_runtime() -> None:

--- a/backend/tests/test_forge_formal_collection_v4_lifecycle.py
+++ b/backend/tests/test_forge_formal_collection_v4_lifecycle.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile.evidence import AttemptBudgetExceeded
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v2_runner.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_module("forge_formal_collection_v4_lifecycle_test", RUNNER_PATH)
+
+
+def test_work_deadline_cancels_active_agent_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream_cancelled = asyncio.Event()
+    enforced: list[tuple[str, str]] = []
+
+    class SlowClient:
+        async def astream(self, _message: str, *, thread_id: str):
+            del thread_id
+            try:
+                await asyncio.sleep(60)
+                yield None
+            except asyncio.CancelledError:
+                stream_cancelled.set()
+                raise
+
+    monkeypatch.setattr(
+        runner,
+        "remaining_experiment_work_seconds",
+        lambda _thread_id: 0.01,
+    )
+
+    def reject(thread_id: str, checkpoint: str):
+        enforced.append((thread_id, checkpoint))
+        raise AttemptBudgetExceeded(checkpoint, "attempt_budget_exhausted")
+
+    monkeypatch.setattr(runner, "enforce_experiment_attempt_budget", reject)
+
+    with pytest.raises(AttemptBudgetExceeded) as exc_info:
+        asyncio.run(
+            runner._consume_client_stream_with_attempt_budget(
+                SlowClient(),
+                "compile",
+                thread_id="thread-attempt-budget",
+            )
+        )
+
+    assert exc_info.value.classification == "attempt_budget_exhausted"
+    assert stream_cancelled.is_set()
+    assert enforced == [("thread-attempt-budget", "before_submit_or_replay")]
+
+
+def test_runner_without_attempt_budget_preserves_unbounded_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Client:
+        async def astream(self, _message: str, *, thread_id: str):
+            del thread_id
+            yield type(
+                "Event",
+                (),
+                {"type": "end", "data": None},
+            )()
+
+    monkeypatch.setattr(
+        runner,
+        "remaining_experiment_work_seconds",
+        lambda _thread_id: None,
+    )
+
+    result = asyncio.run(
+        runner._consume_client_stream_with_attempt_budget(
+            Client(),
+            "compile",
+            thread_id="legacy-thread",
+        )
+    )
+
+    assert result == {
+        "tool_call_count": 0,
+        "compile_tool_call_count": 0,
+        "stream_completed": True,
+    }

--- a/backend/tests/test_forge_formal_collection_v4_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_protocol.py
@@ -54,12 +54,22 @@ def _evidence_mount(source: str) -> list[dict]:
     ]
 
 
-def test_v4_manifest_is_committed_schema_valid_and_deterministic() -> None:
+def test_v4_manifest_remains_valid_after_reviewed_runtime_successor() -> None:
     manifest = load_manifest()
     parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
 
     assert formal_collection.validate_manifest(manifest) == manifest
-    assert formal_collection.generate_manifest() == manifest
+    assert formal_collection.manifest_sha256(manifest) == "bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720"
+    regenerated = formal_collection.generate_manifest()
+    assert regenerated != manifest
+    for field in set(manifest) - {
+        "forge",
+        "protocol_artifact_sha256",
+        "prompt_sha256",
+    }:
+        assert regenerated[field] == manifest[field]
+    assert regenerated["forge"]["commit_sha"] == manifest["forge"]["commit_sha"]
+    assert regenerated["forge"]["component_sha256"] != manifest["forge"]["component_sha256"]
     assert manifest["collection_plan"] == parent["collection_plan"]
     assert manifest["cases"] == parent["cases"]
     assert manifest["conditions"] == parent["conditions"]

--- a/backend/tests/test_forge_formal_collection_v4_runtime_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_runtime_protocol.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_runtime_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_runtime_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-runtime-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-runtime-candidate.schema.json"
+PARENT_FILE_SHA256 = {
+    "scripts/forge_formal_collection_v4_protocol.py": ("a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704"),
+    "scripts/forge_formal_collection_v4_runner.py": ("4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a"),
+    "benchmarks/manifests/cpp-formal-v4-collection.json": ("68e752e2ec85964045a9c7e27e87cf61e20b500a127e9326e28c1b4ad6bd592a"),
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": ("6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72"),
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": ("90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4"),
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_formal_collection_v4_runtime_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_formal_collection_v4_runtime_runner_test", RUNNER_PATH)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_runtime_candidate_is_schema_valid_deterministic_and_unapproved() -> None:
+    manifest = load_manifest()
+
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    assert manifest["schema_version"] == "formal-collection-4.1.0-runtime-candidate"
+    assert manifest["scope"]["collection_authorized"] is False
+    assert manifest["scope"]["formal_comparison_enabled"] is False
+    assert manifest["forge"]["commit_sha"] == ("3ac49b92eedecf4932a829e75465dd7ddd16b97e")
+    assert manifest["authorization"]["issue_url"].endswith("/issues/105")
+    assert manifest["authorization"]["collection_constraints"] == {
+        "collection_authorized": False,
+        "provider_canary_forbidden": True,
+        "physical_attempt_creation_forbidden": True,
+        "model_execution_forbidden": True,
+        "batch_execution_forbidden": True,
+        "complete_project_blocks_require_confirmation": True,
+        "slot_count_requires_confirmation": True,
+        "recorded_token_budget_requires_confirmation": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+    }
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_runtime_candidate_preserves_v4_design_and_parent_bytes() -> None:
+    manifest = load_manifest()
+    parent = json.loads((REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json").read_text(encoding="utf-8"))
+
+    for field in (
+        "source_protocols",
+        "model_profiles",
+        "runtime",
+        "budget",
+        "conditions",
+        "collection_plan",
+        "schedule_sha256",
+        "cases",
+        "attempt_budget",
+        "resource_preflight",
+        "analysis_plan",
+    ):
+        assert manifest[field] == parent[field]
+    assert manifest["attempt_budget"]["total_wall_clock_seconds"] == 1800
+    assert manifest["attempt_budget"]["cleanup_reserve_seconds"] == 120
+    assert manifest["attempt_budget"]["max_compiler_invocations"] == 2
+    assert manifest["attempt_budget"]["max_model_requests"] == 48
+    assert manifest["authorization"]["parent_manifest"]["canonical_sha256"] == "bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720"
+
+    for relative_path, expected in PARENT_FILE_SHA256.items():
+        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["scope"].update(collection_authorized=True),
+        lambda value: value["attempt_budget"].update(total_wall_clock_seconds=1801),
+        lambda value: value["attempt_budget"].update(max_model_requests=49),
+        lambda value: value["authorization"]["collection_constraints"].update(model_execution_forbidden=False),
+        lambda value: value["collection_plan"].reverse(),
+    ],
+)
+def test_runtime_candidate_rejects_protocol_or_authorization_drift(
+    mutation,
+) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(protocol.BenchmarkError):
+        protocol.validate_manifest(manifest)
+
+
+def test_runtime_runner_injects_reviewed_budget_into_future_authorized_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    captured = {}
+
+    def fake_run_attempt(
+        observed_manifest,
+        ledger_path,
+        *,
+        async_runner,
+        attempt_budget,
+    ):
+        captured.update(
+            manifest=observed_manifest,
+            ledger_path=ledger_path,
+            async_runner=async_runner,
+            attempt_budget=attempt_budget,
+        )
+        return {"status": "not-executed"}
+
+    monkeypatch.setattr(runner, "_original_run_attempt", fake_run_attempt)
+
+    result = runner.run_attempt_with_budget(
+        manifest,
+        tmp_path / "not-created.jsonl",
+    )
+
+    assert result == {"status": "not-executed"}
+    budget = captured["attempt_budget"]
+    assert budget.total_wall_clock_seconds == 1800
+    assert budget.work_deadline_seconds == 1680
+    assert budget.cleanup_reserve_seconds == 120
+    assert budget.max_compiler_invocations == 2
+    assert budget.max_model_requests == 48
+    assert not captured["ledger_path"].exists()
+
+
+def test_runtime_runner_loads_policy_without_authorizing_collection() -> None:
+    manifest = runner._load_manifest(MANIFEST_PATH)
+    first_slot = manifest["collection_plan"][0]
+
+    policy = runner.build_policy(
+        manifest,
+        case_id=first_slot["case_id"],
+        condition_id=first_slot["condition_id"],
+        repetition=first_slot["repetition"],
+    )
+
+    assert policy.benchmark_id == "forge-cpp-formal-v4-runtime-candidate"
+    assert policy.memory_enabled is False
+    assert policy.artifact_instructions
+
+
+def test_runtime_candidate_cli_rejects_all_external_actions_without_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    first_slot = manifest["collection_plan"][0]
+    common = ["--manifest", str(MANIFEST_PATH)]
+    commands = [
+        ["provider-canary", *common, "--output-dir", str(tmp_path)],
+        [
+            "create-attempt",
+            *common,
+            "--case",
+            first_slot["case_id"],
+            "--condition",
+            first_slot["condition_id"],
+            "--repetition",
+            str(first_slot["repetition"]),
+            "--output-dir",
+            str(tmp_path),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run",
+            *common,
+            "--ledger",
+            str(tmp_path / "missing.jsonl"),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run-batch",
+            *common,
+            "--output-dir",
+            str(tmp_path),
+            "--max-attempts",
+            "1",
+            "--skip-endpoint-check",
+        ],
+    ]
+
+    for command in commands:
+        assert runner.main(command) == 2
+
+    assert list(tmp_path.rglob("*.jsonl")) == []
+    assert list(tmp_path.rglob("*.json")) == []

--- a/backend/tests/test_forge_formal_collection_v4_runtime_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_runtime_protocol.py
@@ -4,6 +4,10 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import jsonschema
@@ -68,6 +72,66 @@ def test_runtime_candidate_is_schema_valid_deterministic_and_unapproved() -> Non
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.Draft202012Validator.check_schema(schema)
     jsonschema.validate(manifest, schema)
+
+
+def test_runtime_protocol_resolves_parent_modules_from_repository_root(
+    tmp_path: Path,
+) -> None:
+    relocated_script_root = tmp_path / "app" / "scripts"
+    relocated_script_root.mkdir(parents=True)
+    relocated_protocol = relocated_script_root / PROTOCOL_PATH.name
+    shutil.copyfile(PROTOCOL_PATH, relocated_protocol)
+    env = {**os.environ, "FORGE_REPO_ROOT": str(REPO_ROOT)}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(relocated_protocol),
+            "validate-manifest",
+            str(MANIFEST_PATH),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert '"status": "valid"' in result.stdout
+
+
+def test_runtime_runner_resolves_parent_modules_before_rejecting_action(
+    tmp_path: Path,
+) -> None:
+    relocated_script_root = tmp_path / "app" / "scripts"
+    relocated_script_root.mkdir(parents=True)
+    relocated_runner = relocated_script_root / RUNNER_PATH.name
+    shutil.copyfile(PROTOCOL_PATH, relocated_script_root / PROTOCOL_PATH.name)
+    shutil.copyfile(RUNNER_PATH, relocated_runner)
+    output_dir = tmp_path / "evidence"
+    env = {**os.environ, "FORGE_REPO_ROOT": str(REPO_ROOT)}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(relocated_runner),
+            "provider-canary",
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "runtime candidate is not authorized" in result.stderr
+    assert not output_dir.exists()
 
 
 def test_runtime_candidate_preserves_v4_design_and_parent_bytes() -> None:

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -12,6 +12,8 @@ from deerflow.agents.middlewares.llm_error_handling_middleware import (
     LLMErrorHandlingMiddleware,
 )
 from deerflow.compile.evidence import (
+    AttemptBudgetExceeded,
+    ExperimentAttemptBudget,
     ExperimentLedger,
     ExperimentPolicy,
     activate_experiment,
@@ -215,3 +217,76 @@ def test_active_experiment_records_one_429_attempt_without_exception_text(
     assert events[2]["payload"]["retry_exhausted"] is True
     assert events[3]["payload"]["domain"] == "model_endpoint"
     assert sentinel not in ledger.path.read_text(encoding="utf-8")
+
+
+def test_attempt_budget_rejects_provider_before_handler(
+    tmp_path: Path,
+) -> None:
+    thread_id = new_evidence_id("thread")
+    ledger = ExperimentLedger.create(
+        tmp_path / "attempt-budget.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"thread_id": thread_id},
+    )
+    policy = ExperimentPolicy(
+        benchmark_id="forge-cpp-pilot-v1",
+        manifest_sha256="1" * 64,
+        case_id="fmt",
+        condition="baseline",
+        repetition=1,
+        expected_repo_url="https://github.com/fmtlib/fmt.git",
+        expected_commit_sha="2" * 40,
+        expected_build_system="cmake",
+        compile_image="autocompiler:gcc13",
+        image_id=f"sha256:{'3' * 64}",
+        model_name="gpt-5.6-sol",
+        endpoint="https://example.invalid/v1",
+        credential_env="OpenAI_AK",
+        request_timeout_seconds=120,
+        model_max_retries=0,
+        compiler_max_turns=36,
+        subagent_timeout_seconds=180,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+    )
+    activate_experiment(
+        thread_id=thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+        attempt_budget=ExperimentAttemptBudget(
+            total_wall_clock_seconds=60,
+            cleanup_reserve_seconds=10,
+            max_compiler_invocations=2,
+            max_model_requests=1,
+        ),
+    )
+    request = SimpleNamespace(
+        runtime=SimpleNamespace(context={"thread_id": thread_id, "agent_name": "lead"}),
+        model=SimpleNamespace(model_name=policy.model_name, base_url=policy.endpoint),
+    )
+    handler_calls = 0
+
+    def handler(_request) -> AIMessage:
+        nonlocal handler_calls
+        handler_calls += 1
+        return AIMessage(content="ok")
+
+    middleware = LLMErrorHandlingMiddleware()
+    try:
+        assert middleware.wrap_model_call(request, handler).content == "ok"
+        with pytest.raises(AttemptBudgetExceeded):
+            middleware.wrap_model_call(request, handler)
+    finally:
+        deactivate_experiment(thread_id)
+
+    assert handler_calls == 1
+    checkpoints = [event["payload"] for event in ledger.read() if event["event"] == "attempt.budget_checkpoint"]
+    assert [payload["allowed"] for payload in checkpoints] == [True, False]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -518,3 +518,26 @@ derivation in addition to the Draft 2020-12 Schema. The committed protocol has
 `create-attempt` and `run` fail before ledger creation or model execution.
 Collection requires a separate reviewed protocol identity and explicit human
 budget authorization; never toggle the frozen manifest in place.
+
+## Formal v4 lifecycle runtime candidate
+
+`benchmarks/manifests/cpp-formal-v4-runtime-candidate.json` binds the Issue
+#105 lifecycle implementation to baseline commit
+`3ac49b92eedecf4932a829e75465dd7ddd16b97e`. It preserves the formal-v4
+attempt limits and analysis plan while connecting one runtime budget to the
+provider, Compiler, submit/clean replay, finalization, cleanup, and runner
+cancellation paths.
+
+Generate and validate the candidate with:
+
+```bash
+python scripts/forge_formal_collection_v4_runtime_protocol.py generate
+python scripts/forge_formal_collection_v4_runtime_protocol.py validate-manifest \
+  benchmarks/manifests/cpp-formal-v4-runtime-candidate.json
+```
+
+The candidate remains `collection_authorized=false`. Its CLI rejects provider
+canary, attempt creation, model execution, and batch execution before evidence
+creation. Complete project blocks, slot count, recorded-token ceiling, evidence
+directory, and network observation require a later experiment-owner decision
+and a new authorized child identity.

--- a/benchmarks/manifests/cpp-formal-v4-runtime-candidate.json
+++ b/benchmarks/manifests/cpp-formal-v4-runtime-candidate.json
@@ -85,8 +85,8 @@
     "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
     "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
     "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
-    "scripts/forge_formal_collection_v4_runtime_protocol.py": "31da594614bd6715c6788cfeaa7374efe2ed249021bb144f7ca1e199121f4c3f",
-    "scripts/forge_formal_collection_v4_runtime_runner.py": "a9fe581fbf92b2aa35e74f832c831b0a878559a536a45bfaa2b74b8f6b870cd2",
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": "e0b14b5e2f224846f1c5c0c213f66e0667a5d008d4e246d37b1b805c4ccf595e",
+    "scripts/forge_formal_collection_v4_runtime_runner.py": "9b4ba4f4eabb5888fd663b241d69a00dfc5e369474755dd64338b02fc146e42f",
     "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
     "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
   },

--- a/benchmarks/manifests/cpp-formal-v4-runtime-candidate.json
+++ b/benchmarks/manifests/cpp-formal-v4-runtime-candidate.json
@@ -1,0 +1,2809 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+  "schema_version": "formal-collection-4.1.0-runtime-candidate",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v4-runtime-candidate",
+    "name": "Forge C/C++ attempt-bounded formal v4 runtime candidate",
+    "purpose": "unapproved lifecycle enforcement implementation review",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v4_runtime_candidate",
+    "formal_comparison_enabled": false,
+    "collection_authorized": false,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "3ac49b92eedecf4932a829e75465dd7ddd16b97e",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": "90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4",
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": "2fbdbbb2c419e2dcea24be1c6bd5650febdbd64509068e6ecd78fe64a5f9f04a",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": "69bba99ca4fba5afd10e170976f509c90e089a5769d3939cea416411276dda60",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": "6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "d81d1e973b44be0b1a042dfdafea77b64faa79d4596eca16ce20fb8455351718",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
+    "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": "31da594614bd6715c6788cfeaa7374efe2ed249021bb144f7ca1e199121f4c3f",
+    "scripts/forge_formal_collection_v4_runtime_runner.py": "a9fe581fbf92b2aa35e74f832c831b0a878559a536a45bfaa2b74b8f6b870cd2",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    }
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v4-runtime-candidate-review",
+    "status": "runtime_implemented_collection_pending",
+    "implemented_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/105",
+    "implementation_baseline_commit": "3ac49b92eedecf4932a829e75465dd7ddd16b97e",
+    "collection_constraints": {
+      "collection_authorized": false,
+      "provider_canary_forbidden": true,
+      "physical_attempt_creation_forbidden": true,
+      "model_execution_forbidden": true,
+      "batch_execution_forbidden": true,
+      "complete_project_blocks_require_confirmation": true,
+      "slot_count_requires_confirmation": true,
+      "recorded_token_budget_requires_confirmation": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v4-collection",
+      "path": "benchmarks/manifests/cpp-formal-v4-collection.json",
+      "canonical_sha256": "bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720"
+    }
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit"
+    ],
+    "sensitive_host_identifiers_forbidden": true
+  },
+  "analysis_plan": {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": true,
+    "retry_replacement_backfill_forbidden": true
+  }
+}

--- a/benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md
+++ b/benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md
@@ -1,0 +1,41 @@
+# Forge C/C++ formal v4 lifecycle runtime amendment
+
+## Status
+
+This document records the Issue #105 implementation candidate. It does not
+authorize a provider canary, physical-attempt ledger, model request, or batch.
+
+## Frozen implementation
+
+- Implementation baseline: `3ac49b92eedecf4932a829e75465dd7ddd16b97e`.
+- One active physical attempt owns one monotonic clock and one append-only
+  budget state.
+- Provider requests and Compiler invocations claim their limits atomically
+  before the external action starts.
+- Submit and clean replay check the same work deadline before creating new
+  work.
+- The runner cancels an active asynchronous agent stream when the 1,680-second
+  work deadline expires.
+- Finalization, container cleanup, and orphan reconciliation remain mandatory
+  after the work deadline and after the 1,800-second total wall clock.
+- The final ledger records the bounded checkpoint state and any overrun without
+  persisting prompts, credentials, provider bodies, host paths, or raw logs.
+
+## Preserved research boundaries
+
+The v4 limits remain 1,800 seconds total wall clock, 120 seconds cleanup
+reserve, two Compiler invocations, and 48 model requests. The 30 exact-commit
+C/C++ cases, 180-slot schedule, model profiles, Compose/DooD topology, Compile
+Session, clean replay, artifact oracle, and analysis plan remain unchanged.
+
+The seven formal-v3 observations remain a separate descriptive protocol
+stratum. A v4 primary estimate may use only complete project blocks collected
+under one later authorized v4 identity.
+
+## Remaining authorization
+
+Before any collection, the experiment owner must separately confirm complete
+project blocks, slot count, recorded-token ceiling, evidence directory, and
+network observation. The authorized child must retain the runtime component
+hashes from this candidate and continue to forbid retry, fallback,
+replacement, and backfill.

--- a/benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json
@@ -1,0 +1,505 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+  "title": "Forge C/C++ unapproved formal v4 lifecycle runtime candidate",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "manifest_canonicalization",
+    "benchmark",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "model_profiles",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "attempt_budget",
+    "resource_preflight",
+    "analysis_plan",
+    "authorization"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-4.1.0-runtime-candidate"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "const": {
+        "languages": [
+          "C",
+          "C++"
+        ],
+        "phase": "formal_collection_v4_runtime_candidate",
+        "formal_comparison_enabled": false,
+        "collection_authorized": false,
+        "instrumentation_blocker": false
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "3ac49b92eedecf4932a829e75465dd7ddd16b97e"
+        },
+        "component_sha256": {
+          "type": "object",
+          "required": [
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/client.py",
+            "backend/packages/harness/deerflow/compile/__init__.py",
+            "backend/packages/harness/deerflow/compile/docker_runtime.py",
+            "backend/packages/harness/deerflow/compile/evidence.py",
+            "backend/packages/harness/deerflow/compile/manager.py",
+            "backend/packages/harness/deerflow/compile/operations.py",
+            "backend/packages/harness/deerflow/compile/schemas.py",
+            "backend/packages/harness/deerflow/models/factory.py",
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+            "backend/packages/harness/deerflow/subagents/executor.py",
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+            "backend/uv.lock",
+            "config.example.yaml",
+            "docker/compile/Dockerfile",
+            "docker/docker-compose-dev.yaml"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/client.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/__init__.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/evidence.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/manager.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/operations.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/schemas.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/models/factory.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/executor.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/uv.lock": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "config.example.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/compile/Dockerfile": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/docker-compose-dev.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "required": [
+        "backend/Dockerfile",
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+        "scripts/forge_benchmark.py",
+        "scripts/forge_benchmark_runner.py",
+        "scripts/forge_formal_case_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_runner.py",
+        "scripts/forge_formal_collection_v2_protocol.py",
+        "scripts/forge_formal_collection_v2_runner.py",
+        "scripts/forge_formal_collection_v3_authorized_protocol.py",
+        "scripts/forge_formal_collection_v3_authorized_runner.py",
+        "scripts/forge_formal_collection_v3_protocol.py",
+        "scripts/forge_formal_collection_v3_runner.py",
+        "scripts/forge_formal_collection_v4_protocol.py",
+        "scripts/forge_formal_collection_v4_runner.py",
+        "scripts/forge_formal_collection_v4_runtime_protocol.py",
+        "scripts/forge_formal_collection_v4_runtime_runner.py",
+        "scripts/forge_formal_preregistration.py",
+        "scripts/forge_formal_runtime_protocol.py"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/Dockerfile": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_case_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_preregistration.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "required": [
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "const": {
+        "id": "forge-cpp-formal-v4-runtime-candidate-review",
+        "status": "runtime_implemented_collection_pending",
+        "implemented_on": "2026-08-11",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/105",
+        "implementation_baseline_commit": "3ac49b92eedecf4932a829e75465dd7ddd16b97e",
+        "collection_constraints": {
+          "collection_authorized": false,
+          "provider_canary_forbidden": true,
+          "physical_attempt_creation_forbidden": true,
+          "model_execution_forbidden": true,
+          "batch_execution_forbidden": true,
+          "complete_project_blocks_require_confirmation": true,
+          "slot_count_requires_confirmation": true,
+          "recorded_token_budget_requires_confirmation": true,
+          "replacement_forbidden": true,
+          "fallback_forbidden": true,
+          "retry_forbidden": true,
+          "backfill_forbidden": true
+        },
+        "parent_manifest": {
+          "id": "forge-cpp-formal-v4-collection",
+          "path": "benchmarks/manifests/cpp-formal-v4-collection.json",
+          "canonical_sha256": "bb151473b276c48b9faf287a9dcbdddd96145abf3acc605f952275cf3d3f6720"
+        }
+      }
+    },
+    "$schema": {
+      "const": "../schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json"
+    },
+    "manifest_canonicalization": {
+      "const": "UTF-8 JSON, sorted object keys, compact separators, no NaN"
+    },
+    "benchmark": {
+      "const": {
+        "id": "forge-cpp-formal-v4-runtime-candidate",
+        "name": "Forge C/C++ attempt-bounded formal v4 runtime candidate",
+        "purpose": "unapproved lifecycle enforcement implementation review",
+        "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+      }
+    },
+    "model_profiles": {
+      "const": {
+        "richlab-gpt-5.5": {
+          "endpoint": "https://rich-api.choosefire.com/v1",
+          "credential_env": "OpenAI_AK",
+          "roles": {
+            "lead": "gpt-5.5",
+            "compiler": "gpt-5.5"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        },
+        "deepseek-v4-flash": {
+          "endpoint": "https://api.deepseek.com",
+          "credential_env": "DEEPSEEK_API_KEY",
+          "roles": {
+            "lead": "deepseek-v4-flash",
+            "compiler": "deepseek-v4-flash"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        }
+      }
+    },
+    "attempt_budget": {
+      "const": {
+        "total_wall_clock_seconds": 1800,
+        "cleanup_reserve_seconds": 120,
+        "max_compiler_invocations": 2,
+        "max_model_requests": 48,
+        "enforcement_checkpoints": [
+          "before_provider_request",
+          "before_compiler_invocation",
+          "before_submit_or_replay",
+          "before_finalize",
+          "before_cleanup"
+        ],
+        "new_work_forbidden_after_limit": true,
+        "cleanup_mandatory_after_limit": true,
+        "terminal_classification": "attempt_budget_exhausted"
+      }
+    },
+    "resource_preflight": {
+      "const": {
+        "minimum_available_memory_bytes": 2147483648,
+        "docker_daemon_timeout_seconds": 10,
+        "maximum_docker_daemon_latency_seconds": 5,
+        "required_checks": [
+          "host_available_memory_at_least_minimum",
+          "docker_daemon_responded",
+          "docker_daemon_latency_within_limit"
+        ],
+        "sensitive_host_identifiers_forbidden": true
+      }
+    },
+    "analysis_plan": {
+      "const": {
+        "protocol_version_pooling": "forbidden",
+        "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+        "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+        "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+        "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+        "provider_and_case_imbalance_must_be_reported": true,
+        "retry_replacement_backfill_forbidden": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/forge_formal_collection_v2_runner.py
+++ b/scripts/forge_formal_collection_v2_runner.py
@@ -45,12 +45,17 @@ import forge_formal_collection_v2_protocol as protocol_formal_collection  # noqa
 import forge_formal_runtime_protocol as protocol_formal  # noqa: E402
 
 from deerflow.compile.evidence import (  # noqa: E402
+    AttemptBudgetExceeded,
     EvidenceError,
+    ExperimentAttemptBudget,
     ExperimentLedger,
     ExperimentPolicy,
     activate_experiment,
     deactivate_experiment,
+    enforce_experiment_attempt_budget,
     new_evidence_id,
+    record_experiment_attempt_budget_completion,
+    remaining_experiment_work_seconds,
 )
 
 
@@ -1526,6 +1531,28 @@ async def _consume_client_stream(
     }
 
 
+async def _consume_client_stream_with_attempt_budget(
+    client: Any,
+    message: str,
+    *,
+    thread_id: str,
+) -> dict[str, int | bool]:
+    remaining_seconds = remaining_experiment_work_seconds(thread_id)
+    if remaining_seconds is None:
+        return await _consume_client_stream(client, message, thread_id=thread_id)
+    if remaining_seconds <= 0:
+        enforce_experiment_attempt_budget(thread_id, "before_submit_or_replay")
+        raise AssertionError("attempt-budget enforcement did not reject an expired run")
+    try:
+        return await asyncio.wait_for(
+            _consume_client_stream(client, message, thread_id=thread_id),
+            timeout=remaining_seconds,
+        )
+    except TimeoutError:
+        enforce_experiment_attempt_budget(thread_id, "before_submit_or_replay")
+        raise AssertionError("attempt-budget enforcement did not classify the timeout")
+
+
 @contextmanager
 def _benchmark_memory_scope(policy: ExperimentPolicy):
     from deerflow.config.memory_config import (
@@ -1569,6 +1596,7 @@ def run_attempt(
     ledger_path: Path,
     *,
     async_runner: asyncio.Runner | None = None,
+    attempt_budget: ExperimentAttemptBudget | None = None,
 ) -> dict[str, Any]:
     if manifest.get("scope", {}).get("collection_authorized") is False:
         raise RunnerError("Formal collection is not authorized; model execution is forbidden")
@@ -1617,8 +1645,17 @@ def run_attempt(
         physical_attempt_id=ledger.physical_attempt_id,
         ledger=ledger,
         policy=policy,
+        attempt_budget=attempt_budget,
     )
     run_status = "failed"
+    attempt_budget_exhausted = False
+    attempt_budget_completion = None
+    reconciliation = {
+        "scan_succeeded": False,
+        "orphan_count": 0,
+        "removed_count": 0,
+        "cleanup_succeeded": False,
+    }
     session_finalization_succeeded = False
     build_identity_snapshot_recorded = manifest["schema_version"] not in {
         protocol_v5.SCHEMA_VERSION,
@@ -1638,7 +1675,7 @@ def run_attempt(
                 plan_mode=False,
                 available_skills=set(),
             )
-            stream_coro = _consume_client_stream(
+            stream_coro = _consume_client_stream_with_attempt_budget(
                 client,
                 _attempt_message(policy),
                 thread_id=thread_id,
@@ -1660,57 +1697,63 @@ def run_attempt(
             )
         run_status = "completed"
     except BaseException as exc:
+        attempt_budget_exhausted = isinstance(exc, AttemptBudgetExceeded)
         ledger.append(
             "run.failed",
             {
                 "failure_id": new_evidence_id("failure"),
-                "classification": type(exc).__name__,
+                "classification": (exc.classification if attempt_budget_exhausted else type(exc).__name__),
             },
         )
         if isinstance(exc, (KeyboardInterrupt, SystemExit)):
             raise
     finally:
-        interrupted_status = "failed" if run_status == "failed" else None
-        termination_error = "Benchmark run ended before compile session finalization." if interrupted_status is not None else None
-        session_finalization_succeeded = _finalize_attempt_sessions(
-            thread_id,
-            interrupted_status=interrupted_status,
-            error=termination_error,
-        )
-        deactivate_experiment(thread_id)
-        reconciliation = reconcile_orphans(ledger.physical_attempt_id)
-        if not session_finalization_succeeded and reconciliation["cleanup_succeeded"]:
+        try:
+            interrupted_status = "timed_out" if attempt_budget_exhausted else ("failed" if run_status == "failed" else None)
+            termination_error = (
+                "Physical-attempt budget was exhausted before compile session finalization." if attempt_budget_exhausted else ("Benchmark run ended before compile session finalization." if interrupted_status is not None else None)
+            )
             session_finalization_succeeded = _finalize_attempt_sessions(
                 thread_id,
                 interrupted_status=interrupted_status,
                 error=termination_error,
             )
-        if manifest["schema_version"] in {
-            protocol_v5.SCHEMA_VERSION,
-            protocol_v6.SCHEMA_VERSION,
-            protocol_v7.SCHEMA_VERSION,
-            protocol_v8.SCHEMA_VERSION,
-            protocol_formal_collection.SCHEMA_VERSION,
-        }:
-            build_identity_snapshot_recorded = _record_attempt_build_identity(thread_id, ledger)
-        ledger.append("orphan.reconciled", reconciliation)
+            reconciliation = reconcile_orphans(ledger.physical_attempt_id)
+            if not session_finalization_succeeded and reconciliation["cleanup_succeeded"]:
+                session_finalization_succeeded = _finalize_attempt_sessions(
+                    thread_id,
+                    interrupted_status=interrupted_status,
+                    error=termination_error,
+                )
+            if manifest["schema_version"] in {
+                protocol_v5.SCHEMA_VERSION,
+                protocol_v6.SCHEMA_VERSION,
+                protocol_v7.SCHEMA_VERSION,
+                protocol_v8.SCHEMA_VERSION,
+                protocol_formal_collection.SCHEMA_VERSION,
+            }:
+                build_identity_snapshot_recorded = _record_attempt_build_identity(thread_id, ledger)
+            ledger.append("orphan.reconciled", reconciliation)
+            attempt_budget_completion = record_experiment_attempt_budget_completion(thread_id)
+        finally:
+            deactivate_experiment(thread_id)
 
     events = ledger.read()
     gates = recompute_gates(events)
     oracle = run_oracle(manifest, events)
     ledger.append("oracle.completed", oracle)
     final_status = "passed" if run_status == "completed" and gates["valid"] and oracle["passed"] and reconciliation["cleanup_succeeded"] and session_finalization_succeeded and build_identity_snapshot_recorded else "failed"
-    ledger.append(
-        "experiment.completed",
-        {
-            "status": final_status,
-            "gate_recomputation_valid": gates["valid"],
-            "oracle_passed": oracle["passed"],
-            "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
-            "session_finalization_succeeded": session_finalization_succeeded,
-            "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
-        },
-    )
+    completion_payload = {
+        "status": final_status,
+        "gate_recomputation_valid": gates["valid"],
+        "oracle_passed": oracle["passed"],
+        "orphan_cleanup_succeeded": reconciliation["cleanup_succeeded"],
+        "session_finalization_succeeded": session_finalization_succeeded,
+        "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
+    }
+    if attempt_budget_completion is not None:
+        completion_payload["attempt_budget"] = attempt_budget_completion
+    ledger.append("experiment.completed", completion_payload)
     return {
         "status": final_status,
         "gate_recomputation": gates,
@@ -1718,6 +1761,7 @@ def run_attempt(
         "orphan_reconciliation": reconciliation,
         "session_finalization_succeeded": session_finalization_succeeded,
         "build_identity_snapshot_recorded": build_identity_snapshot_recorded,
+        "attempt_budget": attempt_budget_completion,
     }
 
 

--- a/scripts/forge_formal_collection_v4_runtime_protocol.py
+++ b/scripts/forge_formal_collection_v4_runtime_protocol.py
@@ -7,13 +7,16 @@ import argparse
 import copy
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
 SCRIPT_ROOT = Path(__file__).resolve().parent
-if str(SCRIPT_ROOT) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_ROOT))
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+REPOSITORY_SCRIPT_ROOT = REPOSITORY_ROOT / "scripts"
+if str(REPOSITORY_SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_SCRIPT_ROOT))
 
 import forge_benchmark as v1  # noqa: E402
 import forge_formal_collection_v4_protocol as parent_protocol  # noqa: E402
@@ -23,7 +26,6 @@ SCHEMA_VERSION = "formal-collection-4.1.0-runtime-candidate"
 BASELINE_COMMIT = "3ac49b92eedecf4932a829e75465dd7ddd16b97e"
 REVISION_POLICY = parent_protocol.REVISION_POLICY
 CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
-REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json"
 DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-runtime-candidate.json"
 DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-runtime-candidate.schema.json"

--- a/scripts/forge_formal_collection_v4_runtime_protocol.py
+++ b/scripts/forge_formal_collection_v4_runtime_protocol.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Generate and validate the unapproved formal-v4 lifecycle runtime candidate."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v4_protocol as parent_protocol  # noqa: E402
+import forge_formal_runtime_protocol as _hasher  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-4.1.0-runtime-candidate"
+BASELINE_COMMIT = "3ac49b92eedecf4932a829e75465dd7ddd16b97e"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-collection.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-runtime-candidate.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-runtime-candidate.schema.json"
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_collection_v4_runtime_protocol.py",
+    "scripts/forge_formal_collection_v4_runtime_runner.py",
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+}
+ATTEMPT_BUDGET = copy.deepcopy(parent_protocol.ATTEMPT_BUDGET)
+RESOURCE_PREFLIGHT = copy.deepcopy(parent_protocol.RESOURCE_PREFLIGHT)
+ANALYSIS_PLAN = copy.deepcopy(parent_protocol.ANALYSIS_PLAN)
+AUTHORIZATION = {
+    "id": "forge-cpp-formal-v4-runtime-candidate-review",
+    "status": "runtime_implemented_collection_pending",
+    "implemented_on": "2026-08-11",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/105",
+    "implementation_baseline_commit": BASELINE_COMMIT,
+    "collection_constraints": {
+        "collection_authorized": False,
+        "provider_canary_forbidden": True,
+        "physical_attempt_creation_forbidden": True,
+        "model_execution_forbidden": True,
+        "batch_execution_forbidden": True,
+        "complete_project_blocks_require_confirmation": True,
+        "slot_count_requires_confirmation": True,
+        "recorded_token_budget_requires_confirmation": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    return parent_protocol.validate_manifest(parent)
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v4-collection.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def _build_manifest(
+    repo_root: Path,
+    *,
+    parent: dict[str, Any],
+) -> dict[str, Any]:
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v4-runtime-candidate",
+        "name": "Forge C/C++ attempt-bounded formal v4 runtime candidate",
+        "purpose": "unapproved lifecycle enforcement implementation review",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection_v4_runtime_candidate",
+        "formal_comparison_enabled": False,
+        "collection_authorized": False,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": _hasher._hash_paths(repo_root, COMPONENT_PATHS),
+    }
+    manifest["protocol_artifact_sha256"] = _hasher._hash_paths(
+        repo_root,
+        PROTOCOL_ARTIFACT_PATHS,
+    )
+    manifest["prompt_sha256"] = _hasher._hash_paths(
+        repo_root,
+        set(parent["prompt_sha256"]),
+    )
+    manifest["attempt_budget"] = copy.deepcopy(ATTEMPT_BUDGET)
+    manifest["resource_preflight"] = copy.deepcopy(RESOURCE_PREFLIGHT)
+    manifest["analysis_plan"] = copy.deepcopy(ANALYSIS_PLAN)
+    manifest["authorization"] = _authorization(parent)
+    return manifest
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _build_manifest(repo_root, parent=_parent_manifest(parent))
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    repo_root: Path = REPOSITORY_ROOT,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected = _build_manifest(repo_root, parent=_parent_manifest(parent))
+        if manifest != expected:
+            v1._fail(
+                "manifest",
+                "must match the reviewed formal v4 runtime candidate exactly",
+            )
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise BenchmarkError(f"manifest: invalid runtime candidate: {exc}") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(manifest)
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest, repo_root=repo_root)
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            if _hasher._file_sha256(repo_root / relative_path) != expected:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match")
+
+
+def _hash_map_schema(paths: set[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": sorted(paths),
+        "additionalProperties": False,
+        "properties": {relative_path: {"type": "string", "pattern": "^[0-9a-f]{64}$"} for relative_path in sorted(paths)},
+    }
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    parent = _parent_manifest()
+    schema["$id"] = "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json"
+    schema["title"] = "Forge C/C++ unapproved formal v4 lifecycle runtime candidate"
+    properties = schema["properties"]
+    properties["$schema"] = {"const": "../schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json"}
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["benchmark"] = {
+        "const": {
+            "id": "forge-cpp-formal-v4-runtime-candidate",
+            "name": "Forge C/C++ attempt-bounded formal v4 runtime candidate",
+            "purpose": "unapproved lifecycle enforcement implementation review",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }
+    }
+    properties["scope"] = {
+        "const": {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection_v4_runtime_candidate",
+            "formal_comparison_enabled": False,
+            "collection_authorized": False,
+            "instrumentation_blocker": False,
+        }
+    }
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["forge"]["properties"]["component_sha256"] = _hash_map_schema(COMPONENT_PATHS)
+    properties["protocol_artifact_sha256"] = _hash_map_schema(PROTOCOL_ARTIFACT_PATHS)
+    properties["prompt_sha256"] = _hash_map_schema(set(parent["prompt_sha256"]))
+    properties["attempt_budget"] = {"const": copy.deepcopy(ATTEMPT_BUDGET)}
+    properties["resource_preflight"] = {"const": copy.deepcopy(RESOURCE_PREFLIGHT)}
+    properties["analysis_plan"] = {"const": copy.deepcopy(ANALYSIS_PLAN)}
+    properties["authorization"] = {"const": _authorization(parent)}
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorization_status": manifest["authorization"]["status"],
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "physical_attempt_wall_clock_seconds": manifest["attempt_budget"]["total_wall_clock_seconds"],
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_runtime_runner.py
+++ b/scripts/forge_formal_collection_v4_runtime_runner.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Unapproved formal-v4 lifecycle runtime adapter with real budget wiring."""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_collection_v4_runner as parent_runner  # noqa: E402
+import forge_formal_collection_v4_runtime_protocol as protocol  # noqa: E402
+
+_runner = parent_runner._load_private_base_runner()
+_original_manifest_protocol = _runner._manifest_protocol
+_original_build_policy = _runner.build_policy
+_original_collect_runtime_launch_preflight = _runner.collect_runtime_launch_preflight
+_original_run_attempt = _runner.run_attempt
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+_EVIDENCE_MOUNT_ROOT = Path("/workspace/.compile-sessions")
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+):
+    policy = _original_build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        return policy
+    case = _runner._manifest_case(manifest, case_id)
+    artifacts = tuple(
+        (
+            artifact["relative_path"],
+            artifact.get("build_output_path", artifact["relative_path"]),
+            artifact["artifact_type"],
+        )
+        for artifact in case["oracle"]["required_artifacts"]
+    )
+    return replace(policy, artifact_instructions=artifacts)
+
+
+def _evidence_mount_source_matches_host_workspace(
+    mounts: list[dict[str, Any]] | None,
+    *,
+    host_workspace_root: str | None = None,
+) -> bool:
+    root = host_workspace_root if host_workspace_root is not None else os.environ.get("DEER_FLOW_HOST_WORKSPACE_ROOT")
+    if not isinstance(root, str) or not root.strip():
+        return False
+    normalized_root = posixpath.normpath(root.strip())
+    if not PurePosixPath(normalized_root).is_absolute() or normalized_root == "/":
+        return False
+    expected_source = posixpath.join(normalized_root, ".compile-sessions")
+    evidence_mounts = [mount for mount in mounts or [] if mount.get("Type") == "bind" and mount.get("Destination") == _EVIDENCE_MOUNT_ROOT.as_posix() and mount.get("RW") is True]
+    if len(evidence_mounts) != 1:
+        return False
+    source = evidence_mounts[0].get("Source")
+    return isinstance(source, str) and PurePosixPath(posixpath.normpath(source)).is_absolute() and posixpath.normpath(source) == expected_source
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    result = _original_collect_runtime_launch_preflight(output_dir, repo_root=repo_root)
+    _labels, mounts = _runner._current_container_metadata(repo_root)
+    source_matches = _evidence_mount_source_matches_host_workspace(mounts)
+    available_memory = parent_runner._available_memory_bytes()
+    daemon = parent_runner._docker_daemon_probe(protocol.RESOURCE_PREFLIGHT["docker_daemon_timeout_seconds"])
+    checks = {
+        **result["checks"],
+        "evidence_mount_source_matches_host_workspace": source_matches,
+        "host_available_memory_at_least_minimum": (available_memory is not None and available_memory >= protocol.RESOURCE_PREFLIGHT["minimum_available_memory_bytes"]),
+        "docker_daemon_responded": daemon["responded"] is True,
+        "docker_daemon_latency_within_limit": (daemon["responded"] is True and daemon["latency_seconds"] <= protocol.RESOURCE_PREFLIGHT["maximum_docker_daemon_latency_seconds"]),
+    }
+    return {
+        **result,
+        "ready": all(checks.values()),
+        "checks": checks,
+        "observations": {
+            **result.get("observations", {}),
+            "available_memory_bytes": available_memory,
+            "minimum_available_memory_bytes": protocol.RESOURCE_PREFLIGHT["minimum_available_memory_bytes"],
+            "docker_daemon_latency_seconds": daemon["latency_seconds"],
+            "maximum_docker_daemon_latency_seconds": protocol.RESOURCE_PREFLIGHT["maximum_docker_daemon_latency_seconds"],
+        },
+    }
+
+
+def run_attempt_with_budget(
+    manifest: dict[str, Any],
+    ledger_path: Path,
+    *,
+    async_runner: Any | None = None,
+) -> dict[str, Any]:
+    """Execute a future authorized child with the reviewed v4 runtime budget."""
+    return _original_run_attempt(
+        manifest,
+        ledger_path,
+        async_runner=async_runner,
+        attempt_budget=_runner.ExperimentAttemptBudget.from_mapping(manifest["attempt_budget"]),
+    )
+
+
+def _reject_unapproved_action(action: str) -> None:
+    raise RunnerError(f"Formal v4 runtime candidate is not authorized; {action} is forbidden")
+
+
+def collect_provider_canary(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("provider canary")
+
+
+def create_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("physical-attempt ledger creation")
+
+
+def run_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("model execution")
+
+
+def run_formal_batch(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("batch execution")
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.build_policy = build_policy
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_formal_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_runtime_runner.py
+++ b/scripts/forge_formal_collection_v4_runtime_runner.py
@@ -14,8 +14,11 @@ SCRIPT_ROOT = Path(__file__).resolve().parent
 if str(SCRIPT_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_ROOT))
 
-import forge_formal_collection_v4_runner as parent_runner  # noqa: E402
 import forge_formal_collection_v4_runtime_protocol as protocol  # noqa: E402
+
+# The protocol establishes the repository import root before the parent loads.
+# isort: split
+import forge_formal_collection_v4_runner as parent_runner  # noqa: E402
 
 _runner = parent_runner._load_private_base_runner()
 _original_manifest_protocol = _runner._manifest_protocol


### PR DESCRIPTION
## 变更摘要

- 将 physical-attempt 生命周期预算接入 provider、Compiler、submit/clean replay、finalize/cleanup 与 runner 工作截止取消路径。
- 派生未授权 `formal-collection-4.1.0-runtime-candidate`，保持冻结的 formal v4 父协议逐字不变。
- 修复 Compose 中 `/app/scripts` 与 `/repo` 分离时的协议导入根和模块缓存顺序，确保候选安全门禁在容器内按预期拒绝未授权动作。

## 验证

- 扩大单元回归：`227 passed`
- 最终候选聚焦回归：`12 passed`
- 真实 Docker 生命周期回归：`1 passed`
- Compose/DooD runtime preflight：11/11 checks 通过
- 未授权 provider canary：退出码 2、明确拒绝、0 evidence
- Ruff、格式、Draft 2020-12 Schema、冻结父文件、diff 与敏感信息检查通过

## 安全边界

本分支没有调用模型、消耗 AK、创建实验 ledger 或启动正式采集。候选仍禁止 provider canary、physical attempt、模型执行和 batch；完整 project block、slot 数和 token 上限仍需实验负责人另行确认。

Closes #105