### PR TITLE
研究：固定 Ubuntu 原生 Docker 门禁与 v4 决策包

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -8,6 +8,14 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-12 — 固定 Ubuntu 原生 Docker 门禁并形成 formal v4 首批授权决策包
+  - GitHub: Issue #109 记录双 daemon 混淆风险、门禁目标和 0 模型/0 ledger 边界；实现分支为 `research/formal-v4-ubuntu-daemon-gate`。
+  - 环境门禁: 新增 `scripts/require-ubuntu-native-docker.sh`，要求 WSL2 `Ubuntu`、active `docker.service`、`dockerd` MainPID、`default` context、`/var/run/docker.sock` 和 Ubuntu daemon OS；失败时停止并请求用户介入，不启动 Docker Desktop 或切换 daemon。`docker.sh`、`wsl-check.sh` 与 `AGENTS.md` 已统一调用该门禁。
+  - 协议: 新增未授权 `formal-collection-4.2.0-ubuntu-candidate`，canonical SHA-256 为 `77e80eb39b01eeba73d1fdd07e2b8da658032fcc124cacbf45ae2d06f6831601`；冻结 `daemon_provider=ubuntu-native` 和 socket source gate，父级 v4 runtime candidate 保持逐字不变。
+  - 决策包: 结果盲态选择冻结 schedule 的第一个项目 `cppitertools`，完整 block 使用原 slot identity `1, 2, 73, 74, 153, 154`，覆盖双 condition × 三次重复；建议 980,000 recorded-token 上限，但 `collection_authorized=false`，provider canary、ledger、模型与 batch 仍全部禁止。
+  - 验证: 门禁/新协议聚焦 `23 passed`，formal v1-v4 与 Docker 扩大回归 `138 passed`；Ruff、shell 语法、Schema、确定性再生成和父协议校验通过。真实 Ubuntu 宿主门禁通过，Compose/DooD preflight 13/13 通过，0 JSON/JSONL、0 compile/replay orphan。
+  - 文件: `scripts/require-ubuntu-native-docker.sh`, `scripts/docker.sh`, `scripts/wsl-check.sh`, `scripts/forge_formal_collection_v4_ubuntu_protocol.py`, `scripts/forge_formal_collection_v4_ubuntu_runner.py`, `benchmarks/manifests/cpp-formal-v4-ubuntu-candidate.json`, `benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md`
+
 - 2026-08-12 — 接通并合并 formal v4 physical-attempt 生命周期预算
   - GitHub: Issue #105 / PR #106 已 squash 合并为 `main@484f6999`，Issue 自动关闭；backend unit tests、backend lint 与 frontend lint 三项 CI 全绿。
   - 实现: experiment evidence 保存单调时钟与原子 claim；provider、Compiler、submit/clean replay、finalize、cleanup 使用同一预算上下文，runner 在 1,680 秒工作 deadline 主动取消 agent stream，并在强制收口后记录最终 overrun 快照。
@@ -279,6 +287,9 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- Windows `docker` CLI 的 `desktop-linux` context 只反映 Docker Desktop daemon，不能据此判断 Forge 状态。Forge 容器实际属于 WSL2 Ubuntu 原生 `dockerd`；所有项目 Docker 命令必须先通过 `scripts/require-ubuntu-native-docker.sh`，并从 `wsl.exe -d Ubuntu` 或该发行版内执行。门禁失败时请求用户恢复服务，不得启动 Docker Desktop 作为回退。
+- LangGraph 容器内 `/repo` 是只读挂载。可在容器中使用 Ruff `--check --no-cache`，但不能直接格式化文件；写入格式化必须在可写工作树中使用相同 `backend/ruff.toml`，不要修改挂载权限或重建服务来绕过只读边界。
 
 - Compose 同时把脚本挂到 `/app/scripts`、完整仓库挂到 `/repo`；仅设置 `FORGE_REPO_ROOT=/repo` 不足以修复版本化协议链，因为先导入的父 runner 会把 `/app` 根协议放入 `sys.modules`。runtime adapter 必须先从 `/repo/scripts` 导入协议链，再导入父 runner；preflight 还必须使用 `/app/backend/.venv/bin/python` 和 `/workspace/.compile-sessions` 子目录，否则解释器、runtime import 与 evidence 持久化 gate 会按设计拒绝。
 - 历史 formal manifest 应冻结当时的 runner SHA，但共享基础 runner 会由后续版本继续演进；回归测试应直接断言历史 manifest 中的旧 identity 保持不变，并由新版本 manifest 绑定当前 runtime，不能要求工作树中的共享 runner 永远等于最早候选字节。旧协议遇到 current-tree runtime 漂移时拒绝执行是预期 gate。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,15 @@ Read and follow `CLAUDE.md` before changing this repository. Files below
   remain healthy.
 - If the WSL helper exhausts its bounded retries, report the failure. Git Data
   API publication is an explicit fallback, not an automatic side effect.
+
+## Forge Docker Runtime
+
+- Forge development, Compose/DooD, Compile Session, clean replay, and formal
+  experiments use only the native Docker Engine managed by `docker.service`
+  inside the `Ubuntu` WSL2 distribution.
+- Run Forge Docker commands through `wsl.exe -d Ubuntu -- ...` from Windows or
+  directly inside that Ubuntu distribution. Do not use the Windows `docker`
+  CLI, Docker Desktop contexts, or Docker Desktop as a fallback.
+- Before Docker work, run `scripts/require-ubuntu-native-docker.sh` or an entry
+  point that invokes it. If the gate fails, stop and ask the user to restore
+  the Ubuntu service; do not start desktop applications or switch daemons.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,10 @@
 
 #### 前置
 
-- Docker Desktop 或 Docker Engine
+- WSL2 Ubuntu 内由 `docker.service` 管理的原生 Docker Engine 与 Compose v2
 - pnpm（用于宿主机侧缓存共享，加速构建）
+
+在 Windows 宿主机上，先进入 `wsl -d Ubuntu` 并运行 `./scripts/wsl-check.sh`。Forge 不使用 Windows `docker.exe` 或 Docker Desktop daemon；门禁失败时停止并请求用户恢复 Ubuntu 服务，不要自动切换 daemon。
 
 #### 步骤
 

--- a/Install.md
+++ b/Install.md
@@ -22,9 +22,9 @@ agent 会自动按下面的流程执行。
 
 ## Windows + WSL2（推荐路径）
 
-Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。推荐在 WSL2 Ubuntu 中运行仓库命令，由 Docker Desktop 提供 Linux 容器引擎。已有 WSL 原生 Docker Engine 也可以使用，但不要把它和 Docker Desktop daemon 混用：两边的镜像、网络和容器互不可见。
+Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。Forge 固定在 WSL2 Ubuntu 中运行仓库命令，并使用该发行版内由 `docker.service` 管理的原生 Docker Engine。Docker Desktop 是另一套 daemon，两边的镜像、网络和容器互不可见，不作为 Forge 的启动或故障回退路径。
 
-1. 选择一套 Docker daemon。推荐安装并启动 Docker Desktop，在 **Settings > Resources > WSL Integration** 中启用 Ubuntu；若明确使用 WSL 原生 Docker Engine，则确认 Docker 服务和 Compose v2 插件已启动，不要同时混用两套 daemon。
+1. 在 Ubuntu 内安装 Docker Engine 和 Compose v2 插件，并由用户确认 `docker.service` 已启动。助手和仓库脚本不会自动启动服务或桌面应用。
 2. 进入 WSL：
 
    ```powershell
@@ -59,15 +59,16 @@ Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。�
 
 常见故障：
 
-- `docker: command not found`：没有为当前发行版启用 Docker Desktop WSL Integration，也没有安装 WSL 原生 Docker Engine。
-- `Docker daemon is not reachable`：Docker Desktop 尚未启动完成，或 WSL 原生 Docker 服务没有启动。
+- `docker: command not found`：Ubuntu 内没有安装原生 Docker Engine。
+- `Ubuntu docker.service is not active`：停止自动重试并请求用户恢复 Ubuntu Docker 服务；不要启动 Docker Desktop。
+- `Docker context must be default` 或 daemon provider 不匹配：当前命令可能连接了另一套 daemon，清除显式 `DOCKER_HOST` / `DOCKER_CONTEXT` 后重新运行门禁；不要迁移或复制容器来绕过检查。
 - `make: command not found`：安装 `build-essential`。
 - 构建镜像下载依赖超时：在根目录 `.env` 中按网络情况设置 `NPM_REGISTRY`、`UV_INDEX_URL` 或 `APT_MIRROR`；`UV_HTTP_TIMEOUT` 默认是 600 秒。
 - 编译镜像需要代理时使用 `COMPILE_HTTP_PROXY` / `COMPILE_HTTPS_PROXY`；不要填写容器内不可达的 WSL `127.0.0.1` 代理地址。
 - 会话编译容器需要代理时使用 `COMPILE_RUNTIME_HTTP_PROXY` / `COMPILE_RUNTIME_HTTPS_PROXY` / `COMPILE_RUNTIME_NO_PROXY`。代理值对容器内构建脚本及 `docker inspect` 可见，不要在编译不可信仓库时填入带凭据的代理。
-- Docker Desktop bridge 模式使用容器可达地址。`COMPILE_RUNTIME_NETWORK=host` 只用于可信仓库，因为构建脚本将能访问 WSL 的 loopback 服务；`127.0.0.1` 仅在代理运行于同一 WSL，或 WSL 启用 mirrored networking 时才能到达目标代理。
+- 容器代理必须使用 Ubuntu Docker bridge 可达的地址。`COMPILE_RUNTIME_NETWORK=host` 只用于可信仓库，因为构建脚本将能访问 WSL 的 loopback 服务；`127.0.0.1` 仅在代理运行于同一 WSL，或 WSL 启用 mirrored networking 时才能到达目标代理。
 - 当前容器内 clone 只验证了公开 HTTPS 仓库，不会继承宿主 Git credential helper、SSH agent 或 `known_hosts`。不要把 token 写进仓库 URL，因为 URL 会进入 session 日志。
-- 不要在启用 Docker Desktop 集成后，再在 WSL 内同时启动第二套 Docker daemon。若明确使用 WSL 原生 Docker，请始终在同一个 WSL 发行版中运行 `make` 和 `docker`；保持该 WSL 会话运行，Windows 侧的 `docker.exe` 看不到这些容器。
+- 始终在 Ubuntu 内运行 `make` 和 `docker`。Windows 侧的 `docker.exe` 与 Docker Desktop 看不到 Ubuntu 原生 daemon 中的 Forge 容器，不得用于项目状态判断。
 
 **默认优先级**：
 
@@ -102,14 +103,15 @@ Windows 不走“原生 PowerShell + Git Bash 拼装全部依赖”的路径。�
 2. 检查仓库根存在 `Makefile`、`backend/`、`frontend/`、`config.example.yaml`。
 3. 判断 `config.yaml` 是否已存在。
 4. 不存在则跑 `make config`（注意：**`make config` 非幂等**，已存在会主动 abort，这是正常行为）。
-5. `docker info` 检查 Docker 是否可用。
+5. 运行 `./scripts/require-ubuntu-native-docker.sh`，确认 Ubuntu 原生 Docker 门禁通过。
 6. **若 Docker 可用**：
    - 跑 `make docker-init`
    - 这一步只算「Docker 准备就绪」，不要声称服务已启动、compose 已校验、镜像已构建完
    - 除非用户明确要求或要做启动验证，**不要自动 `make docker-start`** 起后台服务
    - 告知用户下一条命令是 `make docker-start`
 7. **若 Docker 不可用**：
-   - 跑 `make check`
+   - 停止 Docker 路径并明确报告失败的门禁项；若 `docker.service` 未启动或需要权限，由用户介入恢复，不要启动 Docker Desktop
+   - 仅当用户选择本机非 Docker 开发路径时再跑 `make check`
    - 若报缺 `node`/`pnpm`/`uv`/`nginx`，**停下并报告**，不要擅自 `sudo apt install`
    - 前置满足则 `make install`
    - 告知用户下一条命令是 `make dev`

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,7 +45,7 @@
 
 ### Windows + WSL2
 
-Windows 用户请在 WSL2 Ubuntu 中运行项目。推荐使用 Docker Desktop 的 WSL Integration；也支持有意安装在 WSL 内的 Docker Engine，但所有构建和启动命令必须始终使用同一个 daemon。不要从 PowerShell 直接运行 Linux `.sh` 启动链。
+Windows 用户请在 WSL2 Ubuntu 中运行项目。Forge 固定使用该 Ubuntu 发行版内由 `docker.service` 管理的原生 Docker Engine；Docker Desktop 是另一套不共享镜像、网络和容器的 daemon，不是本项目的启动或故障回退路径。不要从 PowerShell 直接运行 Linux `.sh` 启动链，也不要使用 Windows `docker.exe` 操作 Forge。
 
 ```powershell
 wsl -d Ubuntu
@@ -60,6 +60,8 @@ make config             # 仅首次
 make compile-image      # 首次构建 C/C++ 编译环境
 make docker-start
 ```
+
+`wsl-check.sh` 会验证 Ubuntu、systemd `dockerd`、`default` context 和 `/var/run/docker.sock`。检查失败时先停止并由用户恢复 Ubuntu Docker 服务；脚本不会自动启动 Docker Desktop 或切换 daemon。
 
 访问 <http://localhost:8000>。完整安装和故障排查见 [Install.md](Install.md#windows--wsl2推荐路径)。
 

--- a/backend/tests/test_forge_formal_collection_v4_ubuntu_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_ubuntu_protocol.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_ubuntu_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_ubuntu_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-ubuntu-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"
+PARENT_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-runtime-candidate.json"
+PARENT_FILE_SHA256 = {
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": ("e0b14b5e2f224846f1c5c0c213f66e0667a5d008d4e246d37b1b805c4ccf595e"),
+    "scripts/forge_formal_collection_v4_runtime_runner.py": ("9b4ba4f4eabb5888fd663b241d69a00dfc5e369474755dd64338b02fc146e42f"),
+    "benchmarks/manifests/cpp-formal-v4-runtime-candidate.json": ("88f2fa42b891816fdab7956dc223f8195f49f46479b55700c5030f0568d52144"),
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": ("69bba99ca4fba5afd10e170976f509c90e089a5769d3939cea416411276dda60"),
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": ("2fbdbbb2c419e2dcea24be1c6bd5650febdbd64509068e6ecd78fe64a5f9f04a"),
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_formal_collection_v4_ubuntu_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_formal_collection_v4_ubuntu_runner_test",
+    RUNNER_PATH,
+)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_ubuntu_candidate_is_deterministic_schema_valid_and_unapproved() -> None:
+    manifest = load_manifest()
+
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    assert manifest["schema_version"] == "formal-collection-4.2.0-ubuntu-candidate"
+    assert manifest["scope"]["collection_authorized"] is False
+    assert manifest["scope"]["formal_comparison_enabled"] is False
+    assert manifest["forge"]["commit_sha"] == ("65c2a739ba054375158cbddb27a885e8206a48aa")
+    assert manifest["runtime"]["docker_daemon_provider"] == "ubuntu-native"
+    assert manifest["runtime"]["docker_socket_path"] == "/var/run/docker.sock"
+    assert manifest["authorization"]["issue_url"].endswith("/issues/109")
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_initial_batch_is_one_complete_result_independent_project_block() -> None:
+    manifest = load_manifest()
+    decision = manifest["initial_batch_decision"]
+    selected = [slot for slot in manifest["collection_plan"] if slot["order"] in decision["selected_schedule_orders"]]
+
+    assert decision["selection_rule"] == "first_project_in_frozen_schedule"
+    assert decision["project_ids"] == ["cppitertools"]
+    assert decision["selected_schedule_orders"] == [1, 2, 73, 74, 153, 154]
+    assert decision["planned_attempts"] == 6
+    assert decision["maximum_recorded_tokens"] == 980_000
+    assert len(selected) == 6
+    assert {slot["case_id"] for slot in selected} == {"cppitertools"}
+    assert {(slot["condition_id"], slot["repetition"]) for slot in selected} == {(condition["id"], repetition) for condition in manifest["conditions"] for repetition in range(1, 4)}
+
+
+def test_parent_runtime_candidate_files_remain_byte_identical() -> None:
+    parent = json.loads(PARENT_MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest = load_manifest()
+
+    assert manifest["authorization"]["parent_manifest"]["canonical_sha256"] == ("d1c211e638ee2fd71c5c2f9e70f250306a131f9ae8759c9bd064e48a96252473")
+    assert manifest["collection_plan"] == parent["collection_plan"]
+    assert manifest["conditions"] == parent["conditions"]
+    assert manifest["attempt_budget"] == parent["attempt_budget"]
+    for relative_path, expected in PARENT_FILE_SHA256.items():
+        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == (expected)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["scope"].update(collection_authorized=True),
+        lambda value: value["runtime"].update(docker_daemon_provider="docker-desktop-wsl2"),
+        lambda value: value["resource_preflight"].update(docker_socket_path="//./pipe/dockerDesktopLinuxEngine"),
+        lambda value: value["initial_batch_decision"].update(selected_schedule_orders=[1, 2]),
+        lambda value: value["initial_batch_decision"].update(maximum_recorded_tokens=980_001),
+        lambda value: value["authorization"]["collection_constraints"].update(model_execution_forbidden=False),
+    ],
+)
+def test_ubuntu_candidate_rejects_environment_budget_or_authorization_drift(
+    mutation,
+) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(protocol.BenchmarkError):
+        protocol.validate_manifest(manifest)
+
+
+def test_runtime_preflight_accepts_only_ubuntu_native_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runner,
+        "_original_collect_runtime_launch_preflight",
+        lambda *args, **kwargs: {"ready": True, "checks": {"base": True}},
+    )
+    monkeypatch.setattr(
+        runner._runner,
+        "_current_container_metadata",
+        lambda *args, **kwargs: (
+            {},
+            [
+                {
+                    "Type": "bind",
+                    "Source": "/var/run/docker.sock",
+                    "Destination": "/var/run/docker.sock",
+                    "RW": True,
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_docker_daemon_provider_probe",
+        lambda timeout: {
+            "provider": "ubuntu-native",
+            "responded": True,
+            "latency_seconds": 0.1,
+        },
+    )
+
+    result = runner.collect_runtime_launch_preflight(tmp_path)
+
+    assert result["ready"] is True
+    assert result["checks"]["docker_daemon_provider_matches"] is True
+    assert result["checks"]["docker_socket_source_matches_native_path"] is True
+    assert result["observations"]["docker_daemon_provider"] == "ubuntu-native"
+    assert "operating_system" not in result["observations"]
+
+
+@pytest.mark.parametrize(
+    ("provider", "source", "failed_check"),
+    [
+        (
+            "other",
+            "/var/run/docker.sock",
+            "docker_daemon_provider_matches",
+        ),
+        (
+            "ubuntu-native",
+            "/run/desktop/mnt/host/wsl/docker-desktop-bind-mounts/socket",
+            "docker_socket_source_matches_native_path",
+        ),
+    ],
+)
+def test_runtime_preflight_rejects_desktop_or_socket_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    source: str,
+    failed_check: str,
+) -> None:
+    monkeypatch.setattr(
+        runner,
+        "_original_collect_runtime_launch_preflight",
+        lambda *args, **kwargs: {"ready": True, "checks": {"base": True}},
+    )
+    monkeypatch.setattr(
+        runner._runner,
+        "_current_container_metadata",
+        lambda *args, **kwargs: (
+            {},
+            [
+                {
+                    "Type": "bind",
+                    "Source": source,
+                    "Destination": "/var/run/docker.sock",
+                    "RW": True,
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "_docker_daemon_provider_probe",
+        lambda timeout: {
+            "provider": provider,
+            "responded": True,
+            "latency_seconds": 0.1,
+        },
+    )
+
+    result = runner.collect_runtime_launch_preflight(tmp_path)
+
+    assert result["ready"] is False
+    assert result["checks"][failed_check] is False
+
+
+def test_unapproved_candidate_rejects_external_actions_without_evidence(
+    tmp_path: Path,
+) -> None:
+    manifest = load_manifest()
+    first_slot = manifest["collection_plan"][0]
+    common = ["--manifest", str(MANIFEST_PATH)]
+    commands = [
+        ["provider-canary", *common, "--output-dir", str(tmp_path)],
+        [
+            "create-attempt",
+            *common,
+            "--case",
+            first_slot["case_id"],
+            "--condition",
+            first_slot["condition_id"],
+            "--repetition",
+            str(first_slot["repetition"]),
+            "--output-dir",
+            str(tmp_path),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run",
+            *common,
+            "--ledger",
+            str(tmp_path / "missing.jsonl"),
+            "--skip-endpoint-check",
+        ],
+        [
+            "run-batch",
+            *common,
+            "--output-dir",
+            str(tmp_path),
+            "--max-attempts",
+            "1",
+            "--skip-endpoint-check",
+        ],
+    ]
+
+    for command in commands:
+        assert runner.main(command) == 2
+
+    assert list(tmp_path.rglob("*.jsonl")) == []
+    assert list(tmp_path.rglob("*.json")) == []

--- a/backend/tests/test_ubuntu_native_docker_gate.py
+++ b/backend/tests/test_ubuntu_native_docker_gate.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "require-ubuntu-native-docker.sh"
+DOCKER_SCRIPT_PATH = REPO_ROOT / "scripts" / "docker.sh"
+WSL_CHECK_PATH = REPO_ROOT / "scripts" / "wsl-check.sh"
+BASH_CANDIDATES = [
+    Path(r"C:\Program Files\Git\bin\bash.exe"),
+    Path(which("bash")) if which("bash") else None,
+]
+BASH_EXECUTABLE = next(
+    (str(path) for path in BASH_CANDIDATES if path is not None and path.exists() and "WindowsApps" not in str(path)),
+    None,
+)
+
+if BASH_EXECUTABLE is None:
+    pytestmark = pytest.mark.skip(reason="bash is required for Docker gate tests")
+
+
+def _run_gate(*, overrides: str = "", env: dict[str, str] | None = None):
+    helpers = """
+_forge_kernel_release() { echo '6.6.0-microsoft-standard-WSL2'; }
+_forge_command_exists() { return 0; }
+_forge_docker_service_state() { echo active; }
+_forge_docker_service_pid() { echo 42; }
+_forge_process_name() { echo dockerd; }
+_forge_docker_context() { echo default; }
+_forge_docker_endpoint() { echo unix:///var/run/docker.sock; }
+_forge_docker_operating_system() { echo 'Ubuntu 26.04 LTS'; }
+_forge_docker_socket_ready() { return 0; }
+_forge_docker_compose_ready() { return 0; }
+"""
+    command = f"source '{SCRIPT_PATH}'\n{helpers}\n{overrides}\nrequire_ubuntu_native_docker"
+    return subprocess.run(
+        [BASH_EXECUTABLE, "-lc", command],
+        env={"PATH": "", "WSL_DISTRO_NAME": "Ubuntu", **(env or {})},
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_gate_accepts_only_the_reviewed_ubuntu_native_daemon() -> None:
+    result = _run_gate()
+
+    assert result.returncode == 0, result.stderr
+    assert "provider=ubuntu-native" in result.stdout
+    assert "Docker Desktop" not in result.stdout
+
+
+def test_forge_docker_entrypoints_require_the_gate() -> None:
+    docker_script = DOCKER_SCRIPT_PATH.read_text(encoding="utf-8")
+    wsl_check = WSL_CHECK_PATH.read_text(encoding="utf-8")
+
+    source_line = 'source "$SCRIPT_DIR/require-ubuntu-native-docker.sh"'
+    assert source_line in docker_script
+    assert source_line in wsl_check
+    assert "require_ubuntu_native_docker --quiet" in docker_script
+    assert "require_ubuntu_native_docker" in wsl_check
+    assert "init|start|restart|model-preflight|logs|stop)" in docker_script
+
+
+@pytest.mark.parametrize(
+    ("overrides", "env", "message"),
+    [
+        ("", {"WSL_DISTRO_NAME": "Debian"}, "must be Ubuntu"),
+        ("", {"DOCKER_CONTEXT": "desktop-linux"}, "overrides are forbidden"),
+        ("_forge_docker_service_state() { echo inactive; }", None, "not active"),
+        ("_forge_process_name() { echo desktop-backend; }", None, "not owned by dockerd"),
+        ("_forge_docker_context() { echo desktop-linux; }", None, "context must be default"),
+        ("_forge_docker_endpoint() { echo npipe:////./pipe/dockerDesktopLinuxEngine; }", None, "default Docker endpoint"),
+        ("_forge_docker_socket_ready() { return 1; }", None, "not a Unix socket"),
+        ("_forge_docker_operating_system() { echo 'Docker Desktop'; }", None, "not Ubuntu"),
+    ],
+)
+def test_gate_rejects_daemon_ambiguity(
+    overrides: str,
+    env: dict[str, str] | None,
+    message: str,
+) -> None:
+    result = _run_gate(overrides=overrides, env=env)
+
+    assert result.returncode == 1
+    assert message in result.stderr
+    assert "Do not start or switch to Docker Desktop" in result.stderr

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -541,3 +541,29 @@ canary, attempt creation, model execution, and batch execution before evidence
 creation. Complete project blocks, slot count, recorded-token ceiling, evidence
 directory, and network observation require a later experiment-owner decision
 and a new authorized child identity.
+
+## Formal v4 Ubuntu-daemon candidate
+
+`benchmarks/manifests/cpp-formal-v4-ubuntu-candidate.json` derives an
+unapproved successor from the frozen lifecycle runtime candidate. It fixes the
+Docker provider to the native Engine managed by `docker.service` inside the
+WSL2 `Ubuntu` distribution and rejects Docker Desktop daemon drift during
+runtime preflight. Host commands must first pass
+`scripts/require-ubuntu-native-docker.sh`; the gate never starts Docker or a
+desktop application.
+
+Generate and validate the candidate with:
+
+```bash
+python scripts/forge_formal_collection_v4_ubuntu_protocol.py generate
+python scripts/forge_formal_collection_v4_ubuntu_protocol.py validate-manifest \
+  benchmarks/manifests/cpp-formal-v4-ubuntu-candidate.json
+```
+
+The decision package proposes one complete, result-independent project block:
+the six original `cppitertools` schedule identities covering two conditions
+and three repetitions, with a 980,000 recorded-token ceiling checked only
+after an attempt has finalized and cleaned up. This is still a proposal, not
+collection authorization. Provider canary, ledger creation, model execution,
+and batch execution remain forbidden until the experiment owner confirms the
+block, budget, and stop conditions in a separate authorized identity.

--- a/benchmarks/manifests/cpp-formal-v4-ubuntu-candidate.json
+++ b/benchmarks/manifests/cpp-formal-v4-ubuntu-candidate.json
@@ -1,0 +1,2855 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+  "schema_version": "formal-collection-4.2.0-ubuntu-candidate",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v4-ubuntu-candidate",
+    "name": "Forge C/C++ formal v4 Ubuntu-daemon candidate",
+    "purpose": "unapproved native-daemon gate and initial complete-block decision",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v4_ubuntu_candidate",
+    "formal_comparison_enabled": false,
+    "collection_authorized": false,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "65c2a739ba054375158cbddb27a885e8206a48aa",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": "90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4",
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": "2fbdbbb2c419e2dcea24be1c6bd5650febdbd64509068e6ecd78fe64a5f9f04a",
+    "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": "4118549635ec99b60d9126f1ae82f7d6df74e4b699c57aa3448d302e26aa312d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": "69bba99ca4fba5afd10e170976f509c90e089a5769d3939cea416411276dda60",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": "2a3ab3b2d3a0543470f136e8465fd64cee2cc5dc9f6343b4b40a7a186739e55f",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": "6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/docker.sh": "6c79dfd5fd79019dcd51b2445a09d29b229bbe8c0017c3262afa6e90ef3e344b",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "d81d1e973b44be0b1a042dfdafea77b64faa79d4596eca16ce20fb8455351718",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
+    "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": "e0b14b5e2f224846f1c5c0c213f66e0667a5d008d4e246d37b1b805c4ccf595e",
+    "scripts/forge_formal_collection_v4_runtime_runner.py": "9b4ba4f4eabb5888fd663b241d69a00dfc5e369474755dd64338b02fc146e42f",
+    "scripts/forge_formal_collection_v4_ubuntu_protocol.py": "273ba1b711b9d89c218ccae2fd95f6d934b4af1b6fdc39715dbcbea6f4602a31",
+    "scripts/forge_formal_collection_v4_ubuntu_runner.py": "070f48d76d9a06f9f68d67f6abcdf3e885a5d1096c7b7725aa5df56a09082cc8",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6",
+    "scripts/require-ubuntu-native-docker.sh": "5f1ea83c92a55f3ebfb00ad617db4946c73a9b6d6b8b8c4ca2d6cd0e9a893e32",
+    "scripts/wsl-check.sh": "891c8238d481a1aa8f76d146b48ef95a1dc974995e742671a1942a83475188ba"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    },
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v4-ubuntu-candidate-review",
+    "status": "environment_gate_implemented_collection_pending",
+    "implemented_on": "2026-08-12",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/109",
+    "implementation_baseline_commit": "65c2a739ba054375158cbddb27a885e8206a48aa",
+    "collection_constraints": {
+      "collection_authorized": false,
+      "provider_canary_forbidden": true,
+      "physical_attempt_creation_forbidden": true,
+      "model_execution_forbidden": true,
+      "batch_execution_forbidden": true,
+      "experiment_owner_confirmation_required": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v4-runtime-candidate",
+      "path": "benchmarks/manifests/cpp-formal-v4-runtime-candidate.json",
+      "canonical_sha256": "d1c211e638ee2fd71c5c2f9e70f250306a131f9ae8759c9bd064e48a96252473"
+    }
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit",
+      "docker_daemon_provider_matches",
+      "docker_socket_source_matches_native_path"
+    ],
+    "sensitive_host_identifiers_forbidden": true,
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "analysis_plan": {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": true,
+    "retry_replacement_backfill_forbidden": true
+  },
+  "initial_batch_decision": {
+    "status": "pending_experiment_owner_confirmation",
+    "selection_rule": "first_project_in_frozen_schedule",
+    "project_ids": [
+      "cppitertools"
+    ],
+    "complete_project_blocks": 1,
+    "conditions_per_project": 2,
+    "repetitions_per_condition": 3,
+    "planned_attempts": 6,
+    "selected_schedule_orders": [
+      1,
+      2,
+      73,
+      74,
+      153,
+      154
+    ],
+    "maximum_recorded_tokens": 980000,
+    "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+    "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+    "maximum_attempt_wall_clock_seconds": 1800,
+    "maximum_batch_attempt_wall_clock_seconds": 10800,
+    "stop_conditions": [
+      "six_selected_attempts_terminalized",
+      "recorded_token_boundary_reached",
+      "runtime_preflight_failed",
+      "provider_canary_failed",
+      "daemon_provider_drift",
+      "ledger_or_cleanup_invariant_failed",
+      "user_interrupted"
+    ],
+    "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+    "retry_replacement_backfill_forbidden": true
+  }
+}

--- a/benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md
+++ b/benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md
@@ -1,0 +1,37 @@
+# Forge C/C++ formal v4 Ubuntu daemon gate and initial-block decision
+
+## 状态与边界
+
+- 状态：结果盲态设计候选，等待实验负责人确认。
+- 本文不授权 provider canary、physical attempt、batch 或模型调用。
+- formal v1-v4 runtime candidate、v3 的 7 个 ledger 和所有历史 evidence 保持不变。
+- v3 slot 8-10 不创建；v3 与本候选不进入同一个 primary estimate。
+
+## 固定运行环境
+
+- Windows 仅为物理宿主机。
+- Forge 的 Compose/DooD 控制面、Compile Session 和 clean replay 只使用 WSL2 `Ubuntu` 发行版内由 `docker.service` 管理的原生 Docker Engine。
+- Docker context 固定为 `default`，socket 固定为 `/var/run/docker.sock`，daemon provider 固定为 `ubuntu-native`。
+- Docker Desktop 是独立 daemon，不作为启动、诊断或故障回退路径；门禁失败时停止并请求用户恢复 Ubuntu 服务。
+- formal preflight 只记录 provider 分类和布尔检查，不记录主机名、IP、代理、凭据或原始 daemon 标识。
+
+## 首批完整 project block 建议
+
+- 选择规则：冻结 schedule 中第一个项目，不依据 v3 结果选择。
+- 项目：`cppitertools`。
+- 完整 block：两个 condition 各三次重复，共 6 个 physical attempt。
+- 保留原 schedule identity：`1, 2, 73, 74, 153, 154`；不把它们改写成新的连续 slot。
+- 两个 condition 保持 `richlab-gpt-5.5` 与 `deepseek-v4-flash`，禁止 fallback、replacement、retry 和 backfill。
+
+## 预算与停止条件
+
+- 单个 physical attempt 继续使用 1,800 秒总墙钟、120 秒 cleanup reserve、最多 2 次 Compiler 调用和 48 次模型请求。
+- 首批最多 6 个 attempt；attempt 墙钟上界合计 10,800 秒，不含人工等待。
+- recorded-token 上限建议为 980,000。计算依据是正式预注册的 29,396,970 contingency tokens 按 30 个项目线性分摊后向上取整，不使用 v3 单项目结果调低预算。
+- token 边界只在当前 attempt 终结、finalize、cleanup 和 orphan reconciliation 完成后，于创建下一 attempt 前检查，因此最后一个 attempt 可能产生有限越界；不得中断 cleanup 来硬截 token。
+- 任一 runtime preflight、双 provider canary、daemon provider、ledger hash chain、Session finalization 或 cleanup/orphan 不变量失败时停止。
+- 若 token 边界导致 block 未完成，所有 attempt 保留在端到端描述性分母，但该 block 不进入 paired primary estimate。
+
+## 下一授权动作
+
+实验负责人需要单独确认：一个完整 block、6 个指定 schedule slot、980,000 recorded-token 上限，以及上述停止条件。确认后才创建新的中文授权 Issue 和 authorized identity，并在首条 ledger 前执行宿主门禁、Compose/DooD runtime preflight 与一次双 provider canary。

--- a/benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json
@@ -1,0 +1,588 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+  "title": "Forge C/C++ unapproved formal v4 Ubuntu-daemon candidate",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "manifest_canonicalization",
+    "benchmark",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "model_profiles",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "attempt_budget",
+    "resource_preflight",
+    "analysis_plan",
+    "authorization",
+    "initial_batch_decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-4.2.0-ubuntu-candidate"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "const": {
+        "languages": [
+          "C",
+          "C++"
+        ],
+        "phase": "formal_collection_v4_ubuntu_candidate",
+        "formal_comparison_enabled": false,
+        "collection_authorized": false,
+        "instrumentation_blocker": false
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "65c2a739ba054375158cbddb27a885e8206a48aa"
+        },
+        "component_sha256": {
+          "type": "object",
+          "required": [
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/client.py",
+            "backend/packages/harness/deerflow/compile/__init__.py",
+            "backend/packages/harness/deerflow/compile/docker_runtime.py",
+            "backend/packages/harness/deerflow/compile/evidence.py",
+            "backend/packages/harness/deerflow/compile/manager.py",
+            "backend/packages/harness/deerflow/compile/operations.py",
+            "backend/packages/harness/deerflow/compile/schemas.py",
+            "backend/packages/harness/deerflow/models/factory.py",
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+            "backend/packages/harness/deerflow/subagents/executor.py",
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+            "backend/uv.lock",
+            "config.example.yaml",
+            "docker/compile/Dockerfile",
+            "docker/docker-compose-dev.yaml"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/client.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/__init__.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/evidence.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/manager.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/operations.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/schemas.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/models/factory.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/executor.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/uv.lock": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "config.example.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/compile/Dockerfile": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/docker-compose-dev.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "required": [
+        "backend/Dockerfile",
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+        "scripts/docker.sh",
+        "scripts/forge_benchmark.py",
+        "scripts/forge_benchmark_runner.py",
+        "scripts/forge_formal_case_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_runner.py",
+        "scripts/forge_formal_collection_v2_protocol.py",
+        "scripts/forge_formal_collection_v2_runner.py",
+        "scripts/forge_formal_collection_v3_authorized_protocol.py",
+        "scripts/forge_formal_collection_v3_authorized_runner.py",
+        "scripts/forge_formal_collection_v3_protocol.py",
+        "scripts/forge_formal_collection_v3_runner.py",
+        "scripts/forge_formal_collection_v4_protocol.py",
+        "scripts/forge_formal_collection_v4_runner.py",
+        "scripts/forge_formal_collection_v4_runtime_protocol.py",
+        "scripts/forge_formal_collection_v4_runtime_runner.py",
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py",
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py",
+        "scripts/forge_formal_preregistration.py",
+        "scripts/forge_formal_runtime_protocol.py",
+        "scripts/require-ubuntu-native-docker.sh",
+        "scripts/wsl-check.sh"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/Dockerfile": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_case_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_preregistration.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/require-ubuntu-native-docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/wsl-check.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "required": [
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs",
+        "docker_daemon_provider",
+        "docker_socket_path"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        },
+        "docker_daemon_provider": {
+          "const": "ubuntu-native"
+        },
+        "docker_socket_path": {
+          "const": "/var/run/docker.sock"
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "const": {
+        "id": "forge-cpp-formal-v4-ubuntu-candidate-review",
+        "status": "environment_gate_implemented_collection_pending",
+        "implemented_on": "2026-08-12",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/109",
+        "implementation_baseline_commit": "65c2a739ba054375158cbddb27a885e8206a48aa",
+        "collection_constraints": {
+          "collection_authorized": false,
+          "provider_canary_forbidden": true,
+          "physical_attempt_creation_forbidden": true,
+          "model_execution_forbidden": true,
+          "batch_execution_forbidden": true,
+          "experiment_owner_confirmation_required": true,
+          "replacement_forbidden": true,
+          "fallback_forbidden": true,
+          "retry_forbidden": true,
+          "backfill_forbidden": true
+        },
+        "parent_manifest": {
+          "id": "forge-cpp-formal-v4-runtime-candidate",
+          "path": "benchmarks/manifests/cpp-formal-v4-runtime-candidate.json",
+          "canonical_sha256": "d1c211e638ee2fd71c5c2f9e70f250306a131f9ae8759c9bd064e48a96252473"
+        }
+      }
+    },
+    "$schema": {
+      "const": "../schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"
+    },
+    "manifest_canonicalization": {
+      "const": "UTF-8 JSON, sorted object keys, compact separators, no NaN"
+    },
+    "benchmark": {
+      "const": {
+        "id": "forge-cpp-formal-v4-ubuntu-candidate",
+        "name": "Forge C/C++ formal v4 Ubuntu-daemon candidate",
+        "purpose": "unapproved native-daemon gate and initial complete-block decision",
+        "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+      }
+    },
+    "model_profiles": {
+      "const": {
+        "richlab-gpt-5.5": {
+          "endpoint": "https://rich-api.choosefire.com/v1",
+          "credential_env": "OpenAI_AK",
+          "roles": {
+            "lead": "gpt-5.5",
+            "compiler": "gpt-5.5"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        },
+        "deepseek-v4-flash": {
+          "endpoint": "https://api.deepseek.com",
+          "credential_env": "DEEPSEEK_API_KEY",
+          "roles": {
+            "lead": "deepseek-v4-flash",
+            "compiler": "deepseek-v4-flash"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        }
+      }
+    },
+    "attempt_budget": {
+      "const": {
+        "total_wall_clock_seconds": 1800,
+        "cleanup_reserve_seconds": 120,
+        "max_compiler_invocations": 2,
+        "max_model_requests": 48,
+        "enforcement_checkpoints": [
+          "before_provider_request",
+          "before_compiler_invocation",
+          "before_submit_or_replay",
+          "before_finalize",
+          "before_cleanup"
+        ],
+        "new_work_forbidden_after_limit": true,
+        "cleanup_mandatory_after_limit": true,
+        "terminal_classification": "attempt_budget_exhausted"
+      }
+    },
+    "resource_preflight": {
+      "const": {
+        "minimum_available_memory_bytes": 2147483648,
+        "docker_daemon_timeout_seconds": 10,
+        "maximum_docker_daemon_latency_seconds": 5,
+        "required_checks": [
+          "host_available_memory_at_least_minimum",
+          "docker_daemon_responded",
+          "docker_daemon_latency_within_limit",
+          "docker_daemon_provider_matches",
+          "docker_socket_source_matches_native_path"
+        ],
+        "sensitive_host_identifiers_forbidden": true,
+        "docker_daemon_provider": "ubuntu-native",
+        "docker_socket_path": "/var/run/docker.sock"
+      }
+    },
+    "analysis_plan": {
+      "const": {
+        "protocol_version_pooling": "forbidden",
+        "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+        "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+        "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+        "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+        "provider_and_case_imbalance_must_be_reported": true,
+        "retry_replacement_backfill_forbidden": true
+      }
+    },
+    "initial_batch_decision": {
+      "const": {
+        "status": "pending_experiment_owner_confirmation",
+        "selection_rule": "first_project_in_frozen_schedule",
+        "project_ids": [
+          "cppitertools"
+        ],
+        "complete_project_blocks": 1,
+        "conditions_per_project": 2,
+        "repetitions_per_condition": 3,
+        "planned_attempts": 6,
+        "selected_schedule_orders": [
+          1,
+          2,
+          73,
+          74,
+          153,
+          154
+        ],
+        "maximum_recorded_tokens": 980000,
+        "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+        "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+        "maximum_attempt_wall_clock_seconds": 1800,
+        "maximum_batch_attempt_wall_clock_seconds": 10800,
+        "stop_conditions": [
+          "six_selected_attempts_terminalized",
+          "recorded_token_boundary_reached",
+          "runtime_preflight_failed",
+          "provider_canary_failed",
+          "daemon_provider_drift",
+          "ledger_or_cleanup_invariant_failed",
+          "user_interrupted"
+        ],
+        "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+        "retry_replacement_backfill_forbidden": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -12,6 +12,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DOCKER_DIR="$PROJECT_ROOT/docker"
 
+# shellcheck source=require-ubuntu-native-docker.sh
+source "$SCRIPT_DIR/require-ubuntu-native-docker.sh"
+
 # The Compose services and nested compile containers both need the same path as
 # seen by the host Docker daemon. In WSL2 this is the WSL path to the checkout.
 export DEER_FLOW_ROOT="${DEER_FLOW_ROOT:-$PROJECT_ROOT}"
@@ -110,17 +113,7 @@ cleanup() {
 trap cleanup INT TERM
 
 docker_available() {
-    # Check that the docker CLI exists
-    if ! command -v docker >/dev/null 2>&1; then
-        return 1
-    fi
-
-    # Check that the Docker daemon is reachable
-    if ! docker info >/dev/null 2>&1; then
-        return 1
-    fi
-
-    return 0
+    require_ubuntu_native_docker --quiet
 }
 
 # Initialize: pre-pull the sandbox image so first Pod startup is fast
@@ -206,9 +199,8 @@ start() {
     echo ""
 
     if ! docker_available; then
-        echo -e "${YELLOW}Docker is not reachable.${NC}"
-        echo "Start Docker Desktop with WSL integration, or start the native WSL Docker service."
-        echo "Then rerun: make docker-start"
+        echo -e "${YELLOW}The required Ubuntu native Docker Engine is not ready.${NC}"
+        echo "Ask the user to restore Ubuntu docker.service, then rerun: make docker-start"
         exit 1
     fi
 
@@ -419,6 +411,12 @@ help() {
 }
 
 main() {
+    case "${1:-}" in
+        init|start|restart|model-preflight|logs|stop)
+            require_ubuntu_native_docker
+            ;;
+    esac
+
     # Main command dispatcher
     case "$1" in
         init)

--- a/scripts/forge_formal_collection_v4_ubuntu_protocol.py
+++ b/scripts/forge_formal_collection_v4_ubuntu_protocol.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""生成并校验未授权的 formal v4 Ubuntu daemon 候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+REPOSITORY_SCRIPT_ROOT = REPOSITORY_ROOT / "scripts"
+if str(REPOSITORY_SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v4_runtime_protocol as parent_protocol  # noqa: E402
+import forge_formal_runtime_protocol as _hasher  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-4.2.0-ubuntu-candidate"
+BASELINE_COMMIT = "65c2a739ba054375158cbddb27a885e8206a48aa"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+DOCKER_DAEMON_PROVIDER = "ubuntu-native"
+DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-runtime-candidate.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-ubuntu-candidate.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/docker.sh",
+    "scripts/require-ubuntu-native-docker.sh",
+    "scripts/wsl-check.sh",
+    "scripts/forge_formal_collection_v4_ubuntu_protocol.py",
+    "scripts/forge_formal_collection_v4_ubuntu_runner.py",
+    "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+}
+ATTEMPT_BUDGET = copy.deepcopy(parent_protocol.ATTEMPT_BUDGET)
+RESOURCE_PREFLIGHT = {
+    **copy.deepcopy(parent_protocol.RESOURCE_PREFLIGHT),
+    "docker_daemon_provider": DOCKER_DAEMON_PROVIDER,
+    "docker_socket_path": DOCKER_SOCKET_PATH,
+}
+RESOURCE_PREFLIGHT["required_checks"] = [
+    *RESOURCE_PREFLIGHT["required_checks"],
+    "docker_daemon_provider_matches",
+    "docker_socket_source_matches_native_path",
+]
+ANALYSIS_PLAN = copy.deepcopy(parent_protocol.ANALYSIS_PLAN)
+INITIAL_BATCH_DECISION = {
+    "status": "pending_experiment_owner_confirmation",
+    "selection_rule": "first_project_in_frozen_schedule",
+    "project_ids": ["cppitertools"],
+    "complete_project_blocks": 1,
+    "conditions_per_project": 2,
+    "repetitions_per_condition": 3,
+    "planned_attempts": 6,
+    "selected_schedule_orders": [1, 2, 73, 74, 153, 154],
+    "maximum_recorded_tokens": 980_000,
+    "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+    "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+    "maximum_attempt_wall_clock_seconds": 1_800,
+    "maximum_batch_attempt_wall_clock_seconds": 10_800,
+    "stop_conditions": [
+        "six_selected_attempts_terminalized",
+        "recorded_token_boundary_reached",
+        "runtime_preflight_failed",
+        "provider_canary_failed",
+        "daemon_provider_drift",
+        "ledger_or_cleanup_invariant_failed",
+        "user_interrupted",
+    ],
+    "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+    "retry_replacement_backfill_forbidden": True,
+}
+AUTHORIZATION = {
+    "id": "forge-cpp-formal-v4-ubuntu-candidate-review",
+    "status": "environment_gate_implemented_collection_pending",
+    "implemented_on": "2026-08-12",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/109",
+    "implementation_baseline_commit": BASELINE_COMMIT,
+    "collection_constraints": {
+        "collection_authorized": False,
+        "provider_canary_forbidden": True,
+        "physical_attempt_creation_forbidden": True,
+        "model_execution_forbidden": True,
+        "batch_execution_forbidden": True,
+        "experiment_owner_confirmation_required": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    return parent_protocol.validate_manifest(parent)
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v4-runtime-candidate.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def _build_manifest(
+    repo_root: Path,
+    *,
+    parent: dict[str, Any],
+) -> dict[str, Any]:
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v4-ubuntu-candidate",
+        "name": "Forge C/C++ formal v4 Ubuntu-daemon candidate",
+        "purpose": "unapproved native-daemon gate and initial complete-block decision",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection_v4_ubuntu_candidate",
+        "formal_comparison_enabled": False,
+        "collection_authorized": False,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": _hasher._hash_paths(repo_root, COMPONENT_PATHS),
+    }
+    manifest["protocol_artifact_sha256"] = _hasher._hash_paths(
+        repo_root,
+        PROTOCOL_ARTIFACT_PATHS,
+    )
+    manifest["prompt_sha256"] = _hasher._hash_paths(
+        repo_root,
+        set(parent["prompt_sha256"]),
+    )
+    manifest["runtime"] = {
+        **copy.deepcopy(parent["runtime"]),
+        "docker_daemon_provider": DOCKER_DAEMON_PROVIDER,
+        "docker_socket_path": DOCKER_SOCKET_PATH,
+    }
+    manifest["attempt_budget"] = copy.deepcopy(ATTEMPT_BUDGET)
+    manifest["resource_preflight"] = copy.deepcopy(RESOURCE_PREFLIGHT)
+    manifest["analysis_plan"] = copy.deepcopy(ANALYSIS_PLAN)
+    manifest["initial_batch_decision"] = copy.deepcopy(INITIAL_BATCH_DECISION)
+    manifest["authorization"] = _authorization(parent)
+    return manifest
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _build_manifest(repo_root, parent=_parent_manifest(parent))
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    repo_root: Path = REPOSITORY_ROOT,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected = _build_manifest(repo_root, parent=_parent_manifest(parent))
+        if manifest != expected:
+            v1._fail(
+                "manifest",
+                "must match the reviewed formal v4 Ubuntu candidate exactly",
+            )
+        selected = [slot for slot in manifest["collection_plan"] if slot["order"] in manifest["initial_batch_decision"]["selected_schedule_orders"]]
+        if len(selected) != 6 or {slot["case_id"] for slot in selected} != {"cppitertools"}:
+            v1._fail(
+                "manifest.initial_batch_decision",
+                "must select the complete cppitertools project block",
+            )
+        if {(slot["condition_id"], slot["repetition"]) for slot in selected} != {(condition["id"], repetition) for condition in manifest["conditions"] for repetition in range(1, 4)}:
+            v1._fail(
+                "manifest.initial_batch_decision",
+                "must cover both conditions and all three repetitions",
+            )
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise BenchmarkError(f"manifest: invalid Ubuntu candidate: {exc}") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(manifest)
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest, repo_root=repo_root)
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        (
+            "manifest.protocol_artifact_sha256",
+            manifest["protocol_artifact_sha256"],
+        ),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            if _hasher._file_sha256(repo_root / relative_path) != expected:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match")
+
+
+def _hash_map_schema(paths: set[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": sorted(paths),
+        "additionalProperties": False,
+        "properties": {
+            relative_path: {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+            }
+            for relative_path in sorted(paths)
+        },
+    }
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    parent = _parent_manifest()
+    schema["$id"] = "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"
+    schema["title"] = "Forge C/C++ unapproved formal v4 Ubuntu-daemon candidate"
+    schema["required"] = [
+        *schema["required"],
+        "initial_batch_decision",
+    ]
+    properties = schema["properties"]
+    properties["$schema"] = {"const": "../schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json"}
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["benchmark"] = {
+        "const": {
+            "id": "forge-cpp-formal-v4-ubuntu-candidate",
+            "name": "Forge C/C++ formal v4 Ubuntu-daemon candidate",
+            "purpose": "unapproved native-daemon gate and initial complete-block decision",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }
+    }
+    properties["scope"] = {
+        "const": {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection_v4_ubuntu_candidate",
+            "formal_comparison_enabled": False,
+            "collection_authorized": False,
+            "instrumentation_blocker": False,
+        }
+    }
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["forge"]["properties"]["component_sha256"] = _hash_map_schema(COMPONENT_PATHS)
+    properties["protocol_artifact_sha256"] = _hash_map_schema(PROTOCOL_ARTIFACT_PATHS)
+    properties["prompt_sha256"] = _hash_map_schema(set(parent["prompt_sha256"]))
+    properties["runtime"]["required"] = [
+        *properties["runtime"]["required"],
+        "docker_daemon_provider",
+        "docker_socket_path",
+    ]
+    properties["runtime"]["properties"]["docker_daemon_provider"] = {"const": DOCKER_DAEMON_PROVIDER}
+    properties["runtime"]["properties"]["docker_socket_path"] = {"const": DOCKER_SOCKET_PATH}
+    properties["attempt_budget"] = {"const": copy.deepcopy(ATTEMPT_BUDGET)}
+    properties["resource_preflight"] = {"const": copy.deepcopy(RESOURCE_PREFLIGHT)}
+    properties["analysis_plan"] = {"const": copy.deepcopy(ANALYSIS_PLAN)}
+    properties["initial_batch_decision"] = {"const": copy.deepcopy(INITIAL_BATCH_DECISION)}
+    properties["authorization"] = {"const": _authorization(parent)}
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorization_status": manifest["authorization"]["status"],
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "collection_authorized": manifest["scope"]["collection_authorized"],
+                    "daemon_provider": manifest["runtime"]["docker_daemon_provider"],
+                    "initial_batch_attempts": manifest["initial_batch_decision"]["planned_attempts"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_ubuntu_runner.py
+++ b/scripts/forge_formal_collection_v4_ubuntu_runner.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""为未授权 formal v4 候选接入 Ubuntu 原生 daemon 门禁。"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_collection_v4_ubuntu_protocol as protocol  # noqa: E402
+
+# 协议模块先建立仓库导入根，再加载父 runner。
+# isort: split
+import forge_formal_collection_v4_runtime_runner as parent_runner  # noqa: E402
+
+_runner = parent_runner._runner
+_original_manifest_protocol = _runner._manifest_protocol
+_original_collect_runtime_launch_preflight = parent_runner.collect_runtime_launch_preflight
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def _docker_socket_source_matches_native_path(
+    mounts: list[dict[str, Any]] | None,
+) -> bool:
+    socket_mounts = [mount for mount in mounts or [] if mount.get("Type") == "bind" and mount.get("Source") == protocol.DOCKER_SOCKET_PATH and mount.get("Destination") == protocol.DOCKER_SOCKET_PATH and mount.get("RW") is True]
+    return len(socket_mounts) == 1
+
+
+def _docker_daemon_provider_probe(timeout_seconds: int) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{json .OperatingSystem}}"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {
+            "provider": None,
+            "responded": False,
+            "latency_seconds": round(time.monotonic() - started, 6),
+        }
+
+    provider = None
+    if result.returncode == 0:
+        try:
+            operating_system = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            operating_system = None
+        if isinstance(operating_system, str):
+            provider = protocol.DOCKER_DAEMON_PROVIDER if operating_system.startswith("Ubuntu") else "other"
+    return {
+        "provider": provider,
+        "responded": provider is not None,
+        "latency_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    result = _original_collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+    _labels, mounts = _runner._current_container_metadata(repo_root)
+    provider = _docker_daemon_provider_probe(protocol.RESOURCE_PREFLIGHT["docker_daemon_timeout_seconds"])
+    checks = {
+        **result["checks"],
+        "docker_daemon_provider_matches": (provider["provider"] == protocol.DOCKER_DAEMON_PROVIDER),
+        "docker_socket_source_matches_native_path": (_docker_socket_source_matches_native_path(mounts)),
+    }
+    return {
+        **result,
+        "ready": all(checks.values()),
+        "checks": checks,
+        "observations": {
+            **result.get("observations", {}),
+            "docker_daemon_provider": provider["provider"],
+        },
+    }
+
+
+def _reject_unapproved_action(action: str) -> None:
+    raise RunnerError(f"Formal v4 Ubuntu candidate is not authorized; {action} is forbidden")
+
+
+def collect_provider_canary(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("provider canary")
+
+
+def create_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("physical-attempt ledger creation")
+
+
+def run_attempt(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("model execution")
+
+
+def run_formal_batch(*args: Any, **kwargs: Any):
+    _reject_unapproved_action("batch execution")
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_formal_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/require-ubuntu-native-docker.sh
+++ b/scripts/require-ubuntu-native-docker.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# Forge 的开发与正式实验固定使用 Ubuntu 发行版内的原生 Docker Engine。
+# 本脚本只验证现状；不会启动服务、Docker Desktop 或修改 Docker 配置。
+
+_forge_kernel_release() {
+    cat /proc/sys/kernel/osrelease 2>/dev/null
+}
+
+_forge_command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+_forge_docker_service_state() {
+    systemctl is-active docker 2>/dev/null
+}
+
+_forge_docker_service_pid() {
+    systemctl show docker --property=MainPID --value 2>/dev/null
+}
+
+_forge_process_name() {
+    cat "/proc/$1/comm" 2>/dev/null
+}
+
+_forge_docker_context() {
+    docker context show 2>/dev/null
+}
+
+_forge_docker_endpoint() {
+    docker context inspect default --format '{{.Endpoints.docker.Host}}' 2>/dev/null
+}
+
+_forge_docker_operating_system() {
+    docker info --format '{{.OperatingSystem}}' 2>/dev/null
+}
+
+_forge_docker_socket_ready() {
+    [ -S /var/run/docker.sock ]
+}
+
+_forge_docker_compose_ready() {
+    docker compose version >/dev/null 2>&1
+}
+
+_forge_native_docker_error() {
+    echo "ERROR: $1" >&2
+    echo "Forge requires the native Docker Engine managed by systemd inside WSL2 Ubuntu." >&2
+    echo "Do not start or switch to Docker Desktop. Ask the user to restore the Ubuntu Docker service, then rerun this check." >&2
+    return 1
+}
+
+require_ubuntu_native_docker() {
+    local kernel_release
+    local service_state
+    local service_pid
+    local process_name
+    local docker_context
+    local docker_endpoint
+    local docker_os
+    local quiet=false
+
+    if [ "${1:-}" = "--quiet" ]; then
+        quiet=true
+    elif [ "$#" -gt 0 ]; then
+        _forge_native_docker_error "Unknown gate argument: $1"
+        return 1
+    fi
+
+    kernel_release="$(_forge_kernel_release)"
+    if [[ "${kernel_release,,}" != *microsoft* ]]; then
+        _forge_native_docker_error "This command must run inside WSL2 Ubuntu."
+        return 1
+    fi
+    if [ "${WSL_DISTRO_NAME:-}" != "Ubuntu" ]; then
+        _forge_native_docker_error "WSL_DISTRO_NAME must be Ubuntu."
+        return 1
+    fi
+    if [ -n "${DOCKER_HOST:-}" ] || [ -n "${DOCKER_CONTEXT:-}" ]; then
+        _forge_native_docker_error "DOCKER_HOST and DOCKER_CONTEXT overrides are forbidden."
+        return 1
+    fi
+    if ! _forge_command_exists docker || ! _forge_command_exists systemctl; then
+        _forge_native_docker_error "docker and systemctl must be installed inside Ubuntu."
+        return 1
+    fi
+
+    service_state="$(_forge_docker_service_state)"
+    if [ "$service_state" != "active" ]; then
+        _forge_native_docker_error "Ubuntu docker.service is not active."
+        return 1
+    fi
+    service_pid="$(_forge_docker_service_pid)"
+    if [[ ! "$service_pid" =~ ^[1-9][0-9]*$ ]]; then
+        _forge_native_docker_error "Ubuntu docker.service has no live MainPID."
+        return 1
+    fi
+    process_name="$(_forge_process_name "$service_pid")"
+    if [ "$process_name" != "dockerd" ]; then
+        _forge_native_docker_error "Ubuntu docker.service is not owned by dockerd."
+        return 1
+    fi
+
+    docker_context="$(_forge_docker_context)"
+    if [ "$docker_context" != "default" ]; then
+        _forge_native_docker_error "Docker context must be default, not $docker_context."
+        return 1
+    fi
+    docker_endpoint="$(_forge_docker_endpoint)"
+    if [ "$docker_endpoint" != "unix:///var/run/docker.sock" ]; then
+        _forge_native_docker_error "The default Docker endpoint must be unix:///var/run/docker.sock."
+        return 1
+    fi
+    if ! _forge_docker_socket_ready; then
+        _forge_native_docker_error "/var/run/docker.sock is not a Unix socket."
+        return 1
+    fi
+    docker_os="$(_forge_docker_operating_system)"
+    if [[ "$docker_os" != Ubuntu* ]]; then
+        _forge_native_docker_error "Docker daemon operating system is not Ubuntu."
+        return 1
+    fi
+    if ! _forge_docker_compose_ready; then
+        _forge_native_docker_error "Docker Compose v2 is unavailable in Ubuntu."
+        return 1
+    fi
+
+    if ! $quiet; then
+        echo "OK: Forge Docker daemon provider=ubuntu-native; context=default; endpoint=/var/run/docker.sock"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    require_ubuntu_native_docker "$@"
+fi

--- a/scripts/wsl-check.sh
+++ b/scripts/wsl-check.sh
@@ -5,6 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 missing=()
 
+# shellcheck source=require-ubuntu-native-docker.sh
+source "$SCRIPT_DIR/require-ubuntu-native-docker.sh"
+
 echo "=========================================="
 echo "  Forge-AutoCompiler WSL2 Preflight"
 echo "=========================================="
@@ -36,28 +39,13 @@ if [ ${#missing[@]} -gt 0 ]; then
         echo "  sudo apt update && sudo apt install -y build-essential git python3"
     fi
     if [[ " ${missing[*]} " == *" docker "* ]]; then
-        echo "Enable Docker Desktop > Settings > Resources > WSL Integration for ${WSL_DISTRO_NAME:-this distribution},"
-        echo "or intentionally install Docker Engine inside this WSL distribution."
+        echo "Install Docker Engine and the Compose v2 plugin inside WSL2 Ubuntu."
     fi
     exit 1
 fi
 
-if ! docker compose version >/dev/null 2>&1; then
-    echo "ERROR: Docker Compose v2 is unavailable in WSL."
-    echo "Enable Docker Desktop WSL integration or install the Compose v2 plugin for the WSL Docker Engine."
-    exit 1
-fi
+require_ubuntu_native_docker
 echo "OK: docker compose"
-
-if ! docker info >/dev/null 2>&1; then
-    echo "ERROR: The Linux Docker daemon is not reachable from this WSL distribution."
-    echo "Start Docker Desktop, or start the native WSL Docker service, and rerun this check."
-    exit 1
-fi
-docker_os="$(docker info --format '{{.OperatingSystem}}' 2>/dev/null || echo unknown)"
-docker_context="$(docker context show 2>/dev/null || echo unknown)"
-echo "OK: Docker daemon ($docker_os; context=$docker_context)"
-echo "NOTE: Run all Forge Docker commands against this same daemon; Docker Desktop and native WSL images are not shared."
 
 if docker image inspect autocompiler:gcc13 >/dev/null 2>&1; then
     echo "OK: compile image (autocompiler:gcc13)"
@@ -73,5 +61,5 @@ if [[ "$PROJECT_ROOT" == /mnt/* ]]; then
 fi
 
 echo ""
-echo "WSL2 + Docker prerequisites are ready."
+echo "WSL2 Ubuntu + native Docker prerequisites are ready."
 echo "Next: make config (first run), make compile-image, then make docker-start"


### PR DESCRIPTION
## 背景

本机同时存在 Ubuntu 原生 Docker Engine 与 Docker Desktop daemon。Forge 的 Compose/DooD、Compile Session、clean replay 和 formal evidence 均属于 Ubuntu 原生 daemon，因此 formal v4 首批采集前需要把 daemon 归属从人工约定提升为可执行门禁。

Closes #109

## 变更

- 新增 Ubuntu 原生 Docker 门禁，固定 `Ubuntu`、`docker.service`、`default` context 与 `unix:///var/run/docker.sock`。
- 让 `scripts/docker.sh` 和 `scripts/wsl-check.sh` 统一复用门禁；失败时停止并请求人工恢复，不启动 Docker Desktop。
- 派生未授权的 `formal-collection-4.2.0-ubuntu-candidate`，冻结 `docker_daemon_provider=ubuntu-native`。
- 形成结果盲态的 formal v4 首批决策包：一个完整 `cppitertools` project block，共 6 attempts，recorded-token 建议上限 980,000。
- 保持 provider canary、physical attempt、batch 与模型执行入口硬拒绝，不创建 formal ledger。

## 验证

- 聚焦回归：23 passed
- LangGraph 权威环境扩大回归：138 passed
- Ruff lint/format、Shell 语法、Schema 校验通过
- manifest/Schema 确定性再生成前后哈希一致
- 父 v4 runtime candidate 文件校验通过
- 真实 Ubuntu 原生 Docker 宿主门禁通过
- 真实 Compose/DooD preflight：13/13
- 未授权 canary 入口拒绝
- 0 JSON/JSONL、0 Compile Session/replay orphan
- 暂存变更敏感值匹配：0
- 本阶段未调用模型、未消耗 AK、未创建 formal ledger