### PR TITLE
研究：实现 verifier-driven repair 运行时门禁（#125）

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -24,6 +24,15 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-14 — 完成 verifier-driven repair 运行时与未授权证据门禁
+  - GitHub: 中文 Issue #125 已创建并回读；实现分支为 `research/issue-125-verifier-repair-runtime`，基线为 `main@97f252b4`。
+  - 实现: 新增版本化 submit feedback adapter、严格白名单 `repair_packet`、独立 hash-chain sidecar、treatment fidelity gate、硬拒绝 canary/attempt/batch 的未授权 runner，以及只做配对描述性统计的 analyzer。
+  - 修复: 失败 submit 缺少对应 `submit.completed` 时明确记为 `failed/evidence_missing`；baseline 原始/返回 SHA-256 不一致时拒绝；sidecar 事件 payload 严格校验；动态 failed-check 名称只保留安全标识，合法 artifact 名不再被宽泛敏感词扫描误拒绝。
+  - 指标: analyzer 已覆盖 actionable verifier failures、repair conversions、false acceptance、submit/replay 次数、failure transitions、token、请求数和墙钟差值；仍禁止 p-value 和模型排名。
+  - 验证: 聚焦测试 `17 passed`，Ruff check/format、`py_compile`、Schema、protocol/runner validate、确定性再生成、共享 compile blob、diff 与敏感信息扫描通过；canonical manifest SHA-256 为 `880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045`。
+  - 边界: 未启动 Docker、未调用模型、未创建实验 evidence；12 slots、provider canary、physical attempt、batch 和 maximum 2,400,000 recorded tokens 仍未授权。
+  - 文件: `scripts/forge_verifier_repair_runtime.py`, `scripts/forge_verifier_repair_pilot_protocol.py`, `scripts/forge_verifier_repair_pilot_runner.py`, `scripts/forge_verifier_repair_pilot_analyzer.py`, `backend/tests/test_forge_verifier_repair_pilot.py`, `benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json`, `benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json`, `benchmarks/schemas/forge-verifier-repair-pilot-runtime-v1.schema.json`
+
 - 2026-08-14 — 完成 verifier-driven repair 配对 pilot 未授权决策包
   - GitHub: Issue #123 与 PR #124 使用中文创建并回读；核心设计提交为 `f5798c5e`。
   - 证据: formal v4 中一个槽在 `candidate_verification_failed -> build_system_unproven` 后自然修复并通过，另一个 `recipe_execution_failed` 槽被后续 endpoint timeout 混杂；这些轨迹只支持 treatment 设计，不能估计效果。
@@ -363,6 +372,7 @@
 - 成功 bash 记录只是候选 recipe；失败命令可能留下持久副作用。进入研究基线前必须在新容器与空 `/workspace`、`/artifacts` 中实际 replay，不能把 `repro_bundle` 生成成功等同于独立复现成功。
 - Windows 挂载目录在编译镜像中可能触发 Git `dubious ownership`；replay 初始化仓库后必须把 `/workspace/repo` 加入 `safe.directory`。
 - 不要把含 `$()`、重定向和多层引号的后验校验直接嵌进 PowerShell → WSL → `docker run ... bash -lc`；参数可能被中间层重解释。应先单独运行 `bash /repro/build.sh` 获取退出码，再用独立命令检查类型、输出与哈希。
+- PowerShell → WSL 的审计命令也不要嵌套 `python -c` 与多层单双引号；即使前置生成已成功，末尾展示命令仍可能因引号截断让整段汇总失败。应把 manifest 校验、哈希显示和 PowerShell 文件审计拆成固定参数的独立命令。
 - `docker run` 客户端超时不证明 daemon 没有稍后创建容器；replay 必须使用确定性名称，在超时后反复对账并幂等删除，且 create/checkpoint/parent cleanup 必须由同一 session lock 串行化。
 - 取消、超时与同步 submit 可能持有不同的 stale session 副本；第一条持久化 termination reason 必须胜出，终态后的 cleanup 只能按 `attempt_id` 白名单合并可变清理字段，不能覆盖镜像、commit、recipe、产物或检查证据。
 - Manifest 中声明的模型、端点、镜像和运行参数只是实验意图，不是实际运行证明；observed 字段必须由 runner 从真实请求、Forge 状态和 Docker 结果写入。

--- a/backend/tests/test_forge_verifier_repair_pilot.py
+++ b/backend/tests/test_forge_verifier_repair_pilot.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_runtime.py"
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_pilot_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_pilot_runner.py"
+ANALYZER_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_pilot_analyzer.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-runtime-candidate.json"
+MANIFEST_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-pilot-runtime-v1.schema.json"
+PACKET_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-packet-v1.schema.json"
+
+SHARED_COMPONENT_BLOBS = {
+    "backend/packages/harness/deerflow/compile/operations.py": "d48cd0fe8108023fa4128ae2a6e048498b881259",
+    "backend/packages/harness/deerflow/compile/evidence.py": "d6c22034889e6c62a35289ca0901c2a550da9984",
+    "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "a99c062dddf450088477ab813713bd5d250fa636",
+}
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime = _load_module("forge_verifier_repair_runtime_test", RUNTIME_PATH)
+protocol = _load_module("forge_verifier_repair_pilot_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_verifier_repair_pilot_runner_test", RUNNER_PATH)
+analyzer = _load_module("forge_verifier_repair_pilot_analyzer_test", ANALYZER_PATH)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _candidate_failure_events() -> list[dict]:
+    return [
+        {
+            "event": "build.system_checked",
+            "payload": {
+                "expected_build_system": "cmake",
+                "observed_build_system": "cmake",
+                "selected_build_system": "cmake",
+                "matches": True,
+            },
+        },
+        {
+            "event": "submit.completed",
+            "payload": {
+                "status": "failed",
+                "candidate_status": "failed",
+                "submit_attempt_id": "submit_1",
+                "supporting_command_id": "command_1",
+                "checks": [{"name": "benchmark_constraints", "passed": False, "exit_code": 1}],
+                "artifacts": [{"path": "artifact.a", "artifact_type": "static_library"}],
+                "replay": None,
+            },
+        },
+    ]
+
+
+def _result(status: str = "failed") -> str:
+    return json.dumps(
+        {
+            "exit_code": 1 if status == "failed" else 0,
+            "status": status,
+            "candidate_status": "failed" if status == "failed" else "passed",
+            "replay_status": "not_run" if status == "failed" else "passed",
+            "replay_attempt_id": None,
+            "submit_attempt_id": "submit_1",
+            "supporting_command_id": "command_1",
+            "artifacts": [],
+            "message": "Error: candidate rejected" if status == "failed" else "accepted",
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def _context(tmp_path: Path, *, treatment: str, events: list[dict]):
+    ledger = runtime.RepairEvidenceLedger.create(
+        tmp_path / f"{treatment}.jsonl",
+        {
+            "manifest_sha256": "0" * 64,
+            "thread_id": "thread_1",
+            "physical_attempt_id": "physical_attempt_1",
+            "order": 1,
+            "pair_id": "pair_1",
+            "case_id": "case_1",
+            "provider_condition": "provider_1",
+            "treatment": treatment,
+            "repetition": 1,
+        },
+    )
+    return runtime.RepairFeedbackContext(
+        thread_id="thread_1",
+        pair_id="pair_1",
+        case_id="case_1",
+        provider_condition="provider_1",
+        treatment=treatment,
+        repetition=1,
+        expected_build_system="cmake",
+        expected_artifacts=(("artifact.a", "static_library"),),
+        event_reader=lambda: events,
+        evidence=ledger,
+    )
+
+
+def test_baseline_submit_response_is_byte_identical(tmp_path: Path) -> None:
+    original = _result()
+    fake_tools = SimpleNamespace(_submit_with_post_build_phase=lambda _session, supporting_command_id=None: original)
+    context = _context(tmp_path, treatment=runtime.BASELINE_ARM, events=_candidate_failure_events())
+
+    with runtime.submit_feedback_scope(context, fake_tools):
+        returned = fake_tools._submit_with_post_build_phase(SimpleNamespace(thread_id="thread_1"))
+
+    assert returned == original
+    records = context.evidence.read()
+    assert records[-1]["payload"]["packet_attached"] is False
+    assert runtime.evaluate_treatment_fidelity(records) == {
+        "status": "passed",
+        "evidence_complete": True,
+        "exposures": 1,
+        "actionable_exposures": 1,
+        "failures": [],
+    }
+
+
+def test_treatment_attaches_deterministic_valid_packet(tmp_path: Path) -> None:
+    original = _result()
+    fake_tools = SimpleNamespace(_submit_with_post_build_phase=lambda _session, supporting_command_id=None: original)
+    context = _context(tmp_path, treatment=runtime.TREATMENT_ARM, events=_candidate_failure_events())
+
+    with runtime.submit_feedback_scope(context, fake_tools):
+        returned = fake_tools._submit_with_post_build_phase(SimpleNamespace(thread_id="thread_1"))
+
+    payload = json.loads(returned)
+    packet = payload["repair_packet"]
+    assert packet["primary_classification"] == "build_system_unproven"
+    assert packet["failed_checks"] == [{"name": "benchmark_constraints", "exit_code": 1}]
+    assert packet["artifact_identity_diff"] == {
+        "expected_only": [],
+        "observed_only": [],
+        "mismatches": [],
+        "truncated": False,
+    }
+    jsonschema.validate(packet, json.loads(PACKET_SCHEMA_PATH.read_text(encoding="utf-8")))
+    assert runtime.evaluate_treatment_fidelity(context.evidence.read())["status"] == "passed"
+
+
+def test_successful_or_non_actionable_submit_does_not_attach_packet(tmp_path: Path) -> None:
+    original = _result(status="passed")
+    fake_tools = SimpleNamespace(_submit_with_post_build_phase=lambda _session, supporting_command_id=None: original)
+    context = _context(tmp_path, treatment=runtime.TREATMENT_ARM, events=[])
+
+    with runtime.submit_feedback_scope(context, fake_tools):
+        returned = fake_tools._submit_with_post_build_phase(SimpleNamespace(thread_id="thread_1"))
+
+    assert returned == original
+    assert runtime.evaluate_treatment_fidelity(context.evidence.read())["status"] == "not_exposed"
+
+
+def test_failed_submit_without_persisted_evidence_fails_fidelity(tmp_path: Path) -> None:
+    original = _result()
+    fake_tools = SimpleNamespace(_submit_with_post_build_phase=lambda _session, supporting_command_id=None: original)
+    context = _context(tmp_path, treatment=runtime.TREATMENT_ARM, events=[])
+
+    with runtime.submit_feedback_scope(context, fake_tools):
+        returned = fake_tools._submit_with_post_build_phase(SimpleNamespace(thread_id="thread_1"))
+
+    assert returned == original
+    assert runtime.evaluate_treatment_fidelity(context.evidence.read()) == {
+        "status": "failed",
+        "evidence_complete": False,
+        "exposures": 1,
+        "actionable_exposures": 0,
+        "failures": ["evidence_missing"],
+    }
+
+
+def test_baseline_digest_drift_fails_fidelity(tmp_path: Path) -> None:
+    context = _context(tmp_path, treatment=runtime.BASELINE_ARM, events=_candidate_failure_events())
+    context.evidence.append(
+        "repair.feedback_observed",
+        {
+            "treatment": runtime.BASELINE_ARM,
+            "status": "failed",
+            "actionable": True,
+            "evidence_complete": True,
+            "primary_classification": "build_system_unproven",
+            "packet_attached": False,
+            "packet": None,
+            "original_sha256": "1" * 64,
+            "returned_sha256": "2" * 64,
+            "submit_attempt_id": "submit_1",
+        },
+    )
+
+    fidelity = runtime.evaluate_treatment_fidelity(context.evidence.read())
+
+    assert fidelity["status"] == "failed"
+    assert fidelity["failures"] == ["baseline_response_modified"]
+
+
+def test_replay_mismatch_is_normalized_without_raw_output() -> None:
+    payload = json.loads(_result())
+    payload.update(candidate_status="passed", replay_status="failed", replay_attempt_id="replay_1")
+    events = [
+        {
+            "event": "submit.completed",
+            "payload": {
+                "status": "failed",
+                "candidate_status": "passed",
+                "submit_attempt_id": "submit_1",
+                "supporting_command_id": "command_1",
+                "checks": [{"name": "clean_replay", "passed": False, "exit_code": 1}],
+                "artifacts": [{"path": "artifact.a", "artifact_type": "static_library"}],
+                "replay": {"status": "failed", "replay_attempt_id": "replay_1"},
+            },
+        },
+        {
+            "event": "replay.completed",
+            "payload": {
+                "submit_attempt_id": "submit_1",
+                "replay_attempt_id": "replay_1",
+                "status": "failed",
+                "primary_failure_classification": "sha256_mismatch",
+                "artifacts": [{"path": "artifact.a", "mismatches": ["sha256"]}],
+            },
+        },
+    ]
+
+    packet = runtime.build_repair_packet(payload, events, expected_artifacts=(("artifact.a", "static_library"),))
+
+    assert packet is not None
+    assert packet["primary_classification"] == "sha256_mismatch"
+    assert packet["artifact_identity_diff"]["mismatches"] == [{"path": "artifact.a", "kinds": ["sha256"]}]
+    serialized = json.dumps(packet).lower()
+    assert "stdout" not in serialized
+    assert "stderr" not in serialized
+    assert "prompt" not in serialized
+
+
+def test_packet_allows_safe_artifact_name_containing_forbidden_word() -> None:
+    events = _candidate_failure_events()
+    events[-1]["payload"]["artifacts"] = [{"path": "prompt-output.a", "artifact_type": "static_library"}]
+
+    packet = runtime.build_repair_packet(
+        json.loads(_result()),
+        events,
+        expected_artifacts=(("prompt-output.a", "static_library"),),
+    )
+
+    assert packet is not None
+    assert packet["artifact_identity_diff"]["expected_only"] == []
+
+
+def test_unsafe_dynamic_failed_check_name_is_omitted() -> None:
+    events = _candidate_failure_events()
+    events[-1]["payload"]["checks"].append({"name": "unsafe/check", "passed": False, "exit_code": 1})
+
+    packet = runtime.build_repair_packet(json.loads(_result()), events, expected_artifacts=(("artifact.a", "static_library"),))
+
+    assert packet is not None
+    assert packet["failed_checks"] == [{"name": "benchmark_constraints", "exit_code": 1}]
+
+
+def test_sidecar_hash_chain_detects_tampering(tmp_path: Path) -> None:
+    context = _context(tmp_path, treatment=runtime.BASELINE_ARM, events=[])
+    context.evidence.append("repair.context_completed", {"status": "failed"})
+    lines = context.evidence.path.read_text(encoding="utf-8").splitlines()
+    lines[0] = lines[0].replace("pair_1", "pair_2")
+    context.evidence.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    with pytest.raises(runtime.RepairRuntimeError, match="hash chain"):
+        context.evidence.read()
+
+
+def test_sidecar_rejects_non_whitelisted_payload_fields(tmp_path: Path) -> None:
+    context = _context(tmp_path, treatment=runtime.BASELINE_ARM, events=[])
+
+    with pytest.raises(runtime.RepairRuntimeError, match="completion fields"):
+        context.evidence.append("repair.context_completed", {"status": "failed", "detail": "not allowed"})
+
+
+def test_protocol_is_deterministic_strict_and_unauthed() -> None:
+    manifest = _manifest()
+
+    assert protocol.generate_manifest() == manifest
+    assert protocol.validate_manifest(manifest) == manifest
+    assert manifest["protocolization"]["runtime_implementation_authorized"] is True
+    assert manifest["protocolization"]["collection_authorized"] is False
+    assert len(manifest["pilot_schedule"]) == 12
+    assert len({slot["pair_id"] for slot in manifest["pilot_schedule"]}) == 6
+    first_arms = []
+    for pair_id in sorted({slot["pair_id"] for slot in manifest["pilot_schedule"]}):
+        first_arms.append(min((slot for slot in manifest["pilot_schedule"] if slot["pair_id"] == pair_id), key=lambda slot: slot["order"])["treatment"])
+    assert first_arms.count(runtime.BASELINE_ARM) == 3
+    assert first_arms.count(runtime.TREATMENT_ARM) == 3
+
+    manifest_schema = json.loads(MANIFEST_SCHEMA_PATH.read_text(encoding="utf-8"))
+    packet_schema = json.loads(PACKET_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(manifest_schema)
+    jsonschema.Draft202012Validator.check_schema(packet_schema)
+    jsonschema.validate(manifest, manifest_schema)
+
+    changed = copy.deepcopy(manifest)
+    changed["protocolization"]["collection_authorized"] = True
+    with pytest.raises(protocol.ProtocolError):
+        protocol.validate_manifest(changed)
+
+
+def test_shared_frozen_compile_components_remain_byte_identical() -> None:
+    for relative_path, expected_blob in SHARED_COMPONENT_BLOBS.items():
+        payload = (REPO_ROOT / relative_path).read_bytes()
+        header = f"blob {len(payload)}\0".encode()
+        assert hashlib.sha1(header + payload).hexdigest() == expected_blob
+
+
+@pytest.mark.parametrize("entrypoint", [runner.provider_canary, runner.run_attempt, runner.run_batch])
+def test_unauthed_runner_rejects_before_evidence_or_model_work(entrypoint, tmp_path: Path) -> None:
+    with pytest.raises(runner.RunnerError, match="not authorized"):
+        entrypoint(_manifest(), output_dir=tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def _attempts(manifest: dict) -> list[dict]:
+    attempts = []
+    for slot in manifest["pilot_schedule"]:
+        treatment = slot["treatment"] == runtime.TREATMENT_ARM
+        converted = treatment and slot["pair_id"] == "liblouis-richlab-r1"
+        attempts.append(
+            {
+                **{field: slot[field] for field in ("order", "pair_id", "case_id", "provider_condition", "treatment", "repetition")},
+                "oracle_passed": treatment and slot["pair_id"] == "liblouis-richlab-r1",
+                "terminal_passed": False,
+                "fidelity_status": "passed" if treatment else "not_exposed",
+                "recorded_tokens": 100 + int(treatment),
+                "model_requests": 10,
+                "wall_clock_seconds": 20.0 + int(treatment),
+                "actionable_verifier_failures": int(treatment),
+                "repair_conversions": int(converted),
+                "submit_attempts": 1 + int(treatment),
+                "clean_replay_attempts": int(treatment),
+                "failure_transitions": ([{"from": "candidate_verification_failed", "to": "oracle_passed"}] if converted else []),
+            }
+        )
+    return attempts
+
+
+def test_analyzer_reports_only_complete_descriptive_pairs() -> None:
+    manifest = _manifest()
+    report = analyzer.build_report(manifest, _attempts(manifest))
+
+    assert report["scope"] == {
+        "descriptive_only": True,
+        "p_value_computed": False,
+        "model_ranking_performed": False,
+        "paired_primary_eligible": True,
+    }
+    assert report["collection"] == {
+        "planned_slots": 12,
+        "observed_slots": 12,
+        "complete_pairs": 6,
+        "incomplete_pairs": [],
+    }
+    assert report["oracle_discordance"]["treatment_only_passed"] == 1
+    assert all(pair["recorded_tokens_delta"] == 1 for pair in report["pairs"])
+    assert report["secondary_outcomes"] == {
+        "repair_conversion": {
+            "baseline": {"actionable_failures": 0, "conversions": 0, "rate": None},
+            "treatment": {"actionable_failures": 6, "conversions": 1, "rate": 0.166667},
+        },
+        "false_acceptance_count": {"baseline": 0, "treatment": 0},
+        "submit_attempts": {"baseline": 6, "treatment": 12},
+        "clean_replay_attempts": {"baseline": 0, "treatment": 6},
+        "failure_transitions": {
+            "baseline": {},
+            "treatment": {"candidate_verification_failed->oracle_passed": 1},
+        },
+    }
+    converted_pair = next(pair for pair in report["pairs"] if pair["pair_id"] == "liblouis-richlab-r1")
+    assert converted_pair["repair_conversions"] == {"baseline": 0, "treatment": 1, "delta": 1}
+
+
+def test_analyzer_keeps_incomplete_pair_out_of_pair_results() -> None:
+    manifest = _manifest()
+    attempts = _attempts(manifest)[:-1]
+
+    report = analyzer.build_report(manifest, attempts)
+
+    assert report["collection"]["observed_slots"] == 11
+    assert report["collection"]["complete_pairs"] == 5
+    assert report["collection"]["incomplete_pairs"] == ["mupdf-deepseek-r1"]
+    assert report["scope"]["paired_primary_eligible"] is False

--- a/benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json
+++ b/benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json
@@ -1,0 +1,458 @@
+{
+  "$schema": "../schemas/forge-verifier-repair-pilot-runtime-v1.schema.json",
+  "schema_version": "verifier-driven-repair-pilot-runtime-1.0.0",
+  "benchmark": {
+    "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+    "purpose": "freeze a baseline-versus-structured-verifier-feedback paired pilot runtime without authorizing collection",
+    "languages": [
+      "C",
+      "C++"
+    ]
+  },
+  "protocolization": {
+    "issue": 125,
+    "base_commit": "97f252b414a6f2acbac694b116ed75acef6ac988",
+    "design_parent": {
+      "path": "benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json",
+      "sha256": "c20d767253dd2a5f0fbba7e6aebfccd5b6ac0f94c3f417dddccd3b498439b420"
+    },
+    "model_source": {
+      "path": "benchmarks/manifests/cpp-formal-timeout-calibration.json",
+      "sha256": "31e48e14e32113a556d44f6fa62cd98235acc884baf8a98240410e513a093f1e"
+    },
+    "runtime_implementation_authorized": true,
+    "collection_authorized": false,
+    "provider_canary_forbidden": true,
+    "physical_attempt_creation_forbidden": true,
+    "model_execution_forbidden": true,
+    "batch_execution_forbidden": true
+  },
+  "runtime": {
+    "adapter": "scripts/forge_verifier_repair_runtime.py",
+    "packet_schema_version": "forge-verifier-repair-packet-1.0.0",
+    "sidecar_schema_version": "forge-verifier-repair-sidecar-1.0.0",
+    "baseline_byte_identity_required": true,
+    "shared_compile_components_modified": false,
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "docker_daemon_provider": "ubuntu-native"
+  },
+  "repair_packet": {
+    "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+    "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+    "actionable_classifications": [
+      "artifact_set_mismatch",
+      "artifact_type_mismatch",
+      "build_system_mismatch",
+      "build_system_selection_mismatch",
+      "build_system_unproven",
+      "candidate_verification_failed",
+      "recipe_execution_failed",
+      "sha256_mismatch",
+      "size_mismatch",
+      "smoke_mismatch"
+    ],
+    "repair_goals": {
+      "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+      "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+      "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+      "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+      "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+      "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+      "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+      "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+    },
+    "forbidden_content": [
+      "stdout",
+      "stderr",
+      "prompt",
+      "model_body",
+      "credential",
+      "host_path",
+      "generated_repair_command"
+    ]
+  },
+  "cases": [
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "build_system": "autotools",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ],
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "configure.ac",
+          "url": "https://github.com/liblouis/liblouis/blob/b52ab11ade4cf0917315991b54a8558a2589cf55/configure.ac",
+          "supports": [
+            "build_path"
+          ]
+        },
+        {
+          "kind": "upstream_exact_commit",
+          "path": "liblouis/Makefile.am",
+          "url": "https://github.com/liblouis/liblouis/blob/b52ab11ade4cf0917315991b54a8558a2589cf55/liblouis/Makefile.am",
+          "supports": [
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "liblouis/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/liblouis/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "build_system": "cmake",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "CMakeLists.txt",
+          "url": "https://github.com/openthread/openthread/blob/044aa98f1b5255731e0a6f2816e267b282299684/CMakeLists.txt",
+          "supports": [
+            "build_path"
+          ]
+        },
+        {
+          "kind": "upstream_exact_commit",
+          "path": "src/core/CMakeLists.txt",
+          "url": "https://github.com/openthread/openthread/blob/044aa98f1b5255731e0a6f2816e267b282299684/src/core/CMakeLists.txt",
+          "supports": [
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "openthread/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openthread/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "build_system": "make",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "Makefile",
+          "url": "https://github.com/ArtifexSoftware/mupdf/blob/b29caae1ab8c602187d4fc36d7b540bac493635d/Makefile",
+          "supports": [
+            "build_path",
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "mupdf/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/mupdf/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    }
+  ],
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    }
+  },
+  "treatments": [
+    {
+      "id": "baseline-current-verifier-output",
+      "repair_packet_enabled": false,
+      "definition": "保持 main@6eb69e64 的 submit_build_result 失败返回和 Compiler prompt 不变。"
+    },
+    {
+      "id": "structured-verifier-repair-packet",
+      "repair_packet_enabled": true,
+      "definition": "只在可修复的 verification-domain submit 失败后，在同一工具返回中增加确定性的 repair_packet；不增加模型调用、Compiler invocation、turn、timeout 或 token 预算。",
+      "packet_fields": [
+        "schema_version",
+        "failure_domain",
+        "primary_classification",
+        "failed_checks",
+        "build_system_identity",
+        "artifact_identity_diff",
+        "replay_status",
+        "repair_goal",
+        "supporting_command_id",
+        "submit_attempt_id",
+        "replay_attempt_id"
+      ],
+      "packet_constraints": [
+        "只包含 verifier 已持久化的白名单结构化字段。",
+        "不包含 stdout、stderr、prompt、模型正文、密钥、宿主路径或生成式修复命令。",
+        "repair_goal 由固定 classification 映射生成，不调用模型。",
+        "acceptance gate、artifact Oracle、clean replay 与 delivery 语义保持不变。"
+      ]
+    }
+  ],
+  "pilot_schedule": [
+    {
+      "order": 1,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    }
+  ],
+  "budget": {
+    "authorized": false,
+    "request_timeout_seconds": 300,
+    "provider_retries": 0,
+    "attempt_total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "model_turn_limit": 36,
+    "maximum_recorded_tokens": 2400000,
+    "expected_recorded_tokens": 800000,
+    "budget_check_boundary": "before_each_complete_pair",
+    "remaining_pairs_require_confirmation": true
+  },
+  "outcomes": {
+    "primary": "oracle_passed",
+    "secondary": [
+      "terminal_passed",
+      "repair_conversion_after_actionable_verifier_failure",
+      "false_acceptance_count",
+      "submit_attempts",
+      "clean_replay_attempts",
+      "model_requests",
+      "recorded_tokens",
+      "attempt_wall_clock_seconds",
+      "failure_classification_transition"
+    ],
+    "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+    "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+  },
+  "fidelity_gate": {
+    "statuses": [
+      "passed",
+      "not_exposed",
+      "failed"
+    ],
+    "baseline_packet_count": 0,
+    "treatment_requires_packet_for_each_actionable_submit": true,
+    "paired_analysis_requires_both_arms": true,
+    "p_value_forbidden": true,
+    "model_ranking_forbidden": true
+  },
+  "implementation_sha256": {
+    "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+    "scripts/forge_verifier_repair_pilot_analyzer.py": "24818232cee5220995a048916752ee1d231d8017ce305fe5673fcd2479a5626b",
+    "scripts/forge_verifier_repair_pilot_protocol.py": "dd2d2dcd20cffdaee37b3c1376b3f35d7535a2328aa54bdfe992a1d6f4e879c2",
+    "scripts/forge_verifier_repair_pilot_runner.py": "83a7aa055316d8491223a264e844151586f6c88c8eb28a0ecb879d7d4fe11a59",
+    "scripts/forge_verifier_repair_runtime.py": "1d5f4eee3388f10c3f6a1f7f405b530263d5a84019c1bae53cd7d2ae047b2637"
+  }
+}

--- a/benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json
+++ b/benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+  "title": "Forge verifier-driven repair packet",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "failure_domain",
+    "primary_classification",
+    "failed_checks",
+    "build_system_identity",
+    "artifact_identity_diff",
+    "replay_status",
+    "repair_goal",
+    "supporting_command_id",
+    "submit_attempt_id",
+    "replay_attempt_id"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "forge-verifier-repair-packet-1.0.0"
+    },
+    "failure_domain": {
+      "const": "submit_replay"
+    },
+    "primary_classification": {
+      "enum": [
+        "artifact_set_mismatch",
+        "artifact_type_mismatch",
+        "build_system_mismatch",
+        "build_system_selection_mismatch",
+        "build_system_unproven",
+        "candidate_verification_failed",
+        "recipe_execution_failed",
+        "sha256_mismatch",
+        "size_mismatch",
+        "smoke_mismatch"
+      ]
+    },
+    "failed_checks": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "exit_code"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160,
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          },
+          "exit_code": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "build_system_identity": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "expected",
+        "observed",
+        "selected",
+        "matches"
+      ],
+      "properties": {
+        "expected": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "cmake",
+            "make",
+            "autotools",
+            null
+          ]
+        },
+        "observed": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "cmake",
+            "make",
+            "autotools",
+            null
+          ]
+        },
+        "selected": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "cmake",
+            "make",
+            "autotools",
+            null
+          ]
+        },
+        "matches": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "artifact_identity_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_only",
+        "observed_only",
+        "mismatches",
+        "truncated"
+      ],
+      "properties": {
+        "expected_only": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+          }
+        },
+        "observed_only": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+          }
+        },
+        "mismatches": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "path",
+              "kinds"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+              },
+              "kinds": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "sha256",
+                    "size",
+                    "smoke",
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      }
+    },
+    "replay_status": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9_-]+$"
+    },
+    "repair_goal": {
+      "enum": [
+        "Make the recorded successful build and staging commands replayable from a clean workspace.",
+        "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+        "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+        "Repair runtime behavior so executable smoke output reproduces in clean replay.",
+        "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+        "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+        "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+        "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+        "Use the frozen expected build system and rebuild before resubmitting.",
+        "Use the frozen expected build system and rebuild before resubmitting."
+      ]
+    },
+    "supporting_command_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z0-9_.-]{1,160}$"
+    },
+    "submit_attempt_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z0-9_.-]{1,160}$"
+    },
+    "replay_attempt_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[A-Za-z0-9_.-]{1,160}$"
+    }
+  }
+}

--- a/benchmarks/schemas/forge-verifier-repair-pilot-runtime-v1.schema.json
+++ b/benchmarks/schemas/forge-verifier-repair-pilot-runtime-v1.schema.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-runtime-v1.schema.json",
+  "title": "Forge verifier-driven repair pilot runtime candidate",
+  "const": {
+    "$schema": "../schemas/forge-verifier-repair-pilot-runtime-v1.schema.json",
+    "schema_version": "verifier-driven-repair-pilot-runtime-1.0.0",
+    "benchmark": {
+      "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+      "purpose": "freeze a baseline-versus-structured-verifier-feedback paired pilot runtime without authorizing collection",
+      "languages": [
+        "C",
+        "C++"
+      ]
+    },
+    "protocolization": {
+      "issue": 125,
+      "base_commit": "97f252b414a6f2acbac694b116ed75acef6ac988",
+      "design_parent": {
+        "path": "benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json",
+        "sha256": "c20d767253dd2a5f0fbba7e6aebfccd5b6ac0f94c3f417dddccd3b498439b420"
+      },
+      "model_source": {
+        "path": "benchmarks/manifests/cpp-formal-timeout-calibration.json",
+        "sha256": "31e48e14e32113a556d44f6fa62cd98235acc884baf8a98240410e513a093f1e"
+      },
+      "runtime_implementation_authorized": true,
+      "collection_authorized": false,
+      "provider_canary_forbidden": true,
+      "physical_attempt_creation_forbidden": true,
+      "model_execution_forbidden": true,
+      "batch_execution_forbidden": true
+    },
+    "runtime": {
+      "adapter": "scripts/forge_verifier_repair_runtime.py",
+      "packet_schema_version": "forge-verifier-repair-packet-1.0.0",
+      "sidecar_schema_version": "forge-verifier-repair-sidecar-1.0.0",
+      "baseline_byte_identity_required": true,
+      "shared_compile_components_modified": false,
+      "compile_image": "autocompiler:gcc13",
+      "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+      "control_plane_topology": "compose-dood",
+      "docker_daemon_provider": "ubuntu-native"
+    },
+    "repair_packet": {
+      "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+      "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+      "actionable_classifications": [
+        "artifact_set_mismatch",
+        "artifact_type_mismatch",
+        "build_system_mismatch",
+        "build_system_selection_mismatch",
+        "build_system_unproven",
+        "candidate_verification_failed",
+        "recipe_execution_failed",
+        "sha256_mismatch",
+        "size_mismatch",
+        "smoke_mismatch"
+      ],
+      "repair_goals": {
+        "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+        "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+        "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+        "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+        "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+        "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+        "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+        "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+      },
+      "forbidden_content": [
+        "stdout",
+        "stderr",
+        "prompt",
+        "model_body",
+        "credential",
+        "host_path",
+        "generated_repair_command"
+      ]
+    },
+    "cases": [
+      {
+        "id": "liblouis",
+        "repository_url": "https://github.com/liblouis/liblouis",
+        "commit": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+        "build_system": "autotools",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [
+            "autoreconf -fi"
+          ],
+          "configure_arguments": [
+            "--disable-shared",
+            "--enable-static"
+          ],
+          "build_targets": [
+            "all"
+          ],
+          "required_system_packages": [
+            "autoconf",
+            "automake",
+            "build-essential",
+            "libtool",
+            "pkg-config"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "liblouis.a",
+              "build_output_path": "liblouis/.libs/liblouis.a",
+              "artifact_type": "static_library",
+              "producing_target": "all"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "configure.ac",
+            "url": "https://github.com/liblouis/liblouis/blob/b52ab11ade4cf0917315991b54a8558a2589cf55/configure.ac",
+            "supports": [
+              "build_path"
+            ]
+          },
+          {
+            "kind": "upstream_exact_commit",
+            "path": "liblouis/Makefile.am",
+            "url": "https://github.com/liblouis/liblouis/blob/b52ab11ade4cf0917315991b54a8558a2589cf55/liblouis/Makefile.am",
+            "supports": [
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "liblouis/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/liblouis/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "openthread",
+        "repository_url": "https://github.com/openthread/openthread",
+        "commit": "044aa98f1b5255731e0a6f2816e267b282299684",
+        "build_system": "cmake",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "build_targets": [
+            "openthread-ftd"
+          ],
+          "required_system_packages": [
+            "build-essential",
+            "cmake",
+            "python3"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "libopenthread-ftd.a",
+              "build_output_path": "build/src/core/libopenthread-ftd.a",
+              "artifact_type": "static_library",
+              "producing_target": "openthread-ftd"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "CMakeLists.txt",
+            "url": "https://github.com/openthread/openthread/blob/044aa98f1b5255731e0a6f2816e267b282299684/CMakeLists.txt",
+            "supports": [
+              "build_path"
+            ]
+          },
+          {
+            "kind": "upstream_exact_commit",
+            "path": "src/core/CMakeLists.txt",
+            "url": "https://github.com/openthread/openthread/blob/044aa98f1b5255731e0a6f2816e267b282299684/src/core/CMakeLists.txt",
+            "supports": [
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "openthread/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openthread/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "mupdf",
+        "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+        "commit": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+        "build_system": "make",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [],
+          "build_targets": [
+            "libs"
+          ],
+          "required_system_packages": [
+            "build-essential",
+            "libfreetype6-dev",
+            "libjpeg-dev",
+            "zlib1g-dev"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "libmupdf.a",
+              "build_output_path": "build/release/libmupdf.a",
+              "artifact_type": "static_library",
+              "producing_target": "libs"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "Makefile",
+            "url": "https://github.com/ArtifexSoftware/mupdf/blob/b29caae1ab8c602187d4fc36d7b540bac493635d/Makefile",
+            "supports": [
+              "build_path",
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "mupdf/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/mupdf/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      }
+    ],
+    "model_profiles": {
+      "richlab-gpt-5.5": {
+        "endpoint": "https://rich-api.choosefire.com/v1",
+        "credential_env": "OpenAI_AK",
+        "roles": {
+          "lead": "gpt-5.5",
+          "compiler": "gpt-5.5"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      },
+      "deepseek-v4-flash": {
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "roles": {
+          "lead": "deepseek-v4-flash",
+          "compiler": "deepseek-v4-flash"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      }
+    },
+    "treatments": [
+      {
+        "id": "baseline-current-verifier-output",
+        "repair_packet_enabled": false,
+        "definition": "保持 main@6eb69e64 的 submit_build_result 失败返回和 Compiler prompt 不变。"
+      },
+      {
+        "id": "structured-verifier-repair-packet",
+        "repair_packet_enabled": true,
+        "definition": "只在可修复的 verification-domain submit 失败后，在同一工具返回中增加确定性的 repair_packet；不增加模型调用、Compiler invocation、turn、timeout 或 token 预算。",
+        "packet_fields": [
+          "schema_version",
+          "failure_domain",
+          "primary_classification",
+          "failed_checks",
+          "build_system_identity",
+          "artifact_identity_diff",
+          "replay_status",
+          "repair_goal",
+          "supporting_command_id",
+          "submit_attempt_id",
+          "replay_attempt_id"
+        ],
+        "packet_constraints": [
+          "只包含 verifier 已持久化的白名单结构化字段。",
+          "不包含 stdout、stderr、prompt、模型正文、密钥、宿主路径或生成式修复命令。",
+          "repair_goal 由固定 classification 映射生成，不调用模型。",
+          "acceptance gate、artifact Oracle、clean replay 与 delivery 语义保持不变。"
+        ]
+      }
+    ],
+    "pilot_schedule": [
+      {
+        "order": 1,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 2,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 3,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 4,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 5,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 6,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 7,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 8,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 9,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 10,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 11,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 12,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      }
+    ],
+    "budget": {
+      "authorized": false,
+      "request_timeout_seconds": 300,
+      "provider_retries": 0,
+      "attempt_total_wall_clock_seconds": 1800,
+      "cleanup_reserve_seconds": 120,
+      "max_compiler_invocations": 2,
+      "max_model_requests": 48,
+      "model_turn_limit": 36,
+      "maximum_recorded_tokens": 2400000,
+      "expected_recorded_tokens": 800000,
+      "budget_check_boundary": "before_each_complete_pair",
+      "remaining_pairs_require_confirmation": true
+    },
+    "outcomes": {
+      "primary": "oracle_passed",
+      "secondary": [
+        "terminal_passed",
+        "repair_conversion_after_actionable_verifier_failure",
+        "false_acceptance_count",
+        "submit_attempts",
+        "clean_replay_attempts",
+        "model_requests",
+        "recorded_tokens",
+        "attempt_wall_clock_seconds",
+        "failure_classification_transition"
+      ],
+      "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+      "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+    },
+    "fidelity_gate": {
+      "statuses": [
+        "passed",
+        "not_exposed",
+        "failed"
+      ],
+      "baseline_packet_count": 0,
+      "treatment_requires_packet_for_each_actionable_submit": true,
+      "paired_analysis_requires_both_arms": true,
+      "p_value_forbidden": true,
+      "model_ranking_forbidden": true
+    },
+    "implementation_sha256": {
+      "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+      "scripts/forge_verifier_repair_pilot_analyzer.py": "24818232cee5220995a048916752ee1d231d8017ce305fe5673fcd2479a5626b",
+      "scripts/forge_verifier_repair_pilot_protocol.py": "dd2d2dcd20cffdaee37b3c1376b3f35d7535a2328aa54bdfe992a1d6f4e879c2",
+      "scripts/forge_verifier_repair_pilot_runner.py": "83a7aa055316d8491223a264e844151586f6c88c8eb28a0ecb879d7d4fe11a59",
+      "scripts/forge_verifier_repair_runtime.py": "1d5f4eee3388f10c3f6a1f7f405b530263d5a84019c1bae53cd7d2ae047b2637"
+    }
+  }
+}

--- a/scripts/forge_verifier_repair_pilot_analyzer.py
+++ b/scripts/forge_verifier_repair_pilot_analyzer.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""对 verifier-driven repair pilot attempt summaries 做配对描述性分析。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_pilot_protocol as protocol  # noqa: E402
+import forge_verifier_repair_runtime as repair_runtime  # noqa: E402
+
+REQUIRED_ATTEMPT_FIELDS = {
+    "order",
+    "pair_id",
+    "case_id",
+    "provider_condition",
+    "treatment",
+    "repetition",
+    "oracle_passed",
+    "terminal_passed",
+    "fidelity_status",
+    "recorded_tokens",
+    "model_requests",
+    "wall_clock_seconds",
+    "actionable_verifier_failures",
+    "repair_conversions",
+    "submit_attempts",
+    "clean_replay_attempts",
+    "failure_transitions",
+}
+
+
+class AnalyzerError(ValueError):
+    pass
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AnalyzerError(f"cannot read JSON: {path}") from exc
+
+
+def _validate_attempt(attempt: Any, slot: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(attempt, dict) or set(attempt) != REQUIRED_ATTEMPT_FIELDS:
+        raise AnalyzerError(
+            "attempt summary fields do not match the frozen analyzer contract"
+        )
+    for field in (
+        "order",
+        "pair_id",
+        "case_id",
+        "provider_condition",
+        "treatment",
+        "repetition",
+    ):
+        if attempt[field] != slot[field]:
+            raise AnalyzerError(f"attempt summary identity drifted: {field}")
+    if (
+        type(attempt["oracle_passed"]) is not bool
+        or type(attempt["terminal_passed"]) is not bool
+    ):
+        raise AnalyzerError("attempt outcomes must be boolean")
+    if attempt["fidelity_status"] not in {"passed", "not_exposed", "failed"}:
+        raise AnalyzerError("attempt fidelity status is invalid")
+    for field in (
+        "recorded_tokens",
+        "model_requests",
+        "actionable_verifier_failures",
+        "repair_conversions",
+        "submit_attempts",
+        "clean_replay_attempts",
+    ):
+        if type(attempt[field]) is not int or attempt[field] < 0:
+            raise AnalyzerError(f"attempt {field} must be a non-negative integer")
+    if attempt["repair_conversions"] > attempt["actionable_verifier_failures"]:
+        raise AnalyzerError(
+            "repair conversions cannot exceed actionable verifier failures"
+        )
+    transitions = attempt["failure_transitions"]
+    if not isinstance(transitions, list) or len(transitions) > 64:
+        raise AnalyzerError("attempt failure transitions are invalid")
+    for transition in transitions:
+        if not isinstance(transition, dict) or set(transition) != {"from", "to"}:
+            raise AnalyzerError("attempt failure transition fields are invalid")
+        for field in ("from", "to"):
+            value = transition[field]
+            if (
+                not isinstance(value, str)
+                or not value
+                or len(value) > 160
+                or any(
+                    character
+                    not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
+                    for character in value
+                )
+            ):
+                raise AnalyzerError("attempt failure transition value is invalid")
+    wall_clock = attempt["wall_clock_seconds"]
+    if (
+        not isinstance(wall_clock, (int, float))
+        or isinstance(wall_clock, bool)
+        or wall_clock < 0
+    ):
+        raise AnalyzerError("attempt wall_clock_seconds must be non-negative")
+    return attempt
+
+
+def _outcome_label(baseline: bool, treatment: bool) -> str:
+    if baseline and treatment:
+        return "both_passed"
+    if baseline:
+        return "baseline_only_passed"
+    if treatment:
+        return "treatment_only_passed"
+    return "neither_passed"
+
+
+def _count_metric(
+    baseline: dict[str, Any], treatment: dict[str, Any], field: str
+) -> dict[str, int]:
+    return {
+        "baseline": baseline[field],
+        "treatment": treatment[field],
+        "delta": treatment[field] - baseline[field],
+    }
+
+
+def _transition_counts(attempts: list[dict[str, Any]], arm: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for attempt in attempts:
+        if attempt["treatment"] != arm:
+            continue
+        for transition in attempt["failure_transitions"]:
+            label = f"{transition['from']}->{transition['to']}"
+            counts[label] = counts.get(label, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _conversion_summary(attempts: list[dict[str, Any]], arm: str) -> dict[str, Any]:
+    selected = [attempt for attempt in attempts if attempt["treatment"] == arm]
+    actionable = sum(attempt["actionable_verifier_failures"] for attempt in selected)
+    conversions = sum(attempt["repair_conversions"] for attempt in selected)
+    return {
+        "actionable_failures": actionable,
+        "conversions": conversions,
+        "rate": round(conversions / actionable, 6) if actionable else None,
+    }
+
+
+def build_report(
+    manifest: dict[str, Any], attempts: list[dict[str, Any]]
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    slots_by_order = {slot["order"]: slot for slot in manifest["pilot_schedule"]}
+    observed: dict[int, dict[str, Any]] = {}
+    for raw_attempt in attempts:
+        order = raw_attempt.get("order") if isinstance(raw_attempt, dict) else None
+        if order not in slots_by_order or order in observed:
+            raise AnalyzerError("attempt summary has an unknown or duplicate order")
+        observed[order] = _validate_attempt(raw_attempt, slots_by_order[order])
+
+    pairs: list[dict[str, Any]] = []
+    incomplete_pairs: list[str] = []
+    for pair_id in sorted({slot["pair_id"] for slot in manifest["pilot_schedule"]}):
+        pair_slots = sorted(
+            (slot for slot in manifest["pilot_schedule"] if slot["pair_id"] == pair_id),
+            key=lambda slot: slot["order"],
+        )
+        pair_attempts = [observed.get(slot["order"]) for slot in pair_slots]
+        if any(attempt is None for attempt in pair_attempts):
+            incomplete_pairs.append(pair_id)
+            continue
+        by_arm = {
+            attempt["treatment"]: attempt
+            for attempt in pair_attempts
+            if attempt is not None
+        }
+        if set(by_arm) != {repair_runtime.BASELINE_ARM, repair_runtime.TREATMENT_ARM}:
+            raise AnalyzerError(
+                "complete pair does not contain exactly one attempt per arm"
+            )
+        baseline = by_arm[repair_runtime.BASELINE_ARM]
+        treatment = by_arm[repair_runtime.TREATMENT_ARM]
+        pairs.append(
+            {
+                "pair_id": pair_id,
+                "case_id": baseline["case_id"],
+                "provider_condition": baseline["provider_condition"],
+                "oracle_outcome": _outcome_label(
+                    baseline["oracle_passed"], treatment["oracle_passed"]
+                ),
+                "terminal_outcome": _outcome_label(
+                    baseline["terminal_passed"], treatment["terminal_passed"]
+                ),
+                "fidelity_eligible": baseline["fidelity_status"] != "failed"
+                and treatment["fidelity_status"] != "failed",
+                "actionable_verifier_failures": _count_metric(
+                    baseline, treatment, "actionable_verifier_failures"
+                ),
+                "repair_conversions": _count_metric(
+                    baseline, treatment, "repair_conversions"
+                ),
+                "false_acceptance": {
+                    "baseline": baseline["terminal_passed"]
+                    and not baseline["oracle_passed"],
+                    "treatment": treatment["terminal_passed"]
+                    and not treatment["oracle_passed"],
+                },
+                "submit_attempts": _count_metric(
+                    baseline, treatment, "submit_attempts"
+                ),
+                "clean_replay_attempts": _count_metric(
+                    baseline, treatment, "clean_replay_attempts"
+                ),
+                "failure_transitions": {
+                    "baseline": baseline["failure_transitions"],
+                    "treatment": treatment["failure_transitions"],
+                },
+                "recorded_tokens_delta": treatment["recorded_tokens"]
+                - baseline["recorded_tokens"],
+                "model_requests_delta": treatment["model_requests"]
+                - baseline["model_requests"],
+                "wall_clock_seconds_delta": round(
+                    treatment["wall_clock_seconds"] - baseline["wall_clock_seconds"], 6
+                ),
+            }
+        )
+
+    oracle_counts = {
+        label: sum(pair["oracle_outcome"] == label for pair in pairs)
+        for label in (
+            "both_passed",
+            "baseline_only_passed",
+            "treatment_only_passed",
+            "neither_passed",
+        )
+    }
+    complete_attempts = [
+        observed[slot["order"]]
+        for pair in pairs
+        for slot in manifest["pilot_schedule"]
+        if slot["pair_id"] == pair["pair_id"]
+    ]
+    baseline_attempts = [
+        attempt
+        for attempt in complete_attempts
+        if attempt["treatment"] == repair_runtime.BASELINE_ARM
+    ]
+    treatment_attempts = [
+        attempt
+        for attempt in complete_attempts
+        if attempt["treatment"] == repair_runtime.TREATMENT_ARM
+    ]
+    return {
+        "report_version": "verifier-driven-repair-pilot-descriptive-1.0.0",
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "scope": {
+            "descriptive_only": True,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "paired_primary_eligible": len(pairs) == 6
+            and not incomplete_pairs
+            and all(pair["fidelity_eligible"] for pair in pairs),
+        },
+        "collection": {
+            "planned_slots": 12,
+            "observed_slots": len(observed),
+            "complete_pairs": len(pairs),
+            "incomplete_pairs": incomplete_pairs,
+        },
+        "oracle_discordance": oracle_counts,
+        "secondary_outcomes": {
+            "repair_conversion": {
+                "baseline": _conversion_summary(
+                    complete_attempts, repair_runtime.BASELINE_ARM
+                ),
+                "treatment": _conversion_summary(
+                    complete_attempts, repair_runtime.TREATMENT_ARM
+                ),
+            },
+            "false_acceptance_count": {
+                "baseline": sum(
+                    attempt["terminal_passed"] and not attempt["oracle_passed"]
+                    for attempt in baseline_attempts
+                ),
+                "treatment": sum(
+                    attempt["terminal_passed"] and not attempt["oracle_passed"]
+                    for attempt in treatment_attempts
+                ),
+            },
+            "submit_attempts": {
+                "baseline": sum(
+                    attempt["submit_attempts"] for attempt in baseline_attempts
+                ),
+                "treatment": sum(
+                    attempt["submit_attempts"] for attempt in treatment_attempts
+                ),
+            },
+            "clean_replay_attempts": {
+                "baseline": sum(
+                    attempt["clean_replay_attempts"] for attempt in baseline_attempts
+                ),
+                "treatment": sum(
+                    attempt["clean_replay_attempts"] for attempt in treatment_attempts
+                ),
+            },
+            "failure_transitions": {
+                "baseline": _transition_counts(
+                    complete_attempts, repair_runtime.BASELINE_ARM
+                ),
+                "treatment": _transition_counts(
+                    complete_attempts, repair_runtime.TREATMENT_ARM
+                ),
+            },
+        },
+        "pairs": pairs,
+        "limitations": [
+            "The pilot has one repetition per case-provider pair and does not estimate a population effect.",
+            "Endpoint and infrastructure failures remain descriptive and are not attributed to verifier feedback.",
+        ],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--attempts", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = protocol.validate_manifest(_load_json(args.manifest))
+        attempts = _load_json(args.attempts)
+        if not isinstance(attempts, list):
+            raise AnalyzerError("attempts document must be an array")
+        report = build_report(manifest, attempts)
+        rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+        if args.output is None:
+            print(rendered, end="")
+        else:
+            args.output.write_text(rendered, encoding="utf-8", newline="\n")
+    except (AnalyzerError, OSError, protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_pilot_protocol.py
+++ b/scripts/forge_verifier_repair_pilot_protocol.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""生成并校验未授权 verifier-driven repair pilot runtime identity。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_runtime as repair_runtime  # noqa: E402
+
+SCHEMA_VERSION = "verifier-driven-repair-pilot-runtime-1.0.0"
+BASE_COMMIT = "97f252b414a6f2acbac694b116ed75acef6ac988"
+DESIGN_SHA256 = "c20d767253dd2a5f0fbba7e6aebfccd5b6ac0f94c3f417dddccd3b498439b420"
+MODEL_SOURCE_SHA256 = "31e48e14e32113a556d44f6fa62cd98235acc884baf8a98240410e513a093f1e"
+
+DEFAULT_DESIGN = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "preregistrations"
+    / "cpp-verifier-driven-repair-pilot-v1.json"
+)
+DEFAULT_CASE_PROTOCOL = (
+    REPOSITORY_ROOT / "benchmarks" / "preregistrations" / "cpp-formal-v1-cases.json"
+)
+DEFAULT_MODEL_SOURCE = (
+    REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-timeout-calibration.json"
+)
+DEFAULT_MANIFEST = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "manifests"
+    / "cpp-verifier-repair-pilot-runtime-candidate.json"
+)
+DEFAULT_SCHEMA = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "schemas"
+    / "forge-verifier-repair-pilot-runtime-v1.schema.json"
+)
+DEFAULT_PACKET_SCHEMA = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "schemas"
+    / "forge-verifier-repair-packet-v1.schema.json"
+)
+
+IMPLEMENTATION_PATHS = {
+    "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+    "scripts/forge_verifier_repair_runtime.py",
+    "scripts/forge_verifier_repair_pilot_protocol.py",
+    "scripts/forge_verifier_repair_pilot_runner.py",
+    "scripts/forge_verifier_repair_pilot_analyzer.py",
+}
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot read JSON document: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON document must be an object: {path}")
+    return value
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"implementation component is missing: {relative_path}")
+        hashes[relative_path] = _file_sha256(path)
+    return hashes
+
+
+def _parents(
+    design: dict[str, Any] | None = None,
+    case_protocol: dict[str, Any] | None = None,
+    model_source: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    selected_design = design or _load_json(DEFAULT_DESIGN)
+    selected_cases = case_protocol or _load_json(DEFAULT_CASE_PROTOCOL)
+    selected_models = model_source or _load_json(DEFAULT_MODEL_SOURCE)
+    if _file_sha256(DEFAULT_DESIGN) != DESIGN_SHA256:
+        raise ProtocolError("verifier-driven repair design SHA-256 does not match")
+    if _file_sha256(DEFAULT_MODEL_SOURCE) != MODEL_SOURCE_SHA256:
+        raise ProtocolError("model source SHA-256 does not match")
+    if (
+        selected_design.get("protocolization", {}).get("collection_authorized")
+        is not False
+    ):
+        raise ProtocolError("parent design must remain collection_authorized=false")
+    return selected_design, selected_cases, selected_models
+
+
+def _selected_cases(
+    design: dict[str, Any], case_protocol: dict[str, Any]
+) -> list[dict[str, Any]]:
+    source_by_id = {case["id"]: case for case in case_protocol.get("cases", [])}
+    selected: list[dict[str, Any]] = []
+    for frozen in design["case_selection"]["cases"]:
+        source = source_by_id.get(frozen["id"])
+        if source is None:
+            raise ProtocolError(
+                f"selected case is missing from formal-v1: {frozen['id']}"
+            )
+        artifact = source["artifact_oracle"]["required_artifacts"][0]
+        if (
+            source["repository_url"] != frozen["repository_url"]
+            or source["commit"] != frozen["commit"]
+            or source["build_system"] != frozen["build_system"]
+            or artifact["staged_relative_path"] != frozen["required_artifact"]
+        ):
+            raise ProtocolError(f"selected case drifted from formal-v1: {frozen['id']}")
+        selected.append(copy.deepcopy(source))
+    return selected
+
+
+def _model_profiles(design: dict[str, Any], source: dict[str, Any]) -> dict[str, Any]:
+    profiles = source.get("model_profiles", {})
+    selected: dict[str, Any] = {}
+    for condition in design["provider_conditions"]:
+        profile = profiles.get(condition["id"])
+        if not isinstance(profile, dict):
+            raise ProtocolError(f"model profile is missing: {condition['id']}")
+        if set(profile.get("roles", {}).values()) != {condition["model"]}:
+            raise ProtocolError(f"model profile identity drifted: {condition['id']}")
+        selected[condition["id"]] = copy.deepcopy(profile)
+    return selected
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    design: dict[str, Any] | None = None,
+    case_protocol: dict[str, Any] | None = None,
+    model_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    design, case_protocol, model_source = _parents(design, case_protocol, model_source)
+    packet_schema = repair_runtime.repair_packet_schema()
+    return {
+        "$schema": "../schemas/forge-verifier-repair-pilot-runtime-v1.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "benchmark": {
+            "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+            "purpose": "freeze a baseline-versus-structured-verifier-feedback paired pilot runtime without authorizing collection",
+            "languages": ["C", "C++"],
+        },
+        "protocolization": {
+            "issue": 125,
+            "base_commit": BASE_COMMIT,
+            "design_parent": {
+                "path": "benchmarks/preregistrations/cpp-verifier-driven-repair-pilot-v1.json",
+                "sha256": DESIGN_SHA256,
+            },
+            "model_source": {
+                "path": "benchmarks/manifests/cpp-formal-timeout-calibration.json",
+                "sha256": MODEL_SOURCE_SHA256,
+            },
+            "runtime_implementation_authorized": True,
+            "collection_authorized": False,
+            "provider_canary_forbidden": True,
+            "physical_attempt_creation_forbidden": True,
+            "model_execution_forbidden": True,
+            "batch_execution_forbidden": True,
+        },
+        "runtime": {
+            "adapter": "scripts/forge_verifier_repair_runtime.py",
+            "packet_schema_version": repair_runtime.PACKET_SCHEMA_VERSION,
+            "sidecar_schema_version": repair_runtime.SIDECAR_SCHEMA_VERSION,
+            "baseline_byte_identity_required": True,
+            "shared_compile_components_modified": False,
+            "compile_image": model_source["runtime"]["compile_image"],
+            "image_id": model_source["runtime"]["image_id"],
+            "control_plane_topology": "compose-dood",
+            "docker_daemon_provider": "ubuntu-native",
+        },
+        "repair_packet": {
+            "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+            "schema_sha256": hashlib.sha256(
+                (json.dumps(packet_schema, ensure_ascii=False, indent=2) + "\n").encode(
+                    "utf-8"
+                )
+            ).hexdigest(),
+            "actionable_classifications": sorted(repair_runtime.REPAIR_GOALS),
+            "repair_goals": dict(sorted(repair_runtime.REPAIR_GOALS.items())),
+            "forbidden_content": [
+                "stdout",
+                "stderr",
+                "prompt",
+                "model_body",
+                "credential",
+                "host_path",
+                "generated_repair_command",
+            ],
+        },
+        "cases": _selected_cases(design, case_protocol),
+        "model_profiles": _model_profiles(design, model_source),
+        "treatments": copy.deepcopy(design["treatments"]),
+        "pilot_schedule": copy.deepcopy(design["pilot_schedule"]),
+        "budget": copy.deepcopy(design["budget_proposal"]),
+        "outcomes": copy.deepcopy(design["outcomes"]),
+        "fidelity_gate": {
+            "statuses": ["passed", "not_exposed", "failed"],
+            "baseline_packet_count": 0,
+            "treatment_requires_packet_for_each_actionable_submit": True,
+            "paired_analysis_requires_both_arms": True,
+            "p_value_forbidden": True,
+            "model_ranking_forbidden": True,
+        },
+        "implementation_sha256": _hash_paths(repo_root, IMPLEMENTATION_PATHS),
+    }
+
+
+def validate_manifest(
+    document: Any, repo_root: Path = REPOSITORY_ROOT
+) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise ProtocolError("runtime candidate manifest must be an object")
+    expected = generate_manifest(repo_root)
+    if document != expected:
+        raise ProtocolError(
+            "runtime candidate manifest does not match the frozen implementation"
+        )
+    if (
+        len(document["pilot_schedule"]) != 12
+        or len({slot["pair_id"] for slot in document["pilot_schedule"]}) != 6
+    ):
+        raise ProtocolError(
+            "runtime candidate schedule must contain 12 slots and 6 pairs"
+        )
+    if document["protocolization"]["collection_authorized"] is not False:
+        raise ProtocolError("runtime candidate must not authorize collection")
+    return document
+
+
+def manifest_schema() -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-runtime-v1.schema.json",
+        "title": "Forge verifier-driven repair pilot runtime candidate",
+        "const": generate_manifest(),
+    }
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def generate_artifacts() -> dict[str, Any]:
+    _write_json(DEFAULT_PACKET_SCHEMA, repair_runtime.repair_packet_schema())
+    manifest = generate_manifest()
+    _write_json(DEFAULT_MANIFEST, manifest)
+    _write_json(DEFAULT_SCHEMA, manifest_schema())
+    return manifest
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("generate")
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path, nargs="?", default=DEFAULT_MANIFEST)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = (
+            generate_artifacts()
+            if args.command == "generate"
+            else validate_manifest(_load_json(args.manifest))
+        )
+    except (OSError, ProtocolError, repair_runtime.RepairRuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "collection_authorized": False,
+                "manifest_sha256": manifest_sha256(manifest),
+                "status": "valid",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_pilot_runner.py
+++ b/scripts/forge_verifier_repair_pilot_runner.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""未授权 verifier-driven repair pilot runner 门禁与反馈 context 构造器。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_pilot_protocol as protocol  # noqa: E402
+import forge_verifier_repair_runtime as repair_runtime  # noqa: E402
+
+
+class RunnerError(ValueError):
+    pass
+
+
+def load_manifest(path: Path = protocol.DEFAULT_MANIFEST) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError(f"cannot read runtime candidate manifest: {path}") from exc
+    try:
+        return protocol.validate_manifest(document)
+    except protocol.ProtocolError as exc:
+        raise RunnerError(str(exc)) from exc
+
+
+def slot_by_order(manifest: dict[str, Any], order: int) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    matches = [slot for slot in manifest["pilot_schedule"] if slot["order"] == order]
+    if len(matches) != 1:
+        raise RunnerError("pilot schedule order is invalid")
+    return matches[0]
+
+
+def build_feedback_context(
+    manifest: dict[str, Any],
+    *,
+    order: int,
+    thread_id: str,
+    event_reader: Callable[[], Sequence[Mapping[str, Any]]],
+    evidence: repair_runtime.RepairEvidenceLedger,
+) -> repair_runtime.RepairFeedbackContext:
+    slot = slot_by_order(manifest, order)
+    case = next(
+        (item for item in manifest["cases"] if item["id"] == slot["case_id"]), None
+    )
+    if case is None:
+        raise RunnerError("pilot case is missing")
+    expected_artifacts = tuple(
+        (artifact["staged_relative_path"], artifact["artifact_type"])
+        for artifact in case["artifact_oracle"]["required_artifacts"]
+    )
+    return repair_runtime.RepairFeedbackContext(
+        thread_id=thread_id,
+        pair_id=slot["pair_id"],
+        case_id=slot["case_id"],
+        provider_condition=slot["provider_condition"],
+        treatment=slot["treatment"],
+        repetition=slot["repetition"],
+        expected_build_system=case["build_system"],
+        expected_artifacts=expected_artifacts,
+        event_reader=event_reader,
+        evidence=evidence,
+    )
+
+
+def sidecar_context_payload(
+    manifest: dict[str, Any], *, order: int, thread_id: str, physical_attempt_id: str
+) -> dict[str, Any]:
+    slot = slot_by_order(manifest, order)
+    return {
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "thread_id": thread_id,
+        "physical_attempt_id": physical_attempt_id,
+        "order": slot["order"],
+        "pair_id": slot["pair_id"],
+        "case_id": slot["case_id"],
+        "provider_condition": slot["provider_condition"],
+        "treatment": slot["treatment"],
+        "repetition": slot["repetition"],
+    }
+
+
+def _reject_collection() -> None:
+    raise RunnerError(
+        "Verifier-driven repair collection is not authorized; model execution and evidence creation are forbidden"
+    )
+
+
+def provider_canary(*_args: Any, **_kwargs: Any) -> None:
+    _reject_collection()
+
+
+def run_attempt(*_args: Any, **_kwargs: Any) -> None:
+    _reject_collection()
+
+
+def run_batch(*_args: Any, **_kwargs: Any) -> None:
+    _reject_collection()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("validate-manifest", "provider-canary", "run-attempt", "run-batch"),
+    )
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        if args.command != "validate-manifest":
+            _reject_collection()
+    except (RunnerError, protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "collection_authorized": False,
+                "manifest_sha256": protocol.manifest_sha256(manifest),
+                "status": "valid",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_runtime.py
+++ b/scripts/forge_verifier_repair_runtime.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""为 verifier-driven repair pilot 提供版本化反馈适配与证据门禁。"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import threading
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from types import ModuleType
+from typing import Any
+
+BASELINE_ARM = "baseline-current-verifier-output"
+TREATMENT_ARM = "structured-verifier-repair-packet"
+ALLOWED_ARMS = frozenset({BASELINE_ARM, TREATMENT_ARM})
+PACKET_SCHEMA_VERSION = "forge-verifier-repair-packet-1.0.0"
+SIDECAR_SCHEMA_VERSION = "forge-verifier-repair-sidecar-1.0.0"
+MAX_DIFF_ENTRIES = 64
+
+REPAIR_GOALS = {
+    "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+    "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+    "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+    "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+    "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+    "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+    "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+    "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+    "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+    "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay.",
+}
+
+_REPLAY_CLASSIFICATION_MAP = {
+    "artifact_set_mismatch": "artifact_set_mismatch",
+    "type_mismatch": "artifact_type_mismatch",
+    "size_mismatch": "size_mismatch",
+    "sha256_mismatch": "sha256_mismatch",
+    "smoke_mismatch": "smoke_mismatch",
+    "recipe_execution_failed": "recipe_execution_failed",
+}
+_ARTIFACT_MISMATCH_KINDS = frozenset({"type", "size", "sha256", "smoke"})
+_SIDECAR_RECORD_FIELDS = {
+    "schema_version",
+    "sequence",
+    "timestamp",
+    "event",
+    "payload",
+    "previous_sha256",
+    "record_sha256",
+}
+_CONTEXT_STARTED_FIELDS = {
+    "manifest_sha256",
+    "thread_id",
+    "physical_attempt_id",
+    "order",
+    "pair_id",
+    "case_id",
+    "provider_condition",
+    "treatment",
+    "repetition",
+}
+_FEEDBACK_OBSERVED_FIELDS = {
+    "treatment",
+    "status",
+    "actionable",
+    "evidence_complete",
+    "primary_classification",
+    "packet_attached",
+    "packet",
+    "original_sha256",
+    "returned_sha256",
+    "submit_attempt_id",
+}
+
+
+class RepairRuntimeError(ValueError):
+    pass
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+
+
+def _sha256(value: bytes | str) -> str:
+    payload = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _safe_relative_path(value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 512
+        or any(character in value for character in ("\0", "\r", "\n", "\\"))
+    ):
+        raise RepairRuntimeError(f"{label} must be a bounded POSIX relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise RepairRuntimeError(f"{label} must be a safe relative path")
+    return value
+
+
+def _safe_id(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 160
+        or any(
+            character
+            not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
+            for character in value
+        )
+    ):
+        raise RepairRuntimeError(f"{label} must be a safe identifier")
+    return value
+
+
+def _is_safe_id(value: Any) -> bool:
+    try:
+        _safe_id(value, "identifier")
+    except RepairRuntimeError:
+        return False
+    return True
+
+
+def _safe_optional_id(value: Any) -> str | None:
+    return value if value is not None and _is_safe_id(value) else None
+
+
+def _safe_sha256(value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise RepairRuntimeError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def repair_packet_schema() -> dict[str, Any]:
+    nullable_id = {"type": ["string", "null"], "pattern": "^[A-Za-z0-9_.-]{1,160}$"}
+    relative_path = {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512,
+        "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$",
+    }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+        "title": "Forge verifier-driven repair packet",
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "schema_version",
+            "failure_domain",
+            "primary_classification",
+            "failed_checks",
+            "build_system_identity",
+            "artifact_identity_diff",
+            "replay_status",
+            "repair_goal",
+            "supporting_command_id",
+            "submit_attempt_id",
+            "replay_attempt_id",
+        ],
+        "properties": {
+            "schema_version": {"const": PACKET_SCHEMA_VERSION},
+            "failure_domain": {"const": "submit_replay"},
+            "primary_classification": {"enum": sorted(REPAIR_GOALS)},
+            "failed_checks": {
+                "type": "array",
+                "maxItems": MAX_DIFF_ENTRIES,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["name", "exit_code"],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 160,
+                            "pattern": "^[A-Za-z0-9_.-]+$",
+                        },
+                        "exit_code": {"type": ["integer", "null"]},
+                    },
+                },
+            },
+            "build_system_identity": {
+                "type": ["object", "null"],
+                "additionalProperties": False,
+                "required": ["expected", "observed", "selected", "matches"],
+                "properties": {
+                    "expected": {
+                        "type": ["string", "null"],
+                        "enum": ["cmake", "make", "autotools", None],
+                    },
+                    "observed": {
+                        "type": ["string", "null"],
+                        "enum": ["cmake", "make", "autotools", None],
+                    },
+                    "selected": {
+                        "type": ["string", "null"],
+                        "enum": ["cmake", "make", "autotools", None],
+                    },
+                    "matches": {"type": ["boolean", "null"]},
+                },
+            },
+            "artifact_identity_diff": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "expected_only",
+                    "observed_only",
+                    "mismatches",
+                    "truncated",
+                ],
+                "properties": {
+                    "expected_only": {
+                        "type": "array",
+                        "maxItems": MAX_DIFF_ENTRIES,
+                        "items": relative_path,
+                    },
+                    "observed_only": {
+                        "type": "array",
+                        "maxItems": MAX_DIFF_ENTRIES,
+                        "items": relative_path,
+                    },
+                    "mismatches": {
+                        "type": "array",
+                        "maxItems": MAX_DIFF_ENTRIES,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "required": ["path", "kinds"],
+                            "properties": {
+                                "path": relative_path,
+                                "kinds": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "uniqueItems": True,
+                                    "items": {"enum": sorted(_ARTIFACT_MISMATCH_KINDS)},
+                                },
+                            },
+                        },
+                    },
+                    "truncated": {"type": "boolean"},
+                },
+            },
+            "replay_status": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64,
+                "pattern": "^[a-z0-9_-]+$",
+            },
+            "repair_goal": {"enum": sorted(REPAIR_GOALS.values())},
+            "supporting_command_id": nullable_id,
+            "submit_attempt_id": nullable_id,
+            "replay_attempt_id": nullable_id,
+        },
+    }
+
+
+def validate_repair_packet(packet: Any) -> dict[str, Any]:
+    if not isinstance(packet, dict) or set(packet) != set(
+        repair_packet_schema()["required"]
+    ):
+        raise RepairRuntimeError("repair packet fields do not match the frozen schema")
+    classification = packet.get("primary_classification")
+    if (
+        classification not in REPAIR_GOALS
+        or packet.get("repair_goal") != REPAIR_GOALS[classification]
+    ):
+        raise RepairRuntimeError("repair packet classification and goal do not match")
+    if (
+        packet.get("schema_version") != PACKET_SCHEMA_VERSION
+        or packet.get("failure_domain") != "submit_replay"
+    ):
+        raise RepairRuntimeError("repair packet identity is invalid")
+    checks = packet.get("failed_checks")
+    if not isinstance(checks, list) or len(checks) > MAX_DIFF_ENTRIES:
+        raise RepairRuntimeError("repair packet failed_checks are invalid")
+    for check in checks:
+        if not isinstance(check, dict) or set(check) != {"name", "exit_code"}:
+            raise RepairRuntimeError("repair packet check fields are invalid")
+        _safe_id(check["name"], "failed check name")
+        if check["exit_code"] is not None and type(check["exit_code"]) is not int:
+            raise RepairRuntimeError("failed check exit_code is invalid")
+    identity = packet.get("build_system_identity")
+    if identity is not None:
+        if not isinstance(identity, dict) or set(identity) != {
+            "expected",
+            "observed",
+            "selected",
+            "matches",
+        }:
+            raise RepairRuntimeError("build-system identity fields are invalid")
+        for name in ("expected", "observed", "selected"):
+            if identity[name] not in {None, "cmake", "make", "autotools"}:
+                raise RepairRuntimeError("build-system identity value is invalid")
+        if identity["matches"] is not None and not isinstance(
+            identity["matches"], bool
+        ):
+            raise RepairRuntimeError("build-system match flag is invalid")
+    diff = packet.get("artifact_identity_diff")
+    if not isinstance(diff, dict) or set(diff) != {
+        "expected_only",
+        "observed_only",
+        "mismatches",
+        "truncated",
+    }:
+        raise RepairRuntimeError("artifact identity diff fields are invalid")
+    for name in ("expected_only", "observed_only"):
+        values = diff[name]
+        if not isinstance(values, list) or len(values) > MAX_DIFF_ENTRIES:
+            raise RepairRuntimeError("artifact identity path set is invalid")
+        for value in values:
+            _safe_relative_path(value, f"artifact_identity_diff.{name}")
+    mismatches = diff["mismatches"]
+    if not isinstance(mismatches, list) or len(mismatches) > MAX_DIFF_ENTRIES:
+        raise RepairRuntimeError("artifact mismatch list is invalid")
+    for mismatch in mismatches:
+        if not isinstance(mismatch, dict) or set(mismatch) != {"path", "kinds"}:
+            raise RepairRuntimeError("artifact mismatch fields are invalid")
+        _safe_relative_path(mismatch["path"], "artifact mismatch path")
+        kinds = mismatch["kinds"]
+        if (
+            not isinstance(kinds, list)
+            or not kinds
+            or len(kinds) != len(set(kinds))
+            or any(kind not in _ARTIFACT_MISMATCH_KINDS for kind in kinds)
+        ):
+            raise RepairRuntimeError("artifact mismatch kinds are invalid")
+    if not isinstance(diff["truncated"], bool):
+        raise RepairRuntimeError("artifact diff truncated flag is invalid")
+    replay_status = packet.get("replay_status")
+    _safe_id(replay_status, "replay_status")
+    for field in ("supporting_command_id", "submit_attempt_id", "replay_attempt_id"):
+        _safe_id(packet.get(field), field, optional=True)
+    return packet
+
+
+def _latest_event(
+    events: Sequence[Mapping[str, Any]],
+    name: str,
+    *,
+    submit_attempt_id: str | None = None,
+) -> Mapping[str, Any] | None:
+    for event in reversed(events):
+        if event.get("event") != name:
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, Mapping):
+            continue
+        if (
+            submit_attempt_id is None
+            or payload.get("submit_attempt_id") == submit_attempt_id
+        ):
+            return payload
+    return None
+
+
+def _build_system_identity(
+    events: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    payload = _latest_event(events, "build.system_checked")
+    if payload is None:
+        return None
+    return {
+        "expected": payload.get("expected_build_system")
+        if payload.get("expected_build_system") in {"cmake", "make", "autotools"}
+        else None,
+        "observed": payload.get("observed_build_system")
+        if payload.get("observed_build_system") in {"cmake", "make", "autotools"}
+        else None,
+        "selected": payload.get("selected_build_system")
+        if payload.get("selected_build_system") in {"cmake", "make", "autotools"}
+        else None,
+        "matches": payload.get("matches")
+        if isinstance(payload.get("matches"), bool)
+        else None,
+    }
+
+
+def _artifact_diff(
+    submit: Mapping[str, Any],
+    replay: Mapping[str, Any] | None,
+    expected_artifacts: tuple[tuple[str, str], ...],
+) -> dict[str, Any]:
+    expected = {path: artifact_type for path, artifact_type in expected_artifacts}
+    observed = {
+        artifact["path"]: artifact.get("artifact_type")
+        for artifact in submit.get("artifacts", [])
+        if isinstance(artifact, Mapping) and isinstance(artifact.get("path"), str)
+    }
+    expected_only = sorted(set(expected) - set(observed))
+    observed_only = sorted(set(observed) - set(expected))
+    mismatches: dict[str, set[str]] = {}
+    for path in sorted(set(expected) & set(observed)):
+        if expected[path] != observed[path]:
+            mismatches.setdefault(path, set()).add("type")
+    if replay is not None:
+        for artifact in replay.get("artifacts", []):
+            if not isinstance(artifact, Mapping) or not isinstance(
+                artifact.get("path"), str
+            ):
+                continue
+            kinds = {
+                kind
+                for kind in artifact.get("mismatches", [])
+                if kind in _ARTIFACT_MISMATCH_KINDS
+            }
+            if kinds:
+                mismatches.setdefault(artifact["path"], set()).update(kinds)
+    raw_entries = [(path, sorted(kinds)) for path, kinds in sorted(mismatches.items())]
+    total_entries = len(expected_only) + len(observed_only) + len(raw_entries)
+    return {
+        "expected_only": expected_only[:MAX_DIFF_ENTRIES],
+        "observed_only": observed_only[:MAX_DIFF_ENTRIES],
+        "mismatches": [
+            {"path": path, "kinds": kinds}
+            for path, kinds in raw_entries[:MAX_DIFF_ENTRIES]
+        ],
+        "truncated": total_entries > MAX_DIFF_ENTRIES,
+    }
+
+
+def _classification(
+    submit: Mapping[str, Any],
+    replay: Mapping[str, Any] | None,
+    identity: Mapping[str, Any] | None,
+) -> str | None:
+    if replay is not None:
+        normalized = _REPLAY_CLASSIFICATION_MAP.get(
+            replay.get("primary_failure_classification")
+        )
+        if normalized is not None:
+            return normalized
+    if submit.get("candidate_status") != "failed":
+        return None
+    failed_names = {
+        check.get("name")
+        for check in submit.get("checks", [])
+        if isinstance(check, Mapping) and check.get("passed") is False
+    }
+    if "benchmark_constraints" in failed_names:
+        if identity is not None and identity.get("matches") is False:
+            return "build_system_selection_mismatch"
+        return "build_system_unproven"
+    return "candidate_verification_failed"
+
+
+def build_repair_packet(
+    result_payload: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]],
+    *,
+    expected_artifacts: tuple[tuple[str, str], ...],
+) -> dict[str, Any] | None:
+    if result_payload.get("status") != "failed":
+        return None
+    submit_attempt_id = result_payload.get("submit_attempt_id")
+    if not _is_safe_id(submit_attempt_id):
+        return None
+    submit = _latest_event(
+        events, "submit.completed", submit_attempt_id=submit_attempt_id
+    )
+    if submit is None:
+        return None
+    replay = _latest_event(
+        events, "replay.completed", submit_attempt_id=submit_attempt_id
+    )
+    identity = _build_system_identity(events)
+    classification = _classification(submit, replay, identity)
+    if classification not in REPAIR_GOALS:
+        return None
+    checks = [
+        {
+            "name": check["name"],
+            "exit_code": check.get("exit_code")
+            if type(check.get("exit_code")) is int
+            else None,
+        }
+        for check in submit.get("checks", [])
+        if isinstance(check, Mapping)
+        and check.get("passed") is False
+        and _is_safe_id(check.get("name"))
+    ][:MAX_DIFF_ENTRIES]
+    replay_snapshot = (
+        submit.get("replay") if isinstance(submit.get("replay"), Mapping) else None
+    )
+    packet = {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "failure_domain": "submit_replay",
+        "primary_classification": classification,
+        "failed_checks": checks,
+        "build_system_identity": identity,
+        "artifact_identity_diff": _artifact_diff(submit, replay, expected_artifacts),
+        "replay_status": _safe_optional_id(
+            result_payload.get("replay_status") or (replay_snapshot or {}).get("status")
+        )
+        or "not_run",
+        "repair_goal": REPAIR_GOALS[classification],
+        "supporting_command_id": _safe_optional_id(
+            result_payload.get("supporting_command_id")
+        ),
+        "submit_attempt_id": submit_attempt_id,
+        "replay_attempt_id": _safe_optional_id(
+            result_payload.get("replay_attempt_id")
+            or (replay_snapshot or {}).get("replay_attempt_id")
+        ),
+    }
+    return validate_repair_packet(packet)
+
+
+def _validate_sidecar_payload(event: str, payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RepairRuntimeError("repair sidecar payload must be an object")
+    if event == "repair.context_started":
+        if set(payload) != _CONTEXT_STARTED_FIELDS:
+            raise RepairRuntimeError(
+                "repair context fields do not match the frozen sidecar contract"
+            )
+        _safe_sha256(payload["manifest_sha256"], "manifest_sha256")
+        for field in (
+            "thread_id",
+            "physical_attempt_id",
+            "pair_id",
+            "case_id",
+            "provider_condition",
+        ):
+            _safe_id(payload[field], field)
+        if payload["treatment"] not in ALLOWED_ARMS:
+            raise RepairRuntimeError("repair context treatment is invalid")
+        for field in ("order", "repetition"):
+            if type(payload[field]) is not int or payload[field] < 1:
+                raise RepairRuntimeError(f"repair context {field} is invalid")
+        return payload
+    if event == "repair.feedback_observed":
+        if set(payload) != _FEEDBACK_OBSERVED_FIELDS:
+            raise RepairRuntimeError(
+                "repair feedback fields do not match the frozen sidecar contract"
+            )
+        if payload["treatment"] not in ALLOWED_ARMS:
+            raise RepairRuntimeError("repair feedback treatment is invalid")
+        _safe_id(payload["status"], "feedback status")
+        for field in ("actionable", "evidence_complete", "packet_attached"):
+            if type(payload[field]) is not bool:
+                raise RepairRuntimeError(f"repair feedback {field} is invalid")
+        classification = payload["primary_classification"]
+        if classification is not None and classification not in REPAIR_GOALS:
+            raise RepairRuntimeError("repair feedback classification is invalid")
+        if payload["actionable"] != (classification is not None):
+            raise RepairRuntimeError("repair feedback actionable flag is inconsistent")
+        packet = payload["packet"]
+        if payload["packet_attached"] != (packet is not None):
+            raise RepairRuntimeError("repair feedback packet flag is inconsistent")
+        if packet is not None:
+            validate_repair_packet(packet)
+            if packet["primary_classification"] != classification:
+                raise RepairRuntimeError(
+                    "repair feedback packet classification drifted"
+                )
+        _safe_sha256(payload["original_sha256"], "original_sha256")
+        _safe_sha256(payload["returned_sha256"], "returned_sha256")
+        _safe_id(payload["submit_attempt_id"], "submit_attempt_id", optional=True)
+        return payload
+    if event == "repair.context_completed":
+        if set(payload) != {"status"}:
+            raise RepairRuntimeError(
+                "repair completion fields do not match the frozen sidecar contract"
+            )
+        _safe_id(payload["status"], "completion status")
+        return payload
+    raise RepairRuntimeError("repair sidecar event is unsupported")
+
+
+class RepairEvidenceLedger:
+    def __init__(self, path: Path):
+        self.path = path
+        self._lock = threading.RLock()
+
+    @classmethod
+    def create(cls, path: Path, context: Mapping[str, Any]) -> RepairEvidenceLedger:
+        if path.exists():
+            raise RepairRuntimeError("repair sidecar already exists")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        ledger = cls(path)
+        ledger.append("repair.context_started", dict(context))
+        return ledger
+
+    def read(self) -> list[dict[str, Any]]:
+        if not self.path.is_file():
+            raise RepairRuntimeError("repair sidecar does not exist")
+        records = [
+            json.loads(line)
+            for line in self.path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        previous = None
+        for index, record in enumerate(records, start=1):
+            if not isinstance(record, dict) or set(record) != _SIDECAR_RECORD_FIELDS:
+                raise RepairRuntimeError("repair sidecar record fields are invalid")
+            if (
+                record.get("schema_version") != SIDECAR_SCHEMA_VERSION
+                or record.get("sequence") != index
+                or record.get("previous_sha256") != previous
+            ):
+                raise RepairRuntimeError("repair sidecar chain metadata is invalid")
+            try:
+                timestamp = datetime.fromisoformat(record["timestamp"])
+            except (TypeError, ValueError) as exc:
+                raise RepairRuntimeError("repair sidecar timestamp is invalid") from exc
+            if timestamp.tzinfo is None:
+                raise RepairRuntimeError(
+                    "repair sidecar timestamp must include a timezone"
+                )
+            _validate_sidecar_payload(record.get("event"), record.get("payload"))
+            expected_hash = _sha256(
+                _canonical_bytes(
+                    {
+                        key: value
+                        for key, value in record.items()
+                        if key != "record_sha256"
+                    }
+                )
+            )
+            if record.get("record_sha256") != expected_hash:
+                raise RepairRuntimeError("repair sidecar hash chain is invalid")
+            previous = record["record_sha256"]
+        return records
+
+    def append(self, event: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        validated_payload = _validate_sidecar_payload(event, dict(payload))
+        with self._lock:
+            records = (
+                self.read() if self.path.exists() and self.path.stat().st_size else []
+            )
+            record = {
+                "schema_version": SIDECAR_SCHEMA_VERSION,
+                "sequence": len(records) + 1,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "event": event,
+                "payload": validated_payload,
+                "previous_sha256": records[-1]["record_sha256"] if records else None,
+            }
+            record["record_sha256"] = _sha256(_canonical_bytes(record))
+            with self.path.open("a", encoding="utf-8", newline="\n") as stream:
+                stream.write(
+                    json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+                )
+                stream.flush()
+                os.fsync(stream.fileno())
+            return record
+
+
+@dataclass(frozen=True)
+class RepairFeedbackContext:
+    thread_id: str
+    pair_id: str
+    case_id: str
+    provider_condition: str
+    treatment: str
+    repetition: int
+    expected_build_system: str
+    expected_artifacts: tuple[tuple[str, str], ...]
+    event_reader: Callable[[], Sequence[Mapping[str, Any]]]
+    evidence: RepairEvidenceLedger
+
+    def __post_init__(self) -> None:
+        _safe_id(self.thread_id, "thread_id")
+        _safe_id(self.pair_id, "pair_id")
+        _safe_id(self.case_id, "case_id")
+        _safe_id(self.provider_condition, "provider_condition")
+        if (
+            self.treatment not in ALLOWED_ARMS
+            or self.repetition < 1
+            or self.expected_build_system not in {"cmake", "make", "autotools"}
+        ):
+            raise RepairRuntimeError("repair feedback context identity is invalid")
+        for path, artifact_type in self.expected_artifacts:
+            _safe_relative_path(path, "expected artifact")
+            if artifact_type not in {
+                "executable",
+                "shared_library",
+                "static_library",
+                "object",
+            }:
+                raise RepairRuntimeError("expected artifact type is invalid")
+
+
+_CONTEXTS: dict[str, RepairFeedbackContext] = {}
+_CONTEXT_LOCK = threading.RLock()
+
+
+def _adapt_submit_result(context: RepairFeedbackContext, result: str) -> str:
+    original_digest = _sha256(result if isinstance(result, str) else repr(result))
+    try:
+        payload = json.loads(result)
+    except (TypeError, json.JSONDecodeError):
+        context.evidence.append(
+            "repair.feedback_observed",
+            {
+                "treatment": context.treatment,
+                "status": "invalid_response",
+                "actionable": False,
+                "evidence_complete": False,
+                "primary_classification": None,
+                "packet_attached": False,
+                "packet": None,
+                "original_sha256": original_digest,
+                "returned_sha256": original_digest,
+                "submit_attempt_id": None,
+            },
+        )
+        return result
+    if not isinstance(payload, dict):
+        context.evidence.append(
+            "repair.feedback_observed",
+            {
+                "treatment": context.treatment,
+                "status": "invalid_response",
+                "actionable": False,
+                "evidence_complete": False,
+                "primary_classification": None,
+                "packet_attached": False,
+                "packet": None,
+                "original_sha256": original_digest,
+                "returned_sha256": original_digest,
+                "submit_attempt_id": None,
+            },
+        )
+        return result
+    events = context.event_reader()
+    status = payload.get("status") if _is_safe_id(payload.get("status")) else "unknown"
+    submit_attempt_id = _safe_optional_id(payload.get("submit_attempt_id"))
+    failed_submit_evidence = (
+        submit_attempt_id is not None
+        and _latest_event(
+            events, "submit.completed", submit_attempt_id=submit_attempt_id
+        )
+        is not None
+    )
+    evidence_complete = status != "failed" or failed_submit_evidence
+    packet = (
+        build_repair_packet(
+            payload, events, expected_artifacts=context.expected_artifacts
+        )
+        if evidence_complete
+        else None
+    )
+    actionable = packet is not None
+    returned = result
+    attached_packet = None
+    if context.treatment == TREATMENT_ARM and packet is not None:
+        payload["repair_packet"] = packet
+        attached_packet = packet
+        returned = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    context.evidence.append(
+        "repair.feedback_observed",
+        {
+            "treatment": context.treatment,
+            "status": status,
+            "actionable": actionable,
+            "evidence_complete": evidence_complete,
+            "primary_classification": packet.get("primary_classification")
+            if packet
+            else None,
+            "packet_attached": attached_packet is not None,
+            "packet": attached_packet,
+            "original_sha256": original_digest,
+            "returned_sha256": _sha256(returned),
+            "submit_attempt_id": submit_attempt_id,
+        },
+    )
+    return returned
+
+
+@contextlib.contextmanager
+def submit_feedback_scope(
+    context: RepairFeedbackContext, bound_compile_tools: ModuleType
+) -> Iterator[None]:
+    with _CONTEXT_LOCK:
+        if _CONTEXTS or context.thread_id in _CONTEXTS:
+            raise RepairRuntimeError("repair feedback scopes must execute serially")
+        original = bound_compile_tools._submit_with_post_build_phase
+        _CONTEXTS[context.thread_id] = context
+
+        def wrapped(session, *, supporting_command_id=None):
+            result = original(session, supporting_command_id=supporting_command_id)
+            active = _CONTEXTS.get(session.thread_id)
+            return (
+                _adapt_submit_result(active, result) if active is not None else result
+            )
+
+        bound_compile_tools._submit_with_post_build_phase = wrapped
+    try:
+        yield
+    finally:
+        with _CONTEXT_LOCK:
+            bound_compile_tools._submit_with_post_build_phase = original
+            _CONTEXTS.pop(context.thread_id, None)
+
+
+def evaluate_treatment_fidelity(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not records or records[0].get("event") != "repair.context_started":
+        return {
+            "status": "failed",
+            "evidence_complete": False,
+            "exposures": 0,
+            "actionable_exposures": 0,
+            "failures": ["context_missing"],
+        }
+    context_payload = records[0].get("payload")
+    treatment = (
+        context_payload.get("treatment")
+        if isinstance(context_payload, Mapping)
+        else None
+    )
+    if treatment not in ALLOWED_ARMS:
+        return {
+            "status": "failed",
+            "evidence_complete": False,
+            "exposures": 0,
+            "actionable_exposures": 0,
+            "failures": ["arm_invalid"],
+        }
+    observed = [
+        record.get("payload")
+        for record in records
+        if record.get("event") == "repair.feedback_observed"
+        and isinstance(record.get("payload"), Mapping)
+    ]
+    failures: list[str] = []
+    actionable_count = 0
+    for payload in observed:
+        if payload.get("treatment") != treatment:
+            failures.append("arm_mismatch")
+            continue
+        if payload.get("evidence_complete") is not True:
+            failures.append("evidence_missing")
+        actionable = payload.get("actionable") is True
+        attached = payload.get("packet_attached") is True
+        actionable_count += int(actionable)
+        if treatment == BASELINE_ARM and attached:
+            failures.append("baseline_packet_attached")
+        if treatment == BASELINE_ARM and payload.get("original_sha256") != payload.get(
+            "returned_sha256"
+        ):
+            failures.append("baseline_response_modified")
+        if treatment == TREATMENT_ARM and actionable != attached:
+            failures.append("treatment_exposure_mismatch")
+        if attached:
+            try:
+                validate_repair_packet(payload.get("packet"))
+            except RepairRuntimeError:
+                failures.append("packet_invalid")
+    status = (
+        "failed" if failures else ("not_exposed" if actionable_count == 0 else "passed")
+    )
+    return {
+        "status": status,
+        "evidence_complete": all(
+            payload.get("evidence_complete") is True for payload in observed
+        ),
+        "exposures": len(observed),
+        "actionable_exposures": actionable_count,
+        "failures": sorted(set(failures)),
+    }


### PR DESCRIPTION
## 概要

本 PR 落地 Issue #125 的 verifier-driven repair 未授权运行时候选。在不修改共享编译核心的前提下，为 treatment arm 增加由持久化 verifier evidence 确定性生成的结构化 `repair_packet`，并冻结 sidecar、fidelity gate、未授权 runner 与配对描述性分析契约。

## 核心行为

- baseline submit 返回保持字节级不变；原始与返回 SHA-256 不一致时 fidelity 拒绝；
- treatment 只对有对应 `submit.completed` evidence 的 actionable verification failure 附加一个 packet；
- 失败 submit 缺少持久化 evidence 时标记为 `failed/evidence_missing`，不再误报为 `not_exposed`；
- packet 与 sidecar 使用严格字段白名单，不包含 stdout、stderr、prompt、模型正文、密钥、宿主路径或生成式修复命令；
- analyzer 描述性报告 actionable failure、repair conversion、false acceptance、submit/replay 次数、failure transition、请求、token 与墙钟，不计算 p-value、不做模型排名；
- canary、attempt 和 batch 入口在模型调用与 evidence 创建前硬拒绝。

## 冻结边界

- 未修改 `operations.py`、`evidence.py`、`bound_compile_tools.py`，三个共享 blob 保持不变；
- 未修改任何历史 manifest、Schema、runner、ledger 或 report；
- protocol identity：`verifier-driven-repair-pilot-runtime-1.0.0`；
- `runtime_implementation_authorized=true`，`collection_authorized=false`；
- canonical manifest SHA-256：`880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045`。

## 验证

- 聚焦 pytest：`17 passed`；
- Ruff check 与 format-check 通过；
- `py_compile`、packet/manifest Schema、protocol/runner validate 通过；
- 生成器重复执行字节稳定；
- `git diff --check`、共享 compile blob 与敏感信息扫描通过；
- 本阶段未启动 Docker、未调用模型、未创建实验 ledger，也未消耗实验 token。

实现合并后仍不构成 12 slots 与 maximum 2,400,000 recorded tokens 的采集授权，实验负责人需另行确认并派生 authorized identity。

Closes #125