### PR TITLE
研究：冻结 formal 模型请求 300 秒超时校准

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-14 — 完成 formal 模型请求 300 秒超时校准实现，等待 PR/CI 后真实执行
+  - GitHub: 中文 Issue #117 已创建并回读；实现分支为 `research/issue-117-timeout-calibration`。
+  - 协议: 从 formal v4 canary amendment 派生独立 `formal-collection-4.5.0-timeout-calibration` identity；只授权 `cppitertools` 原 schedule order `1, 2`，RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各一次。
+  - 单变量: Lead/Compiler 请求超时统一从 120 秒改为 300 秒，`max_retries=0`；模型、endpoint、attempt budget、Compiler invocation、Memory/Skill、Docker daemon 与 Compose/DooD 均不变。
+  - 研究边界: 独立 append-only evidence 目录，maximum recorded tokens 为 500,000；`formal_comparison_enabled=false` 且禁止 primary pooling，不补跑或替换既有六槽。
+  - 当前验证: canonical SHA-256 为 `aeb1e66b85da53dbbe91c33059825d092143a4c0fa0b3045c327524767c9b10b`；聚焦测试 `12 passed`、历史 v4 扩大回归 `51 passed`，Ruff、format、Schema、确定性再生成、父文件和敏感信息检查通过。
+  - 下一步: 中文提交并通过 WSL helper 推送，创建中文 PR；PR/主干 CI 全绿后才运行 Ubuntu daemon gate、非模型 preflight、一次双 provider canary 和两次真实校准 attempt。
+
 - 2026-08-13 — 完成 formal v4 有限诊断与新 canary amendment
   - GitHub: 中文 Issue #115 已创建并回读；实现分支为 `research/formal-v4-canary-amendment`，PR 尚未创建。
   - 授权: RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各最多 2 次低成本诊断，首次成功即停止；之后最多 1 次新的双 provider canary，成功才执行原六槽，token 上限仍为 980,000。

--- a/backend/tests/test_forge_formal_timeout_calibration.py
+++ b/backend/tests/test_forge_formal_timeout_calibration.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_formal_timeout_calibration_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_formal_timeout_calibration_runner.py"
+REPORT_PATH = REPO_ROOT / "scripts" / "forge_formal_timeout_calibration_report.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-formal-timeout-calibration.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-timeout-calibration.schema.json"
+PARENT_FILES = {
+    "benchmarks/manifests/cpp-formal-v4-canary-amendment.json": "74a4133bad3b9b0566c3248aaed3ce58f1afb95c",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json": "5006c922e6043913c5aa9111bdb1ec46b04aad2f",
+    "scripts/forge_formal_collection_v4_canary_amendment_protocol.py": "0aa5ba6345a1b92e81ba65419360e7e422a001d2",
+    "scripts/forge_formal_collection_v4_canary_amendment_runner.py": "4da71f20537b1d2318141222546174c03881422a",
+    "scripts/forge_formal_collection_v4_canary_amendment_report.py": "cf34697e796fedd15df170f8415d910f9db3b45f",
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_formal_timeout_calibration_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_formal_timeout_calibration_runner_test", RUNNER_PATH)
+report = _load_module("forge_formal_timeout_calibration_report_test", REPORT_PATH)
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_is_deterministic_schema_valid_and_single_variable() -> None:
+    manifest = load_manifest()
+
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    assert manifest["schema_version"] == "formal-collection-4.5.0-timeout-calibration"
+    assert manifest["scope"]["formal_comparison_enabled"] is False
+    assert manifest["authorization"]["issue_url"].endswith("/issues/117")
+    assert manifest["authorization"]["collection_constraints"]["authorized_schedule_orders"] == [1, 2]
+    assert manifest["authorization"]["collection_constraints"]["formal_primary_pooling_forbidden"] is True
+    assert {(profile["request_timeout_seconds"], profile["max_retries"]) for profile in manifest["model_profiles"].values()} == {(300, 0)}
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+
+
+def test_calibration_uses_one_attempt_per_provider() -> None:
+    slots = runner._authorized_slots(load_manifest())
+
+    assert [slot["order"] for slot in slots] == [1, 2]
+    assert [(slot["condition_id"], slot["repetition"]) for slot in slots] == [
+        ("richlab-gpt-5.5", 1),
+        ("deepseek-v4-flash", 1),
+    ]
+
+
+def test_parent_protocol_files_remain_byte_identical() -> None:
+    for relative_path, expected_git_blob in PARENT_FILES.items():
+        payload = (REPO_ROOT / relative_path).read_bytes()
+        header = f"blob {len(payload)}\0".encode()
+        assert hashlib.sha1(header + payload).hexdigest() == expected_git_blob
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["model_profiles"]["richlab-gpt-5.5"].update(request_timeout_seconds=120),
+        lambda value: value["model_profiles"]["deepseek-v4-flash"].update(max_retries=1),
+        lambda value: value["scope"].update(formal_comparison_enabled=True),
+        lambda value: value["authorization"]["collection_constraints"].update(authorized_schedule_orders=[1]),
+        lambda value: value["authorization"]["collection_constraints"].update(formal_primary_pooling_forbidden=False),
+    ],
+)
+def test_manifest_rejects_timeout_retry_or_scope_drift(mutation) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    mutation(manifest)
+
+    with pytest.raises(protocol.BenchmarkError):
+        protocol.validate_manifest(manifest)
+
+
+def test_batch_is_bounded_to_two_attempts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    captured: dict[str, object] = {}
+
+    def run_parent(*args, **kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "authorized_complete_project_block_reached",
+            "next_authorized_index": 2,
+        }
+
+    monkeypatch.setattr(runner._runner, "run_formal_batch", run_parent)
+    result = runner.run_timeout_calibration_batch(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        max_attempts=2,
+        check_endpoint=False,
+    )
+
+    assert result["status"] == "timeout_calibration_complete"
+    assert captured["max_attempts"] == 2
+    with pytest.raises(runner.RunnerError, match="at most two"):
+        runner.run_timeout_calibration_batch(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+            max_attempts=3,
+        )
+
+
+def test_build_policy_keeps_300_seconds_and_zero_retries() -> None:
+    manifest = load_manifest()
+    policy = runner.build_policy(
+        manifest,
+        case_id="cppitertools",
+        condition_id="richlab-gpt-5.5",
+        repetition=1,
+    )
+
+    assert policy.request_timeout_seconds == 300
+    assert policy.model_max_retries == 0
+
+
+def test_run_attempt_preserves_existing_attempt_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_manifest()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(runner._runner, "_authorized_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(runner._runner, "_ensure_token_budget_remaining", lambda *args, **kwargs: 0)
+
+    def fake_run(_manifest, _ledger_path, **kwargs):
+        captured.update(kwargs)
+        return {"status": "failed"}
+
+    monkeypatch.setattr(runner._runner, "_original_run_attempt", fake_run)
+    runner.run_attempt(manifest, tmp_path / "attempt.jsonl")
+
+    budget = captured["attempt_budget"]
+    assert budget.total_wall_clock_seconds == 1_800
+    assert budget.max_compiler_invocations == 2
+    assert budget.max_model_requests == 48
+
+
+def test_report_forbids_primary_pooling(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    synthetic = {
+        "report_version": "parent",
+        "scope": {
+            "formal_comparison_enabled": True,
+            "paired_primary_eligible": True,
+            "descriptive_only": False,
+        },
+        "collection": {"stop_reason": "authorized_complete_project_block_reached"},
+        "interpretation": {},
+        "limitations": [],
+    }
+    monkeypatch.setattr(report.parent_report, "build_report", lambda *args, **kwargs: synthetic)
+
+    result = report.build_report(load_manifest(), tmp_path)
+
+    assert result["scope"] == {
+        "formal_comparison_enabled": False,
+        "paired_primary_eligible": False,
+        "descriptive_only": True,
+    }
+    assert result["collection"]["stop_reason"] == "timeout_calibration_complete"
+    assert result["interpretation"]["request_timeout_seconds"] == 300
+    assert result["interpretation"]["provider_retries"] == 0
+    assert result["interpretation"]["formal_primary_pooling_forbidden"] is True

--- a/benchmarks/manifests/cpp-formal-timeout-calibration.json
+++ b/benchmarks/manifests/cpp-formal-timeout-calibration.json
@@ -1,0 +1,2900 @@
+{
+  "$schema": "../schemas/forge-cpp-formal-timeout-calibration.schema.json",
+  "schema_version": "formal-collection-4.5.0-timeout-calibration",
+  "document_type": "manifest",
+  "manifest_canonicalization": "UTF-8 JSON, sorted object keys, compact separators, no NaN",
+  "benchmark": {
+    "id": "forge-cpp-formal-timeout-calibration",
+    "name": "Forge C/C++ formal model timeout calibration",
+    "purpose": "calibrate a 300-second client request deadline without changing retry policy",
+    "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "formal_timeout_calibration",
+    "formal_comparison_enabled": false,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "source_protocols": {
+    "preregistration": {
+      "id": "forge-cpp-formal-v1",
+      "path": "benchmarks/preregistrations/cpp-formal-v1.json",
+      "sha256": "9385fc04fa2b0bfd365b1496d5ff6cd32f42ac8179325f71e78aa8d99a540d22"
+    },
+    "case_protocol": {
+      "id": "forge-cpp-formal-v1-cases",
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "ce9cc50f9ade201d20a65f057ba6763732c4190259d71980edf155c92a5b8210"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "762b53c6024f5fac45b82a9fc1194b4b86cf5fe0",
+    "revision_policy": "baseline_ancestor_with_frozen_components",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "backend/Dockerfile": "c62dc1a6b47a8f76d63d99f7aa3b431a487947236e907565cf9c3f5098c4c2a8",
+    "benchmarks/preregistrations/cpp-formal-timeout-calibration.md": "9b789f6e5e84ef283265c2592027a4e40131fd0468af4ff629dfbcd40993ef85",
+    "benchmarks/preregistrations/cpp-formal-v4-amendment.md": "90e43a47bb54a9de036d026faeaacfedf051a6e4ec0f82da355c32a29198aef4",
+    "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md": "7d77fd41f0df1692c79808bc8dfe13a0267fb89f7238f0ed3cfbe7152b7344f1",
+    "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md": "da1ef392311b532ad82d67228176a0e1aed5d72c3cf97a4db075f192955a52cc",
+    "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": "2fbdbbb2c419e2dcea24be1c6bd5650febdbd64509068e6ecd78fe64a5f9f04a",
+    "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": "4118549635ec99b60d9126f1ae82f7d6df74e4b699c57aa3448d302e26aa312d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": "f562667fffac23a22da52bfa2425769bd659b5e51854f1ae8e019954cbe23dc6",
+    "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": "aebe5e227419a47d248f3bbdc7b1cb4edae680acdd852ca1d29538be358f0f30",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": "30e6506a25090548bc29b650c74c5b9205008aeb8222af8393a6da9549a4284d",
+    "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": "de81f78924d4c6c26d9a62a403278767e518ebfc78ac7248b22a5c8ee79721f0",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json": "12f8610792f81ce19106fda5a1e602e391487b274bfa7bfabeb02b3942d5c20a",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json": "243749ea7868fccab6c30f9a66bae0483c0efb22c6873d119ee05a9a3084a67a",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": "69bba99ca4fba5afd10e170976f509c90e089a5769d3939cea416411276dda60",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": "2a3ab3b2d3a0543470f136e8465fd64cee2cc5dc9f6343b4b40a7a186739e55f",
+    "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": "6ac282bbbe47cd871f582d26b002bf0e3650bcfe5de03b0692225b57ba4acd72",
+    "benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json": "28fddc392015a301bc194edf1ee09159a2d904a3826d6473c47f3da5f57f75b7",
+    "benchmarks/schemas/forge-cpp-formal-v1.schema.json": "6a357d88dfa8351001efb1223e59d60c8b8574744e3037e45d55eedaef60949e",
+    "scripts/docker.sh": "6c79dfd5fd79019dcd51b2445a09d29b229bbe8c0017c3262afa6e90ef3e344b",
+    "scripts/forge_benchmark.py": "d4c18b5e558a7b29812624ea9661aab47cba610b9bc12d0050c0528bbfaa0278",
+    "scripts/forge_benchmark_runner.py": "1d07eff64607d8d2d6437a971f67fa4de5874f82efd3a9344cf2eb30361c599a",
+    "scripts/forge_formal_case_protocol.py": "2aa66dd3ded88d8e95c68a1fa75d67ddf8834c2d2e811a70e2ce25fcd86ffdb0",
+    "scripts/forge_formal_collection_v2_authorized_protocol.py": "33aec026fd851351577e35f4a83566d693277309dbb23bae94de2deb2e655bfc",
+    "scripts/forge_formal_collection_v2_authorized_runner.py": "45dae0a84dd968bb9cca9ab3d0ae7ce3c96c69867393e5967ec48d7e07499a67",
+    "scripts/forge_formal_collection_v2_protocol.py": "f35be9b66801defb5cf924089b00be801c12e121b1d7f33c565493bb08608499",
+    "scripts/forge_formal_collection_v2_runner.py": "d81d1e973b44be0b1a042dfdafea77b64faa79d4596eca16ce20fb8455351718",
+    "scripts/forge_formal_collection_v3_authorized_protocol.py": "148ee83f732973f4e3dca0c8386683a4e8135eade4eede76702896f1222b5868",
+    "scripts/forge_formal_collection_v3_authorized_runner.py": "88a16306fcda5df0ea0128b545db80ea76c9405cb48eab57eeca6d7b2a357158",
+    "scripts/forge_formal_collection_v3_protocol.py": "6e170463e6b73eb9dfdea775a952501cad33386102edcf181289e145b561e6c2",
+    "scripts/forge_formal_collection_v3_runner.py": "9d5a5eea9c8371929ba7e816eea36ed22d105023f115d32dc1e37f46b7c28704",
+    "scripts/forge_formal_collection_v4_authorized_protocol.py": "5adb07e261e14cbd3831e8d58a08d83a1efe97b80b4d9acf499fadd6acd74574",
+    "scripts/forge_formal_collection_v4_authorized_report.py": "2fc3b3efe325c3f3bd4dea61b7775c91a3cf1144ee978c2b5524130a6ef58641",
+    "scripts/forge_formal_collection_v4_authorized_runner.py": "96181cbb03a5e660cccf7cc8bfa8a0bfb5d25fa07633eafec71095df611aa15d",
+    "scripts/forge_formal_collection_v4_canary_amendment_protocol.py": "a91d964b7167729b6702f9b593b7c215bfd051ae3311da86c6fd60c13684fae1",
+    "scripts/forge_formal_collection_v4_canary_amendment_report.py": "bde9da99ef52a2658ea0b54b2665a0d054955c08049981190d73eff0c94f9375",
+    "scripts/forge_formal_collection_v4_canary_amendment_runner.py": "c9b78e8cc6fe5b8da19703964edf8ba01222045cd356157c974e742abf496af0",
+    "scripts/forge_formal_collection_v4_protocol.py": "a021ceafa91af6e308bba2f702ab1e8ce985b672e1097ddbea479db336959704",
+    "scripts/forge_formal_collection_v4_runner.py": "4470d28388fcff73498a509e382716edc864ee1503b8791d39fa516a9ae5b73a",
+    "scripts/forge_formal_collection_v4_runtime_protocol.py": "e0b14b5e2f224846f1c5c0c213f66e0667a5d008d4e246d37b1b805c4ccf595e",
+    "scripts/forge_formal_collection_v4_runtime_runner.py": "9b4ba4f4eabb5888fd663b241d69a00dfc5e369474755dd64338b02fc146e42f",
+    "scripts/forge_formal_collection_v4_ubuntu_protocol.py": "273ba1b711b9d89c218ccae2fd95f6d934b4af1b6fdc39715dbcbea6f4602a31",
+    "scripts/forge_formal_collection_v4_ubuntu_runner.py": "070f48d76d9a06f9f68d67f6abcdf3e885a5d1096c7b7725aa5df56a09082cc8",
+    "scripts/forge_formal_preregistration.py": "efd6a34aada18e137a226d91ab52736a6308acb0040ca0d9019e0af8763c79ae",
+    "scripts/forge_formal_runtime_protocol.py": "30de86dca5c2ac4bc63d3ed1ea1b16523b00e7404e2f5f635ff14716fe3fe0f6",
+    "scripts/forge_formal_timeout_calibration_protocol.py": "3f0175af6c483422f61bae0603625fc002c89460acf8fd5c1d15d41378be1348",
+    "scripts/forge_formal_timeout_calibration_report.py": "9cdb88c04e570b48382f0574fa6e9be2a017497fed36682f4d79c07e8a153968",
+    "scripts/forge_formal_timeout_calibration_runner.py": "4e26e0ea85d7ece736ee39f5878cd0e856ea4b9e52cd08e5a64daece0a336a9a",
+    "scripts/require-ubuntu-native-docker.sh": "5f1ea83c92a55f3ebfb00ad617db4946c73a9b6d6b8b8c4ca2d6cd0e9a893e32",
+    "scripts/wsl-check.sh": "891c8238d481a1aa8f76d146b48ef95a1dc974995e742671a1942a83475188ba"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    },
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "budget": {
+    "policy": {
+      "planned_attempts": 180,
+      "linear_projected_tokens": 23517576,
+      "linear_projected_serial_hours": 25.041,
+      "planning_contingency_multiplier": 1.25,
+      "contingency_tokens": 29396970,
+      "contingency_serial_hours": 31.301,
+      "human_confirmation_required_before_collection": true
+    },
+    "budget_sha256": "1a790642a7709df6834ada84725bd9d713af160f273220e323565a5ae5018636"
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model_profile": "richlab-gpt-5.5",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model_profile": "deepseek-v4-flash",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 3,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 13,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 14,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 15,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 16,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 17,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 18,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 19,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 20,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 21,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 22,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 23,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 24,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 25,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 26,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 27,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 28,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 29,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 30,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 31,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 32,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 33,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 34,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 35,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 36,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 37,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 38,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 39,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 40,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 41,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 42,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 43,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 44,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 45,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 46,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 47,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 48,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 49,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 50,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 51,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 52,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 53,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 54,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 55,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 56,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 57,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 58,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 59,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 1
+    },
+    {
+      "order": 60,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 1
+    },
+    {
+      "order": 61,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 62,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 63,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 64,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 65,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 66,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 67,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 68,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 69,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 70,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 71,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 72,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 73,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 74,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 75,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 76,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 77,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 78,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 79,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 80,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 81,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 82,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 83,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 84,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 85,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 86,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 87,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 88,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 89,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 90,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 91,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 92,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 93,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 94,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 95,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 96,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 97,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 98,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 99,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 100,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 101,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 102,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 103,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 104,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 105,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 106,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 107,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 108,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 109,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 110,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 111,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 112,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 113,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 114,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 115,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 116,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 117,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 118,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 119,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 2
+    },
+    {
+      "order": 120,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 2
+    },
+    {
+      "order": 121,
+      "case_id": "fftw3",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 122,
+      "case_id": "fftw3",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 123,
+      "case_id": "mruby",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 124,
+      "case_id": "mruby",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 125,
+      "case_id": "libass",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 126,
+      "case_id": "libass",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 127,
+      "case_id": "ada-url",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 128,
+      "case_id": "ada-url",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 129,
+      "case_id": "pupnp",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 130,
+      "case_id": "pupnp",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 131,
+      "case_id": "openthread",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 132,
+      "case_id": "openthread",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 133,
+      "case_id": "janus-gateway",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 134,
+      "case_id": "janus-gateway",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 135,
+      "case_id": "fio",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 136,
+      "case_id": "fio",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 137,
+      "case_id": "lodepng",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 138,
+      "case_id": "lodepng",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 139,
+      "case_id": "liblouis",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 140,
+      "case_id": "liblouis",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 141,
+      "case_id": "uwebsockets",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 142,
+      "case_id": "uwebsockets",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 143,
+      "case_id": "gpac",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 144,
+      "case_id": "gpac",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 145,
+      "case_id": "yyjson",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 146,
+      "case_id": "yyjson",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 147,
+      "case_id": "args",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 148,
+      "case_id": "args",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 149,
+      "case_id": "freeradius",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 150,
+      "case_id": "freeradius",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 151,
+      "case_id": "sql-parser",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 152,
+      "case_id": "sql-parser",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 153,
+      "case_id": "cppitertools",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 154,
+      "case_id": "cppitertools",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 155,
+      "case_id": "jpegoptim",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 156,
+      "case_id": "jpegoptim",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 157,
+      "case_id": "sentencepiece",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 158,
+      "case_id": "sentencepiece",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 159,
+      "case_id": "hoextdown",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 160,
+      "case_id": "hoextdown",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 161,
+      "case_id": "powerdns",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 162,
+      "case_id": "powerdns",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 163,
+      "case_id": "libusb",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 164,
+      "case_id": "libusb",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 165,
+      "case_id": "c-ares",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 166,
+      "case_id": "c-ares",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 167,
+      "case_id": "libspdm",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 168,
+      "case_id": "libspdm",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 169,
+      "case_id": "firestore",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 170,
+      "case_id": "firestore",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 171,
+      "case_id": "janet",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 172,
+      "case_id": "janet",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 173,
+      "case_id": "mupdf",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 174,
+      "case_id": "mupdf",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 175,
+      "case_id": "numactl",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 176,
+      "case_id": "numactl",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 177,
+      "case_id": "openh264",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    },
+    {
+      "order": 178,
+      "case_id": "openh264",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 179,
+      "case_id": "open62541",
+      "condition_id": "deepseek-v4-flash",
+      "repetition": 3
+    },
+    {
+      "order": 180,
+      "case_id": "open62541",
+      "condition_id": "richlab-gpt-5.5",
+      "repetition": 3
+    }
+  ],
+  "schedule_sha256": "9cfca53bb8c7ab8f07eb5c9a852383eb1877dc377cf56bb834b8eee3587fa469",
+  "cases": [
+    {
+      "id": "powerdns",
+      "repository_url": "https://github.com/PowerDNS/pdns",
+      "commit_sha": "211f7ec30208100b44010e71cac4712878821243",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -vi"
+        ],
+        "configure_arguments": [
+          "--without-dynmodules",
+          "--disable-lua-records",
+          "--without-systemd"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "pdns_server",
+            "build_output_path": "pdns/pdns_server",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libboost-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--without-dynmodules",
+            "--disable-lua-records",
+            "--without-systemd"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "freeradius",
+      "repository_url": "https://github.com/FreeRADIUS/freeradius-server",
+      "commit_sha": "0b778ffcd109b4590b056c48822beff77a46927b",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "--disable-developer",
+          "--without-openssl"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfreeradius-util.a",
+            "build_output_path": "build/lib/.libs/libfreeradius-util.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-developer",
+            "--without-openssl"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "c-ares",
+      "repository_url": "https://github.com/c-ares/c-ares",
+      "commit_sha": "589b5887d47736e5b70a1fddaf9bf90297adde65",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-tests"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libcares.a",
+            "build_output_path": "src/lib/.libs/libcares.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-tests"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fftw3",
+      "repository_url": "https://github.com/fftw/fftw3",
+      "commit_sha": "93ed4c786934aec9946f8dda4b4e3eb08f8be41c",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-fortran"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfftw3.a",
+            "build_output_path": ".libs/libfftw3.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-fortran"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libusb",
+      "repository_url": "https://github.com/libusb/libusb",
+      "commit_sha": "6bb97402df0ec0c09defcbd4f5146447c7f7cc53",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-udev"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libusb-1.0.a",
+            "build_output_path": "libusb/.libs/libusb-1.0.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-udev"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janus-gateway",
+      "repository_url": "https://github.com/meetecho/janus-gateway",
+      "commit_sha": "4602fcc5315b77dce2a5d8363a4286ac672183b1",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "sh autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-docs",
+          "--disable-data-channels",
+          "--disable-websockets",
+          "--disable-rabbitmq",
+          "--disable-mqtt"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "janus",
+            "build_output_path": "janus",
+            "artifact_type": "executable",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libglib2.0-dev",
+          "libjansson-dev",
+          "libssl-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-docs",
+            "--disable-data-channels",
+            "--disable-websockets",
+            "--disable-rabbitmq",
+            "--disable-mqtt"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "numactl",
+      "repository_url": "https://github.com/numactl/numactl",
+      "commit_sha": "93c1fe5fabf38502ca315598bf74699c41300df9",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "libnuma.la"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libnuma.a",
+            "build_output_path": ".libs/libnuma.a",
+            "artifact_type": "static_library",
+            "producing_target": "libnuma.la"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libass",
+      "repository_url": "https://github.com/libass/libass",
+      "commit_sha": "f9fd3d20dff1cd84b7c74c8ae7f79711ad7736fa",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "autotools",
+      "license": "ISC",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./autogen.sh"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-require-system-font-provider"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libass.a",
+            "build_output_path": "libass/.libs/libass.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libfreetype6-dev",
+          "libfribidi-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static",
+            "--disable-require-system-font-provider"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "jpegoptim",
+      "repository_url": "https://github.com/tjko/jpegoptim",
+      "commit_sha": "14a3155acccdcbbfa4ea0d1d2fa11ffb9a373191",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "GPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "jpegoptim"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "jpegoptim",
+            "build_output_path": "jpegoptim",
+            "artifact_type": "executable",
+            "producing_target": "jpegoptim"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libjpeg-dev",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "open62541",
+      "repository_url": "https://github.com/open62541/open62541",
+      "commit_sha": "712aec6e8ca5f85d35b8f070077c20528fcbf18f",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DUA_BUILD_EXAMPLES=OFF",
+          "-DUA_BUILD_UNIT_TESTS=OFF"
+        ],
+        "build_targets": [
+          "open62541"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopen62541.a",
+            "build_output_path": "build/bin/libopen62541.a",
+            "artifact_type": "static_library",
+            "producing_target": "open62541"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DUA_BUILD_EXAMPLES=OFF",
+            "-DUA_BUILD_UNIT_TESTS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "firestore",
+      "repository_url": "https://github.com/firebase/firebase-ios-sdk",
+      "commit_sha": "1111d6715d897e4af0b33eef1832721612fbfedb",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+          "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+          "-DFIRESTORE_INCLUDE_OBJC=OFF"
+        ],
+        "build_targets": [
+          "firestore_core"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libfirestore_core.a",
+            "build_output_path": "build/Firestore/core/libfirestore_core.a",
+            "artifact_type": "static_library",
+            "producing_target": "firestore_core"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "libssl-dev",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DFIREBASE_IOS_BUILD_TESTS=OFF",
+            "-DFIREBASE_IOS_BUILD_BENCHMARKS=OFF",
+            "-DFIRESTORE_INCLUDE_OBJC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "build_targets": [
+          "upnp_static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libupnp.a",
+            "build_output_path": "build/upnp/libupnp.a",
+            "artifact_type": "static_library",
+            "producing_target": "upnp_static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DUPNP_ENABLE_TESTING=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "build_targets": [
+          "ada"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libada.a",
+            "build_output_path": "build/src/libada.a",
+            "artifact_type": "static_library",
+            "producing_target": "ada"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DADA_TESTING=OFF",
+            "-DADA_BENCHMARKS=OFF",
+            "-DADA_TOOLS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "libspdm",
+      "repository_url": "https://github.com/DMTF/libspdm",
+      "commit_sha": "1cc1f1f51696f1cb657e59ed4c58a6064c8b948f",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DARCH=x64",
+          "-DTOOLCHAIN=GCC",
+          "-DTARGET=Release",
+          "-DCRYPTO=mbedtls"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libspdm_common_lib.a",
+            "build_output_path": "build/lib/libspdm_common_lib.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DARCH=x64",
+            "-DTOOLCHAIN=GCC",
+            "-DTARGET=Release",
+            "-DCRYPTO=mbedtls"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sentencepiece",
+      "repository_url": "https://github.com/google/sentencepiece",
+      "commit_sha": "1192370fbb50ee8cde9056bdd1055073917e59dc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DSPM_ENABLE_SHARED=OFF",
+          "-DSPM_BUILD_TEST=OFF",
+          "-DSPM_ENABLE_TCMALLOC=OFF"
+        ],
+        "build_targets": [
+          "sentencepiece-static"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsentencepiece.a",
+            "build_output_path": "build/src/libsentencepiece.a",
+            "artifact_type": "static_library",
+            "producing_target": "sentencepiece-static"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DSPM_ENABLE_SHARED=OFF",
+            "-DSPM_BUILD_TEST=OFF",
+            "-DSPM_ENABLE_TCMALLOC=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "build_targets": [
+          "gitlike"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "gitlike",
+            "build_output_path": "build/gitlike",
+            "artifact_type": "executable",
+            "producing_target": "gitlike"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DARGS_BUILD_EXAMPLE=ON",
+            "-DARGS_BUILD_UNITTESTS=OFF",
+            "-DBUILD_FUZZERS=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "languages": [
+        "C"
+      ],
+      "build_system": "cmake",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "cppitertools",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": "examples",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release"
+        ],
+        "build_targets": [
+          "accumulate_examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "accumulate_examples",
+            "build_output_path": "build/accumulate_examples",
+            "artifact_type": "executable",
+            "producing_target": "accumulate_examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "BSD-2-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "languages": [
+        "C"
+      ],
+      "build_system": "make",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "lib"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libgpac_static.a",
+            "build_output_path": "bin/gcc/libgpac_static.a",
+            "artifact_type": "static_library",
+            "producing_target": "lib"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "janet",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libjanet.a",
+            "build_output_path": "build/libjanet.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "uwebsockets",
+      "repository_url": "https://github.com/uNetworking/uWebSockets",
+      "commit_sha": "fe7c01a477b688a7743f754fee33bdd78d52ad91",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Apache-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "git submodule update --init --recursive"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "examples"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "HelloWorld",
+            "build_output_path": "HelloWorld",
+            "artifact_type": "executable",
+            "producing_target": "examples"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libssl-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mruby",
+      "repository_url": "https://github.com/mruby/mruby",
+      "commit_sha": "33b228bdbed842efc88a62e5b139dd2c358f08d5",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmruby.a",
+            "build_output_path": "build/host/lib/libmruby.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "ruby"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "GPL-2.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "build_targets": [
+          "fio"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "fio",
+            "build_output_path": "fio",
+            "artifact_type": "executable",
+            "producing_target": "fio"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "library"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "lodepng",
+      "repository_url": "https://github.com/lvandeve/lodepng",
+      "commit_sha": "ed6fe5825c6a4fbb7f58ab35a4231c7543cd452a",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "Zlib",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "unittest"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "unittest",
+            "build_output_path": "unittest",
+            "artifact_type": "executable",
+            "producing_target": "unittest"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "MIT",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "authorization": {
+    "id": "forge-cpp-formal-timeout-calibration",
+    "status": "authorized_bounded_timeout_calibration",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-14",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/117",
+    "implementation_baseline_commit": "762b53c6024f5fac45b82a9fc1194b4b86cf5fe0",
+    "network_observation": {
+      "access_medium": "mobile_hotspot",
+      "browser_ui_required": false
+    },
+    "calibration_hypothesis": {
+      "observed_timeout_boundary_seconds": 120,
+      "calibrated_timeout_seconds": 300,
+      "success_criterion": "all_started_requests_close_with_append_only_evidence",
+      "interpretation": "infrastructure_parameter_calibration_only"
+    },
+    "budget_confirmation": {
+      "confirmed": true,
+      "maximum_recorded_tokens": 500000,
+      "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+      "terminalization_cleanup_precedes_token_boundary_check": true
+    },
+    "collection_constraints": {
+      "authorized_slot_count": 2,
+      "authorized_schedule_orders": [
+        1,
+        2
+      ],
+      "remaining_slots_require_additional_confirmation": true,
+      "provider_canary_required_before_first_ledger": true,
+      "provider_canary_max_attempts": 1,
+      "empty_ledger_required_before_canary": true,
+      "zero_residual_formal_containers_required_before_canary": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "formal_primary_pooling_forbidden": true,
+      "required_runtime_launch_checks": [
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit",
+        "docker_daemon_provider_matches",
+        "docker_socket_source_matches_native_path"
+      ],
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-timeout-calibration"
+    },
+    "parent_manifest": {
+      "id": "forge-cpp-formal-v4-canary-amendment",
+      "path": "benchmarks/manifests/cpp-formal-v4-canary-amendment.json",
+      "canonical_sha256": "e296138d6464adc6e7c12d4ee29d1f22c178d53a463b3467e2d2442e5fd66587"
+    }
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit",
+      "docker_daemon_provider_matches",
+      "docker_socket_source_matches_native_path"
+    ],
+    "sensitive_host_identifiers_forbidden": true,
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "analysis_plan": {
+    "protocol_version_pooling": "forbidden",
+    "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+    "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+    "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+    "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+    "provider_and_case_imbalance_must_be_reported": true,
+    "retry_replacement_backfill_forbidden": true
+  },
+  "initial_batch_decision": {
+    "status": "authorized_by_experiment_owner",
+    "selection_rule": "first_project_in_frozen_schedule",
+    "project_ids": [
+      "cppitertools"
+    ],
+    "complete_project_blocks": 1,
+    "conditions_per_project": 2,
+    "repetitions_per_condition": 3,
+    "planned_attempts": 6,
+    "selected_schedule_orders": [
+      1,
+      2,
+      73,
+      74,
+      153,
+      154
+    ],
+    "maximum_recorded_tokens": 980000,
+    "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+    "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+    "maximum_attempt_wall_clock_seconds": 1800,
+    "maximum_batch_attempt_wall_clock_seconds": 10800,
+    "stop_conditions": [
+      "six_selected_attempts_terminalized",
+      "recorded_token_boundary_reached",
+      "runtime_preflight_failed",
+      "provider_canary_failed",
+      "daemon_provider_drift",
+      "ledger_or_cleanup_invariant_failed",
+      "user_interrupted"
+    ],
+    "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+    "retry_replacement_backfill_forbidden": true
+  }
+}

--- a/benchmarks/preregistrations/cpp-formal-timeout-calibration.md
+++ b/benchmarks/preregistrations/cpp-formal-timeout-calibration.md
@@ -1,0 +1,25 @@
+# C/C++ formal 模型请求 300 秒超时校准预注册
+
+## 研究问题
+
+formal v4 的 63 次模型请求中有 8 次在 120.01–120.85 秒被客户端截止点终止。本校准检验：在模型、endpoint、编译任务、调用预算和重试策略不变时，将客户端请求超时延长到 300 秒后，请求能否形成完整闭合证据。
+
+## 冻结设计
+
+- 项目固定为 `cppitertools@531b3d753d2bbfe3b0ababe61c2e95e965c54a66`。
+- 只执行原 schedule order `1` 和 `2`：RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各一次。
+- Lead 与 Compiler 的请求超时统一为 300 秒，`max_retries=0`。
+- Memory、Skill、fallback、replacement 和 backfill 保持关闭。
+- 使用 WSL2 `Ubuntu` 原生 Docker Engine、Compose/DooD、Compile Session 与 clean replay。
+- evidence 使用独立 append-only 目录，maximum recorded tokens 为 500,000。
+
+## 判定
+
+- 报告每次请求的角色、终态、延迟和安全错误分类，不保存响应正文、请求头或凭据。
+- 超过 120 秒后成功闭合的请求构成“延长截止点可挽救慢请求”的直接证据。
+- 若所有请求均在 120 秒内完成，只能证明 300 秒配置路径可运行，不能证明历史 8 次超时可被挽救。
+- 300 秒仍超时说明客户端等待更久仍未获得响应，但不能单独定位上游服务、跨境链路或本机接入的具体责任层。
+
+## 边界
+
+本校准不进入 formal 模型能力主比较，不修复 Oracle/端到端预算语义，不开展 verifier-driven repair treatment，也不授权其他项目或 slot。

--- a/benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json
+++ b/benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json
@@ -1,0 +1,693 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json",
+  "title": "Forge C/C++ formal model timeout calibration",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "manifest_canonicalization",
+    "benchmark",
+    "scope",
+    "source_protocols",
+    "forge",
+    "protocol_artifact_sha256",
+    "prompt_sha256",
+    "model_profiles",
+    "runtime",
+    "budget",
+    "conditions",
+    "collection_plan",
+    "schedule_sha256",
+    "cases",
+    "attempt_budget",
+    "resource_preflight",
+    "analysis_plan",
+    "authorization",
+    "initial_batch_decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "formal-collection-4.5.0-timeout-calibration"
+    },
+    "document_type": {
+      "const": "manifest"
+    },
+    "scope": {
+      "const": {
+        "languages": [
+          "C",
+          "C++"
+        ],
+        "phase": "formal_timeout_calibration",
+        "formal_comparison_enabled": false,
+        "collection_authorized": true,
+        "instrumentation_blocker": false
+      }
+    },
+    "source_protocols": {
+      "type": "object"
+    },
+    "forge": {
+      "type": "object",
+      "required": [
+        "commit_sha",
+        "component_sha256"
+      ],
+      "properties": {
+        "commit_sha": {
+          "const": "762b53c6024f5fac45b82a9fc1194b4b86cf5fe0"
+        },
+        "component_sha256": {
+          "type": "object",
+          "required": [
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py",
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py",
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py",
+            "backend/packages/harness/deerflow/client.py",
+            "backend/packages/harness/deerflow/compile/__init__.py",
+            "backend/packages/harness/deerflow/compile/docker_runtime.py",
+            "backend/packages/harness/deerflow/compile/evidence.py",
+            "backend/packages/harness/deerflow/compile/manager.py",
+            "backend/packages/harness/deerflow/compile/operations.py",
+            "backend/packages/harness/deerflow/compile/schemas.py",
+            "backend/packages/harness/deerflow/models/factory.py",
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+            "backend/packages/harness/deerflow/subagents/executor.py",
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py",
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py",
+            "backend/uv.lock",
+            "config.example.yaml",
+            "docker/compile/Dockerfile",
+            "docker/docker-compose-dev.yaml"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "backend/packages/harness/deerflow/agents/lead_agent/agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/client.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/__init__.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/docker_runtime.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/evidence.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/manager.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/operations.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/compile/schemas.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/models/factory.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/subagents/executor.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/bound_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "backend/uv.lock": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "config.example.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/compile/Dockerfile": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "docker/docker-compose-dev.yaml": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "protocol_artifact_sha256": {
+      "type": "object",
+      "required": [
+        "backend/Dockerfile",
+        "benchmarks/preregistrations/cpp-formal-timeout-calibration.md",
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md",
+        "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md",
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json",
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json",
+        "scripts/docker.sh",
+        "scripts/forge_benchmark.py",
+        "scripts/forge_benchmark_runner.py",
+        "scripts/forge_formal_case_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_protocol.py",
+        "scripts/forge_formal_collection_v2_authorized_runner.py",
+        "scripts/forge_formal_collection_v2_protocol.py",
+        "scripts/forge_formal_collection_v2_runner.py",
+        "scripts/forge_formal_collection_v3_authorized_protocol.py",
+        "scripts/forge_formal_collection_v3_authorized_runner.py",
+        "scripts/forge_formal_collection_v3_protocol.py",
+        "scripts/forge_formal_collection_v3_runner.py",
+        "scripts/forge_formal_collection_v4_authorized_protocol.py",
+        "scripts/forge_formal_collection_v4_authorized_report.py",
+        "scripts/forge_formal_collection_v4_authorized_runner.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_protocol.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_report.py",
+        "scripts/forge_formal_collection_v4_canary_amendment_runner.py",
+        "scripts/forge_formal_collection_v4_protocol.py",
+        "scripts/forge_formal_collection_v4_runner.py",
+        "scripts/forge_formal_collection_v4_runtime_protocol.py",
+        "scripts/forge_formal_collection_v4_runtime_runner.py",
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py",
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py",
+        "scripts/forge_formal_preregistration.py",
+        "scripts/forge_formal_runtime_protocol.py",
+        "scripts/forge_formal_timeout_calibration_protocol.py",
+        "scripts/forge_formal_timeout_calibration_report.py",
+        "scripts/forge_formal_timeout_calibration_runner.py",
+        "scripts/require-ubuntu-native-docker.sh",
+        "scripts/wsl-check.sh"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/Dockerfile": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-timeout-calibration.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-authorized-initial-block.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-canary-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-runtime-amendment.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/preregistrations/cpp-formal-v4-ubuntu-gate-and-initial-block.md": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v2.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v3.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-authorized.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-canary-amendment.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-runtime-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4-ubuntu-candidate.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-collection-v4.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "benchmarks/schemas/forge-cpp-formal-v1.schema.json": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_benchmark_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_case_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v2_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v3_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_report.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_authorized_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_report.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_canary_amendment_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_runtime_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_collection_v4_ubuntu_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_preregistration.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_runtime_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_timeout_calibration_protocol.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_timeout_calibration_report.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/forge_formal_timeout_calibration_runner.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/require-ubuntu-native-docker.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "scripts/wsl-check.sh": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "prompt_sha256": {
+      "type": "object",
+      "required": [
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": [
+        "image_id",
+        "control_plane_topology",
+        "max_parallel_runs",
+        "docker_daemon_provider",
+        "docker_socket_path"
+      ],
+      "properties": {
+        "image_id": {
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "control_plane_topology": {
+          "const": "compose-dood"
+        },
+        "max_parallel_runs": {
+          "const": 1
+        },
+        "docker_daemon_provider": {
+          "const": "ubuntu-native"
+        },
+        "docker_socket_path": {
+          "const": "/var/run/docker.sock"
+        }
+      }
+    },
+    "budget": {
+      "type": "object"
+    },
+    "conditions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "collection_plan": {
+      "type": "array",
+      "minItems": 180,
+      "maxItems": 180
+    },
+    "schedule_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 30,
+      "maxItems": 30
+    },
+    "authorization": {
+      "const": {
+        "id": "forge-cpp-formal-timeout-calibration",
+        "status": "authorized_bounded_timeout_calibration",
+        "authorized_by": "experiment_owner",
+        "authorized_on": "2026-08-14",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/117",
+        "implementation_baseline_commit": "762b53c6024f5fac45b82a9fc1194b4b86cf5fe0",
+        "network_observation": {
+          "access_medium": "mobile_hotspot",
+          "browser_ui_required": false
+        },
+        "calibration_hypothesis": {
+          "observed_timeout_boundary_seconds": 120,
+          "calibrated_timeout_seconds": 300,
+          "success_criterion": "all_started_requests_close_with_append_only_evidence",
+          "interpretation": "infrastructure_parameter_calibration_only"
+        },
+        "budget_confirmation": {
+          "confirmed": true,
+          "maximum_recorded_tokens": 500000,
+          "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+          "terminalization_cleanup_precedes_token_boundary_check": true
+        },
+        "collection_constraints": {
+          "authorized_slot_count": 2,
+          "authorized_schedule_orders": [
+            1,
+            2
+          ],
+          "remaining_slots_require_additional_confirmation": true,
+          "provider_canary_required_before_first_ledger": true,
+          "provider_canary_max_attempts": 1,
+          "empty_ledger_required_before_canary": true,
+          "zero_residual_formal_containers_required_before_canary": true,
+          "replacement_forbidden": true,
+          "fallback_forbidden": true,
+          "retry_forbidden": true,
+          "backfill_forbidden": true,
+          "formal_primary_pooling_forbidden": true,
+          "required_runtime_launch_checks": [
+            "host_available_memory_at_least_minimum",
+            "docker_daemon_responded",
+            "docker_daemon_latency_within_limit",
+            "docker_daemon_provider_matches",
+            "docker_socket_source_matches_native_path"
+          ],
+          "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-formal-timeout-calibration"
+        },
+        "parent_manifest": {
+          "id": "forge-cpp-formal-v4-canary-amendment",
+          "path": "benchmarks/manifests/cpp-formal-v4-canary-amendment.json",
+          "canonical_sha256": "e296138d6464adc6e7c12d4ee29d1f22c178d53a463b3467e2d2442e5fd66587"
+        }
+      }
+    },
+    "$schema": {
+      "const": "../schemas/forge-cpp-formal-timeout-calibration.schema.json"
+    },
+    "manifest_canonicalization": {
+      "const": "UTF-8 JSON, sorted object keys, compact separators, no NaN"
+    },
+    "benchmark": {
+      "const": {
+        "id": "forge-cpp-formal-timeout-calibration",
+        "name": "Forge C/C++ formal model timeout calibration",
+        "purpose": "calibrate a 300-second client request deadline without changing retry policy",
+        "dataset_provenance": "OSS-Fuzz metadata snapshot 08682bfc"
+      }
+    },
+    "model_profiles": {
+      "const": {
+        "richlab-gpt-5.5": {
+          "endpoint": "https://rich-api.choosefire.com/v1",
+          "credential_env": "OpenAI_AK",
+          "roles": {
+            "lead": "gpt-5.5",
+            "compiler": "gpt-5.5"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 300,
+          "max_retries": 0
+        },
+        "deepseek-v4-flash": {
+          "endpoint": "https://api.deepseek.com",
+          "credential_env": "DEEPSEEK_API_KEY",
+          "roles": {
+            "lead": "deepseek-v4-flash",
+            "compiler": "deepseek-v4-flash"
+          },
+          "fallback_policy": "forbidden",
+          "request_timeout_seconds": 300,
+          "max_retries": 0
+        }
+      }
+    },
+    "attempt_budget": {
+      "const": {
+        "total_wall_clock_seconds": 1800,
+        "cleanup_reserve_seconds": 120,
+        "max_compiler_invocations": 2,
+        "max_model_requests": 48,
+        "enforcement_checkpoints": [
+          "before_provider_request",
+          "before_compiler_invocation",
+          "before_submit_or_replay",
+          "before_finalize",
+          "before_cleanup"
+        ],
+        "new_work_forbidden_after_limit": true,
+        "cleanup_mandatory_after_limit": true,
+        "terminal_classification": "attempt_budget_exhausted"
+      }
+    },
+    "resource_preflight": {
+      "const": {
+        "minimum_available_memory_bytes": 2147483648,
+        "docker_daemon_timeout_seconds": 10,
+        "maximum_docker_daemon_latency_seconds": 5,
+        "required_checks": [
+          "host_available_memory_at_least_minimum",
+          "docker_daemon_responded",
+          "docker_daemon_latency_within_limit",
+          "docker_daemon_provider_matches",
+          "docker_socket_source_matches_native_path"
+        ],
+        "sensitive_host_identifiers_forbidden": true,
+        "docker_daemon_provider": "ubuntu-native",
+        "docker_socket_path": "/var/run/docker.sock"
+      }
+    },
+    "analysis_plan": {
+      "const": {
+        "protocol_version_pooling": "forbidden",
+        "v3_initial_batch_role": "separate_descriptive_protocol_stratum",
+        "v4_primary_estimand": "complete_project_blocks_collected_under_v4_only",
+        "incomplete_block_primary_handling": "exclude_from_paired_primary_estimate",
+        "incomplete_block_secondary_handling": "retain_in_end_to_end_descriptive_denominator",
+        "provider_and_case_imbalance_must_be_reported": true,
+        "retry_replacement_backfill_forbidden": true
+      }
+    },
+    "initial_batch_decision": {
+      "const": {
+        "status": "authorized_by_experiment_owner",
+        "selection_rule": "first_project_in_frozen_schedule",
+        "project_ids": [
+          "cppitertools"
+        ],
+        "complete_project_blocks": 1,
+        "conditions_per_project": 2,
+        "repetitions_per_condition": 3,
+        "planned_attempts": 6,
+        "selected_schedule_orders": [
+          1,
+          2,
+          73,
+          74,
+          153,
+          154
+        ],
+        "maximum_recorded_tokens": 980000,
+        "token_budget_basis": "preregistered_full_budget_linear_share_times_1.25_rounded_up",
+        "token_boundary_check": "after_attempt_terminalization_before_next_attempt",
+        "maximum_attempt_wall_clock_seconds": 1800,
+        "maximum_batch_attempt_wall_clock_seconds": 10800,
+        "stop_conditions": [
+          "six_selected_attempts_terminalized",
+          "recorded_token_boundary_reached",
+          "runtime_preflight_failed",
+          "provider_canary_failed",
+          "daemon_provider_drift",
+          "ledger_or_cleanup_invariant_failed",
+          "user_interrupted"
+        ],
+        "incomplete_block_handling": "descriptive_only_not_primary_paired_estimate",
+        "retry_replacement_backfill_forbidden": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/forge_formal_timeout_calibration_protocol.py
+++ b/scripts/forge_formal_timeout_calibration_protocol.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""生成并校验 formal 模型请求 300 秒超时校准协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_benchmark as v1  # noqa: E402
+import forge_formal_collection_v4_canary_amendment_protocol as parent_protocol  # noqa: E402
+import forge_formal_runtime_protocol as _hasher  # noqa: E402
+
+SCHEMA_VERSION = "formal-collection-4.5.0-timeout-calibration"
+BASELINE_COMMIT = "762b53c6024f5fac45b82a9fc1194b4b86cf5fe0"
+REQUEST_TIMEOUT_SECONDS = 300
+AUTHORIZED_SCHEDULE_ORDERS = [1, 2]
+RECORDED_TOKEN_LIMIT = 500_000
+PARENT_CANONICAL_SHA256 = "e296138d6464adc6e7c12d4ee29d1f22c178d53a463b3467e2d2442e5fd66587"
+
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+DOCKER_DAEMON_PROVIDER = parent_protocol.DOCKER_DAEMON_PROVIDER
+DOCKER_SOCKET_PATH = parent_protocol.DOCKER_SOCKET_PATH
+COMPONENT_PATHS = parent_protocol.COMPONENT_PATHS
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-v4-canary-amendment.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-timeout-calibration.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-cpp-formal-timeout-calibration.schema.json"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-formal-timeout-calibration"
+PROTOCOL_ARTIFACT_PATHS = parent_protocol.PROTOCOL_ARTIFACT_PATHS | {
+    "scripts/forge_formal_timeout_calibration_protocol.py",
+    "scripts/forge_formal_timeout_calibration_runner.py",
+    "scripts/forge_formal_timeout_calibration_report.py",
+    "benchmarks/preregistrations/cpp-formal-timeout-calibration.md",
+    "benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json",
+}
+
+AUTHORIZATION = {
+    "id": "forge-cpp-formal-timeout-calibration",
+    "status": "authorized_bounded_timeout_calibration",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-14",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/117",
+    "implementation_baseline_commit": BASELINE_COMMIT,
+    "network_observation": {
+        "access_medium": "mobile_hotspot",
+        "browser_ui_required": False,
+    },
+    "calibration_hypothesis": {
+        "observed_timeout_boundary_seconds": 120,
+        "calibrated_timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+        "success_criterion": "all_started_requests_close_with_append_only_evidence",
+        "interpretation": "infrastructure_parameter_calibration_only",
+    },
+    "budget_confirmation": {
+        "confirmed": True,
+        "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+        "enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+        "terminalization_cleanup_precedes_token_boundary_check": True,
+    },
+    "collection_constraints": {
+        "authorized_slot_count": 2,
+        "authorized_schedule_orders": AUTHORIZED_SCHEDULE_ORDERS,
+        "remaining_slots_require_additional_confirmation": True,
+        "provider_canary_required_before_first_ledger": True,
+        "provider_canary_max_attempts": 1,
+        "empty_ledger_required_before_canary": True,
+        "zero_residual_formal_containers_required_before_canary": True,
+        "replacement_forbidden": True,
+        "fallback_forbidden": True,
+        "retry_forbidden": True,
+        "backfill_forbidden": True,
+        "formal_primary_pooling_forbidden": True,
+        "required_runtime_launch_checks": copy.deepcopy(parent_protocol.AMENDMENT["collection_constraints"]["required_runtime_launch_checks"]),
+        "evidence_directory": EVIDENCE_DIRECTORY,
+    },
+}
+
+BenchmarkError = v1.BenchmarkError
+load_json_document = v1.load_json_document
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = parent_protocol.validate_manifest(document or load_json_document(DEFAULT_PARENT_MANIFEST))
+    if parent_protocol.manifest_sha256(parent) != PARENT_CANONICAL_SHA256:
+        v1._fail("manifest.authorization.parent_manifest", "does not match formal v4 canary amendment")
+    return parent
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **copy.deepcopy(AUTHORIZATION),
+        "parent_manifest": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-formal-v4-canary-amendment.json",
+            "canonical_sha256": parent_protocol.manifest_sha256(parent),
+        },
+    }
+
+
+def _build_manifest(repo_root: Path, *, parent: dict[str, Any]) -> dict[str, Any]:
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-cpp-formal-timeout-calibration.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-cpp-formal-timeout-calibration",
+        "name": "Forge C/C++ formal model timeout calibration",
+        "purpose": "calibrate a 300-second client request deadline without changing retry policy",
+        "dataset_provenance": parent["benchmark"]["dataset_provenance"],
+    }
+    manifest["scope"] = {
+        "languages": ["C", "C++"],
+        "phase": "formal_timeout_calibration",
+        "formal_comparison_enabled": False,
+        "collection_authorized": True,
+        "instrumentation_blocker": False,
+    }
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+        "component_sha256": _hasher._hash_paths(repo_root, COMPONENT_PATHS),
+    }
+    for profile in manifest["model_profiles"].values():
+        profile["request_timeout_seconds"] = REQUEST_TIMEOUT_SECONDS
+        profile["max_retries"] = 0
+    manifest["protocol_artifact_sha256"] = _hasher._hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS)
+    manifest["prompt_sha256"] = _hasher._hash_paths(repo_root, set(parent["prompt_sha256"]))
+    manifest["authorization"] = _authorization(parent)
+    return manifest
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _build_manifest(repo_root, parent=_parent_manifest(parent))
+
+
+def selected_slots(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    by_order = {slot["order"]: slot for slot in manifest["collection_plan"]}
+    return [by_order[order] for order in AUTHORIZED_SCHEDULE_ORDERS]
+
+
+def validate_manifest(
+    document: Any,
+    *,
+    repo_root: Path = REPOSITORY_ROOT,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        manifest = v1._as_object(document, "manifest")
+        expected = _build_manifest(repo_root, parent=_parent_manifest(parent))
+        if manifest != expected:
+            v1._fail("manifest", "must match the 300-second timeout calibration exactly")
+        slots = selected_slots(manifest)
+        if [(slot["condition_id"], slot["repetition"]) for slot in slots] != [
+            ("richlab-gpt-5.5", 1),
+            ("deepseek-v4-flash", 1),
+        ]:
+            v1._fail("manifest.authorization", "must contain one attempt per provider")
+        return manifest
+    except BenchmarkError:
+        raise
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise BenchmarkError(f"manifest: invalid timeout calibration: {exc}") from exc
+
+
+def canonical_manifest_bytes(manifest: dict[str, Any]) -> bytes:
+    return canonical_json_bytes(manifest)
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPOSITORY_ROOT) -> None:
+    validate_manifest(manifest, repo_root=repo_root)
+    for path_prefix, hashes in (
+        ("manifest.forge.component_sha256", manifest["forge"]["component_sha256"]),
+        ("manifest.protocol_artifact_sha256", manifest["protocol_artifact_sha256"]),
+        ("manifest.prompt_sha256", manifest["prompt_sha256"]),
+    ):
+        for relative_path, expected in hashes.items():
+            if _hasher._file_sha256(repo_root / relative_path) != expected:
+                v1._fail(f"{path_prefix}.{relative_path}", "does not match")
+
+
+def _hash_map_schema(paths: set[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": sorted(paths),
+        "additionalProperties": False,
+        "properties": {relative_path: {"type": "string", "pattern": "^[0-9a-f]{64}$"} for relative_path in sorted(paths)},
+    }
+
+
+def schema_document() -> dict[str, Any]:
+    schema = copy.deepcopy(parent_protocol.schema_document())
+    parent = _parent_manifest()
+    schema["$id"] = "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-cpp-formal-timeout-calibration.schema.json"
+    schema["title"] = "Forge C/C++ formal model timeout calibration"
+    properties = schema["properties"]
+    properties["$schema"] = {"const": "../schemas/forge-cpp-formal-timeout-calibration.schema.json"}
+    properties["schema_version"] = {"const": SCHEMA_VERSION}
+    properties["benchmark"] = {"const": _build_manifest(REPOSITORY_ROOT, parent=parent)["benchmark"]}
+    properties["scope"] = {"const": _build_manifest(REPOSITORY_ROOT, parent=parent)["scope"]}
+    properties["forge"]["properties"]["commit_sha"] = {"const": BASELINE_COMMIT}
+    properties["forge"]["properties"]["component_sha256"] = _hash_map_schema(COMPONENT_PATHS)
+    properties["model_profiles"] = {"const": _build_manifest(REPOSITORY_ROOT, parent=parent)["model_profiles"]}
+    properties["protocol_artifact_sha256"] = _hash_map_schema(PROTOCOL_ARTIFACT_PATHS)
+    properties["prompt_sha256"] = _hash_map_schema(set(parent["prompt_sha256"]))
+    properties["authorization"] = {"const": _authorization(parent)}
+    return schema
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            _write_json(args.schema, schema_document())
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+        else:
+            manifest = validate_manifest(load_json_document(args.manifest))
+            verify_frozen_components(manifest)
+        print(
+            json.dumps(
+                {
+                    "authorized_schedule_orders": AUTHORIZED_SCHEDULE_ORDERS,
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "manifest_sha256": manifest_sha256(manifest),
+                    "max_retries": 0,
+                    "request_timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+                    "status": "valid",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (BenchmarkError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_timeout_calibration_report.py
+++ b/scripts/forge_formal_timeout_calibration_report.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""为 formal 模型请求 300 秒超时校准生成审计报告。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+SCRIPT_ROOT = Path(__file__).resolve().parent
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+for root in (str(SCRIPT_ROOT), str(HARNESS_ROOT)):
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+import forge_formal_collection_v4_authorized_report as parent_report  # noqa: E402
+import forge_formal_timeout_calibration_protocol as protocol  # noqa: E402
+import forge_formal_timeout_calibration_runner as runner  # noqa: E402
+
+from deerflow.compile.evidence import EvidenceError  # noqa: E402
+
+REPORT_VERSION = "formal-timeout-calibration-report-1.0.0"
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_EVIDENCE_DIR = Path(protocol.EVIDENCE_DIRECTORY)
+DEFAULT_JSON_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-timeout-calibration.json"
+DEFAULT_MARKDOWN_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-timeout-calibration.md"
+ReportError = parent_report.ReportError
+
+
+def _load_canary_attempt_marker(evidence_dir: Path, *, manifest_sha256: str) -> dict[str, Any]:
+    marker_path = evidence_dir / "provider-canaries" / "formal-v4-provider-canary-attempt.json"
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError("缺少有效的 timeout calibration canary marker") from exc
+    if marker.get("benchmark_id") != "forge-cpp-formal-timeout-calibration":
+        raise ReportError("timeout calibration canary identity 不匹配")
+    if marker.get("manifest_sha256") != manifest_sha256 or marker.get("status") != "passed":
+        raise ReportError("timeout calibration canary 未成功")
+    return {
+        "status": marker["status"],
+        "updated_at": marker.get("updated_at"),
+        "error_class": marker.get("error_class"),
+    }
+
+
+def build_report(manifest: dict[str, Any], evidence_dir: Path, **kwargs: Any) -> dict[str, Any]:
+    original_protocol = parent_report.protocol
+    original_runner = parent_report.runner
+    original_marker_loader = parent_report._load_canary_attempt_marker
+    parent_report.protocol = protocol
+    parent_report.runner = runner
+    parent_report._load_canary_attempt_marker = _load_canary_attempt_marker
+    try:
+        report = parent_report.build_report(manifest, evidence_dir, **kwargs)
+    finally:
+        parent_report.protocol = original_protocol
+        parent_report.runner = original_runner
+        parent_report._load_canary_attempt_marker = original_marker_loader
+    report["report_version"] = REPORT_VERSION
+    report["scope"].update(
+        {
+            "formal_comparison_enabled": False,
+            "paired_primary_eligible": False,
+            "descriptive_only": True,
+        }
+    )
+    report["collection"]["stop_reason"] = "timeout_calibration_complete"
+    report["interpretation"].update(
+        {
+            "request_timeout_seconds": protocol.REQUEST_TIMEOUT_SECONDS,
+            "provider_retries": 0,
+            "formal_primary_pooling_forbidden": True,
+        }
+    )
+    report["limitations"] = [
+        "本校准只检验 300 秒客户端截止点下的请求闭合情况，不进入模型能力主比较。",
+        "若没有请求超过 120 秒，不能据此证明延长截止点能够挽救历史超时。",
+        "单一项目、每个 provider 一次 attempt 不能支持稳定性或模型优劣结论。",
+    ]
+    return report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    rendered = parent_report.render_markdown(report)
+    rendered = rendered.replace(
+        "# Forge C/C++ formal v4 首批完整项目块审计报告",
+        "# Forge C/C++ formal 模型请求 300 秒超时校准报告",
+        1,
+    )
+    rendered = rendered.replace(
+        "scripts/forge_formal_collection_v4_authorized_report.py",
+        "scripts/forge_formal_timeout_calibration_report.py",
+    )
+    rendered = rendered.replace(
+        "/workspace/.compile-sessions/benchmark-evidence-formal-v4-authorized-initial-block",
+        protocol.EVIDENCE_DIRECTORY,
+    )
+    rendered = rendered.replace(
+        "- 只包含 `cppitertools` 的两个 condition × 三次重复；原 schedule identity 未重编号。",
+        "- 只包含 `cppitertools` 的两个 condition 各一次；沿用原 schedule order `1, 2`。",
+    )
+    rendered = rendered.replace(
+        "- 单个完整 block 只能用于首批工程有效性和配对描述，不能推出总体模型优劣。",
+        "- 本批只校准请求截止点，不进入模型能力比较，也不能推出总体模型优劣。",
+    )
+    boundary = "- 本批 evidence 不进入 formal 模型能力主比较。\n- 请求超时固定 300 秒，provider retry 固定为 0。\n"
+    return rendered.replace("## 复算\n", f"{boundary}\n## 复算\n", 1)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"无法读取 manifest: {path}") from exc
+    return protocol.validate_manifest(document)
+
+
+def write_reports(report: dict[str, Any], *, json_path: Path, markdown_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8", newline="\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument("--json-output", type=Path, default=DEFAULT_JSON_REPORT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_REPORT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = build_report(load_manifest(args.manifest), args.evidence_dir)
+        write_reports(report, json_path=args.json_output, markdown_path=args.markdown_output)
+    except (EvidenceError, ReportError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report["collection"], ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_formal_timeout_calibration_runner.py
+++ b/scripts/forge_formal_timeout_calibration_runner.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""执行 formal 模型请求 300 秒超时校准。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_timeout_calibration_protocol as protocol  # noqa: E402
+
+
+def _load_parent_runner():
+    module_name = f"{__name__}_parent"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_formal_collection_v4_authorized_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the formal v4 authorized runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_runner = _load_parent_runner()
+_runner.protocol = protocol
+_runner._runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+
+
+def _authorized_slots(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    return protocol.selected_slots(manifest)
+
+
+def run_timeout_calibration_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Timeout calibration requires its frozen protocol identity")
+    if max_attempts < 1 or max_attempts > len(protocol.AUTHORIZED_SCHEDULE_ORDERS):
+        raise RunnerError("Timeout calibration permits at most two attempts")
+    result = _runner.run_formal_batch(
+        manifest,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        max_attempts=max_attempts,
+        check_endpoint=check_endpoint,
+    )
+    if result["next_authorized_index"] == len(protocol.AUTHORIZED_SCHEDULE_ORDERS):
+        result["status"] = "timeout_calibration_complete"
+    return result
+
+
+_runner._authorized_slots = _authorized_slots
+_runner._runner.run_formal_batch = run_timeout_calibration_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner._runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

- 从 formal v4 canary amendment 派生独立的 300 秒超时校准 identity
- 只授权 `cppitertools` 原 schedule order `1, 2`，RichLab 与 DeepSeek 各一次
- Lead/Compiler 请求超时统一为 300 秒，provider retry 保持 0
- 使用独立 append-only evidence，禁止进入 formal 模型能力主比较
- 增加确定性 manifest/Schema、薄 runner、报告器、预注册与聚焦回归

## 研究边界

- 不修改既有 formal v1-v4 协议、ledger、报告或失败 marker
- 不补跑或替换既有六槽，不扩大到新项目
- 不修改 Compiler invocation、attempt budget、Memory/Skill、模型、endpoint 或 Docker 拓扑
- 只有请求在 120 秒后、300 秒前成功闭合，才能作为延长截止点挽救慢请求的直接证据
- 若所有请求都在 120 秒内完成，只能证明 300 秒配置路径可运行

## 验证

- 聚焦测试：`12 passed`
- 新协议及历史 v4 扩大回归：`51 passed`
- Ruff check/format：通过
- Schema 校验与确定性再生成：通过
- canonical SHA-256：`aeb1e66b85da53dbbe91c33059825d092143a4c0fa0b3045c327524767c9b10b`
- 父文件字节和敏感信息扫描：通过
- 本 PR 尚未启动 Docker 或调用模型；主干合并后才执行真实 canary 与两次校准 attempt

Closes #117