### PR TITLE
研究：冻结 formal v4 有限诊断与新 canary

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-13 — 完成 formal v4 有限诊断与新 canary amendment
+  - GitHub: 中文 Issue #115 已创建并回读；实现分支为 `research/formal-v4-canary-amendment`，PR 尚未创建。
+  - 授权: RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各最多 2 次低成本诊断，首次成功即停止；之后最多 1 次新的双 provider canary，成功才执行原六槽，token 上限仍为 980,000。
+  - 实现: 新 manifest/Schema/protocol/runner/report 使用独立诊断和 formal evidence 目录；诊断以 append-only started/terminal 文件计次，不保存响应正文、请求头、凭据或网络标识；新路径禁止匿名 `/models` preflight。
+  - 历史边界: 旧 authorized manifest canonical SHA-256、失败 marker SHA-256、`failed` / `RunnerError`、0 provider report 与 0 formal ledger 均在每个后续门禁重新校验，旧文件不修改。
+  - 当前验证: canonical SHA-256 为 `e296138d6464adc6e7c12d4ee29d1f22c178d53a463b3467e2d2442e5fd66587`；聚焦测试 `22 passed`、formal v1-v4 扩大回归 `205 passed`，Ruff、format、`py_compile`、Schema、确定性再生成、父文件/旧 marker、敏感信息、Ubuntu 原生 daemon 与 0 formal 残留容器审计通过。
+  - 下一步: 完成本地验证和文档审计后中文提交、WSL helper 推送、中文 PR；主干合并后运行真实诊断，新 canary 失败立即停止，成功才执行六槽。
+
 - 2026-08-12 — 执行 formal v4 首批完整 `cppitertools` project block
   - GitHub: Issue #111 / PR #112 已 squash 合并为 `main@05e9fdbd`，Issue 自动关闭；PR 与主干的 backend unit tests、backend lint、frontend lint 全绿。
   - 授权: 原 schedule order `1, 2, 73, 74, 153, 154`，双 condition 各三次，共 6 attempts；maximum recorded tokens 为 980,000，禁止 retry、fallback、replacement、backfill 和 v3 slot 8-10。

--- a/backend/tests/test_forge_formal_collection_v4_canary_amendment_protocol.py
+++ b/backend/tests/test_forge_formal_collection_v4_canary_amendment_protocol.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_canary_amendment_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_collection_v4_canary_amendment_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-canary-amendment.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-canary-amendment.schema.json"
+PARENT_FILES = {
+    "scripts/forge_formal_collection_v4_authorized_protocol.py": "5adb07e261e14cbd3831e8d58a08d83a1efe97b80b4d9acf499fadd6acd74574",
+    "scripts/forge_formal_collection_v4_authorized_runner.py": "96181cbb03a5e660cccf7cc8bfa8a0bfb5d25fa07633eafec71095df611aa15d",
+    "scripts/forge_formal_collection_v4_authorized_report.py": "2fc3b3efe325c3f3bd4dea61b7775c91a3cf1144ee978c2b5524130a6ef58641",
+    "benchmarks/manifests/cpp-formal-v4-authorized-initial-block.json": "5f4b2b6af6aac80d43591073f51f9524a71b9c9191deab48c6872dbb731e4ef6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json": "12f8610792f81ce19106fda5a1e602e391487b274bfa7bfabeb02b3942d5c20a",
+    "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md": "7d77fd41f0df1692c79808bc8dfe13a0267fb89f7238f0ed3cfbe7152b7344f1",
+}
+LEGACY_MARKER_BYTES = b"""{
+  "benchmark_id": "forge-cpp-formal-v4-authorized-initial-block",
+  "document_type": "formal_provider_canary_attempt",
+  "error_class": "RunnerError",
+  "manifest_sha256": "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03",
+  "schema_version": "formal-provider-canary-attempt-1.0.0",
+  "status": "failed",
+  "updated_at": "2026-08-12T15:45:00.601026+00:00"
+}
+"""
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_formal_collection_v4_canary_amendment_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_formal_collection_v4_canary_amendment_runner_test",
+    RUNNER_PATH,
+)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_is_deterministic_schema_valid_and_bounded() -> None:
+    manifest = load_manifest()
+
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    assert manifest["schema_version"] == "formal-collection-4.4.0-canary-amendment"
+    assert manifest["forge"]["commit_sha"] == "efc640fedbc4da2e00d553fd37adaa693e8abaa2"
+    assert manifest["authorization"]["issue_url"].endswith("/issues/115")
+    assert manifest["authorization"]["network_observation"]["access_medium"] == "mobile_hotspot"
+    assert manifest["authorization"]["diagnostics"]["maximum_attempts_per_provider"] == 2
+    assert manifest["authorization"]["new_canary"]["maximum_attempts"] == 1
+    assert manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"] == 980_000
+    assert manifest["authorization"]["collection_constraints"]["authorized_schedule_orders"] == [1, 2, 73, 74, 153, 154]
+    assert manifest["authorization"]["superseded_canary_terminal"]["manifest_sha256"] == ("8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03")
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["authorization"]["diagnostics"].update(maximum_attempts_per_provider=3),
+        lambda value: value["authorization"]["diagnostics"].update(response_body_storage_forbidden=False),
+        lambda value: value["authorization"]["diagnostics"].update(stop_conditions=["all_providers_terminal"]),
+        lambda value: value["authorization"]["new_canary"].update(maximum_attempts=2),
+        lambda value: value["authorization"]["new_canary"].update(anonymous_models_endpoint_preflight="required"),
+        lambda value: value["authorization"]["superseded_canary_terminal"].update(status="passed"),
+        lambda value: value["authorization"]["collection_constraints"].update(authorized_schedule_orders=[1, 2]),
+        lambda value: value["authorization"]["budget_confirmation"].update(maximum_recorded_tokens=980_001),
+    ],
+)
+def test_manifest_rejects_diagnostic_canary_or_collection_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(protocol.BenchmarkError):
+        protocol.validate_manifest(manifest)
+
+
+def test_parent_authorized_files_remain_byte_identical() -> None:
+    for relative_path, expected in PARENT_FILES.items():
+        assert hashlib.sha256((REPO_ROOT / relative_path).read_bytes()).hexdigest() == expected
+
+
+def test_legacy_terminal_requires_exact_marker_and_empty_layer(tmp_path: Path) -> None:
+    manifest = load_manifest()
+    marker_path = tmp_path / "provider-canaries" / "formal-v4-provider-canary-attempt.json"
+    marker_path.parent.mkdir(parents=True)
+    assert hashlib.sha256(LEGACY_MARKER_BYTES).hexdigest() == ("9ab297d091967c15fae4f90caf18657b25214903b849fa3a695cd749fc19f724")
+    marker_path.write_bytes(LEGACY_MARKER_BYTES)
+
+    result = runner._verify_legacy_terminal(manifest, legacy_output_dir=tmp_path)
+
+    assert result["status"] == "failed"
+    assert result["provider_report_count"] == 0
+    assert result["formal_ledger_count"] == 0
+
+    (marker_path.parent / "unexpected.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(runner.RunnerError, match="no longer empty"):
+        runner._verify_legacy_terminal(manifest, legacy_output_dir=tmp_path)
+
+
+def _patch_diagnostic_gates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(runner, "_diagnostic_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner, "_verify_legacy_terminal", lambda *args, **kwargs: {"status": "failed"})
+    monkeypatch.setattr(runner, "_formal_container_ids", lambda: [])
+    monkeypatch.setattr(runner._runner, "_running_inside_compose_dood", lambda _repo_root: True)
+    monkeypatch.setattr(runner, "_original_collect_preflight", lambda *args, **kwargs: {"ready": True})
+    monkeypatch.setattr(runner, "_diagnostic_model_config_matches", lambda *args, **kwargs: True)
+
+
+def test_diagnostics_retry_only_after_failure_and_stop_after_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    _patch_diagnostic_gates(monkeypatch, tmp_path)
+    issued: list[str] = []
+
+    def issue(model_name: str, _prompt: str, max_output_tokens: int) -> bool:
+        issued.append(model_name)
+        assert max_output_tokens == 32
+        if model_name == "gpt-5.5" and issued.count(model_name) == 1:
+            raise TimeoutError
+        return True
+
+    summary = runner.collect_endpoint_diagnostics(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        request_issuer=issue,
+    )
+
+    assert summary["passed"] is True
+    assert issued == ["gpt-5.5", "gpt-5.5", "deepseek-v4-flash"]
+    attempts = sorted((tmp_path / "attempts").glob("*.json"))
+    assert len(attempts) == 6
+    assert all(set(json.loads(path.read_text(encoding="utf-8"))) == runner._DIAGNOSTIC_ATTEMPT_KEYS for path in attempts)
+    assert all("DIAGNOSTIC_OK" not in path.read_text(encoding="utf-8") for path in attempts)
+
+    second = runner.collect_endpoint_diagnostics(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        request_issuer=lambda *_args: pytest.fail("terminal diagnostics must not issue another request"),
+    )
+    assert second == summary
+
+
+def test_started_diagnostic_reservation_consumes_an_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    _patch_diagnostic_gates(monkeypatch, tmp_path)
+    provider = manifest["authorization"]["diagnostics"]["providers"][0]
+    path = runner._diagnostic_attempt_path(
+        tmp_path,
+        condition_id=provider["condition_id"],
+        attempt=1,
+    )
+    runner._write_json_exclusive(
+        path,
+        {
+            "schema_version": "formal-endpoint-diagnostic-attempt-1.0.0",
+            "document_type": "formal_endpoint_diagnostic_attempt",
+            "benchmark_id": manifest["benchmark"]["id"],
+            "manifest_sha256": protocol.manifest_sha256(manifest),
+            "condition_id": provider["condition_id"],
+            "provider": provider["provider"],
+            "model": provider["model"],
+            "attempt": 1,
+            "status": "started",
+            "started_at": "2000-01-01T00:00:00+00:00",
+            "completed_at": None,
+            "duration_ms": None,
+            "response_nonempty": False,
+            "error_class": None,
+            "passed": False,
+        },
+    )
+    issued: list[str] = []
+
+    summary = runner.collect_endpoint_diagnostics(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        request_issuer=lambda model, *_args: issued.append(model) or True,
+    )
+
+    assert summary["passed"] is True
+    assert issued == ["gpt-5.5", "deepseek-v4-flash"]
+    assert [condition["attempt_count"] for condition in summary["conditions"]] == [2, 1]
+
+
+def test_failed_diagnostics_consume_two_attempts_and_block_canary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    _patch_diagnostic_gates(monkeypatch, tmp_path)
+
+    summary = runner.collect_endpoint_diagnostics(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        request_issuer=lambda *_args: False,
+    )
+
+    assert summary["passed"] is False
+    assert [condition["attempt_count"] for condition in summary["conditions"]] == [2, 2]
+    with pytest.raises(runner.RunnerError, match="must pass"):
+        runner._load_diagnostic_summary(
+            manifest,
+            output_dir=tmp_path,
+            require_passed=True,
+        )
+
+
+def test_diagnostics_reject_unexpected_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    _patch_diagnostic_gates(monkeypatch, tmp_path)
+    (tmp_path / "unexpected.txt").write_text("not evidence", encoding="utf-8")
+
+    with pytest.raises(runner.RunnerError, match="unexpected file"):
+        runner.collect_endpoint_diagnostics(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+            request_issuer=lambda *_args: True,
+        )
+
+
+def test_canary_is_consumed_once_and_skips_anonymous_models_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(runner, "_formal_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner, "_verify_legacy_terminal", lambda *args, **kwargs: {"status": "failed"})
+    monkeypatch.setattr(runner, "_load_diagnostic_summary", lambda *args, **kwargs: {"passed": True})
+    monkeypatch.setattr(runner, "_observed_authorized_ledgers", lambda *args, **kwargs: [])
+    monkeypatch.setattr(runner, "_formal_container_ids", lambda: [])
+    original_preflight = runner._runner.collect_preflight
+
+    def collect(*args, **kwargs):
+        assert runner._runner.collect_preflight is not original_preflight
+        return {"passed": True}
+
+    monkeypatch.setattr(runner, "_original_collect_provider_canary", collect)
+
+    assert (
+        runner.collect_provider_canary(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+        )["passed"]
+        is True
+    )
+    marker = json.loads(runner._canary_marker_path(tmp_path).read_text(encoding="utf-8"))
+    assert marker["status"] == "passed"
+
+    with pytest.raises(runner.RunnerError, match="already been consumed"):
+        runner.collect_provider_canary(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+        )
+
+
+def test_orphan_canary_report_blocks_new_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    monkeypatch.setattr(runner, "_formal_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner, "_verify_legacy_terminal", lambda *args, **kwargs: {"status": "failed"})
+    monkeypatch.setattr(runner, "_load_diagnostic_summary", lambda *args, **kwargs: {"passed": True})
+    monkeypatch.setattr(runner, "_observed_authorized_ledgers", lambda *args, **kwargs: [])
+    monkeypatch.setattr(runner, "_formal_container_ids", lambda: [])
+    directory = tmp_path / "provider-canaries"
+    directory.mkdir(parents=True)
+    (directory / "orphan.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(runner.RunnerError, match="orphan"):
+        runner.collect_provider_canary(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+        )
+    assert not runner._canary_marker_path(tmp_path).exists()
+
+
+def test_create_attempt_requires_successful_new_canary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    slot = runner._authorized_slots(manifest)[0]
+    monkeypatch.setattr(runner, "_formal_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner, "_verify_legacy_terminal", lambda *args, **kwargs: {"status": "failed"})
+    monkeypatch.setattr(runner, "_load_diagnostic_summary", lambda *args, **kwargs: {"passed": True})
+
+    with pytest.raises(runner.RunnerError, match="canary marker"):
+        runner.create_attempt(
+            manifest,
+            case_id=slot["case_id"],
+            condition_id=slot["condition_id"],
+            repetition=slot["repetition"],
+            output_dir=tmp_path,
+        )
+    assert list(tmp_path.rglob("*.jsonl")) == []
+
+
+def test_batch_preserves_original_six_slot_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    created: list[tuple[str, str, int, bool]] = []
+    monkeypatch.setattr(runner, "_formal_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner, "_verify_legacy_terminal", lambda *args, **kwargs: {"status": "failed"})
+    monkeypatch.setattr(runner, "_load_diagnostic_summary", lambda *args, **kwargs: {"passed": True})
+    monkeypatch.setattr(runner, "_require_successful_canary", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runner, "_observed_authorized_ledgers", lambda *args, **kwargs: [])
+    monkeypatch.setattr(runner, "_ensure_token_budget_remaining", lambda *args, **kwargs: 0)
+
+    def create(manifest, *, case_id, condition_id, repetition, check_endpoint, **kwargs):
+        created.append((case_id, condition_id, repetition, check_endpoint))
+        return SimpleNamespace(
+            path=tmp_path / f"{len(created)}.jsonl",
+            physical_attempt_id=f"physical_attempt_{len(created)}",
+        ), {"ready": True}
+
+    monkeypatch.setattr(runner, "create_attempt", create)
+    monkeypatch.setattr(runner, "run_attempt", lambda *args, **kwargs: {"status": "failed"})
+
+    result = runner.run_formal_batch(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        max_attempts=6,
+    )
+
+    assert [item["schedule_order"] for item in result["results"]] == [1, 2, 73, 74, 153, 154]
+    assert all(check_endpoint is False for *_identity, check_endpoint in created)

--- a/backend/tests/test_forge_formal_collection_v4_canary_amendment_report.py
+++ b/backend/tests/test_forge_formal_collection_v4_canary_amendment_report.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "forge_formal_collection_v4_canary_amendment_report.py"
+SPEC = importlib.util.spec_from_file_location(
+    "forge_formal_collection_v4_canary_amendment_report_test",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+reporter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(reporter)
+
+
+def _parent_report() -> dict:
+    return {
+        "report_version": "parent",
+        "benchmark_id": "forge-cpp-formal-v4-canary-amendment",
+        "manifest_sha256": "1" * 64,
+        "scope": {"paired_primary_eligible": True},
+        "authorization": {},
+        "canary": {},
+        "collection": {
+            "analyzed_slots": 6,
+            "authorized_slots": 6,
+            "stop_reason": "authorized_complete_project_block_reached",
+            "complete_project_block": True,
+            "oracle_passed": 6,
+            "orphan_count": 0,
+            "ledger_hash_chain_valid": 6,
+            "recorded_total_tokens": 100,
+            "recorded_token_limit": 980_000,
+        },
+        "failure_event_counts": {},
+        "conditions": [],
+        "attempts": [],
+        "interpretation": {},
+        "limitations": [],
+    }
+
+
+def test_report_adds_diagnostics_and_preserved_legacy_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_protocol = reporter.parent_report.protocol
+    original_runner = reporter.parent_report.runner
+    monkeypatch.setattr(
+        reporter.parent_report,
+        "build_report",
+        lambda *args, **kwargs: _parent_report(),
+    )
+    monkeypatch.setattr(
+        reporter.runner,
+        "_load_diagnostic_summary",
+        lambda *args, **kwargs: {"passed": True, "conditions": []},
+    )
+    monkeypatch.setattr(
+        reporter.runner,
+        "_verify_legacy_terminal",
+        lambda *args, **kwargs: {"status": "failed", "formal_ledger_count": 0},
+    )
+
+    report = reporter.build_report(
+        {"benchmark": {"id": "forge-cpp-formal-v4-canary-amendment"}},
+        tmp_path,
+        diagnostic_dir=tmp_path / "diagnostics",
+        legacy_evidence_dir=tmp_path / "legacy",
+    )
+
+    assert report["report_version"] == reporter.REPORT_VERSION
+    assert report["diagnostics"]["passed"] is True
+    assert report["superseded_canary_terminal"]["status"] == "failed"
+    assert report["interpretation"]["diagnostics_excluded_from_formal_denominator"] is True
+    assert reporter.parent_report.protocol is original_protocol
+    assert reporter.parent_report.runner is original_runner
+
+
+def test_parent_report_globals_are_restored_after_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_protocol = reporter.parent_report.protocol
+    original_runner = reporter.parent_report.runner
+
+    def fail(*args, **kwargs):
+        raise reporter.ReportError("invalid evidence")
+
+    monkeypatch.setattr(reporter.parent_report, "build_report", fail)
+
+    with pytest.raises(reporter.ReportError, match="invalid evidence"):
+        reporter.build_report({}, tmp_path)
+
+    assert reporter.parent_report.protocol is original_protocol
+    assert reporter.parent_report.runner is original_runner
+
+
+def test_markdown_is_deterministic_and_documents_separation() -> None:
+    report = _parent_report()
+    report["diagnostics"] = {"passed": True}
+    report["superseded_canary_terminal"] = {"status": "failed"}
+
+    first = reporter.render_markdown(report)
+    second = reporter.render_markdown(json.loads(json.dumps(report, sort_keys=True)))
+
+    assert first == second
+    assert "有限诊断与 formal evidence 分目录保存" in first
+    assert "旧 canary 失败 marker" in first
+    assert "forge_formal_collection_v4_canary_amendment_report.py" in first

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,63 @@
 # Forge C/C++ benchmark protocols
 
+## Formal v4 bounded diagnostics and canary amendment
+
+Issue #115 preserves the consumed formal v4 canary failure and authorizes a
+separate amendment identity. The old evidence directory and failed marker are
+immutable. The amendment permits at most two low-cost authenticated requests
+per provider, with the second request allowed only after the first fails. The
+diagnostics run RichLab `gpt-5.5` before DeepSeek `deepseek-v4-flash`, use a
+120-second request timeout, zero provider retries, and a 32-token output limit.
+Diagnostic records are append-only and exclude response text, headers,
+credentials, network identifiers, and formal ledgers.
+
+Generate and validate the amendment identity with:
+
+```bash
+python scripts/forge_formal_collection_v4_canary_amendment_protocol.py generate
+python scripts/forge_formal_collection_v4_canary_amendment_protocol.py validate-manifest \
+  benchmarks/manifests/cpp-formal-v4-canary-amendment.json
+```
+
+After the implementation is merged and the Ubuntu native Docker gate passes,
+run the bounded diagnostics inside the `deer-flow-dev` LangGraph container:
+
+```bash
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v4_canary_amendment_runner.py \
+  endpoint-diagnostics \
+  --output-dir /workspace/.compile-sessions/benchmark-diagnostics-formal-v4-canary-amendment
+```
+
+Only a successful two-provider diagnostic summary permits the one new
+dual-provider canary. This canary no longer uses the anonymous `/models`
+endpoint preflight. Its opportunity is consumed on start, whether it passes,
+fails, or is interrupted:
+
+```bash
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v4_canary_amendment_runner.py \
+  provider-canary \
+  --output-dir /workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment
+```
+
+Stop immediately if the canary fails. Only a successful canary report and
+attempt marker permit the original six slots, still ordered as
+`1, 2, 73, 74, 153, 154` with the unchanged 980,000 recorded-token ceiling:
+
+```bash
+/app/backend/.venv/bin/python \
+  /repo/scripts/forge_formal_collection_v4_canary_amendment_runner.py \
+  run-batch \
+  --output-dir /workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment \
+  --max-attempts 6
+```
+
+Retries, fallback, replacement, backfill, and formal v3 slots 8-10 remain
+forbidden. The deterministic audit uses
+`scripts/forge_formal_collection_v4_canary_amendment_report.py` and reports the
+diagnostics separately from formal compilation outcomes.
+
 ## Formal v4 authorized initial project block
 
 Issue #111 authorizes exactly one complete `cppitertools` project block from

--- a/benchmarks/manifests/cpp-formal-v4-canary-amendment.json
+++ b/benchmarks/manifests/cpp-formal-v4-canary-amendment.json
@@ -1,0 +1,2954 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json",
+  "schema_version": "formal-collection-4.4.0-canary-amendment",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-v4-canary-amendment",
+    "name": "Forge C/C++ formal v4 bounded diagnostics and canary amendment",
+    "purpose": "preserve the consumed canary while authorizing bounded endpoint diagnosis and one new canary",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_collection_v4_canary_amendment",
+    "formal_comparison_enabled": true,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "efc640fedbc4da2e00d553fd37adaa693e8abaa2",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": "90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4",
+    "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md": "7d77fd41f0df1692c79808bc8dfe13a0267fb89f7238f0ed3cfbe7152b7344f1",
+    "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md": "da1ef392311b532ad82d67228176a0e1aed5d72c3cf97a4db075f192955a52cc",
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": "2fbdbbb2c419e2dcea24be1c6bd5650febdbd64509068e6ecd78fe64a5f9f04a",
+    "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": "4118549635ec99b60d9126f1ae82f7d6df74e4b699c57aa3448d302e26aa312d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json": "12f8610792f81ce19106fda5a1e602e391487b274bfa7bfabeb02b3942d5c20a",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json": "243749ea7868fccab6c30f9a66bae0483c0efb22c6873d119ee05a9a3084a67a",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": "69bba99ca4fba5afd10e170976f509c90e089a5769d3939cea416411276dda60",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": "2a3ab3b2d3a0543470f136e8465fd64cee2cc5dc9f6343b4b40a7a186739e55f",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": "6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/docker.sh": "6c79dfd5fd79019dcd51b2445a09d29b229bbe8c0017c3262afa6e90ef3e344b",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "d81d1e973b44be0b1a042dfdafea77b64faa79d4596eca16ce20fb8455351718",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_collection_v4_authorized_protocol.py": "5adb07e261e14cbd3831e8d58a08d83a1efe97b80b4d9acf499fadd6acd74574",
+    "scripts/forge_formal_collection_v4_authorized_report.py": "2fc3b3efe325c3f3bd4dea61b7775c91a3cf1144ee978c2b5524130a6ef58641",
+    "scripts/forge_formal_collection_v4_authorized_runner.py": "96181cbb03a5e660cccf7cc8bfa8a0bfb5d25fa07633eafec71095df611aa15d",
+    "scripts/forge_formal_collection_v4_canary_amendment_protocol.py": "a91d964b7167729b6702f9b593b7c215bfd051ae3311da86c6fd60c13684fae1",
+    "scripts/forge_formal_collection_v4_canary_amendment_report.py": "bde9da99ef52a2658ea0b54b2665a0d054955c08049981190d73eff0c94f9375",
+    "scripts/forge_formal_collection_v4_canary_amendment_runner.py": "c9b78e8cc6fe5b8da19703964edf8ba01222045cd356157c974e742abf496af0",
+    "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
+    "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": "e0b14b5e2f224846f1c5c0c213f66e0667a5d008d4e246d37b1b805c4ccf595e",
+    "scripts/forge_formal_collection_v4_runtime_runner.py": "9b4ba4f4eabb5888fd663b241d69a00dfc5e369474755dd64338b02fc146e42f",
+    "scripts/forge_formal_collection_v4_ubuntu_protocol.py": "273ba1b711b9d89c218ccae2fd95f6d934b4af1b6fdc39715dbcbea6f4602a31",
+    "scripts/forge_formal_collection_v4_ubuntu_runner.py": "070f48d76d9a06f9f68d67f6abcdf3e885a5d1096c7b7725aa5df56a09082cc8",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6",
+    "scripts/require-ubuntu-native-docker.sh": "5f1ea83c92a55f3ebfb00ad617db4946c73a9b6d6b8b8c4ca2d6cd0e9a893e32",
+    "scripts/wsl-check.sh": "891c8238d481a1aa8f76d146b48ef95a1dc974995e742671a1942a83475188ba"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 120,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    },
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-v4-canary-amendment",
+    "status": "authorized_limited_diagnostics_and_single_canary",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-13",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/115",
+    "implementation_baseline_commit": "efc640fedbc4da2e00d553fd37adaa693e8abaa2",
+    "network_observation": {
+      "access_medium": "mobile_hotspot",
+      "browser_ui_required": false
+    },
+    "budget_confirmation": {
+      "confirmed": true,
+      "maximum_recorded_tokens": 980000,
+      "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+      "terminalization_cleanup_precedes_token_boundary_check": true
+    },
+    "collection_constraints": {
+      "planned_attempts": 180,
+      "authorized_slot_count": 6,
+      "authorized_schedule_orders": [
+        1,
+        2,
+        73,
+        74,
+        153,
+        154
+      ],
+      "remaining_slot_count": 174,
+      "remaining_slots_require_additional_confirmation": true,
+      "complete_project_blocks": 1,
+      "provider_canary_required_before_first_ledger": true,
+      "provider_canary_max_attempts": 1,
+      "empty_ledger_required_before_canary": true,
+      "zero_residual_formal_containers_required_before_canary": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "v3_slots_8_to_10_forbidden": true,
+      "required_runtime_launch_checks": [
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit",
+        "docker_daemon_provider_matches",
+        "docker_socket_source_matches_native_path"
+      ],
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment",
+      "endpoint_readiness_source": "bounded_authenticated_diagnostics_then_single_provider_canary"
+    },
+    "diagnostics": {
+      "directory": "/workspace/.compile-sessions/benchmark-diagnostics-formal-v4-canary-amendment",
+      "provider_order": [
+        "richlab-gpt-5.5",
+        "deepseek-v4-flash"
+      ],
+      "providers": [
+        {
+          "condition_id": "richlab-gpt-5.5",
+          "provider": "richlab",
+          "model": "gpt-5.5"
+        },
+        {
+          "condition_id": "deepseek-v4-flash",
+          "provider": "deepseek",
+          "model": "deepseek-v4-flash"
+        }
+      ],
+      "maximum_attempts_per_provider": 2,
+      "request_timeout_seconds": 120,
+      "max_output_tokens": 32,
+      "prompt": "Reply with exactly DIAGNOSTIC_OK and nothing else.",
+      "success_criterion": "request_completed_and_response_nonempty",
+      "stop_after_first_success_per_provider": true,
+      "all_providers_must_pass_before_canary": true,
+      "stop_conditions": [
+        "first_success_for_current_provider",
+        "two_attempts_consumed_for_current_provider",
+        "all_providers_terminal",
+        "user_interrupted"
+      ],
+      "interruption_policy": "started_attempt_remains_consumed_and_only_unconsumed_attempts_may_run",
+      "formal_evidence_separation_required": true,
+      "response_body_storage_forbidden": true,
+      "request_headers_storage_forbidden": true,
+      "credential_material_storage_forbidden": true,
+      "network_identifier_storage_forbidden": true
+    },
+    "superseded_canary_terminal": {
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-v4-authorized-initial-block",
+      "marker_relative_path": "provider-canaries/formal-v4-provider-canary-attempt.json",
+      "marker_sha256": "9ab297d091967c15fae4f90caf18657b25214903b849fa3a695cd749fc19f724",
+      "benchmark_id": "forge-cpp-formal-v4-authorized-initial-block",
+      "manifest_sha256": "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03",
+      "status": "failed",
+      "error_class": "RunnerError",
+      "provider_report_count": 0,
+      "formal_ledger_count": 0,
+      "immutable": true
+    },
+    "new_canary": {
+      "maximum_attempts": 1,
+      "attempt_marker": "formal-v4-canary-amendment-provider-canary-attempt.json",
+      "anonymous_models_endpoint_preflight": "forbidden",
+      "successful_diagnostics_required": true,
+      "success_required_before_formal_ledger": true
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v4-authorized-initial-block",
+      "path": "benchmarks/manifests/cpp-formal-v4-authorized-initial-block.json",
+      "canonical_sha256": "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03"
+    }
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit",
+      "docker_daemon_provider_matches",
+      "docker_socket_source_matches_native_path"
+    ],
+    "sensitive_host_identifiers_forbidden": true,
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "analysis_plan": {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": true,
+    "retry_replacement_backfill_forbidden": true
+  },
+  "initial_batch_decision": {
+    "status": "authorized_by_experiment_owner",
+    "selection_rule": "first_project_in_frozen_schedule",
+    "project_ids": [
+      "cppitertools"
+    ],
+    "complete_project_blocks": 1,
+    "conditions_per_project": 2,
+    "repetitions_per_condition": 3,
+    "planned_attempts": 6,
+    "selected_schedule_orders": [
+      1,
+      2,
+      73,
+      74,
+      153,
+      154
+    ],
+    "maximum_recorded_tokens": 980000,
+    "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+    "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+    "maximum_attempt_wall_clock_seconds": 1800,
+    "maximum_batch_attempt_wall_clock_seconds": 10800,
+    "stop_conditions": [
+      "six_selected_attempts_terminalized",
+      "recorded_token_boundary_reached",
+      "runtime_preflight_failed",
+      "provider_canary_failed",
+      "daemon_provider_drift",
+      "ledger_or_cleanup_invariant_failed",
+      "user_interrupted"
+    ],
+    "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+    "retry_replacement_backfill_forbidden": true
+  }
+}

--- a/benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md
+++ b/benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md
@@ -1,0 +1,34 @@
+# Forge C/C++ formal v4 有限端点诊断与新 canary 修正
+
+## 背景与授权
+
+- formal v4 authorized identity 的唯一双 provider canary 在任何模型请求前被匿名 endpoint preflight 拒绝。
+- 旧 marker 固定为 `failed` / `RunnerError`，其 SHA-256 为 `9ab297d091967c15fae4f90caf18657b25214903b849fa3a695cd749fc19f724`；旧目录保持 0 provider report、0 formal ledger。
+- 实验负责人于 2026-08-13 在 Issue #115 授权有限诊断和一次新的双 provider canary；当前接入介质记录为 `mobile_hotspot`。
+- 该修正不改变模型、正式六槽、token 上限、Docker daemon、控制面或分析计划。
+
+## 有限诊断
+
+- 独立目录固定为 `/workspace/.compile-sessions/benchmark-diagnostics-formal-v4-canary-amendment`，不得包含 JSONL formal ledger。
+- 顺序固定为 RichLab `gpt-5.5`，再 DeepSeek `deepseek-v4-flash`。
+- 每家首先执行一次低成本请求；只有失败时才允许第二次，首次成功后禁止再次请求。
+- 每次请求 timeout 为 120 秒、provider retries 为 0、输出上限为 32 tokens，提示词固定要求仅回复 `DIAGNOSTIC_OK`。
+- 通过标准仅为请求完成且响应非空；两家都至少通过一次，才允许进入新 canary。
+- 每次 attempt 在请求前以排他 `started` 文件预留机会，请求后以另一个排他 `terminal` 文件闭合；两类文件均不可覆盖。它们仅记录 condition/provider/model identity、序号、状态、开始和完成时间、duration、响应非空布尔值、错误类型和通过布尔值。
+- 禁止记录响应正文或哈希、请求头、AK、凭据摘要、代理、SSID、IP、运营商账户或其他网络标识。
+- 诊断不是 Compile Session，不创建 formal ledger，也不进入模型编译能力结果分母。
+
+## 新 canary 与正式采集
+
+- 新 formal evidence 目录固定为 `/workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment`。
+- 新 canary 最多一次，无论成功、失败或进程中断均消耗机会；匿名 `/models` endpoint preflight 不再作为其门禁。
+- canary 前必须重新校验旧 marker 字节哈希与失败终态、旧层 0 report/0 ledger、诊断双通过、新目录空 ledger、0 formal 残留容器和 Ubuntu 原生 daemon 门禁。
+- 只有新双 provider canary 报告和 marker 都成功，才允许创建第一个 formal ledger。
+- 后续仍严格串行执行原 schedule order `1, 2, 73, 74, 153, 154`，maximum recorded tokens 仍为 980,000。
+- 禁止 retry、fallback、replacement、backfill 和 formal v3 slot 8-10；新 canary 失败立即停止，六槽不开始。
+
+## 分析边界
+
+- 旧 canary 失败与新 amendment 结果属于不同协议 identity，不能覆盖、迁移或合并为一次成功尝试。
+- 诊断只能说明该时段内经认证的低成本请求路径是否完成，不能证明 provider 稳定性，也不能解释旧失败的具体网络因果层。
+- 六槽结果继续服从 formal v4 的 complete-project-block 规则：完整六槽才进入 paired primary；token 边界产生的严格前缀只进入端到端描述性分母。

--- a/benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json
@@ -1,0 +1,727 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json",
+  "title": "Forge C/C++ formal v4 bounded diagnostics and canary amendment",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "manifest_canonicalization",
+    "benchmark",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "model_profiles",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "attempt_budget",
+    "resource_preflight",
+    "analysis_plan",
+    "authorization",
+    "initial_batch_decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-4.4.0-canary-amendment"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "const": {
+        "languages": [
+          "C",
+          "C++"
+        ],
+        "phase": "formal_collection_v4_canary_amendment",
+        "formal_comparison_enabled": true,
+        "collection_authorized": true,
+        "instrumentation_blocker": false
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "efc640fedbc4da2e00d553fd37adaa693e8abaa2"
+        },
+        "component_sha256": {
+          "type": "object",
+          "required": [
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/client.py",
+            "backend/packages/harness/deerflow/compile/__init__.py",
+            "backend/packages/harness/deerflow/compile/docker_runtime.py",
+            "backend/packages/harness/deerflow/compile/evidence.py",
+            "backend/packages/harness/deerflow/compile/manager.py",
+            "backend/packages/harness/deerflow/compile/operations.py",
+            "backend/packages/harness/deerflow/compile/schemas.py",
+            "backend/packages/harness/deerflow/models/factory.py",
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+            "backend/packages/harness/deerflow/subagents/executor.py",
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+            "backend/uv.lock",
+            "config.example.yaml",
+            "docker/compile/Dockerfile",
+            "docker/docker-compose-dev.yaml"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/client.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/__init__.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/evidence.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/manager.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/operations.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/schemas.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/models/factory.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/executor.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/uv.lock": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "config.example.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/compile/Dockerfile": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/docker-compose-dev.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "required": [
+        "backend/Dockerfile",
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md",
+        "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+        "scripts/docker.sh",
+        "scripts/forge_benchmark.py",
+        "scripts/forge_benchmark_runner.py",
+        "scripts/forge_formal_case_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_runner.py",
+        "scripts/forge_formal_collection_v2_protocol.py",
+        "scripts/forge_formal_collection_v2_runner.py",
+        "scripts/forge_formal_collection_v3_authorized_protocol.py",
+        "scripts/forge_formal_collection_v3_authorized_runner.py",
+        "scripts/forge_formal_collection_v3_protocol.py",
+        "scripts/forge_formal_collection_v3_runner.py",
+        "scripts/forge_formal_collection_v4_authorized_protocol.py",
+        "scripts/forge_formal_collection_v4_authorized_report.py",
+        "scripts/forge_formal_collection_v4_authorized_runner.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_protocol.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_report.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_runner.py",
+        "scripts/forge_formal_collection_v4_protocol.py",
+        "scripts/forge_formal_collection_v4_runner.py",
+        "scripts/forge_formal_collection_v4_runtime_protocol.py",
+        "scripts/forge_formal_collection_v4_runtime_runner.py",
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py",
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py",
+        "scripts/forge_formal_preregistration.py",
+        "scripts/forge_formal_runtime_protocol.py",
+        "scripts/require-ubuntu-native-docker.sh",
+        "scripts/wsl-check.sh"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/Dockerfile": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_case_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_report.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_report.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_preregistration.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/require-ubuntu-native-docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/wsl-check.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "required": [
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs",
+        "docker_daemon_provider",
+        "docker_socket_path"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        },
+        "docker_daemon_provider": {
+          "const": "ubuntu-native"
+        },
+        "docker_socket_path": {
+          "const": "/var/run/docker.sock"
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "const": {
+        "id": "forge-cpp-formal-v4-canary-amendment",
+        "status": "authorized_limited_diagnostics_and_single_canary",
+        "authorized_by": "experiment_owner",
+        "authorized_on": "2026-08-13",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/115",
+        "implementation_baseline_commit": "efc640fedbc4da2e00d553fd37adaa693e8abaa2",
+        "network_observation": {
+          "access_medium": "mobile_hotspot",
+          "browser_ui_required": false
+        },
+        "budget_confirmation": {
+          "confirmed": true,
+          "maximum_recorded_tokens": 980000,
+          "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+          "terminalization_cleanup_precedes_token_boundary_check": true
+        },
+        "collection_constraints": {
+          "planned_attempts": 180,
+          "authorized_slot_count": 6,
+          "authorized_schedule_orders": [
+            1,
+            2,
+            73,
+            74,
+            153,
+            154
+          ],
+          "remaining_slot_count": 174,
+          "remaining_slots_require_additional_confirmation": true,
+          "complete_project_blocks": 1,
+          "provider_canary_required_before_first_ledger": true,
+          "provider_canary_max_attempts": 1,
+          "empty_ledger_required_before_canary": true,
+          "zero_residual_formal_containers_required_before_canary": true,
+          "replacement_forbidden": true,
+          "fallback_forbidden": true,
+          "retry_forbidden": true,
+          "backfill_forbidden": true,
+          "v3_slots_8_to_10_forbidden": true,
+          "required_runtime_launch_checks": [
+            "host_available_memory_at_least_minimum",
+            "docker_daemon_responded",
+            "docker_daemon_latency_within_limit",
+            "docker_daemon_provider_matches",
+            "docker_socket_source_matches_native_path"
+          ],
+          "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment",
+          "endpoint_readiness_source": "bounded_authenticated_diagnostics_then_single_provider_canary"
+        },
+        "diagnostics": {
+          "directory": "/workspace/.compile-sessions/benchmark-diagnostics-formal-v4-canary-amendment",
+          "provider_order": [
+            "richlab-gpt-5.5",
+            "deepseek-v4-flash"
+          ],
+          "providers": [
+            {
+              "condition_id": "richlab-gpt-5.5",
+              "provider": "richlab",
+              "model": "gpt-5.5"
+            },
+            {
+              "condition_id": "deepseek-v4-flash",
+              "provider": "deepseek",
+              "model": "deepseek-v4-flash"
+            }
+          ],
+          "maximum_attempts_per_provider": 2,
+          "request_timeout_seconds": 120,
+          "max_output_tokens": 32,
+          "prompt": "Reply with exactly DIAGNOSTIC_OK and nothing else.",
+          "success_criterion": "request_completed_and_response_nonempty",
+          "stop_after_first_success_per_provider": true,
+          "all_providers_must_pass_before_canary": true,
+          "stop_conditions": [
+            "first_success_for_current_provider",
+            "two_attempts_consumed_for_current_provider",
+            "all_providers_terminal",
+            "user_interrupted"
+          ],
+          "interruption_policy": "started_attempt_remains_consumed_and_only_unconsumed_attempts_may_run",
+          "formal_evidence_separation_required": true,
+          "response_body_storage_forbidden": true,
+          "request_headers_storage_forbidden": true,
+          "credential_material_storage_forbidden": true,
+          "network_identifier_storage_forbidden": true
+        },
+        "superseded_canary_terminal": {
+          "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-v4-authorized-initial-block",
+          "marker_relative_path": "provider-canaries/formal-v4-provider-canary-attempt.json",
+          "marker_sha256": "9ab297d091967c15fae4f90caf18657b25214903b849fa3a695cd749fc19f724",
+          "benchmark_id": "forge-cpp-formal-v4-authorized-initial-block",
+          "manifest_sha256": "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03",
+          "status": "failed",
+          "error_class": "RunnerError",
+          "provider_report_count": 0,
+          "formal_ledger_count": 0,
+          "immutable": true
+        },
+        "new_canary": {
+          "maximum_attempts": 1,
+          "attempt_marker": "formal-v4-canary-amendment-provider-canary-attempt.json",
+          "anonymous_models_endpoint_preflight": "forbidden",
+          "successful_diagnostics_required": true,
+          "success_required_before_formal_ledger": true
+        },
+        "parent_manifest": {
+          "id": "forge-cpp-formal-v4-authorized-initial-block",
+          "path": "benchmarks/manifests/cpp-formal-v4-authorized-initial-block.json",
+          "canonical_sha256": "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03"
+        }
+      }
+    },
+    "$schema": {
+      "const": "../schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json"
+    },
+    "manifest_canonicalization": {
+      "const": "UTF-8 JSON, sorted object keys, compact separators, no NaN"
+    },
+    "benchmark": {
+      "const": {
+        "id": "forge-cpp-formal-v4-canary-amendment",
+        "name": "Forge C/C++ formal v4 bounded diagnostics and canary amendment",
+        "purpose": "preserve the consumed canary while authorizing bounded endpoint diagnosis and one new canary",
+        "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+      }
+    },
+    "model_profiles": {
+      "const": {
+        "richlab-gpt-5.5": {
+          "endpoint": "https://rich-api.choosefire.com/v1",
+          "credential_env": "OpenAI_AK",
+          "roles": {
+            "lead": "gpt-5.5",
+            "compiler": "gpt-5.5"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        },
+        "deepseek-v4-flash": {
+          "endpoint": "https://api.deepseek.com",
+          "credential_env": "DEEPSEEK_API_KEY",
+          "roles": {
+            "lead": "deepseek-v4-flash",
+            "compiler": "deepseek-v4-flash"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 120,
+          "max_retries": 0
+        }
+      }
+    },
+    "attempt_budget": {
+      "const": {
+        "total_wall_clock_seconds": 1800,
+        "cleanup_reserve_seconds": 120,
+        "max_compiler_invocations": 2,
+        "max_model_requests": 48,
+        "enforcement_checkpoints": [
+          "before_provider_request",
+          "before_compiler_invocation",
+          "before_submit_or_replay",
+          "before_finalize",
+          "before_cleanup"
+        ],
+        "new_work_forbidden_after_limit": true,
+        "cleanup_mandatory_after_limit": true,
+        "terminal_classification": "attempt_budget_exhausted"
+      }
+    },
+    "resource_preflight": {
+      "const": {
+        "minimum_available_memory_bytes": 2147483648,
+        "docker_daemon_timeout_seconds": 10,
+        "maximum_docker_daemon_latency_seconds": 5,
+        "required_checks": [
+          "host_available_memory_at_least_minimum",
+          "docker_daemon_responded",
+          "docker_daemon_latency_within_limit",
+          "docker_daemon_provider_matches",
+          "docker_socket_source_matches_native_path"
+        ],
+        "sensitive_host_identifiers_forbidden": true,
+        "docker_daemon_provider": "ubuntu-native",
+        "docker_socket_path": "/var/run/docker.sock"
+      }
+    },
+    "analysis_plan": {
+      "const": {
+        "protocol_version_pooling": "forbidden",
+        "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+        "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+        "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+        "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+        "provider_and_case_imbalance_must_be_reported": true,
+        "retry_replacement_backfill_forbidden": true
+      }
+    },
+    "initial_batch_decision": {
+      "const": {
+        "status": "authorized_by_experiment_owner",
+        "selection_rule": "first_project_in_frozen_schedule",
+        "project_ids": [
+          "cppitertools"
+        ],
+        "complete_project_blocks": 1,
+        "conditions_per_project": 2,
+        "repetitions_per_condition": 3,
+        "planned_attempts": 6,
+        "selected_schedule_orders": [
+          1,
+          2,
+          73,
+          74,
+          153,
+          154
+        ],
+        "maximum_recorded_tokens": 980000,
+        "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+        "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+        "maximum_attempt_wall_clock_seconds": 1800,
+        "maximum_batch_attempt_wall_clock_seconds": 10800,
+        "stop_conditions": [
+          "six_selected_attempts_terminalized",
+          "recorded_token_boundary_reached",
+          "runtime_preflight_failed",
+          "provider_canary_failed",
+          "daemon_provider_drift",
+          "ledger_or_cleanup_invariant_failed",
+          "user_interrupted"
+        ],
+        "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+        "retry_replacement_backfill_forbidden": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/forge_formal_collection_v4_canary_amendment_protocol.py
+++ b/scripts/forge_formal_collection_v4_canary_amendment_protocol.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""生成并校验 formal v4 有限诊断与新 canary 修正协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+REPOSITORY_SCRIPT_ROOT = REPOSITORY_ROOT / "scripts"
+if str(REPOSITORY_SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v4_authorized_protocol as parent_protocol  # noqa: E402
+import forge_formal_runtime_protocol as _hasher  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-4.4.0-canary-amendment"
+BASELINE_COMMIT = "efc640fedbc4da2e00d553fd37adaa693e8abaa2"
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+DOCKER_DAEMON_PROVIDER = parent_protocol.DOCKER_DAEMON_PROVIDER
+DOCKER_SOCKET_PATH = parent_protocol.DOCKER_SOCKET_PATH
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-authorized-initial-block.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-canary-amendment.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-collection-v4-canary-amendment.schema.json"
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_collection_v4_canary_amendment_protocol.py",
+    "scripts/forge_formal_collection_v4_canary_amendment_runner.py",
+    "scripts/forge_formal_collection_v4_canary_amendment_report.py",
+    "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json",
+}
+
+AUTHORIZED_EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment"
+DIAGNOSTIC_DIRECTORY = "/workspace/.compile-sessions/benchmark-diagnostics-formal-v4-canary-amendment"
+LEGACY_EVIDENCE_DIRECTORY = parent_protocol.AUTHORIZED_EVIDENCE_DIRECTORY
+AUTHORIZED_SCHEDULE_ORDERS = copy.deepcopy(parent_protocol.AUTHORIZED_SCHEDULE_ORDERS)
+BATCH_TOKEN_LIMIT = parent_protocol.BATCH_TOKEN_LIMIT
+LEGACY_MANIFEST_CANONICAL_SHA256 = "8f05820d97054d16cc0cf1ee5646089ccf8f5c9c56108f2781ec45a70c7ccf03"
+LEGACY_CANARY_MARKER_SHA256 = "9ab297d091967c15fae4f90caf18657b25214903b849fa3a695cd749fc19f724"
+DIAGNOSTIC_PROVIDER_ORDER = ["richlab-gpt-5.5", "deepseek-v4-flash"]
+DIAGNOSTIC_PROVIDERS = [
+    {
+        "condition_id": "richlab-gpt-5.5",
+        "provider": "richlab",
+        "model": "gpt-5.5",
+    },
+    {
+        "condition_id": "deepseek-v4-flash",
+        "provider": "deepseek",
+        "model": "deepseek-v4-flash",
+    },
+]
+
+AMENDMENT = {
+    "id": "forge-cpp-formal-v4-canary-amendment",
+    "status": "authorized_limited_diagnostics_and_single_canary",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-13",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/115",
+    "implementation_baseline_commit": BASELINE_COMMIT,
+    "network_observation": {
+        "access_medium": "mobile_hotspot",
+        "browser_ui_required": False,
+    },
+    "budget_confirmation": copy.deepcopy(parent_protocol.AUTHORIZATION["budget_confirmation"]),
+    "collection_constraints": {
+        **copy.deepcopy(parent_protocol.AUTHORIZATION["collection_constraints"]),
+        "evidence_directory": AUTHORIZED_EVIDENCE_DIRECTORY,
+        "endpoint_readiness_source": "bounded_authenticated_diagnostics_then_single_provider_canary",
+    },
+    "diagnostics": {
+        "directory": DIAGNOSTIC_DIRECTORY,
+        "provider_order": DIAGNOSTIC_PROVIDER_ORDER,
+        "providers": DIAGNOSTIC_PROVIDERS,
+        "maximum_attempts_per_provider": 2,
+        "request_timeout_seconds": 120,
+        "max_output_tokens": 32,
+        "prompt": "Reply with exactly DIAGNOSTIC_OK and nothing else.",
+        "success_criterion": "request_completed_and_response_nonempty",
+        "stop_after_first_success_per_provider": True,
+        "all_providers_must_pass_before_canary": True,
+        "stop_conditions": [
+            "first_success_for_current_provider",
+            "two_attempts_consumed_for_current_provider",
+            "all_providers_terminal",
+            "user_interrupted",
+        ],
+        "interruption_policy": "started_attempt_remains_consumed_and_only_unconsumed_attempts_may_run",
+        "formal_evidence_separation_required": True,
+        "response_body_storage_forbidden": True,
+        "request_headers_storage_forbidden": True,
+        "credential_material_storage_forbidden": True,
+        "network_identifier_storage_forbidden": True,
+    },
+    "superseded_canary_terminal": {
+        "evidence_directory": LEGACY_EVIDENCE_DIRECTORY,
+        "marker_relative_path": "provider-canaries/formal-v4-provider-canary-attempt.json",
+        "marker_sha256": LEGACY_CANARY_MARKER_SHA256,
+        "benchmark_id": "forge-cpp-formal-v4-authorized-initial-block",
+        "manifest_sha256": LEGACY_MANIFEST_CANONICAL_SHA256,
+        "status": "failed",
+        "error_class": "RunnerError",
+        "provider_report_count": 0,
+        "formal_ledger_count": 0,
+        "immutable": True,
+    },
+    "new_canary": {
+        "maximum_attempts": 1,
+        "attempt_marker": "formal-v4-canary-amendment-provider-canary-attempt.json",
+        "anonymous_models_endpoint_preflight": "forbidden",
+        "successful_diagnostics_required": True,
+        "success_required_before_formal_ledger": True,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = document or load_json_document(DEFAULT_PARENT_MANIFEST)
+    validated = parent_protocol.validate_manifest(parent)
+    if parent_protocol.manifest_sha256(validated) != LEGACY_MANIFEST_CANONICAL_SHA256:
+        v1._fail("manifest.amendment.parent_manifest", "does not match the consumed authorized v4 identity")
+    return validated
+
+
+def _amendment(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AMENDMENT),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v4-authorized-initial-block.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def _build_manifest(repo_root: Path, *, parent: dict[str, Any]) -> dict[str, Any]:
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-v4-canary-amendment",
+        "name": "Forge C/C++ formal v4 bounded diagnostics and canary amendment",
+        "purpose": "preserve the consumed canary while authorizing bounded endpoint diagnosis and one new canary",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_collection_v4_canary_amendment",
+        "formal_comparison_enabled": True,
+        "collection_authorized": True,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": _hasher._hash_paths(repo_root, COMPONENT_PATHS),
+    }
+    manifest["protocol_artifact_sha256"] = _hasher._hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS)
+    manifest["prompt_sha256"] = _hasher._hash_paths(repo_root, set(parent["prompt_sha256"]))
+    manifest["authorization"] = _amendment(parent)
+    return manifest
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _build_manifest(repo_root, parent=_parent_manifest(parent))
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    repo_root: Path = REPOSITORY_ROOT,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected = _build_manifest(repo_root, parent=_parent_manifest(parent))
+        if manifest != expected:
+            v1._fail("manifest", "must match the formal v4 canary amendment exactly")
+        selected = parent_protocol._selected_slots(manifest)
+        if [slot["order"] for slot in selected] != AUTHORIZED_SCHEDULE_ORDERS:
+            v1._fail("manifest.authorization", "must preserve the original six-slot schedule")
+        if [provider["condition_id"] for provider in manifest["authorization"]["diagnostics"]["providers"]] != DIAGNOSTIC_PROVIDER_ORDER:
+            v1._fail("manifest.authorization.diagnostics", "must preserve the reviewed provider order")
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise BenchmarkError(f"manifest: invalid formal v4 canary amendment: {exc}") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(manifest)
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPOSITORY_ROOT,
+) -> None:
+    validate_manifest(manifest, repo_root=repo_root)
+    parent_path = repo_root / manifest["authorization"]["parent_manifest"]["path"]
+    parent = _parent_manifest(load_json_document(parent_path))
+    if parent_protocol.manifest_sha256(parent) != manifest["authorization"]["parent_manifest"]["canonical_sha256"]:
+        v1._fail("manifest.authorization.parent_manifest", "does not match the consumed authorized v4 manifest")
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            if _hasher._file_sha256(repo_root / relative_path) != expected:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match")
+
+
+def _hash_map_schema(paths: set[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": sorted(paths),
+        "additionalProperties": False,
+        "properties": {relative_path: {"type": "string", "pattern": "^[0-9a-f]{64}$"} for relative_path in sorted(paths)},
+    }
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    parent = _parent_manifest()
+    schema["$id"] = "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json"
+    schema["title"] = "Forge C/C++ formal v4 bounded diagnostics and canary amendment"
+    properties = schema["properties"]
+    properties["$schema"] = {"const": "../schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json"}
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["benchmark"] = {
+        "const": {
+            "id": "forge-cpp-formal-v4-canary-amendment",
+            "name": "Forge C/C++ formal v4 bounded diagnostics and canary amendment",
+            "purpose": "preserve the consumed canary while authorizing bounded endpoint diagnosis and one new canary",
+            "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+        }
+    }
+    properties["scope"] = {
+        "const": {
+            "languages": ["C", "C++"],
+            "phase": "formal_collection_v4_canary_amendment",
+            "formal_comparison_enabled": True,
+            "collection_authorized": True,
+            "instrumentation_blocker": False,
+        }
+    }
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["forge"]["properties"]["component_sha256"] = _hash_map_schema(COMPONENT_PATHS)
+    properties["protocol_artifact_sha256"] = _hash_map_schema(PROTOCOL_ARTIFACT_PATHS)
+    properties["prompt_sha256"] = _hash_map_schema(set(parent["prompt_sha256"]))
+    properties["authorization"] = {"const": _amendment(parent)}
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorization_status": manifest["authorization"]["status"],
+                    "authorized_schedule_orders": AUTHORIZED_SCHEDULE_ORDERS,
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "diagnostic_max_attempts_per_provider": 2,
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "maximum_recorded_tokens": BATCH_TOKEN_LIMIT,
+                    "new_canary_max_attempts": 1,
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_canary_amendment_report.py
+++ b/scripts/forge_formal_collection_v4_canary_amendment_report.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""为 formal v4 canary amendment 生成确定性审计报告。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+SCRIPT_ROOT = Path(__file__).resolve().parent
+for import_root in (str(HARNESS_ROOT), str(SCRIPT_ROOT)):
+    if import_root not in sys.path:
+        sys.path.insert(0, import_root)
+
+import forge_formal_collection_v4_authorized_report as parent_report  # noqa: E402
+import forge_formal_collection_v4_canary_amendment_protocol as protocol  # noqa: E402
+import forge_formal_collection_v4_canary_amendment_runner as runner  # noqa: E402
+
+from deerflow.compile.evidence import EvidenceError  # noqa: E402
+
+REPORT_VERSION = "formal-v4-canary-amendment-report-1.0.0"
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_EVIDENCE_DIR = Path(protocol.AUTHORIZED_EVIDENCE_DIRECTORY)
+DEFAULT_DIAGNOSTIC_DIR = Path(protocol.DIAGNOSTIC_DIRECTORY)
+DEFAULT_LEGACY_EVIDENCE_DIR = Path(protocol.LEGACY_EVIDENCE_DIRECTORY)
+DEFAULT_JSON_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v4-canary-amendment.json"
+DEFAULT_MARKDOWN_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-v4-canary-amendment.md"
+
+ReportError = parent_report.ReportError
+
+
+def _load_canary_attempt_marker(
+    evidence_dir: Path,
+    *,
+    manifest_sha256: str,
+) -> dict[str, Any]:
+    marker_path = evidence_dir / "provider-canaries" / "formal-v4-canary-amendment-provider-canary-attempt.json"
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError("缺少有效的 formal v4 amendment provider-canary attempt marker") from exc
+    if marker.get("document_type") != "formal_provider_canary_attempt":
+        raise ReportError("amendment provider-canary attempt marker 结构无效")
+    if marker.get("benchmark_id") != "forge-cpp-formal-v4-canary-amendment":
+        raise ReportError("amendment provider-canary attempt marker benchmark identity 不匹配")
+    if marker.get("manifest_sha256") != manifest_sha256 or marker.get("status") != "passed":
+        raise ReportError("amendment provider-canary attempt marker 未记录同协议的成功终态")
+    return {
+        "status": marker["status"],
+        "updated_at": marker.get("updated_at"),
+        "error_class": marker.get("error_class"),
+    }
+
+
+def build_report(
+    manifest: dict[str, Any],
+    evidence_dir: Path,
+    *,
+    diagnostic_dir: Path = DEFAULT_DIAGNOSTIC_DIR,
+    legacy_evidence_dir: Path = DEFAULT_LEGACY_EVIDENCE_DIR,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    original_protocol = parent_report.protocol
+    original_runner = parent_report.runner
+    original_marker_loader = parent_report._load_canary_attempt_marker
+    parent_report.protocol = protocol
+    parent_report.runner = runner
+    parent_report._load_canary_attempt_marker = _load_canary_attempt_marker
+    try:
+        report = parent_report.build_report(
+            manifest,
+            evidence_dir,
+            **kwargs,
+        )
+        diagnostics = runner._load_diagnostic_summary(
+            manifest,
+            output_dir=diagnostic_dir,
+            require_passed=True,
+        )
+        legacy_terminal = runner._verify_legacy_terminal(
+            manifest,
+            legacy_output_dir=legacy_evidence_dir,
+        )
+    except runner.RunnerError as exc:
+        raise ReportError(str(exc)) from exc
+    finally:
+        parent_report.protocol = original_protocol
+        parent_report.runner = original_runner
+        parent_report._load_canary_attempt_marker = original_marker_loader
+    report["report_version"] = REPORT_VERSION
+    report["diagnostics"] = diagnostics
+    report["superseded_canary_terminal"] = legacy_terminal
+    report["interpretation"].update(
+        {
+            "diagnostics_excluded_from_formal_denominator": True,
+            "superseded_canary_terminal_preserved": True,
+            "anonymous_models_endpoint_preflight_used": False,
+        }
+    )
+    return report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    rendered = parent_report.render_markdown(report)
+    rendered = rendered.replace(
+        "# Forge C/C++ formal v4 首批完整项目块审计报告",
+        "# Forge C/C++ formal v4 canary amendment 审计报告",
+        1,
+    )
+    rendered = rendered.replace(
+        "scripts/forge_formal_collection_v4_authorized_report.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_report.py",
+    )
+    rendered = rendered.replace(
+        "/workspace/.compile-sessions/benchmark-evidence-formal-v4-authorized-initial-block",
+        "/workspace/.compile-sessions/benchmark-evidence-formal-v4-canary-amendment",
+    )
+    boundary = "- 有限诊断与 formal evidence 分目录保存，不进入模型编译能力分母。\n- 旧 canary 失败 marker 保持原 SHA-256、失败终态、0 report 和 0 ledger。\n"
+    return rendered.replace("## 复算\n", f"{boundary}\n## 复算\n", 1)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"无法读取 manifest: {path}") from exc
+    protocol.validate_manifest(document)
+    return document
+
+
+def write_reports(
+    report: dict[str, Any],
+    *,
+    json_path: Path,
+    markdown_path: Path,
+) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    markdown_path.write_text(
+        render_markdown(report),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument("--diagnostic-dir", type=Path, default=DEFAULT_DIAGNOSTIC_DIR)
+    parser.add_argument("--legacy-evidence-dir", type=Path, default=DEFAULT_LEGACY_EVIDENCE_DIR)
+    parser.add_argument("--json-output", type=Path, default=DEFAULT_JSON_REPORT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_REPORT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = build_report(
+            load_manifest(args.manifest),
+            args.evidence_dir,
+            diagnostic_dir=args.diagnostic_dir,
+            legacy_evidence_dir=args.legacy_evidence_dir,
+        )
+        write_reports(
+            report,
+            json_path=args.json_output,
+            markdown_path=args.markdown_output,
+        )
+    except (EvidenceError, ReportError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report["collection"], ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_collection_v4_canary_amendment_runner.py
+++ b/scripts/forge_formal_collection_v4_canary_amendment_runner.py
@@ -1,0 +1,996 @@
+#!/usr/bin/env python3
+"""执行 formal v4 有限端点诊断、新 canary 与原六槽。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_collection_v4_canary_amendment_protocol as protocol  # noqa: E402
+
+# 协议模块先建立仓库导入根，再加载 Ubuntu 门禁实现。
+# isort: split
+import forge_formal_collection_v4_ubuntu_runner as ubuntu_runner  # noqa: E402
+
+
+def _load_private_base_runner():
+    module_name = f"{__name__}_base"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_formal_collection_v2_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the formal collection base runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_runner = _load_private_base_runner()
+_original_manifest_protocol = _runner._manifest_protocol
+_original_build_policy = _runner.build_policy
+_original_collect_preflight = _runner.collect_preflight
+_original_collect_provider_canary = _runner.collect_provider_canary
+_original_create_attempt = _runner.create_attempt
+_original_run_attempt = _runner.run_attempt
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+_CANARY_ATTEMPT_MARKER = "formal-v4-canary-amendment-provider-canary-attempt.json"
+_DIAGNOSTIC_SUMMARY = "endpoint-diagnostic-summary.json"
+_DIAGNOSTIC_ATTEMPT_KEYS = {
+    "schema_version",
+    "document_type",
+    "benchmark_id",
+    "manifest_sha256",
+    "condition_id",
+    "provider",
+    "model",
+    "attempt",
+    "status",
+    "started_at",
+    "completed_at",
+    "duration_ms",
+    "response_nonempty",
+    "error_class",
+    "passed",
+}
+_SAFE_ERROR_CLASS = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def build_policy(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+):
+    return _original_build_policy(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+    )
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    return ubuntu_runner.collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+
+
+def _formal_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["collection_constraints"]["evidence_directory"])
+
+
+def _diagnostic_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["diagnostics"]["directory"])
+
+
+def _legacy_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["superseded_canary_terminal"]["evidence_directory"])
+
+
+def _require_exact_output_dir(actual: Path, expected: Path, *, purpose: str) -> None:
+    if actual.resolve(strict=False) != expected.resolve(strict=False):
+        raise RunnerError(f"Formal v4 {purpose} must use its frozen directory")
+
+
+def _authorized_slots(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    orders = manifest["authorization"]["collection_constraints"]["authorized_schedule_orders"]
+    by_order = {slot["order"]: slot for slot in manifest["collection_plan"]}
+    try:
+        return [by_order[order] for order in orders]
+    except KeyError as exc:
+        raise RunnerError("An authorized schedule order is missing from the frozen collection") from exc
+
+
+def _slot_identity(slot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "case_id": slot["case_id"],
+        "condition_id": slot["condition_id"],
+        "repetition": slot["repetition"],
+    }
+
+
+def _recorded_total_tokens(
+    observed: list[tuple[dict[str, Any], list[dict[str, Any]]]],
+) -> int:
+    total = 0
+    for _slot, events in observed:
+        for event in events:
+            if event.get("event") != "model.request_completed":
+                continue
+            payload = event.get("payload")
+            usage = payload.get("token_usage") if isinstance(payload, dict) else None
+            value = usage.get("total_tokens") if isinstance(usage, dict) else None
+            if type(value) is int and value >= 0:
+                total += value
+    return total
+
+
+def _token_limit(manifest: dict[str, Any]) -> int:
+    return int(manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"])
+
+
+def _observed_authorized_ledgers(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    return _runner._observed_collection_ledgers(manifest, output_dir=output_dir)
+
+
+def _ensure_token_budget_remaining(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> int:
+    recorded = _recorded_total_tokens(_observed_authorized_ledgers(manifest, output_dir=output_dir))
+    if recorded >= _token_limit(manifest):
+        raise RunnerError("The authorized recorded-token boundary has already been reached")
+    return recorded
+
+
+def _enforce_authorized_order(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+) -> int:
+    plan = [_slot_identity(slot) for slot in _authorized_slots(manifest)]
+    observed = _observed_authorized_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    if observed_slots != plan[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the authorized slot order")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous authorized slot must complete before the next slot is created")
+    if len(observed_slots) >= len(plan):
+        raise RunnerError("All six authorized slots already have physical evidence")
+    requested = {
+        "case_id": case_id,
+        "condition_id": condition_id,
+        "repetition": repetition,
+    }
+    if requested != plan[len(observed_slots)]:
+        raise RunnerError("The requested slot is not next in the authorized slot order")
+    return len(observed_slots)
+
+
+@contextmanager
+def _base_order_gate_already_checked():
+    original = _runner._enforce_frozen_collection_order
+    _runner._enforce_frozen_collection_order = lambda *args, **kwargs: 0
+    try:
+        yield
+    finally:
+        _runner._enforce_frozen_collection_order = original
+
+
+@contextmanager
+def _anonymous_endpoint_preflight_disabled():
+    original = _runner.collect_preflight
+
+    def collect_without_endpoint(*args: Any, **kwargs: Any):
+        kwargs["check_endpoint"] = False
+        return _original_collect_preflight(*args, **kwargs)
+
+    _runner.collect_preflight = collect_without_endpoint
+    try:
+        yield
+    finally:
+        _runner.collect_preflight = original
+
+
+def _formal_container_ids() -> list[str] | None:
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-aq",
+                "--filter",
+                "label=deerflow.compile.physical_attempt_id",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _verify_legacy_terminal(
+    manifest: dict[str, Any],
+    *,
+    legacy_output_dir: Path | None = None,
+) -> dict[str, Any]:
+    frozen = manifest["authorization"]["superseded_canary_terminal"]
+    directory = legacy_output_dir or _legacy_output_dir(manifest)
+    marker_path = directory / frozen["marker_relative_path"]
+    try:
+        raw = marker_path.read_bytes()
+        marker = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("The consumed formal v4 canary marker is missing or invalid") from exc
+    if hashlib.sha256(raw).hexdigest() != frozen["marker_sha256"]:
+        raise RunnerError("The consumed formal v4 canary marker changed")
+    expected = {
+        "benchmark_id": frozen["benchmark_id"],
+        "manifest_sha256": frozen["manifest_sha256"],
+        "status": frozen["status"],
+        "error_class": frozen["error_class"],
+    }
+    if any(marker.get(key) != value for key, value in expected.items()):
+        raise RunnerError("The consumed formal v4 canary terminal identity changed")
+    reports = [path for path in (directory / "provider-canaries").glob("*.json") if path != marker_path]
+    ledgers = list(directory.rglob("*.jsonl"))
+    if len(reports) != frozen["provider_report_count"] or len(ledgers) != frozen["formal_ledger_count"]:
+        raise RunnerError("The consumed formal v4 evidence layer is no longer empty")
+    return {
+        "marker_sha256": frozen["marker_sha256"],
+        "status": marker["status"],
+        "error_class": marker["error_class"],
+        "provider_report_count": len(reports),
+        "formal_ledger_count": len(ledgers),
+    }
+
+
+def _bounded_error_class(exc: BaseException) -> str:
+    name = type(exc).__name__
+    return name if _SAFE_ERROR_CLASS.fullmatch(name) else "DiagnosticFailure"
+
+
+def _model_response_text(response: Any) -> str:
+    return _runner._model_response_text(response)
+
+
+def _issue_diagnostic_request(model_name: str, prompt: str, max_output_tokens: int) -> bool:
+    from deerflow.models.factory import create_chat_model
+
+    model = create_chat_model(name=model_name, thinking_enabled=False)
+    response = model.invoke(prompt, max_tokens=max_output_tokens)
+    return bool(_model_response_text(response).strip())
+
+
+def _diagnostic_model_config_matches(
+    manifest: dict[str, Any],
+    provider: dict[str, Any],
+) -> bool:
+    try:
+        from deerflow.config import get_app_config
+
+        profile = manifest["model_profiles"][provider["condition_id"]]
+        configured = get_app_config().get_model_config(provider["model"])
+        if configured is None:
+            return False
+        settings = configured.model_dump(exclude_none=True)
+        endpoint = settings.get("base_url", settings.get("openai_api_base"))
+        timeout = settings.get("request_timeout")
+        return (
+            configured.model == provider["model"]
+            and endpoint is not None
+            and str(endpoint).rstrip("/") == profile["endpoint"].rstrip("/")
+            and float(timeout) == float(manifest["authorization"]["diagnostics"]["request_timeout_seconds"])
+            and settings.get("max_retries") == 0
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return False
+
+
+def _diagnostic_attempt_path(
+    output_dir: Path,
+    *,
+    condition_id: str,
+    attempt: int,
+) -> Path:
+    return output_dir / "attempts" / f"{condition_id}-{attempt}-started.json"
+
+
+def _diagnostic_terminal_path(
+    output_dir: Path,
+    *,
+    condition_id: str,
+    attempt: int,
+) -> Path:
+    return output_dir / "attempts" / f"{condition_id}-{attempt}-terminal.json"
+
+
+def _write_json_exclusive(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("x", encoding="utf-8", newline="\n") as stream:
+        json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+        stream.write("\n")
+
+
+def _read_diagnostic_document(path: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("A diagnostic attempt record is invalid") from exc
+    if set(record) != _DIAGNOSTIC_ATTEMPT_KEYS:
+        raise RunnerError("A diagnostic attempt record contains non-whitelisted fields")
+    if record.get("document_type") != "formal_endpoint_diagnostic_attempt":
+        raise RunnerError("A diagnostic attempt record has the wrong document type")
+    if record.get("benchmark_id") != manifest["benchmark"]["id"]:
+        raise RunnerError("A diagnostic attempt record has the wrong benchmark identity")
+    if record.get("manifest_sha256") != protocol.manifest_sha256(manifest):
+        raise RunnerError("A diagnostic attempt record has the wrong manifest identity")
+    if type(record.get("attempt")) is not int or record["attempt"] not in {1, 2}:
+        raise RunnerError("A diagnostic attempt number is outside the frozen limit")
+    if record.get("status") not in {"started", "passed", "failed"}:
+        raise RunnerError("A diagnostic attempt status is invalid")
+    if record["status"] == "started":
+        if any(
+            (
+                record.get("completed_at") is not None,
+                record.get("duration_ms") is not None,
+                record.get("response_nonempty") is not False,
+                record.get("error_class") is not None,
+                record.get("passed") is not False,
+            )
+        ):
+            raise RunnerError("A started diagnostic attempt contains terminal evidence")
+        return record
+    if type(record.get("duration_ms")) is not int or record["duration_ms"] < 0:
+        raise RunnerError("A diagnostic attempt duration is invalid")
+    if type(record.get("response_nonempty")) is not bool or type(record.get("passed")) is not bool:
+        raise RunnerError("A diagnostic attempt boolean is invalid")
+    error_class = record.get("error_class")
+    if error_class is not None and (not isinstance(error_class, str) or not _SAFE_ERROR_CLASS.fullmatch(error_class)):
+        raise RunnerError("A diagnostic attempt error class is invalid")
+    if record["passed"] is not (record["response_nonempty"] and error_class is None):
+        raise RunnerError("A diagnostic attempt result is internally inconsistent")
+    if record["status"] != ("passed" if record["passed"] else "failed"):
+        raise RunnerError("A diagnostic attempt terminal status is inconsistent")
+    return record
+
+
+def _read_diagnostic_attempt(
+    output_dir: Path,
+    manifest: dict[str, Any],
+    *,
+    provider: dict[str, Any],
+    attempt: int,
+) -> dict[str, Any] | None:
+    started_path = _diagnostic_attempt_path(
+        output_dir,
+        condition_id=provider["condition_id"],
+        attempt=attempt,
+    )
+    terminal_path = _diagnostic_terminal_path(
+        output_dir,
+        condition_id=provider["condition_id"],
+        attempt=attempt,
+    )
+    if terminal_path.exists() and not started_path.exists():
+        raise RunnerError("A diagnostic terminal record is missing its reservation")
+    if not started_path.exists():
+        return None
+    started = _read_diagnostic_document(started_path, manifest)
+    if started["status"] != "started":
+        raise RunnerError("A diagnostic reservation has a terminal status")
+    if not terminal_path.exists():
+        return started
+    terminal = _read_diagnostic_document(terminal_path, manifest)
+    immutable_keys = {
+        "schema_version",
+        "document_type",
+        "benchmark_id",
+        "manifest_sha256",
+        "condition_id",
+        "provider",
+        "model",
+        "attempt",
+        "started_at",
+    }
+    if any(terminal.get(key) != started.get(key) for key in immutable_keys):
+        raise RunnerError("A diagnostic terminal record changed its reservation identity")
+    if terminal["status"] == "started":
+        raise RunnerError("A diagnostic terminal record is not terminal")
+    return terminal
+
+
+def _existing_diagnostic_attempts(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+    provider: dict[str, Any],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for attempt in (1, 2):
+        record = _read_diagnostic_attempt(
+            output_dir,
+            manifest,
+            provider=provider,
+            attempt=attempt,
+        )
+        if record is None:
+            continue
+        expected_identity = {
+            "condition_id": provider["condition_id"],
+            "provider": provider["provider"],
+            "model": provider["model"],
+            "attempt": attempt,
+        }
+        if any(record.get(key) != value for key, value in expected_identity.items()):
+            raise RunnerError("A diagnostic attempt identity changed")
+        records.append(record)
+    if [record["attempt"] for record in records] != list(range(1, len(records) + 1)):
+        raise RunnerError("Diagnostic attempts must form a strict prefix")
+    if any(record["passed"] for record in records[:-1]):
+        raise RunnerError("A diagnostic provider was retried after its first success")
+    return records
+
+
+def _diagnostic_summary_path(output_dir: Path) -> Path:
+    return output_dir / _DIAGNOSTIC_SUMMARY
+
+
+def _require_diagnostic_layout(manifest: dict[str, Any], *, output_dir: Path) -> None:
+    allowed = {_diagnostic_summary_path(output_dir)}
+    for provider in manifest["authorization"]["diagnostics"]["providers"]:
+        for attempt in (1, 2):
+            allowed.add(
+                _diagnostic_attempt_path(
+                    output_dir,
+                    condition_id=provider["condition_id"],
+                    attempt=attempt,
+                )
+            )
+            allowed.add(
+                _diagnostic_terminal_path(
+                    output_dir,
+                    condition_id=provider["condition_id"],
+                    attempt=attempt,
+                )
+            )
+    unexpected = [path for path in output_dir.rglob("*") if path.is_file() and path not in allowed]
+    if unexpected:
+        raise RunnerError("The endpoint diagnostic directory contains an unexpected file")
+
+
+def _build_diagnostic_summary(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    conditions = []
+    for provider in manifest["authorization"]["diagnostics"]["providers"]:
+        records = _existing_diagnostic_attempts(
+            manifest,
+            output_dir=output_dir,
+            provider=provider,
+        )
+        conditions.append(
+            {
+                "condition_id": provider["condition_id"],
+                "provider": provider["provider"],
+                "model": provider["model"],
+                "attempt_count": len(records),
+                "passed": bool(records and records[-1]["status"] == "passed"),
+            }
+        )
+    return {
+        "schema_version": "formal-endpoint-diagnostic-summary-1.0.0",
+        "document_type": "formal_endpoint_diagnostic_summary",
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "completed_at": datetime.now(UTC).isoformat(),
+        "conditions": conditions,
+        "passed": all(condition["passed"] for condition in conditions),
+    }
+
+
+def _load_diagnostic_summary(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path | None = None,
+    require_passed: bool,
+) -> dict[str, Any]:
+    directory = output_dir or _diagnostic_output_dir(manifest)
+    try:
+        summary = json.loads(_diagnostic_summary_path(directory).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("The endpoint diagnostic summary is missing or invalid") from exc
+    expected_keys = {
+        "schema_version",
+        "document_type",
+        "benchmark_id",
+        "manifest_sha256",
+        "completed_at",
+        "conditions",
+        "passed",
+    }
+    if set(summary) != expected_keys:
+        raise RunnerError("The endpoint diagnostic summary contains non-whitelisted fields")
+    if summary.get("document_type") != "formal_endpoint_diagnostic_summary":
+        raise RunnerError("The endpoint diagnostic summary has the wrong document type")
+    if summary.get("benchmark_id") != manifest["benchmark"]["id"] or summary.get("manifest_sha256") != protocol.manifest_sha256(manifest):
+        raise RunnerError("The endpoint diagnostic summary has the wrong identity")
+    _require_diagnostic_layout(manifest, output_dir=directory)
+    rebuilt = _build_diagnostic_summary(manifest, output_dir=directory)
+    if summary.get("conditions") != rebuilt["conditions"] or summary.get("passed") is not rebuilt["passed"]:
+        raise RunnerError("The endpoint diagnostic summary does not match its attempt records")
+    if require_passed and summary["passed"] is not True:
+        raise RunnerError("Both bounded endpoint diagnostics must pass before the new canary")
+    return summary
+
+
+def collect_endpoint_diagnostics(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    request_issuer: Callable[[str, str, int], bool] = _issue_diagnostic_request,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Endpoint diagnostics are only valid for the formal v4 canary amendment")
+    _require_exact_output_dir(
+        output_dir,
+        _diagnostic_output_dir(manifest),
+        purpose="diagnostics",
+    )
+    if any(output_dir.rglob("*.jsonl")):
+        raise RunnerError("Endpoint diagnostics must never create a formal ledger")
+    _require_diagnostic_layout(manifest, output_dir=output_dir)
+    _verify_legacy_terminal(manifest)
+    container_ids = _formal_container_ids()
+    if container_ids is None:
+        raise RunnerError("Formal container reconciliation failed before endpoint diagnostics")
+    if container_ids:
+        raise RunnerError("Residual formal containers block endpoint diagnostics")
+    if _diagnostic_summary_path(output_dir).exists():
+        return _load_diagnostic_summary(
+            manifest,
+            output_dir=output_dir,
+            require_passed=False,
+        )
+    if not _runner._running_inside_compose_dood(repo_root):
+        raise RunnerError("Endpoint diagnostics must run inside the frozen Compose/DooD control plane")
+    preflight = _original_collect_preflight(
+        manifest,
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        check_endpoint=False,
+    )
+    if preflight["ready"] is not True:
+        raise RunnerError("The non-model diagnostic preflight is not ready")
+
+    diagnostic = manifest["authorization"]["diagnostics"]
+    for provider in diagnostic["providers"]:
+        if not _diagnostic_model_config_matches(manifest, provider):
+            raise RunnerError("The configured diagnostic model does not match the frozen policy")
+        records = _existing_diagnostic_attempts(
+            manifest,
+            output_dir=output_dir,
+            provider=provider,
+        )
+        if records and records[-1]["passed"]:
+            continue
+        while len(records) < diagnostic["maximum_attempts_per_provider"]:
+            attempt = len(records) + 1
+            started_at = datetime.now(UTC).isoformat()
+            attempt_path = _diagnostic_attempt_path(
+                output_dir,
+                condition_id=provider["condition_id"],
+                attempt=attempt,
+            )
+            record = {
+                "schema_version": "formal-endpoint-diagnostic-attempt-1.0.0",
+                "document_type": "formal_endpoint_diagnostic_attempt",
+                "benchmark_id": manifest["benchmark"]["id"],
+                "manifest_sha256": protocol.manifest_sha256(manifest),
+                "condition_id": provider["condition_id"],
+                "provider": provider["provider"],
+                "model": provider["model"],
+                "attempt": attempt,
+                "status": "started",
+                "started_at": started_at,
+                "completed_at": None,
+                "duration_ms": None,
+                "response_nonempty": False,
+                "error_class": None,
+                "passed": False,
+            }
+            _write_json_exclusive(attempt_path, record)
+            started = time.perf_counter()
+            response_nonempty = False
+            error_class: str | None = None
+            try:
+                response_nonempty = request_issuer(
+                    provider["model"],
+                    diagnostic["prompt"],
+                    diagnostic["max_output_tokens"],
+                )
+            except Exception as exc:
+                error_class = _bounded_error_class(exc)
+            completed_at = datetime.now(UTC).isoformat()
+            record.update(
+                {
+                    "status": ("passed" if error_class is None and response_nonempty else "failed"),
+                    "completed_at": completed_at,
+                    "duration_ms": round((time.perf_counter() - started) * 1000),
+                    "response_nonempty": response_nonempty,
+                    "error_class": error_class,
+                    "passed": error_class is None and response_nonempty,
+                }
+            )
+            _write_json_exclusive(
+                _diagnostic_terminal_path(
+                    output_dir,
+                    condition_id=provider["condition_id"],
+                    attempt=attempt,
+                ),
+                record,
+            )
+            records.append(record)
+            if record["passed"]:
+                break
+
+    summary = _build_diagnostic_summary(manifest, output_dir=output_dir)
+    _write_json_exclusive(_diagnostic_summary_path(output_dir), summary)
+    return summary
+
+
+def _canary_marker_path(output_dir: Path) -> Path:
+    return output_dir / "provider-canaries" / _CANARY_ATTEMPT_MARKER
+
+
+def _write_canary_marker(
+    path: Path,
+    *,
+    manifest: dict[str, Any],
+    status: str,
+    error_class: str | None = None,
+) -> None:
+    marker = {
+        "schema_version": "formal-provider-canary-attempt-1.0.0",
+        "document_type": "formal_provider_canary_attempt",
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "status": status,
+        "error_class": error_class,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(marker, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _require_successful_canary(manifest: dict[str, Any], *, output_dir: Path) -> None:
+    try:
+        marker = json.loads(_canary_marker_path(output_dir).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("The formal v4 amendment canary marker is missing or invalid") from exc
+    if marker.get("benchmark_id") != manifest["benchmark"]["id"] or marker.get("manifest_sha256") != protocol.manifest_sha256(manifest) or marker.get("status") != "passed":
+        raise RunnerError("A successful formal v4 amendment canary is required")
+    if _runner._successful_provider_canary(manifest, output_dir=output_dir) is None:
+        raise RunnerError("A successful dual-provider canary report is required")
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Provider canary is only valid for the formal v4 canary amendment")
+    _require_exact_output_dir(output_dir, _formal_output_dir(manifest), purpose="evidence")
+    _verify_legacy_terminal(manifest)
+    _load_diagnostic_summary(manifest, require_passed=True)
+    if any(output_dir.rglob("*.jsonl")):
+        raise RunnerError("Provider canary requires an empty formal ledger directory")
+    if _observed_authorized_ledgers(manifest, output_dir=output_dir):
+        raise RunnerError("Provider canary must complete before the first formal ledger is created")
+    container_ids = _formal_container_ids()
+    if container_ids is None:
+        raise RunnerError("Formal container reconciliation failed before provider canary")
+    if container_ids:
+        raise RunnerError("Residual formal containers block provider canary")
+
+    marker_path = _canary_marker_path(output_dir)
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    if not marker_path.exists() and any(marker_path.parent.glob("*.json")):
+        raise RunnerError("An orphan provider-canary report blocks the amended canary")
+    try:
+        _write_json_exclusive(
+            marker_path,
+            {
+                "schema_version": "formal-provider-canary-attempt-1.0.0",
+                "document_type": "formal_provider_canary_attempt",
+                "benchmark_id": manifest["benchmark"]["id"],
+                "manifest_sha256": protocol.manifest_sha256(manifest),
+                "status": "started",
+                "error_class": None,
+                "updated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+    except FileExistsError as exc:
+        raise RunnerError("The one amended provider-canary attempt has already been consumed") from exc
+
+    try:
+        with _anonymous_endpoint_preflight_disabled():
+            report = _original_collect_provider_canary(
+                manifest,
+                manifest_path=manifest_path,
+                output_dir=output_dir,
+                repo_root=repo_root,
+            )
+    except BaseException as exc:
+        _write_canary_marker(
+            marker_path,
+            manifest=manifest,
+            status="failed",
+            error_class=_bounded_error_class(exc),
+        )
+        raise
+    _write_canary_marker(
+        marker_path,
+        manifest=manifest,
+        status="passed" if report["passed"] else "failed",
+    )
+    return report
+
+
+def create_attempt(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+    **kwargs: Any,
+):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        _require_exact_output_dir(output_dir, _formal_output_dir(manifest), purpose="evidence")
+        _verify_legacy_terminal(manifest)
+        _load_diagnostic_summary(manifest, require_passed=True)
+        _require_successful_canary(manifest, output_dir=output_dir)
+        _ensure_token_budget_remaining(manifest, output_dir=output_dir)
+        _enforce_authorized_order(
+            manifest,
+            case_id=case_id,
+            condition_id=condition_id,
+            repetition=repetition,
+            output_dir=output_dir,
+        )
+        if kwargs.get("replacement_for") is not None:
+            raise RunnerError("The formal v4 amendment forbids replacement attempts")
+        kwargs["check_endpoint"] = False
+        with _base_order_gate_already_checked():
+            return _original_create_attempt(
+                manifest,
+                case_id=case_id,
+                condition_id=condition_id,
+                repetition=repetition,
+                output_dir=output_dir,
+                **kwargs,
+            )
+    return _original_create_attempt(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        output_dir=output_dir,
+        **kwargs,
+    )
+
+
+def run_attempt(
+    manifest: dict[str, Any],
+    ledger_path: Path,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        expected = _formal_output_dir(manifest).resolve(strict=False)
+        try:
+            ledger_path.resolve(strict=False).relative_to(expected)
+        except ValueError as exc:
+            raise RunnerError("Formal v4 amendment ledger is outside the authorized evidence directory") from exc
+        _verify_legacy_terminal(manifest)
+        _load_diagnostic_summary(manifest, require_passed=True)
+        _require_successful_canary(manifest, output_dir=expected)
+        _ensure_token_budget_remaining(manifest, output_dir=expected)
+        kwargs["attempt_budget"] = _runner.ExperimentAttemptBudget.from_mapping(manifest["attempt_budget"])
+    return _original_run_attempt(manifest, ledger_path, **kwargs)
+
+
+def run_formal_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    del check_endpoint
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Batch execution is only valid for the formal v4 canary amendment")
+    _require_exact_output_dir(output_dir, _formal_output_dir(manifest), purpose="evidence")
+    _verify_legacy_terminal(manifest)
+    _load_diagnostic_summary(manifest, require_passed=True)
+    _require_successful_canary(manifest, output_dir=output_dir)
+    authorized_slots = _authorized_slots(manifest)
+    if max_attempts < 1 or max_attempts > len(authorized_slots):
+        raise RunnerError(f"Batch execution must request between 1 and {len(authorized_slots)} attempts")
+    observed = _observed_authorized_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    planned_slots = [_slot_identity(slot) for slot in authorized_slots]
+    if observed_slots != planned_slots[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the authorized slot order")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous authorized slot must complete before batch execution resumes")
+    start_index = len(observed_slots)
+    if start_index >= len(authorized_slots):
+        raise RunnerError("The authorized six-slot boundary has already been reached")
+    if max_attempts > len(authorized_slots) - start_index:
+        raise RunnerError("The requested batch would cross the authorized six-slot boundary")
+
+    results: list[dict[str, Any]] = []
+    stop_reason = "authorized_complete_project_block_reached"
+    with asyncio.Runner() as async_runner:
+        for authorized_index in range(start_index, start_index + max_attempts):
+            recorded_before = _ensure_token_budget_remaining(
+                manifest,
+                output_dir=output_dir,
+            )
+            slot = authorized_slots[authorized_index]
+            ledger, _preflight = create_attempt(
+                manifest,
+                case_id=slot["case_id"],
+                condition_id=slot["condition_id"],
+                repetition=slot["repetition"],
+                output_dir=output_dir,
+                manifest_path=manifest_path,
+                check_endpoint=False,
+            )
+            result = run_attempt(
+                manifest,
+                ledger.path,
+                async_runner=async_runner,
+            )
+            recorded_after = _recorded_total_tokens(_observed_authorized_ledgers(manifest, output_dir=output_dir))
+            results.append(
+                {
+                    "authorized_index": authorized_index,
+                    "schedule_order": slot["order"],
+                    "case_id": slot["case_id"],
+                    "condition_id": slot["condition_id"],
+                    "repetition": slot["repetition"],
+                    "physical_attempt_id": ledger.physical_attempt_id,
+                    "ledger": str(ledger.path),
+                    "status": result["status"],
+                    "recorded_tokens_before": recorded_before,
+                    "recorded_tokens_after": recorded_after,
+                }
+            )
+            if recorded_after >= _token_limit(manifest):
+                stop_reason = "recorded_token_boundary_reached"
+                break
+    return {
+        "status": stop_reason,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "start_authorized_index": start_index,
+        "next_authorized_index": start_index + len(results),
+        "authorized_slot_count": len(authorized_slots),
+        "attempts_completed": len(results),
+        "recorded_total_tokens": (results[-1]["recorded_tokens_after"] if results else _recorded_total_tokens(observed)),
+        "recorded_token_limit": _token_limit(manifest),
+        "results": results,
+    }
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.build_policy = build_policy
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_formal_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def _diagnostic_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="执行 formal v4 有限端点诊断")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments and arguments[0] == "endpoint-diagnostics":
+        args = _diagnostic_parser().parse_args(arguments[1:])
+        try:
+            manifest = _runner._load_manifest(args.manifest)
+            result = collect_endpoint_diagnostics(
+                manifest,
+                manifest_path=args.manifest,
+                output_dir=args.output_dir,
+            )
+            _runner._json_print(result)
+            return 0 if result["passed"] else 2
+        except (_runner.EvidenceError, RunnerError, OSError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

formal v4 的唯一 canary 在模型调用前被匿名 endpoint preflight 拒绝。该失败 marker、0 provider report 与 0 formal ledger 必须保持不变，同时需要在独立协议层进行有限的经认证端点诊断。

## 变更

- 新增 formal v4 canary amendment manifest、Schema、protocol、runner 与确定性报告
- RichLab gpt-5.5 与 DeepSeek deepseek-v4-flash 各最多 2 次低成本诊断，首次成功即停止
- 诊断使用独立目录和 append-only started/terminal 记录，不保存响应正文、请求头、凭据或网络标识
- 每次后续门禁重验旧 marker SHA-256、失败终态、0 report 与 0 ledger
- 新 canary 最多 1 次，并禁止匿名 /models endpoint preflight
- 只有诊断双通过且新 canary 成功，才允许原 schedule order 1, 2, 73, 74, 153, 154
- token 上限仍为 980,000，继续禁止 retry、fallback、replacement、backfill 和 v3 slot 8-10

## 验证

- amendment 聚焦测试：22 passed
- formal v1-v4 扩大回归：205 passed
- Ruff check / format、py_compile、Draft 2020-12 Schema、确定性再生成通过
- 父文件与旧 marker 不变，旧层 0 provider report / 0 ledger
- 敏感值扫描 0 命中
- WSL2 Ubuntu 原生 Docker gate 通过，0 formal 残留容器

Closes #115
