### PR TITLE
研究：冻结 verifier-driven repair 配对试验设计

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -24,6 +24,14 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-14 — 完成 verifier-driven repair 配对 pilot 未授权决策包
+  - GitHub: Issue #123 与 PR #124 使用中文创建并回读；核心设计提交为 `f5798c5e`。
+  - 证据: formal v4 中一个槽在 `candidate_verification_failed -> build_system_unproven` 后自然修复并通过，另一个 `recipe_execution_failed` 槽被后续 endpoint timeout 混杂；这些轨迹只支持 treatment 设计，不能估计效果。
+  - Treatment: baseline 已返回状态、追踪 ID、候选 artifact 元数据与首条错误 message，但没有标准化 failure classification、failed checks、build-system identity 或 artifact diff；treatment 只增加确定性结构化 `repair_packet`，不增加模型请求、Compiler invocation、turn、timeout 或 token 预算，也不改变 Oracle/clean replay/delivery。
+  - Pilot: 从冻结 case protocol 按 prior-exposure 规则选择 `liblouis`、`openthread`、`mupdf`，覆盖 Autotools/CMake/Make；双 provider、双 arm、一次重复，共 12 槽/6 pair，expected 800,000、maximum 2,400,000 recorded tokens。
+  - 边界与验证: `collection_authorized=false`、`runtime_implementation_authorized=false`；12 个唯一槽、6 个完整 pair、3/3 顺序平衡、case 来源、四份冻结 SHA-256、diff 与敏感信息检查通过。未启动 Docker、未调用模型、未修改 Forge 核心或历史 evidence。
+  - 文件: `benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json`, `benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.md`
+
 - 2026-08-14 — 完成 formal 300 秒模型请求超时校准并固化确定性结果
   - GitHub: Issue #119 / PR #120 已将 `formal-collection-4.6.0-timeout-canary-amendment` squash 合并为 `main@2c4981e4`，三项 CI 全绿；Issue #121 跟踪本结果报告并由当前提交收口。
   - 采集: Ubuntu 原生 Docker gate、runtime preflight 13/13 和 formal non-model preflight 通过；唯一新 canary 中 RichLab `gpt-5.5` 为 17.874 秒，DeepSeek `deepseek-v4-flash` 为 0.685 秒。

--- a/benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json
+++ b/benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json
@@ -1,0 +1,251 @@
+{
+  "schema_version": "verifier-driven-repair-pilot-design-1.0.0",
+  "document_type": "preregistration_decision_package",
+  "protocolization": {
+    "id": "forge-cpp-verifier-driven-repair-pilot-v1-candidate",
+    "issue": 123,
+    "designed_at": "2026-08-14",
+    "base_commit": "6eb69e64d6b14df958814e25c917dff801569ab0",
+    "design_only": true,
+    "runtime_implementation_authorized": false,
+    "collection_authorized": false
+  },
+  "research_question": "在相同模型、项目、容器和总预算下，向 Compiler 返回确定性的结构化 verifier repair packet，能否提高 C/C++ 自动编译的 Oracle 与端到端成功率？",
+  "hypotheses": {
+    "primary": "repair_packet treatment 的 Oracle 成功概率高于当前 baseline。",
+    "secondary": [
+      "repair_packet treatment 提高首次 verifier 拒绝后的修复转化率。",
+      "repair_packet treatment 不增加 false acceptance。",
+      "repair_packet treatment 的成功增益不能以更高的请求、token 或墙钟预算换取。"
+    ],
+    "pilot_claim_boundary": "首批 12 槽只验证 treatment fidelity、成本与可行性，不进行显著性检验或总体效果声明。"
+  },
+  "historical_evidence": {
+    "case_protocol": {
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+    },
+    "formal_v4_report": {
+      "local_path": ".compile-sessions/benchmark-evidence-formal-v4-canary-amendment/formal-v4-canary-amendment-report.json",
+      "sha256": "59525c3945714282dbedf53474aa25530b82b119aacf6ca5c72a5c462c4484d9",
+      "summary": {
+        "attempts": 6,
+        "oracle_passed": 2,
+        "terminal_passed": 1,
+        "model_requests_closed": 63,
+        "model_request_timeouts": 8,
+        "orphan_count": 0
+      },
+      "repair_episodes": [
+        {
+          "physical_attempt_id": "physical_attempt_51d6a182c32c4a938a4f65ab948c8a9d",
+          "condition_id": "deepseek-v4-flash",
+          "observed_sequence": [
+            "candidate_verification_failed",
+            "build_system_unproven",
+            "submit_passed",
+            "clean_replay_passed",
+            "experiment_passed"
+          ],
+          "interpretation": "现有通用工具返回下也可能自然修复，证明 repair 可行，但不能证明结构化 packet 的增益。"
+        },
+        {
+          "physical_attempt_id": "physical_attempt_ff3bbf0545054903aa3ef05966dc0ed6",
+          "condition_id": "richlab-gpt-5.5",
+          "observed_sequence": [
+            "recipe_execution_failed",
+            "model_endpoint_timeout",
+            "model_endpoint_timeout",
+            "experiment_failed"
+          ],
+          "interpretation": "verifier 拒绝后的失败与 endpoint timeout 混杂，不能作为 treatment 负例。"
+        }
+      ]
+    },
+    "formal_v3_report": {
+      "path": "benchmarks/reports/cpp-formal-v3-initial-batch.json",
+      "sha256": "1140637ae8ba519aedc9185099e27ddb652f2ee0a31ab2586705d505c312381f"
+    },
+    "pilot_v8_report": {
+      "path": "benchmarks/reports/cpp-pilot-v8-descriptive.json",
+      "sha256": "e3b60b44977af0f5783f156e90b03023b17c3b8dc2a84a7a44ec865a1642b87f"
+    }
+  },
+  "current_baseline": {
+    "submit_failure_payload_fields": [
+      "exit_code",
+      "status",
+      "candidate_status",
+      "replay_status",
+      "replay_attempt_id",
+      "submit_attempt_id",
+      "supporting_command_id",
+      "image_id",
+      "artifact_count",
+      "artifacts",
+      "message"
+    ],
+    "failure_diagnostics_returned_to_compiler": "通用 message、状态、追踪 ID 与候选 artifact 元数据；message 只返回首条 Error note。",
+    "normalized_failure_classification_returned_to_compiler": false,
+    "failed_checks_and_structured_diffs_returned_to_compiler": false,
+    "compiler_already_instructed_to_continue_after_submit_failure": true,
+    "natural_multiple_submit_attempts_allowed_within_existing_limits": true
+  },
+  "treatments": [
+    {
+      "id": "baseline-current-verifier-output",
+      "repair_packet_enabled": false,
+      "definition": "保持 main@6eb69e64 的 submit_build_result 失败返回和 Compiler prompt 不变。"
+    },
+    {
+      "id": "structured-verifier-repair-packet",
+      "repair_packet_enabled": true,
+      "definition": "只在可修复的 verification-domain submit 失败后，在同一工具返回中增加确定性的 repair_packet；不增加模型调用、Compiler invocation、turn、timeout 或 token 预算。",
+      "packet_fields": [
+        "schema_version",
+        "failure_domain",
+        "primary_classification",
+        "failed_checks",
+        "build_system_identity",
+        "artifact_identity_diff",
+        "replay_status",
+        "repair_goal",
+        "supporting_command_id",
+        "submit_attempt_id",
+        "replay_attempt_id"
+      ],
+      "packet_constraints": [
+        "只包含 verifier 已持久化的白名单结构化字段。",
+        "不包含 stdout、stderr、prompt、模型正文、密钥、宿主路径或生成式修复命令。",
+        "repair_goal 由固定 classification 映射生成，不调用模型。",
+        "acceptance gate、artifact Oracle、clean replay 与 delivery 语义保持不变。"
+      ]
+    }
+  ],
+  "activation_policy": {
+    "actionable_classifications": [
+      "candidate_verification_failed",
+      "build_system_selection_mismatch",
+      "build_system_unproven",
+      "build_system_mismatch",
+      "recipe_execution_failed",
+      "artifact_set_mismatch",
+      "artifact_type_mismatch",
+      "size_mismatch",
+      "sha256_mismatch",
+      "smoke_mismatch"
+    ],
+    "non_actionable_for_treatment_attribution": [
+      "model_endpoint_timeout",
+      "provider_connection_failure",
+      "attempt_budget_exhausted",
+      "compiler_wall_clock_timeout",
+      "daemon_or_preflight_failure",
+      "cleanup_or_finalization_failure"
+    ],
+    "maximum_packets_per_submit": 1,
+    "maximum_additional_model_requests": 0,
+    "maximum_additional_compiler_invocations": 0
+  },
+  "case_selection": {
+    "rule": "按冻结 formal-v1 case protocol 的原始顺序，在每个 build-system stratum 中选择第一个从未进入 formal v3/v4 physical attempt 的 case；只看 prior exposure，不看成功或失败结果。",
+    "excluded_prior_exposure": [
+      "powerdns",
+      "open62541",
+      "cppitertools",
+      "janet"
+    ],
+    "cases": [
+      {
+        "id": "liblouis",
+        "build_system": "autotools",
+        "repository_url": "https://github.com/liblouis/liblouis",
+        "commit": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+        "required_artifact": "liblouis.a"
+      },
+      {
+        "id": "openthread",
+        "build_system": "cmake",
+        "repository_url": "https://github.com/openthread/openthread",
+        "commit": "044aa98f1b5255731e0a6f2816e267b282299684",
+        "required_artifact": "libopenthread-ftd.a"
+      },
+      {
+        "id": "mupdf",
+        "build_system": "make",
+        "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+        "commit": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+        "required_artifact": "libmupdf.a"
+      }
+    ]
+  },
+  "provider_conditions": [
+    {
+      "id": "richlab-gpt-5.5",
+      "model": "gpt-5.5"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "model": "deepseek-v4-flash"
+    }
+  ],
+  "pilot_schedule": [
+    {"order": 1, "pair_id": "liblouis-richlab-r1", "case_id": "liblouis", "provider_condition": "richlab-gpt-5.5", "treatment": "baseline-current-verifier-output", "repetition": 1},
+    {"order": 2, "pair_id": "liblouis-richlab-r1", "case_id": "liblouis", "provider_condition": "richlab-gpt-5.5", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 3, "pair_id": "liblouis-deepseek-r1", "case_id": "liblouis", "provider_condition": "deepseek-v4-flash", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 4, "pair_id": "liblouis-deepseek-r1", "case_id": "liblouis", "provider_condition": "deepseek-v4-flash", "treatment": "baseline-current-verifier-output", "repetition": 1},
+    {"order": 5, "pair_id": "openthread-richlab-r1", "case_id": "openthread", "provider_condition": "richlab-gpt-5.5", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 6, "pair_id": "openthread-richlab-r1", "case_id": "openthread", "provider_condition": "richlab-gpt-5.5", "treatment": "baseline-current-verifier-output", "repetition": 1},
+    {"order": 7, "pair_id": "openthread-deepseek-r1", "case_id": "openthread", "provider_condition": "deepseek-v4-flash", "treatment": "baseline-current-verifier-output", "repetition": 1},
+    {"order": 8, "pair_id": "openthread-deepseek-r1", "case_id": "openthread", "provider_condition": "deepseek-v4-flash", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 9, "pair_id": "mupdf-richlab-r1", "case_id": "mupdf", "provider_condition": "richlab-gpt-5.5", "treatment": "baseline-current-verifier-output", "repetition": 1},
+    {"order": 10, "pair_id": "mupdf-richlab-r1", "case_id": "mupdf", "provider_condition": "richlab-gpt-5.5", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 11, "pair_id": "mupdf-deepseek-r1", "case_id": "mupdf", "provider_condition": "deepseek-v4-flash", "treatment": "structured-verifier-repair-packet", "repetition": 1},
+    {"order": 12, "pair_id": "mupdf-deepseek-r1", "case_id": "mupdf", "provider_condition": "deepseek-v4-flash", "treatment": "baseline-current-verifier-output", "repetition": 1}
+  ],
+  "budget_proposal": {
+    "authorized": false,
+    "request_timeout_seconds": 300,
+    "provider_retries": 0,
+    "attempt_total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "model_turn_limit": 36,
+    "maximum_recorded_tokens": 2400000,
+    "expected_recorded_tokens": 800000,
+    "budget_check_boundary": "before_each_complete_pair",
+    "remaining_pairs_require_confirmation": true
+  },
+  "invariants": [
+    "两个 treatment 使用相同 model、prompt、case、commit、image ID、网络、预算和 acceptance gate。",
+    "每个 physical attempt 使用全新 Compile Session 和 clean replay；不共享 workspace、artifacts、Memory 或 Skill。",
+    "同一 pair 必须完整执行两个 arm 才进入 paired pilot 分析；不做 replacement 或 backfill。",
+    "provider timeout 与基础设施失败单独报告，不归因于 repair treatment。",
+    "分析器、失败层级和 treatment fidelity gate 必须在首个模型请求前冻结。",
+    "运行时实现、canary、attempt 和 batch 必须由后续独立中文 Issue/PR 与用户预算授权放行。"
+  ],
+  "outcomes": {
+    "primary": "oracle_passed",
+    "secondary": [
+      "terminal_passed",
+      "repair_conversion_after_actionable_verifier_failure",
+      "false_acceptance_count",
+      "submit_attempts",
+      "clean_replay_attempts",
+      "model_requests",
+      "recorded_tokens",
+      "attempt_wall_clock_seconds",
+      "failure_classification_transition"
+    ],
+    "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+    "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+  },
+  "external_method_references": [
+    {"name": "CXXCrafter", "url": "https://github.com/seclab-fudan/CXXCrafter-Community-Edition", "relevance": "C/C++ 构建脚本生成与执行-反馈-修复闭环。"},
+    {"name": "Self-Refine", "url": "https://arxiv.org/abs/2303.17651", "relevance": "反馈与迭代改进的通用范式。"},
+    {"name": "CRITIC", "url": "https://arxiv.org/abs/2305.11738", "relevance": "外部工具反馈驱动的自我校正。"},
+    {"name": "SWE-agent", "url": "https://arxiv.org/abs/2405.15793", "relevance": "真实软件环境中的 Agent-Computer Interface。"},
+    {"name": "RepairAgent", "url": "https://arxiv.org/abs/2403.17134", "relevance": "测试失败驱动的自主修复循环。"}
+  ]
+}

--- a/benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.md
+++ b/benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.md
@@ -1,0 +1,85 @@
+# Forge C/C++ verifier-driven repair pilot 决策包
+
+> 状态：设计完成，运行时实现与模型采集均未授权。跟踪 Issue：#123。
+
+## 研究问题
+
+在模型、项目、容器、调用次数、token 和墙钟预算都相同的条件下，向 Compiler 返回确定性的结构化 verifier repair packet，能否提高 C/C++ 自动编译的 Oracle 与端到端成功率？
+
+首批 12 槽只是可行性 pilot。它验证 treatment 是否真的只改变反馈、证据是否闭合、成本是否可承受，不做显著性检验、模型排名或总体效果声明。
+
+## 为什么不是“有 verifier / 无 verifier”
+
+当前 baseline 已经具备强制 artifact 检查和 clean replay，Compiler prompt 也要求 `submit_build_result` 失败后继续修复。现有失败返回包含状态、attempt/command ID、镜像、候选 artifact 元数据和首条错误 `message`，并非“没有反馈”；但它没有把 evidence 中的 primary classification、failed checks、build-system identity 或 artifact diff 规范化返回给 Compiler。
+
+因此 treatment 的唯一变化是：在可修复的 verification-domain submit 失败后，把 verifier 已有的白名单结构化事实作为 `repair_packet` 附加到同一次工具返回。它不增加调用次数、turn、timeout 或 token 预算，也不改变 Oracle、clean replay 或 delivery gate。
+
+## 既有证据信号
+
+- formal v4 的 DeepSeek `cppitertools` rep-001 先后出现 `candidate_verification_failed` 和 `build_system_unproven`，第三次 submit 与 clean replay 通过。这证明现有 Agent 能自然修复，但不是 treatment 效果证据。
+- formal v4 的 RichLab rep-002 在 `recipe_execution_failed` 后连续遇到 endpoint timeout，最终失败；该轨迹被网络事件混杂，不能作为 repair treatment 的负例。
+- formal v3 的 `open62541` 和 pilot v8 的 `hiredis`、`libcheck`、`sysstat` 还观察到 size、SHA-256、build-system 与候选验证失败，说明 verifier failure taxonomy 不只存在于单一项目。
+- 所有历史 ledger/report 保持冻结，本决策包只引用路径、SHA-256、physical attempt ID 和白名单事件。
+
+## Treatment
+
+| Arm | 行为 |
+|---|---|
+| Baseline | 保持 `main@6eb69e64` 的失败 payload 和 Compiler prompt 不变。 |
+| Repair packet | 在同一失败 payload 中增加固定 schema 的 `repair_packet`。 |
+
+packet 只允许以下内容：failure domain、primary classification、failed checks、build-system identity、artifact identity diff、replay status、固定 repair goal，以及 submit/replay/supporting-command ID。禁止 stdout/stderr、prompt、模型正文、密钥、宿主路径和生成式修复命令。
+
+以下 verification classification 可激活 treatment：候选验证失败、build-system selection/unproven/mismatch、recipe execution、artifact set/type/size/SHA-256 和 smoke mismatch。
+
+模型 endpoint、provider 连接、attempt/Compiler 预算、daemon/preflight、cleanup/finalization 失败不属于 treatment 可修复事件，必须单列，不能算成 repair 失败。
+
+## Case 选择
+
+选择规则在结果之外固定：按 formal-v1 case protocol 的原始顺序，在 Autotools、CMake、Make 三个 stratum 中分别选择第一个从未进入 formal v3/v4 physical attempt 的项目。只依据 prior exposure，不依据历史成功或失败。
+
+| Case | Build system | Exact commit | Oracle artifact |
+|---|---|---|---|
+| `liblouis` | Autotools | `b52ab11ade4cf0917315991b54a8558a2589cf55` | `liblouis.a` |
+| `openthread` | CMake | `044aa98f1b5255731e0a6f2816e267b282299684` | `libopenthread-ftd.a` |
+| `mupdf` | Make | `b29caae1ab8c602187d4fc36d7b540bac493635d` | `libmupdf.a` |
+
+## Pilot 规模
+
+设计为 `3 cases × 2 providers × 2 treatment arms × 1 repetition = 12 slots`，形成 6 个完整 pair。每个 pair 的 treatment 顺序交叉平衡，防止所有 baseline 或 treatment 总在更早的网络时段运行。
+
+- RichLab：`gpt-5.5`
+- DeepSeek：`deepseek-v4-flash`
+- request timeout：300 秒
+- provider retry：0
+- physical-attempt 总墙钟：1,800 秒
+- 每 attempt 最多 2 次 Compiler invocation、48 次模型请求、36 turns
+- 建议 expected recorded tokens：800,000
+- 建议 maximum recorded tokens：2,400,000
+
+预算只在完整 pair 前检查。若只完成一个 arm，已有 attempt 保留为描述性证据，但该 pair 不进入 paired pilot 结果。禁止 retry、replacement、fallback 和 backfill。
+
+## 指标与判定
+
+主要指标为 `oracle_passed`。次要指标包括：端到端 terminal pass、首次 actionable verifier failure 后的修复转化、false acceptance、submit/replay 次数、模型请求、tokens、墙钟和 failure transition。
+
+pilot 只报告 6 个 pair 的一致/不一致结果与成本，不计算 p-value。只有 treatment fidelity、evidence、预算和运行稳定性都通过，下一阶段才设计至少 3 次重复的正式实验。
+
+## 有效性边界
+
+- 两个 arm 使用相同 prompt、模型、case、commit、镜像、网络与预算；Memory 和 Skill 均关闭。
+- 每个 attempt 使用全新 Compile Session 和 clean replay，不共享 workspace 或 artifacts。
+- packet 本身会增加少量输入 token，必须单独计量，不能隐藏在成功率中。
+- 模型随机性无法由单次 repetition 消除，因此 pilot 不估计正式效应大小。
+- runtime adapter、Schema、runner、canary 和 analyzer 必须在任何模型请求前另行实现和冻结。
+- 本文件和 JSON 均不授权模型调用。真实实现与采集必须另开中文 Issue/PR，并由实验负责人确认槽位和 token ceiling。
+
+## 方法来源
+
+- [CXXCrafter](https://github.com/seclab-fudan/CXXCrafter-Community-Edition)：C/C++ 构建脚本生成与执行-反馈-修复闭环。
+- [Self-Refine](https://arxiv.org/abs/2303.17651)：反馈与迭代改进范式。
+- [CRITIC](https://arxiv.org/abs/2305.11738)：外部工具反馈驱动的自我校正。
+- [SWE-agent](https://arxiv.org/abs/2405.15793)：真实软件环境中的 Agent-Computer Interface。
+- [RepairAgent](https://arxiv.org/abs/2403.17134)：测试失败驱动的自主修复循环。
+
+机器可读来源为 `cpp-verifier-driven-repair-pilot-v1.json`。若 Markdown 与 JSON 冲突，以 JSON 为准。


### PR DESCRIPTION
## 目标

基于 formal v4 冻结 evidence，预注册 verifier-driven repair 的配对可行性 pilot，明确 baseline、treatment、case 选择、预算和有效性边界。

## 设计

- baseline 保持当前 submit 失败反馈不变；
- treatment 只增加由 verifier 已持久化事实生成的结构化 repair packet；
- 不增加模型请求、Compiler invocation、turn、timeout 或 token 预算；
- 结果盲态选择 liblouis、openthread、mupdf，覆盖 Autotools、CMake、Make；
- 双 provider、双 arm、一次重复，共 12 槽、6 个完整 pair，顺序交叉平衡；
- pilot 只做 treatment fidelity、成本和可行性描述，不做显著性检验或模型排名。

## 边界

- collection_authorized=false；
- runtime_implementation_authorized=false；
- 未修改 Forge 编译核心、历史 manifest、runner、Schema、ledger 或 report；
- 未启动 Docker，未调用模型，未消耗实验槽位或 AK。

## 验证

- JSON 解析、12 个唯一槽与 6 个完整 pair 通过；
- case 字段与冻结 formal-v1 case protocol 一致；
- 四份引用 evidence/protocol SHA-256 与记录一致；
- baseline/treatment 顺序为 3/3 交叉平衡；
- git diff --check 与敏感信息扫描通过。

Closes #123