### PR TITLE
研究：固化 300 秒超时校准结果

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,6 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-14 — 修复 formal 300 秒校准 canary 的匿名端点预检接线，等待 PR/CI 后真实执行
-  - GitHub: Issue #117 / PR #118 已将 `formal-collection-4.5.0-timeout-calibration` 合并为 `main@170d0c05`；中文 Issue #119 已创建并回读，修订分支为 `research/issue-119-timeout-canary-amendment`。
-  - 失败证据: 首次唯一 canary 在 0 模型请求时被父 runner 的匿名 endpoint preflight 拒绝；原目录只含 SHA-256 `cf4793d0...dc435` 的 `failed / RunnerError` marker，0 provider report、0 JSONL、0 formal/compile orphan，不得原地重试或删除。
-  - 修订: 新 `formal-collection-4.6.0-timeout-canary-amendment` identity 固定旧终态、新 evidence 目录和唯一 canary；只在实际 canary 调用期间强制 `check_endpoint=false` 并在 `finally` 恢复，后续建账本也禁止匿名 endpoint preflight。
-  - 不变量: 仍只授权 `cppitertools` schedule order `1, 2`，RichLab `gpt-5.5` / DeepSeek `deepseek-v4-flash` 各一次，300 秒、0 retry、500,000 recorded-token ceiling、Ubuntu daemon、Compose/DooD、Compile Session、clean replay 和禁止 primary pooling 均不变。
-  - 当前验证: canonical SHA-256 为 `4ae50bcde9ceb530491d91e214278566f7770a9432af91e3bf04a61c1a30b65a`；新增测试 `10 passed`、扩大回归 `61 passed`，Ruff、format、Schema、确定性生成、父文件、旧 marker 与敏感信息检查通过。
-  - 下一步: 中文提交、WSL helper 推送、中文 PR 和 CI；合并后运行 Ubuntu daemon gate、非模型 preflight、唯一新 canary，成功才执行两个校准槽，失败则审计终态后停止。
-
 - 2026-08-13 — 完成 formal v4 有限诊断与新 canary amendment
   - GitHub: 中文 Issue #115 已创建并回读；实现分支为 `research/formal-v4-canary-amendment`，PR 尚未创建。
   - 授权: RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各最多 2 次低成本诊断，首次成功即停止；之后最多 1 次新的双 provider canary，成功才执行原六槽，token 上限仍为 980,000。
@@ -31,6 +23,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-14 — 完成 formal 300 秒模型请求超时校准并固化确定性结果
+  - GitHub: Issue #119 / PR #120 已将 `formal-collection-4.6.0-timeout-canary-amendment` squash 合并为 `main@2c4981e4`，三项 CI 全绿；Issue #121 跟踪本结果报告并由当前提交收口。
+  - 采集: Ubuntu 原生 Docker gate、runtime preflight 13/13 和 formal non-model preflight 通过；唯一新 canary 中 RichLab `gpt-5.5` 为 17.874 秒，DeepSeek `deepseek-v4-flash` 为 0.685 秒。
+  - 结果: `cppitertools` 两个授权槽均 passed，2/2 Oracle、clean replay、finalization 和 cleanup 成功；23/23 模型请求闭合，记录 142,502/500,000 tokens，0 failed、0 cancelled、0 orphan。
+  - 解释: RichLab 9 次请求最大 33.8912 秒，DeepSeek 14 次请求最大 5.896452 秒，超过 120 秒和 300 秒均为 0。该批证明 300 秒配置路径可完整运行，但没有观测到延长截止点挽救慢请求，不能据此宣称 300 秒优于 120 秒，也不能凭单项目各一次 attempt 排名模型。
+  - 文件: `scripts/forge_formal_timeout_calibration_result.py`, `backend/tests/test_forge_formal_timeout_calibration_result.py`, `benchmarks/reports/cpp-formal-timeout-canary-amendment.json`, `benchmarks/reports/cpp-formal-timeout-canary-amendment.md`
 
 - 2026-08-12 — 固定 Ubuntu 原生 Docker 门禁并形成 formal v4 首批授权决策包
   - GitHub: Issue #109 记录双 daemon 混淆风险、门禁目标和 0 模型/0 ledger 边界；实现分支为 `research/formal-v4-ubuntu-daemon-gate`。

--- a/backend/tests/test_forge_formal_timeout_calibration_result.py
+++ b/backend/tests/test_forge_formal_timeout_calibration_result.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_formal_timeout_calibration_result.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+result = _load_module("forge_formal_timeout_calibration_result_test", SCRIPT_PATH)
+
+
+def _completed(latency: float) -> dict:
+    return {"event": "model.request_completed", "payload": {"latency_seconds": latency}}
+
+
+def test_request_latency_metrics_counts_thresholds() -> None:
+    metrics = result._request_latency_metrics([_completed(1.25), _completed(120.5), _completed(301)])
+
+    assert metrics == {
+        "completed_with_latency": 3,
+        "maximum_seconds": 301.0,
+        "over_120_seconds": 2,
+        "over_300_seconds": 1,
+    }
+
+
+@pytest.mark.parametrize("latency", [None, True, -1])
+def test_request_latency_metrics_rejects_invalid_values(latency) -> None:
+    with pytest.raises(result.ResultError, match="latency_seconds"):
+        result._request_latency_metrics([{"event": "model.request_completed", "payload": {"latency_seconds": latency}}])
+
+
+def test_build_report_adds_latency_without_changing_frozen_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    frozen = {
+        "report_version": "frozen",
+        "attempts": [
+            {
+                "case_id": "cppitertools",
+                "condition_id": "richlab-gpt-5.5",
+                "repetition": 1,
+                "model_requests": {"started": 2, "closed": 2},
+                "oracle_passed": True,
+                "token_usage": {"total_tokens": 10},
+                "attempt_duration_seconds": 1.0,
+            }
+        ],
+        "collection": {
+            "analyzed_slots": 1,
+            "authorized_slots": 1,
+            "oracle_passed": 1,
+            "recorded_total_tokens": 10,
+            "recorded_token_limit": 100,
+            "orphan_count": 0,
+        },
+        "interpretation": {},
+        "limitations": [],
+    }
+    monkeypatch.setattr(result.frozen_report, "build_report", lambda *args, **kwargs: frozen)
+    monkeypatch.setattr(
+        result.runner._authorized_runner,
+        "_observed_authorized_ledgers",
+        lambda *args, **kwargs: [
+            (
+                {"case_id": "cppitertools", "condition_id": "richlab-gpt-5.5", "repetition": 1},
+                [_completed(33.891), _completed(1.2)],
+            )
+        ],
+    )
+
+    report = result.build_report({}, tmp_path)
+
+    assert report["report_version"] == "formal-timeout-calibration-result-1.0.0"
+    assert report["collection"]["model_request_latency"] == {
+        "completed_with_latency": 2,
+        "maximum_seconds": 33.891,
+        "over_120_seconds": 0,
+        "over_300_seconds": 0,
+    }
+    assert report["interpretation"]["timeout_extension_rescue_observed"] is False
+    markdown = result.render_markdown(report)
+    assert "forge_formal_timeout_calibration_result.py" in markdown
+    assert "benchmark-evidence-formal-timeout-canary-amendment" in markdown

--- a/benchmarks/reports/cpp-formal-timeout-canary-amendment.json
+++ b/benchmarks/reports/cpp-formal-timeout-canary-amendment.json
@@ -1,0 +1,372 @@
+{
+  "attempts": [
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "gpt-5.5"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 245.157,
+      "authorized_index": 0,
+      "case_id": "cppitertools",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 6,
+        "successful": 6,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 100.079,
+          "total": 100.079
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "fefa79e80ec6beaa6881bc5d3f82e7cd827f1a1fc75dbe7a5ea04869b7aa6ffb",
+      "model_request_latency": {
+        "completed_with_latency": 9,
+        "maximum_seconds": 33.8912,
+        "over_120_seconds": 0,
+        "over_300_seconds": 0
+      },
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 9,
+        "completed": 9,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 109.173,
+        "started": 9
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": null,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 1,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_37110067b4ce4fcdaecd80d207b5f291",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "schedule_order": 1,
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 41325,
+        "output_tokens": 738,
+        "total_tokens": 42063
+      }
+    },
+    {
+      "actual_model_match": true,
+      "actual_models": [
+        "deepseek-v4-flash"
+      ],
+      "artifact_identity_diff": {
+        "expected_only_count": 0,
+        "observed_only_count": 0,
+        "type_mismatch_count": 0
+      },
+      "attempt_duration_seconds": 150.388,
+      "authorized_index": 1,
+      "case_id": "cppitertools",
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1,
+        "reconciled": 0,
+        "started": 1
+      },
+      "commands": {
+        "completed": 11,
+        "successful": 10,
+        "timed_out": 0
+      },
+      "compiler_subagents": {
+        "elapsed_seconds": {
+          "maximum": 85.159,
+          "total": 85.159
+        },
+        "failure_classifications": {},
+        "invocations": 1,
+        "statuses": {
+          "completed": 1
+        },
+        "wall_clock_limits_seconds": [
+          900
+        ],
+        "worker_stopped": 1
+      },
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "deliveries_succeeded": 1,
+      "failure_domains": {
+        "agent_tool": [],
+        "build": [],
+        "completion": [],
+        "model_endpoint": [],
+        "submit_replay": []
+      },
+      "ledger_terminal_sha256": "61fc2afd27ca4e23d07b908b9d8c32dcf98b3348c908f7258e43d07ccba12b55",
+      "model_request_latency": {
+        "completed_with_latency": 14,
+        "maximum_seconds": 5.896452,
+        "over_120_seconds": 0,
+        "over_300_seconds": 0
+      },
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 14,
+        "completed": 14,
+        "failed": 0,
+        "failure_classifications": {},
+        "latency_seconds": 28.842,
+        "started": 14
+      },
+      "network_preflight": {
+        "access_medium_recorded": false,
+        "endpoint_reachable": null,
+        "network_present": true
+      },
+      "offline_gate_recomputation_valid": true,
+      "oracle_classification": null,
+      "oracle_passed": true,
+      "order": 2,
+      "orphan_cleanup_succeeded": true,
+      "orphan_count": 0,
+      "physical_attempt_id": "physical_attempt_4aff146d10f24a5dbd98797b0f232a11",
+      "recorded_gate_recomputation_valid": true,
+      "repetition": 1,
+      "replay_artifact_diff": {
+        "available": true,
+        "mismatch_count": 0
+      },
+      "schedule_order": 2,
+      "session_finalization_succeeded": true,
+      "submits": {
+        "aborted": 0,
+        "completed": 1,
+        "started": 1
+      },
+      "terminal_status": "passed",
+      "token_usage": {
+        "input_tokens": 97294,
+        "output_tokens": 3145,
+        "total_tokens": 100439
+      }
+    }
+  ],
+  "authorization": {
+    "access_medium": "mobile_hotspot",
+    "authorized_schedule_orders": [
+      1,
+      2
+    ],
+    "budget_enforcement": "stop_before_next_slot_when_recorded_total_reaches_limit",
+    "maximum_recorded_tokens": 500000,
+    "remaining_slots_require_confirmation": true
+  },
+  "benchmark_id": "forge-cpp-formal-timeout-canary-amendment",
+  "canary": {
+    "attempt_marker": {
+      "error_class": null,
+      "status": "passed",
+      "updated_at": "2026-08-13T17:23:24.785577+00:00"
+    },
+    "conditions": [
+      {
+        "duration_ms": 17874,
+        "id": "richlab-gpt-5.5",
+        "model": "gpt-5.5",
+        "passed": true
+      },
+      {
+        "duration_ms": 685,
+        "id": "deepseek-v4-flash",
+        "model": "deepseek-v4-flash",
+        "passed": true
+      }
+    ],
+    "failed_reports": 0,
+    "reports_discovered": 1,
+    "selected_canary_id": "provider_canary_e3aece3ed74e476096d46448078bc58c",
+    "selected_completed_at": "2026-08-13T17:23:24.741714+00:00",
+    "selected_report_sha256": "fdf8f37cd7973b2053aa68d60e39ac14c5800d008277afa4fed3040b0fa8d3ad",
+    "successful_reports": 1
+  },
+  "collection": {
+    "actual_model_matches": 2,
+    "analyzed_slots": 2,
+    "attempt_duration_seconds": 395.545,
+    "authorized_slots": 2,
+    "compiler_subagent_invocations": 2,
+    "complete_project_block": true,
+    "gate_recomputation_valid": 2,
+    "ledger_hash_chain_valid": 2,
+    "model_request_latency": {
+      "completed_with_latency": 23,
+      "maximum_seconds": 33.8912,
+      "over_120_seconds": 0,
+      "over_300_seconds": 0
+    },
+    "model_requests": {
+      "cancelled": 0,
+      "closed": 23,
+      "completed": 23,
+      "failed": 0,
+      "started": 23
+    },
+    "next_authorized_index": 2,
+    "oracle_failed": 0,
+    "oracle_passed": 2,
+    "orphan_cleanup_succeeded": 2,
+    "orphan_count": 0,
+    "recorded_token_limit": 500000,
+    "recorded_tokens_over_boundary": 0,
+    "recorded_total_tokens": 142502,
+    "session_finalization_succeeded": 2,
+    "stop_reason": "timeout_calibration_complete",
+    "terminal_completed": 2
+  },
+  "conditions": [
+    {
+      "attempt_duration_seconds": {
+        "maximum": 245.157,
+        "median": 245.157,
+        "minimum": 245.157,
+        "total": 245.157
+      },
+      "attempts": 1,
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1
+      },
+      "commands_completed": 6,
+      "condition_id": "richlab-gpt-5.5",
+      "configured_model": "gpt-5.5",
+      "failure_event_counts": {},
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 9,
+        "completed": 9,
+        "failed": 0,
+        "started": 9
+      },
+      "oracle_failed": 0,
+      "oracle_passed": 1,
+      "submits_completed": 1,
+      "token_usage": {
+        "input_tokens": 41325,
+        "output_tokens": 738,
+        "total_tokens": 42063
+      }
+    },
+    {
+      "attempt_duration_seconds": {
+        "maximum": 150.388,
+        "median": 150.388,
+        "minimum": 150.388,
+        "total": 150.388
+      },
+      "attempts": 1,
+      "clean_replays": {
+        "completed": 1,
+        "failed": 0,
+        "passed": 1
+      },
+      "commands_completed": 11,
+      "condition_id": "deepseek-v4-flash",
+      "configured_model": "deepseek-v4-flash",
+      "failure_event_counts": {},
+      "model_requests": {
+        "cancelled": 0,
+        "closed": 14,
+        "completed": 14,
+        "failed": 0,
+        "started": 14
+      },
+      "oracle_failed": 0,
+      "oracle_passed": 1,
+      "submits_completed": 1,
+      "token_usage": {
+        "input_tokens": 97294,
+        "output_tokens": 3145,
+        "total_tokens": 100439
+      }
+    }
+  ],
+  "failure_event_counts": {},
+  "interpretation": {
+    "anonymous_models_endpoint_preflight": "forbidden",
+    "complete_block_required_for_paired_primary": true,
+    "formal_primary_pooling_forbidden": true,
+    "historical_ledgers_modified": false,
+    "provider_retries": 0,
+    "request_timeout_seconds": 300,
+    "retry_replacement_backfill_performed": false,
+    "timeout_extension_rescue_observed": false,
+    "ubuntu_native_daemon_required": true,
+    "v3_slots_8_to_10_created": false
+  },
+  "limitations": [
+    "本校准只检验 300 秒客户端截止点下的请求闭合情况，不进入模型能力主比较。",
+    "若没有请求超过 120 秒，不能据此证明延长截止点能够挽救历史超时。",
+    "单一项目、每个 provider 一次 attempt 不能支持稳定性或模型优劣结论。",
+    "旧 canary 失败与本修订层分开保留，不能合并解释为一次成功重试。",
+    "本批没有超过 120 秒的请求时，只能证明 300 秒配置路径可运行，不能证明延长截止点产生了挽救效果。"
+  ],
+  "manifest_sha256": "4ae50bcde9ceb530491d91e214278566f7770a9432af91e3bf04a61c1a30b65a",
+  "report_version": "formal-timeout-calibration-result-1.0.0",
+  "scope": {
+    "descriptive_only": true,
+    "formal_comparison_enabled": false,
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "paired_primary_eligible": false,
+    "phase": "formal_timeout_canary_amendment"
+  }
+}

--- a/benchmarks/reports/cpp-formal-timeout-canary-amendment.md
+++ b/benchmarks/reports/cpp-formal-timeout-canary-amendment.md
@@ -1,0 +1,31 @@
+# Forge C/C++ formal 模型请求 300 秒超时校准结果
+
+> 本报告由只读结果分析器从冻结 manifest 和 append-only ledger 确定性生成。
+
+## 摘要
+
+- 完成 2/2 个授权 slot，Oracle 通过 2/2。
+- 23/23 模型请求闭合，记录 142,502/500,000 tokens，orphan=0。
+- 最大请求延迟 33.891 秒；超过 120 秒 0 次，超过 300 秒 0 次。
+- 本批证明 300 秒配置路径可完整运行；没有请求超过 120 秒，因此没有观察到超时延长实际挽救慢请求。
+
+## 每个条件
+
+| Condition | 请求闭合 | 最大延迟 (s) | >120s | >300s | Oracle | Tokens | Wall time (s) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `richlab-gpt-5.5` | 9/9 | 33.891 | 0 | 0 | pass | 42,063 | 245.157 |
+| `deepseek-v4-flash` | 14/14 | 5.896 | 0 | 0 | pass | 100,439 | 150.388 |
+
+## 研究边界
+
+- 结果为 descriptive-only，不进入 formal 模型能力主比较，也不能用于两个模型的总体排名。
+- 单一项目、每个 provider 一次 attempt 不能估计长期网络稳定性或超时参数的因果效应。
+- 没有 retry、fallback、replacement 或 backfill；旧失败 canary 与本修订层分别保留。
+
+## 复算
+
+```bash
+/app/backend/.venv/bin/python /repo/scripts/forge_formal_timeout_calibration_result.py \
+  --manifest /repo/benchmarks/manifests/cpp-formal-timeout-canary-amendment.json \
+  --evidence-dir /workspace/.compile-sessions/benchmark-evidence-formal-timeout-canary-amendment
+```

--- a/scripts/forge_formal_timeout_calibration_result.py
+++ b/scripts/forge_formal_timeout_calibration_result.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""生成 300 秒超时校准的只读结果报告。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_formal_timeout_calibration_canary_amendment_protocol as protocol  # noqa: E402
+import forge_formal_timeout_calibration_canary_amendment_report as frozen_report  # noqa: E402
+import forge_formal_timeout_calibration_canary_amendment_runner as runner  # noqa: E402
+
+REPORT_VERSION = "formal-timeout-calibration-result-1.0.0"
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_EVIDENCE_DIR = Path(protocol.EVIDENCE_DIRECTORY)
+DEFAULT_JSON_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-timeout-canary-amendment.json"
+DEFAULT_MARKDOWN_REPORT = REPO_ROOT / "benchmarks" / "reports" / "cpp-formal-timeout-canary-amendment.md"
+ResultError = frozen_report.ReportError
+
+
+def _request_latency_metrics(events: list[dict[str, Any]]) -> dict[str, Any]:
+    latencies: list[float] = []
+    for event in events:
+        if event.get("event") != "model.request_completed":
+            continue
+        latency = (event.get("payload") or {}).get("latency_seconds")
+        if isinstance(latency, bool) or not isinstance(latency, (int, float)) or latency < 0:
+            raise ResultError("model.request_completed 缺少有效 latency_seconds")
+        latencies.append(float(latency))
+    return {
+        "completed_with_latency": len(latencies),
+        "maximum_seconds": round(max(latencies), 6) if latencies else None,
+        "over_120_seconds": sum(value > 120 for value in latencies),
+        "over_300_seconds": sum(value > 300 for value in latencies),
+    }
+
+
+def build_report(manifest: dict[str, Any], evidence_dir: Path) -> dict[str, Any]:
+    report = frozen_report.build_report(manifest, evidence_dir)
+    observed = runner._authorized_runner._observed_authorized_ledgers(manifest, output_dir=evidence_dir)
+    metrics_by_slot = {(slot["case_id"], slot["condition_id"], slot["repetition"]): _request_latency_metrics(events) for slot, events in observed}
+    for attempt in report["attempts"]:
+        key = (attempt["case_id"], attempt["condition_id"], attempt["repetition"])
+        try:
+            attempt["model_request_latency"] = metrics_by_slot[key]
+        except KeyError as exc:
+            raise ResultError("结果报告与 physical-attempt ledger 不一致") from exc
+    if len(metrics_by_slot) != len(report["attempts"]):
+        raise ResultError("结果报告未覆盖全部 physical-attempt ledger")
+
+    all_metrics = [attempt["model_request_latency"] for attempt in report["attempts"]]
+    report["collection"]["model_request_latency"] = {
+        "completed_with_latency": sum(item["completed_with_latency"] for item in all_metrics),
+        "maximum_seconds": max(item["maximum_seconds"] for item in all_metrics if item["maximum_seconds"] is not None),
+        "over_120_seconds": sum(item["over_120_seconds"] for item in all_metrics),
+        "over_300_seconds": sum(item["over_300_seconds"] for item in all_metrics),
+    }
+    report["report_version"] = REPORT_VERSION
+    report["interpretation"]["timeout_extension_rescue_observed"] = report["collection"]["model_request_latency"]["over_120_seconds"] > 0
+    report["limitations"].append("本批没有超过 120 秒的请求时，只能证明 300 秒配置路径可运行，不能证明延长截止点产生了挽救效果。")
+    return report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    collection = report["collection"]
+    lines = [
+        "# Forge C/C++ formal 模型请求 300 秒超时校准结果",
+        "",
+        "> 本报告由只读结果分析器从冻结 manifest 和 append-only ledger 确定性生成。",
+        "",
+        "## 摘要",
+        "",
+        f"- 完成 {collection['analyzed_slots']}/{collection['authorized_slots']} 个授权 slot，Oracle 通过 {collection['oracle_passed']}/{collection['analyzed_slots']}。",
+        f"- 23/23 模型请求闭合，记录 {collection['recorded_total_tokens']:,}/{collection['recorded_token_limit']:,} tokens，orphan={collection['orphan_count']}。",
+        f"- 最大请求延迟 {collection['model_request_latency']['maximum_seconds']:.3f} 秒；超过 120 秒 {collection['model_request_latency']['over_120_seconds']} 次，超过 300 秒 {collection['model_request_latency']['over_300_seconds']} 次。",
+        "- 本批证明 300 秒配置路径可完整运行；没有请求超过 120 秒，因此没有观察到超时延长实际挽救慢请求。",
+        "",
+        "## 每个条件",
+        "",
+        "| Condition | 请求闭合 | 最大延迟 (s) | >120s | >300s | Oracle | Tokens | Wall time (s) |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for attempt in report["attempts"]:
+        latency = attempt["model_request_latency"]
+        requests = attempt["model_requests"]
+        lines.append(
+            f"| `{attempt['condition_id']}` | {requests['closed']}/{requests['started']} | {latency['maximum_seconds']:.3f} | "
+            f"{latency['over_120_seconds']} | {latency['over_300_seconds']} | {'pass' if attempt['oracle_passed'] else 'fail'} | "
+            f"{attempt['token_usage']['total_tokens']:,} | {attempt['attempt_duration_seconds']:.3f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## 研究边界",
+            "",
+            "- 结果为 descriptive-only，不进入 formal 模型能力主比较，也不能用于两个模型的总体排名。",
+            "- 单一项目、每个 provider 一次 attempt 不能估计长期网络稳定性或超时参数的因果效应。",
+            "- 没有 retry、fallback、replacement 或 backfill；旧失败 canary 与本修订层分别保留。",
+            "",
+            "## 复算",
+            "",
+            "```bash",
+            "/app/backend/.venv/bin/python /repo/scripts/forge_formal_timeout_calibration_result.py \\",
+            "  --manifest /repo/benchmarks/manifests/cpp-formal-timeout-canary-amendment.json \\",
+            "  --evidence-dir /workspace/.compile-sessions/benchmark-evidence-formal-timeout-canary-amendment",
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_reports(report: dict[str, Any], *, json_path: Path, markdown_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8", newline="\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument("--json-output", type=Path, default=DEFAULT_JSON_REPORT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_REPORT)
+    args = parser.parse_args(argv)
+    try:
+        manifest = protocol.validate_manifest(protocol.load_json_document(args.manifest))
+        report = build_report(manifest, args.evidence_dir)
+        write_reports(report, json_path=args.json_output, markdown_path=args.markdown_output)
+    except (ResultError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report["collection"], ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增只读结果分析器，从冻结 manifest 与 append-only ledger 汇总请求延迟
- 固化 300 秒超时校准的确定性 JSON/Markdown 报告
- 更新项目状态快照，记录实验结果、解释边界和后续研究方向

## 结果

- 两个授权槽均通过，Oracle 2/2
- 23/23 模型请求闭合，记录 142,502/500,000 tokens，0 orphan
- 最大请求延迟 33.8912 秒，超过 120 秒和 300 秒均为 0
- 只证明 300 秒配置路径可完整运行，不宣称 300 秒优于 120 秒，不进行模型总体排名

## 验证

- 分析器测试：5 passed
- Ruff check / format：通过
- 容器内确定性复算：JSON、Markdown 与版本化报告逐字一致
- git diff --check 与敏感信息模式扫描：通过

Closes #121
