### PR TITLE
实现 verifier-driven repair 配对 pilot 授权执行

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-14 — 执行 verifier-driven repair 六对授权 pilot
+  - GitHub: 中文 Issue #127 已创建并回读；实现分支为 `research/issue-127-verifier-repair-authorized`，基线为 `main@fb24fa2b`。
+  - 授权: RichLab `gpt-5.5`、DeepSeek `deepseek-v4-flash`，3 cases × 2 providers × 2 arms × 1 repetition，共 12 slots / 6 complete pairs；expected 800,000、maximum 2,400,000 recorded tokens，禁止 retry、fallback、replacement 和 backfill。
+  - 实现: 新 authorized manifest/Schema 把 provider×arm 展开为四个唯一 condition，同时保持 canary 每个 provider 只请求一次；真实 attempt 在 `submit_feedback_scope` 内运行，独立 sidecar 不使用 `.jsonl` 后缀，避免被主 ledger 扫描器误识别；只读报告器按冻结 order 合并主 ledger 与 sidecar。
+  - 门禁: 合并前禁止模型与 evidence；合并后依次要求 Ubuntu 原生 Docker、非模型 preflight、空 evidence、0 orphan、已确认的 `FORGE_NETWORK_ACCESS_MEDIUM` 与唯一双 provider canary。batch 只能在完整 pair 边界停止，token 在新 pair 前检查。
+  - 验证: 聚焦 repair runtime/authorized 回归 `26 passed`；Ruff check/format、`py_compile`、Schema 实例校验、protocol validate、确定性再生成、父 runtime/共享 compile 与敏感值扫描通过。authorized manifest canonical SHA-256 为 `ad54858ad8cc938e823170bece020b21a7ab221788d5c36ac45c5213d78b56d0`。
+  - 边界与下一步: 当前 0 Docker、0 provider request、0 model token、0 physical attempt。下一步中文提交、WSL helper 推送、中文 PR/CI/合并；canary 前需实验负责人确认当前网络介质。
+  - 文件: `scripts/forge_verifier_repair_authorized_protocol.py`, `scripts/forge_verifier_repair_authorized_runner.py`, `scripts/forge_verifier_repair_authorized_report.py`, `backend/tests/test_forge_verifier_repair_authorized.py`, `benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json`, `benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json`
+
 - 2026-08-13 — 完成 formal v4 有限诊断与新 canary amendment
   - GitHub: 中文 Issue #115 已创建并回读；实现分支为 `research/formal-v4-canary-amendment`，PR 尚未创建。
   - 授权: RichLab `gpt-5.5` 与 DeepSeek `deepseek-v4-flash` 各最多 2 次低成本诊断，首次成功即停止；之后最多 1 次新的双 provider canary，成功才执行原六槽，token 上限仍为 980,000。

--- a/backend/tests/test_forge_verifier_repair_authorized.py
+++ b/backend/tests/test_forge_verifier_repair_authorized.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_authorized_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_authorized_runner.py"
+REPORT_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_authorized_report.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-authorized.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_verifier_repair_authorized_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_verifier_repair_authorized_runner_test", RUNNER_PATH)
+report = _load_module("forge_verifier_repair_authorized_report_test", REPORT_PATH)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_authorized_protocol_is_deterministic_and_binds_parent() -> None:
+    manifest = _manifest()
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    assert manifest["scope"]["collection_authorized"] is True
+    assert manifest["authorization"]["parent_runtime"]["canonical_sha256"] == protocol.PARENT_CANONICAL_SHA256
+    assert manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"] == 2_400_000
+    assert len(manifest["collection_plan"]) == 12
+    assert len({slot["pair_id"] for slot in manifest["collection_plan"]}) == 6
+    assert len({condition["id"] for condition in manifest["conditions"]}) == 4
+    assert {condition["provider_condition"] for condition in manifest["conditions"]} == {
+        "richlab-gpt-5.5",
+        "deepseek-v4-flash",
+    }
+    assert manifest["analysis_plan"]["repair_conversion_definition"] == "adjacent_actionable_classification_to_passed_feedback"
+
+
+def test_authorized_protocol_rejects_budget_or_schedule_drift() -> None:
+    manifest = _manifest()
+    manifest["budget"]["maximum_recorded_tokens"] += 1
+    with pytest.raises(protocol.ProtocolError):
+        protocol.validate_manifest(manifest)
+
+
+def test_canary_invokes_each_provider_once_and_projects_four_conditions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    calls: list[str] = []
+
+    monkeypatch.setattr(runner, "_require_authorized_output_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runner, "_formal_container_ids", lambda: [])
+    monkeypatch.setattr(runner._runner, "_running_inside_compose_dood", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(runner._runner, "collect_preflight", lambda *_args, **_kwargs: {"ready": True})
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "mobile_hotspot")
+
+    def fake_canary(profile: dict) -> dict:
+        calls.append(profile["roles"]["lead"])
+        return {
+            "model": profile["roles"]["lead"],
+            "endpoint": profile["endpoint"],
+            "credential_env": profile["credential_env"],
+            "duration_ms": 1,
+            "response_nonempty": True,
+            "response_sha256": "0" * 64,
+            "error_class": None,
+            "passed": True,
+        }
+
+    monkeypatch.setattr(runner, "_invoke_provider_canary", fake_canary)
+    result = runner.collect_provider_canary(
+        manifest,
+        manifest_path=MANIFEST_PATH,
+        output_dir=tmp_path,
+        repo_root=REPO_ROOT,
+    )
+    assert sorted(calls) == ["deepseek-v4-flash", "gpt-5.5"]
+    assert result["provider_request_count"] == 2
+    assert len(result["providers"]) == 2
+    assert len(result["conditions"]) == 4
+    assert result["network_access_medium"] == "mobile_hotspot"
+    assert result["passed"] is True
+
+
+def test_canary_rejects_unconfirmed_network_before_consuming_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    monkeypatch.setattr(runner, "_require_authorized_output_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.delenv("FORGE_NETWORK_ACCESS_MEDIUM", raising=False)
+    with pytest.raises(runner.RunnerError):
+        runner.collect_provider_canary(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+            repo_root=REPO_ROOT,
+        )
+    assert not runner._canary_marker_path(tmp_path).exists()
+
+
+def test_run_attempt_creates_terminal_sidecar_without_model_work(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    slot = manifest["collection_plan"][0]
+    policy = runner._runner.build_policy(
+        manifest,
+        case_id=slot["case_id"],
+        condition_id=slot["condition_id"],
+        repetition=slot["repetition"],
+    )
+    ledger_path = tmp_path / "attempt.jsonl"
+    ledger = runner._runner.ExperimentLedger.create(
+        ledger_path,
+        experiment_id=runner._runner.new_evidence_id("experiment"),
+        physical_attempt_id=runner._runner.new_evidence_id("physical_attempt"),
+        context={
+            "thread_id": "thread_test",
+            "policy": policy.to_payload(),
+        },
+    )
+    monkeypatch.setattr(runner, "_authorized_output_dir", lambda _manifest: tmp_path)
+    monkeypatch.setattr(
+        runner,
+        "_original_run_attempt",
+        lambda *_args, **_kwargs: {"status": "failed"},
+    )
+
+    result = runner.run_attempt(manifest, ledger.path)
+    sidecar = runner.repair_sidecar_path(ledger.path)
+    records = runner.repair_runtime.RepairEvidenceLedger(sidecar).read()
+    assert result["status"] == "failed"
+    assert result["repair_fidelity"]["status"] == "not_exposed"
+    assert records[0]["payload"]["order"] == 1
+    assert records[-1]["event"] == "repair.context_completed"
+    assert records[-1]["payload"] == {"status": "failed"}
+
+
+def test_pair_budget_only_blocks_start_of_new_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    events = [
+        {
+            "event": "model.request_completed",
+            "payload": {"token_usage": {"total_tokens": 2_400_000}},
+        }
+    ]
+    monkeypatch.setattr(
+        runner,
+        "_observed_ledgers",
+        lambda *_args, **_kwargs: [({}, events)],
+    )
+    with pytest.raises(runner.RunnerError):
+        runner._ensure_pair_budget_remaining(manifest, output_dir=Path("unused"), observed_count=2)
+    assert runner._ensure_pair_budget_remaining(manifest, output_dir=Path("unused"), observed_count=1) == 2_400_000
+
+
+def test_batch_request_must_end_on_complete_pair(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    monkeypatch.setattr(runner, "_require_authorized_output_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runner, "_observed_ledgers", lambda *_args, **_kwargs: [])
+    with pytest.raises(runner.RunnerError):
+        runner.run_repair_batch(
+            manifest,
+            manifest_path=MANIFEST_PATH,
+            output_dir=tmp_path,
+            max_attempts=1,
+            check_endpoint=False,
+        )
+
+
+def test_attempt_summary_derives_repair_conversion_and_costs() -> None:
+    manifest = _manifest()
+    slot = manifest["collection_plan"][1]
+    events = [
+        {
+            "occurred_at": "2026-08-14T00:00:00+00:00",
+            "event": "experiment.started",
+            "payload": {},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:01+00:00",
+            "event": "model.request_started",
+            "payload": {},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:02+00:00",
+            "event": "model.request_completed",
+            "payload": {"token_usage": {"total_tokens": 123}},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:03+00:00",
+            "event": "submit.started",
+            "payload": {},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:04+00:00",
+            "event": "replay.started",
+            "payload": {},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:05+00:00",
+            "event": "oracle.completed",
+            "payload": {"passed": True},
+        },
+        {
+            "occurred_at": "2026-08-14T00:00:06+00:00",
+            "event": "experiment.completed",
+            "payload": {"status": "passed"},
+        },
+    ]
+    records = [
+        {
+            "event": "repair.feedback_observed",
+            "payload": {
+                "actionable": True,
+                "primary_classification": "recipe_execution_failed",
+                "status": "failed",
+            },
+        },
+        {
+            "event": "repair.feedback_observed",
+            "payload": {
+                "actionable": False,
+                "primary_classification": None,
+                "status": "passed",
+            },
+        },
+    ]
+    summary = report.summarize_attempt(
+        manifest,
+        slot,
+        events,
+        records,
+        {"status": "passed"},
+    )
+    assert summary["repair_conversions"] == 1
+    assert summary["actionable_verifier_failures"] == 1
+    assert summary["recorded_tokens"] == 123
+    assert summary["model_requests"] == 1
+    assert summary["submit_attempts"] == 1
+    assert summary["clean_replay_attempts"] == 1
+    assert summary["wall_clock_seconds"] == 6.0
+
+
+def test_report_orders_ledgers_by_frozen_schedule_not_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    first_path = tmp_path / "z-case" / "first.jsonl"
+    second_path = tmp_path / "a-case" / "second.jsonl"
+    first_path.parent.mkdir(parents=True)
+    second_path.parent.mkdir(parents=True)
+    first_path.touch()
+    second_path.touch()
+
+    def fake_events(slot: dict, physical_attempt_id: str) -> list[dict]:
+        return [
+            {
+                "physical_attempt_id": physical_attempt_id,
+                "event": "experiment.started",
+                "payload": {
+                    "thread_id": f"thread_{slot['order']}",
+                    "policy": {
+                        "benchmark_id": manifest["benchmark"]["id"],
+                        "manifest_sha256": protocol.manifest_sha256(manifest),
+                        "case_id": slot["case_id"],
+                        "condition": slot["condition_id"],
+                        "repetition": slot["repetition"],
+                    },
+                },
+            }
+        ]
+
+    by_path = {
+        first_path: fake_events(manifest["collection_plan"][0], "physical_attempt_first"),
+        second_path: fake_events(manifest["collection_plan"][1], "physical_attempt_second"),
+    }
+    monkeypatch.setattr(
+        report.ExperimentLedger,
+        "verify_path",
+        staticmethod(lambda path: by_path[path]),
+    )
+    monkeypatch.setattr(
+        report,
+        "_read_completed_sidecar",
+        lambda *_args, **_kwargs: ([], {"status": "not_exposed"}),
+    )
+
+    def fake_summary(_manifest: dict, slot: dict, *_args, **_kwargs) -> dict:
+        return {
+            "order": slot["order"],
+            "pair_id": slot["pair_id"],
+            "case_id": slot["case_id"],
+            "provider_condition": slot["provider_condition"],
+            "treatment": slot["treatment"],
+            "repetition": slot["repetition"],
+            "oracle_passed": False,
+            "terminal_passed": False,
+            "fidelity_status": "not_exposed",
+            "recorded_tokens": 0,
+            "model_requests": 0,
+            "wall_clock_seconds": 0.0,
+            "actionable_verifier_failures": 0,
+            "repair_conversions": 0,
+            "submit_attempts": 0,
+            "clean_replay_attempts": 0,
+            "failure_transitions": [],
+        }
+
+    monkeypatch.setattr(report, "summarize_attempt", fake_summary)
+    monkeypatch.setattr(report, "_load_canary", lambda *_args, **_kwargs: {"passed": True})
+    result = report.build_report(manifest, tmp_path)
+    assert result["collection"]["observed_slots"] == 2
+    assert result["paired_analysis"]["collection"]["complete_pairs"] == 1
+    assert [attempt["order"] for attempt in result["attempts"]] == [1, 2]

--- a/benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json
+++ b/benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json
@@ -1,0 +1,674 @@
+{
+  "$schema": "../schemas/forge-verifier-repair-pilot-authorized-v1.schema.json",
+  "schema_version": "verifier-driven-repair-pilot-authorized-1.0.0",
+  "document_type": "forge_verifier_repair_pilot_authorization",
+  "benchmark": {
+    "id": "forge-verifier-driven-repair-pilot-authorized",
+    "name": "Forge C/C++ verifier-driven repair paired pilot",
+    "purpose": "execute six bounded baseline-versus-repair pairs"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "verifier_driven_repair_pilot",
+    "formal_comparison_enabled": false,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "authorization": {
+    "id": "forge-verifier-driven-repair-pilot-authorized",
+    "status": "authorized_six_complete_pairs",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-14",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/127",
+    "implementation_baseline_commit": "fb24fa2b7acd0b39826d3440b8221a00a4d1a136",
+    "parent_runtime": {
+      "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+      "path": "benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json",
+      "canonical_sha256": "880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045"
+    },
+    "network_observation": {
+      "access_medium_reconfirmation_required_before_canary": true,
+      "browser_ui_required": false
+    },
+    "budget_confirmation": {
+      "confirmed": true,
+      "expected_recorded_tokens": 800000,
+      "maximum_recorded_tokens": 2400000,
+      "enforcement": "check_before_each_complete_pair",
+      "complete_started_pair_before_next_boundary_check": true
+    },
+    "collection_constraints": {
+      "authorized_slot_count": 12,
+      "authorized_complete_pairs": 6,
+      "provider_canary_required_before_first_ledger": true,
+      "provider_canary_max_attempts": 1,
+      "provider_canary_requests_per_provider": 1,
+      "empty_evidence_required_before_canary": true,
+      "zero_residual_formal_containers_required_before_canary": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "p_value_forbidden": true,
+      "model_ranking_forbidden": true,
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-authorized"
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "fb24fa2b7acd0b39826d3440b8221a00a4d1a136",
+    "revision_policy": "descendant-compatible",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "scripts/forge_verifier_repair_authorized_protocol.py": "48f2e91a2ac97c143e9233e966cae5506d7a3cea30cbd8d03719764fc421f0e6",
+    "scripts/forge_verifier_repair_authorized_report.py": "17b08d96838d364c192dcf27ac21a62af7b1217807d4377f46ef27d32a006ae6",
+    "scripts/forge_verifier_repair_authorized_runner.py": "b1651cbd7b7413a7d5234662c826238e0fdf8b39980bec9025b8609f87dbb2d8"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    },
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit",
+      "docker_daemon_provider_matches",
+      "docker_socket_source_matches_native_path"
+    ],
+    "sensitive_host_identifiers_forbidden": true,
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "budget": {
+    "authorized": true,
+    "request_timeout_seconds": 300,
+    "provider_retries": 0,
+    "attempt_total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "model_turn_limit": 36,
+    "maximum_recorded_tokens": 2400000,
+    "expected_recorded_tokens": 800000,
+    "budget_check_boundary": "before_each_complete_pair",
+    "remaining_pairs_require_confirmation": true
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5-baseline",
+      "model_profile": "richlab-gpt-5.5",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "richlab-gpt-5.5-repair",
+      "model_profile": "richlab-gpt-5.5",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash-baseline",
+      "model_profile": "deepseek-v4-flash",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash-repair",
+      "model_profile": "deepseek-v4-flash",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 2,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 3,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 4,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    },
+    {
+      "order": 5,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 6,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 7,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    },
+    {
+      "order": 8,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 9,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 10,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 11,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 12,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    }
+  ],
+  "schedule_sha256": "588cfae514f827d8ff436285dee80bd2d2dd782cbab4dfd4992c0f99cd8c51b2",
+  "cases": [
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "pilot_schedule": [
+    {
+      "order": 1,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    }
+  ],
+  "repair_packet": {
+    "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+    "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+    "actionable_classifications": [
+      "artifact_set_mismatch",
+      "artifact_type_mismatch",
+      "build_system_mismatch",
+      "build_system_selection_mismatch",
+      "build_system_unproven",
+      "candidate_verification_failed",
+      "recipe_execution_failed",
+      "sha256_mismatch",
+      "size_mismatch",
+      "smoke_mismatch"
+    ],
+    "repair_goals": {
+      "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+      "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+      "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+      "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+      "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+      "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+      "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+      "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+    },
+    "forbidden_content": [
+      "stdout",
+      "stderr",
+      "prompt",
+      "model_body",
+      "credential",
+      "host_path",
+      "generated_repair_command"
+    ]
+  },
+  "fidelity_gate": {
+    "statuses": [
+      "passed",
+      "not_exposed",
+      "failed"
+    ],
+    "baseline_packet_count": 0,
+    "treatment_requires_packet_for_each_actionable_submit": true,
+    "paired_analysis_requires_both_arms": true,
+    "p_value_forbidden": true,
+    "model_ranking_forbidden": true
+  },
+  "outcomes": {
+    "primary": "oracle_passed",
+    "secondary": [
+      "terminal_passed",
+      "repair_conversion_after_actionable_verifier_failure",
+      "false_acceptance_count",
+      "submit_attempts",
+      "clean_replay_attempts",
+      "model_requests",
+      "recorded_tokens",
+      "attempt_wall_clock_seconds",
+      "failure_classification_transition"
+    ],
+    "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+    "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+  },
+  "analysis_plan": {
+    "descriptive_only": true,
+    "complete_pairs_required": 6,
+    "repair_conversion_definition": "adjacent_actionable_classification_to_passed_feedback",
+    "model_request_count_event": "model.request_started",
+    "submit_attempt_count_event": "submit.started",
+    "clean_replay_attempt_count_event": "replay.started",
+    "wall_clock_definition": "experiment_started_to_experiment_completed_ledger_time",
+    "p_value_computed": false,
+    "model_ranking_performed": false
+  }
+}

--- a/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json
+++ b/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json
@@ -1,0 +1,679 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json",
+  "title": "Forge verifier-driven repair pilot authorization",
+  "const": {
+    "$schema": "../schemas/forge-verifier-repair-pilot-authorized-v1.schema.json",
+    "schema_version": "verifier-driven-repair-pilot-authorized-1.0.0",
+    "document_type": "forge_verifier_repair_pilot_authorization",
+    "benchmark": {
+      "id": "forge-verifier-driven-repair-pilot-authorized",
+      "name": "Forge C/C++ verifier-driven repair paired pilot",
+      "purpose": "execute six bounded baseline-versus-repair pairs"
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "phase": "verifier_driven_repair_pilot",
+      "formal_comparison_enabled": false,
+      "collection_authorized": true,
+      "instrumentation_blocker": false
+    },
+    "authorization": {
+      "id": "forge-verifier-driven-repair-pilot-authorized",
+      "status": "authorized_six_complete_pairs",
+      "authorized_by": "experiment_owner",
+      "authorized_on": "2026-08-14",
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/127",
+      "implementation_baseline_commit": "fb24fa2b7acd0b39826d3440b8221a00a4d1a136",
+      "parent_runtime": {
+        "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+        "path": "benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json",
+        "canonical_sha256": "880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045"
+      },
+      "network_observation": {
+        "access_medium_reconfirmation_required_before_canary": true,
+        "browser_ui_required": false
+      },
+      "budget_confirmation": {
+        "confirmed": true,
+        "expected_recorded_tokens": 800000,
+        "maximum_recorded_tokens": 2400000,
+        "enforcement": "check_before_each_complete_pair",
+        "complete_started_pair_before_next_boundary_check": true
+      },
+      "collection_constraints": {
+        "authorized_slot_count": 12,
+        "authorized_complete_pairs": 6,
+        "provider_canary_required_before_first_ledger": true,
+        "provider_canary_max_attempts": 1,
+        "provider_canary_requests_per_provider": 1,
+        "empty_evidence_required_before_canary": true,
+        "zero_residual_formal_containers_required_before_canary": true,
+        "replacement_forbidden": true,
+        "fallback_forbidden": true,
+        "retry_forbidden": true,
+        "backfill_forbidden": true,
+        "p_value_forbidden": true,
+        "model_ranking_forbidden": true,
+        "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-authorized"
+      }
+    },
+    "forge": {
+      "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+      "commit_sha": "fb24fa2b7acd0b39826d3440b8221a00a4d1a136",
+      "revision_policy": "descendant-compatible",
+      "component_sha256": {
+        "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+        "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+        "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+        "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+        "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+        "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+        "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+        "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+        "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+        "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+        "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+        "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+        "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+        "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+        "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+        "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+        "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+        "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+        "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+        "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+      }
+    },
+    "protocol_artifact_sha256": {
+      "scripts/forge_verifier_repair_authorized_protocol.py": "48f2e91a2ac97c143e9233e966cae5506d7a3cea30cbd8d03719764fc421f0e6",
+      "scripts/forge_verifier_repair_authorized_report.py": "17b08d96838d364c192dcf27ac21a62af7b1217807d4377f46ef27d32a006ae6",
+      "scripts/forge_verifier_repair_authorized_runner.py": "b1651cbd7b7413a7d5234662c826238e0fdf8b39980bec9025b8609f87dbb2d8"
+    },
+    "prompt_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+    },
+    "model_profiles": {
+      "richlab-gpt-5.5": {
+        "endpoint": "https://rich-api.choosefire.com/v1",
+        "credential_env": "OpenAI_AK",
+        "roles": {
+          "lead": "gpt-5.5",
+          "compiler": "gpt-5.5"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      },
+      "deepseek-v4-flash": {
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "roles": {
+          "lead": "deepseek-v4-flash",
+          "compiler": "deepseek-v4-flash"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      }
+    },
+    "runtime": {
+      "compile_image": "autocompiler:gcc13",
+      "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+      "control_plane_topology": "compose-dood",
+      "replay_timeout_seconds": 1200,
+      "cleanup_timeout_seconds": 20,
+      "docker_control_timeout_seconds": 30,
+      "model_turn_limit": 36,
+      "graph_recursion_limit": 96,
+      "wall_clock_timeout_seconds": 900,
+      "post_build_reserve_seconds": 120,
+      "max_parallel_runs": 1,
+      "backend_processes": 1,
+      "network_policy": {
+        "network_name": "compile_network_wwf_v1",
+        "egress": "enabled_for_clone_and_dependencies"
+      },
+      "host": {
+        "wsl_distribution": "Ubuntu",
+        "cpu_count": 32,
+        "memory_kib": 7723024,
+        "kernel": "6.6.114.1-microsoft-standard-WSL2",
+        "architecture": "x86_64",
+        "docker_server_version": "29.5.3"
+      },
+      "docker_daemon_provider": "ubuntu-native",
+      "docker_socket_path": "/var/run/docker.sock"
+    },
+    "attempt_budget": {
+      "total_wall_clock_seconds": 1800,
+      "cleanup_reserve_seconds": 120,
+      "max_compiler_invocations": 2,
+      "max_model_requests": 48,
+      "enforcement_checkpoints": [
+        "before_provider_request",
+        "before_compiler_invocation",
+        "before_submit_or_replay",
+        "before_finalize",
+        "before_cleanup"
+      ],
+      "new_work_forbidden_after_limit": true,
+      "cleanup_mandatory_after_limit": true,
+      "terminal_classification": "attempt_budget_exhausted"
+    },
+    "resource_preflight": {
+      "minimum_available_memory_bytes": 2147483648,
+      "docker_daemon_timeout_seconds": 10,
+      "maximum_docker_daemon_latency_seconds": 5,
+      "required_checks": [
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit",
+        "docker_daemon_provider_matches",
+        "docker_socket_source_matches_native_path"
+      ],
+      "sensitive_host_identifiers_forbidden": true,
+      "docker_daemon_provider": "ubuntu-native",
+      "docker_socket_path": "/var/run/docker.sock"
+    },
+    "budget": {
+      "authorized": true,
+      "request_timeout_seconds": 300,
+      "provider_retries": 0,
+      "attempt_total_wall_clock_seconds": 1800,
+      "cleanup_reserve_seconds": 120,
+      "max_compiler_invocations": 2,
+      "max_model_requests": 48,
+      "model_turn_limit": 36,
+      "maximum_recorded_tokens": 2400000,
+      "expected_recorded_tokens": 800000,
+      "budget_check_boundary": "before_each_complete_pair",
+      "remaining_pairs_require_confirmation": true
+    },
+    "conditions": [
+      {
+        "id": "richlab-gpt-5.5-baseline",
+        "model_profile": "richlab-gpt-5.5",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "richlab-gpt-5.5-repair",
+        "model_profile": "richlab-gpt-5.5",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "deepseek-v4-flash-baseline",
+        "model_profile": "deepseek-v4-flash",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "deepseek-v4-flash-repair",
+        "model_profile": "deepseek-v4-flash",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      }
+    ],
+    "collection_plan": [
+      {
+        "order": 1,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 2,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 3,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 4,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      },
+      {
+        "order": 5,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 6,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 7,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      },
+      {
+        "order": 8,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 9,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 10,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 11,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 12,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      }
+    ],
+    "schedule_sha256": "588cfae514f827d8ff436285dee80bd2d2dd782cbab4dfd4992c0f99cd8c51b2",
+    "cases": [
+      {
+        "id": "liblouis",
+        "repository_url": "https://github.com/liblouis/liblouis",
+        "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+        "languages": [
+          "C"
+        ],
+        "build_system": "autotools",
+        "license": "LGPL-2.1",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [
+            "autoreconf -fi"
+          ],
+          "configure_arguments": [
+            "--disable-shared",
+            "--enable-static"
+          ],
+          "build_targets": [
+            "all"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "liblouis.a",
+              "build_output_path": "liblouis/.libs/liblouis.a",
+              "artifact_type": "static_library",
+              "producing_target": "all"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "autoconf",
+            "automake",
+            "build-essential",
+            "libtool",
+            "pkg-config"
+          ],
+          "build_arguments": {
+            "cmake": [],
+            "configure": [
+              "--disable-shared",
+              "--enable-static"
+            ]
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      },
+      {
+        "id": "openthread",
+        "repository_url": "https://github.com/openthread/openthread",
+        "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+        "languages": [
+          "C++"
+        ],
+        "build_system": "cmake",
+        "license": "BSD-3-Clause",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "build_targets": [
+            "openthread-ftd"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "libopenthread-ftd.a",
+              "build_output_path": "build/src/core/libopenthread-ftd.a",
+              "artifact_type": "static_library",
+              "producing_target": "openthread-ftd"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "build-essential",
+            "cmake",
+            "python3"
+          ],
+          "build_arguments": {
+            "cmake": [
+              "-DCMAKE_BUILD_TYPE=Release",
+              "-DOT_BUILD_EXECUTABLES=OFF",
+              "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+            ],
+            "configure": []
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      },
+      {
+        "id": "mupdf",
+        "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+        "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+        "languages": [
+          "C++"
+        ],
+        "build_system": "make",
+        "license": "AGPL-3.0",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [],
+          "build_targets": [
+            "libs"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "libmupdf.a",
+              "build_output_path": "build/release/libmupdf.a",
+              "artifact_type": "static_library",
+              "producing_target": "libs"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "build-essential",
+            "libfreetype6-dev",
+            "libjpeg-dev",
+            "zlib1g-dev"
+          ],
+          "build_arguments": {
+            "cmake": [],
+            "configure": []
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      }
+    ],
+    "pilot_schedule": [
+      {
+        "order": 1,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 2,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 3,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 4,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 5,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 6,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 7,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 8,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 9,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 10,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 11,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 12,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      }
+    ],
+    "repair_packet": {
+      "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+      "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+      "actionable_classifications": [
+        "artifact_set_mismatch",
+        "artifact_type_mismatch",
+        "build_system_mismatch",
+        "build_system_selection_mismatch",
+        "build_system_unproven",
+        "candidate_verification_failed",
+        "recipe_execution_failed",
+        "sha256_mismatch",
+        "size_mismatch",
+        "smoke_mismatch"
+      ],
+      "repair_goals": {
+        "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+        "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+        "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+        "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+        "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+        "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+        "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+        "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+      },
+      "forbidden_content": [
+        "stdout",
+        "stderr",
+        "prompt",
+        "model_body",
+        "credential",
+        "host_path",
+        "generated_repair_command"
+      ]
+    },
+    "fidelity_gate": {
+      "statuses": [
+        "passed",
+        "not_exposed",
+        "failed"
+      ],
+      "baseline_packet_count": 0,
+      "treatment_requires_packet_for_each_actionable_submit": true,
+      "paired_analysis_requires_both_arms": true,
+      "p_value_forbidden": true,
+      "model_ranking_forbidden": true
+    },
+    "outcomes": {
+      "primary": "oracle_passed",
+      "secondary": [
+        "terminal_passed",
+        "repair_conversion_after_actionable_verifier_failure",
+        "false_acceptance_count",
+        "submit_attempts",
+        "clean_replay_attempts",
+        "model_requests",
+        "recorded_tokens",
+        "attempt_wall_clock_seconds",
+        "failure_classification_transition"
+      ],
+      "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+      "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+    },
+    "analysis_plan": {
+      "descriptive_only": true,
+      "complete_pairs_required": 6,
+      "repair_conversion_definition": "adjacent_actionable_classification_to_passed_feedback",
+      "model_request_count_event": "model.request_started",
+      "submit_attempt_count_event": "submit.started",
+      "clean_replay_attempt_count_event": "replay.started",
+      "wall_clock_definition": "experiment_started_to_experiment_completed_ledger_time",
+      "p_value_computed": false,
+      "model_ranking_performed": false
+    }
+  }
+}

--- a/scripts/forge_verifier_repair_authorized_protocol.py
+++ b/scripts/forge_verifier_repair_authorized_protocol.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""生成并校验 verifier-driven repair 配对 pilot 授权协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_pilot_protocol as parent_protocol  # noqa: E402
+
+SCHEMA_VERSION = "verifier-driven-repair-pilot-authorized-1.0.0"
+BASELINE_COMMIT = "fb24fa2b7acd0b39826d3440b8221a00a4d1a136"
+PARENT_CANONICAL_SHA256 = "880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045"
+REVISION_POLICY = "descendant-compatible"
+CONTROL_PLANE_TOPOLOGY = "compose-dood"
+DOCKER_DAEMON_PROVIDER = "ubuntu-native"
+DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-authorized"
+RECORDED_TOKEN_LIMIT = 2_400_000
+EXPECTED_RECORDED_TOKENS = 800_000
+
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-runtime-candidate.json"
+DEFAULT_MODEL_SOURCE = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-formal-timeout-calibration.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-authorized.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-pilot-authorized-v1.schema.json"
+
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_verifier_repair_authorized_protocol.py",
+    "scripts/forge_verifier_repair_authorized_runner.py",
+    "scripts/forge_verifier_repair_authorized_report.py",
+}
+
+BASELINE_ARM = "baseline-current-verifier-output"
+TREATMENT_ARM = "structured-verifier-repair-packet"
+CONDITION_IDS = {
+    ("richlab-gpt-5.5", BASELINE_ARM): "richlab-gpt-5.5-baseline",
+    ("richlab-gpt-5.5", TREATMENT_ARM): "richlab-gpt-5.5-repair",
+    ("deepseek-v4-flash", BASELINE_ARM): "deepseek-v4-flash-baseline",
+    ("deepseek-v4-flash", TREATMENT_ARM): "deepseek-v4-flash-repair",
+}
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot read JSON document: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON document must be an object: {path}")
+    return value
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"protocol artifact is missing: {relative_path}")
+        hashes[relative_path] = _file_sha256(path)
+    return hashes
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = parent_protocol.validate_manifest(document or _load_json(DEFAULT_PARENT_MANIFEST))
+    if parent_protocol.manifest_sha256(parent) != PARENT_CANONICAL_SHA256:
+        raise ProtocolError("parent runtime manifest canonical SHA-256 drifted")
+    return parent
+
+
+def _model_source(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    if _file_sha256(DEFAULT_MODEL_SOURCE) != parent_protocol.MODEL_SOURCE_SHA256:
+        raise ProtocolError("formal timeout model source SHA-256 drifted")
+    source = document or _load_json(DEFAULT_MODEL_SOURCE)
+    if source.get("schema_version") != "formal-collection-4.5.0-timeout-calibration":
+        raise ProtocolError("formal timeout model source identity drifted")
+    return source
+
+
+def _formal_cases(parent: dict[str, Any], source: dict[str, Any]) -> list[dict[str, Any]]:
+    source_by_id = {case["id"]: case for case in source.get("cases", [])}
+    result: list[dict[str, Any]] = []
+    for repair_case in parent["cases"]:
+        case = source_by_id.get(repair_case["id"])
+        if not isinstance(case, dict):
+            raise ProtocolError(f"formal case is missing: {repair_case['id']}")
+        artifact = case["oracle"]["required_artifacts"][0]
+        expected_artifact = repair_case["artifact_oracle"]["required_artifacts"][0]
+        if (
+            case["repository_url"] != repair_case["repository_url"]
+            or case["commit_sha"] != repair_case["commit"]
+            or case["build_system"] != repair_case["build_system"]
+            or artifact["relative_path"] != expected_artifact["staged_relative_path"]
+            or artifact["artifact_type"] != expected_artifact["artifact_type"]
+        ):
+            raise ProtocolError(f"formal case drifted: {repair_case['id']}")
+        result.append(copy.deepcopy(case))
+    return result
+
+
+def _conditions() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": condition_id,
+            "model_profile": provider,
+            "provider_condition": provider,
+            "treatment": treatment,
+            "memory_enabled": False,
+            "skills_enabled": False,
+            "repetitions": 1,
+            "acceptance_gate": "clean_replay",
+        }
+        for (provider, treatment), condition_id in CONDITION_IDS.items()
+    ]
+
+
+def _collection_plan(parent: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            **copy.deepcopy(slot),
+            "condition_id": CONDITION_IDS[(slot["provider_condition"], slot["treatment"])],
+        }
+        for slot in parent["pilot_schedule"]
+    ]
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": "forge-verifier-driven-repair-pilot-authorized",
+        "status": "authorized_six_complete_pairs",
+        "authorized_by": "experiment_owner",
+        "authorized_on": "2026-08-14",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/127",
+        "implementation_baseline_commit": BASELINE_COMMIT,
+        "parent_runtime": {
+            "id": parent["benchmark"]["id"],
+            "path": "benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json",
+            "canonical_sha256": PARENT_CANONICAL_SHA256,
+        },
+        "network_observation": {
+            "access_medium_reconfirmation_required_before_canary": True,
+            "browser_ui_required": False,
+        },
+        "budget_confirmation": {
+            "confirmed": True,
+            "expected_recorded_tokens": EXPECTED_RECORDED_TOKENS,
+            "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+            "enforcement": "check_before_each_complete_pair",
+            "complete_started_pair_before_next_boundary_check": True,
+        },
+        "collection_constraints": {
+            "authorized_slot_count": 12,
+            "authorized_complete_pairs": 6,
+            "provider_canary_required_before_first_ledger": True,
+            "provider_canary_max_attempts": 1,
+            "provider_canary_requests_per_provider": 1,
+            "empty_evidence_required_before_canary": True,
+            "zero_residual_formal_containers_required_before_canary": True,
+            "replacement_forbidden": True,
+            "fallback_forbidden": True,
+            "retry_forbidden": True,
+            "backfill_forbidden": True,
+            "p_value_forbidden": True,
+            "model_ranking_forbidden": True,
+            "evidence_directory": EVIDENCE_DIRECTORY,
+        },
+    }
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+    model_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parent = _parent_manifest(parent)
+    source = _model_source(model_source)
+    plan = _collection_plan(parent)
+    forge = copy.deepcopy(source["forge"])
+    forge["commit_sha"] = BASELINE_COMMIT
+    forge["revision_policy"] = REVISION_POLICY
+    budget = copy.deepcopy(parent["budget"])
+    budget["authorized"] = True
+    return {
+        "$schema": "../schemas/forge-verifier-repair-pilot-authorized-v1.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": "forge_verifier_repair_pilot_authorization",
+        "benchmark": {
+            "id": "forge-verifier-driven-repair-pilot-authorized",
+            "name": "Forge C/C++ verifier-driven repair paired pilot",
+            "purpose": "execute six bounded baseline-versus-repair pairs",
+        },
+        "scope": {
+            "languages": ["C", "C++"],
+            "phase": "verifier_driven_repair_pilot",
+            "formal_comparison_enabled": False,
+            "collection_authorized": True,
+            "instrumentation_blocker": False,
+        },
+        "authorization": _authorization(parent),
+        "forge": forge,
+        "protocol_artifact_sha256": _hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS),
+        "prompt_sha256": copy.deepcopy(source["prompt_sha256"]),
+        "model_profiles": copy.deepcopy(parent["model_profiles"]),
+        "runtime": copy.deepcopy(source["runtime"]),
+        "attempt_budget": copy.deepcopy(source["attempt_budget"]),
+        "resource_preflight": copy.deepcopy(source["resource_preflight"]),
+        "budget": budget,
+        "conditions": _conditions(),
+        "collection_plan": plan,
+        "schedule_sha256": hashlib.sha256(canonical_json_bytes(plan)).hexdigest(),
+        "cases": _formal_cases(parent, source),
+        "pilot_schedule": copy.deepcopy(parent["pilot_schedule"]),
+        "repair_packet": copy.deepcopy(parent["repair_packet"]),
+        "fidelity_gate": copy.deepcopy(parent["fidelity_gate"]),
+        "outcomes": copy.deepcopy(parent["outcomes"]),
+        "analysis_plan": {
+            "descriptive_only": True,
+            "complete_pairs_required": 6,
+            "repair_conversion_definition": "adjacent_actionable_classification_to_passed_feedback",
+            "model_request_count_event": "model.request_started",
+            "submit_attempt_count_event": "submit.started",
+            "clean_replay_attempt_count_event": "replay.started",
+            "wall_clock_definition": "experiment_started_to_experiment_completed_ledger_time",
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+        },
+    }
+
+
+def validate_manifest(
+    document: Any,
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+    model_source: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise ProtocolError("authorized manifest must be an object")
+    expected = generate_manifest(repo_root, parent=parent, model_source=model_source)
+    if document != expected:
+        raise ProtocolError("authorized manifest does not match the frozen protocol")
+    plan = document["collection_plan"]
+    if len(plan) != 12 or len({slot["pair_id"] for slot in plan}) != 6 or [slot["order"] for slot in plan] != list(range(1, 13)):
+        raise ProtocolError("authorized schedule must contain 12 ordered slots and 6 pairs")
+    for pair_id in {slot["pair_id"] for slot in plan}:
+        arms = {slot["treatment"] for slot in plan if slot["pair_id"] == pair_id}
+        if arms != {BASELINE_ARM, TREATMENT_ARM}:
+            raise ProtocolError("each authorized pair must contain both arms")
+    return document
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(manifest)).hexdigest()
+
+
+def schema_document() -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json",
+        "title": "Forge verifier-driven repair pilot authorization",
+        "const": generate_manifest(),
+    }
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPOSITORY_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    parent_path = repo_root / manifest["authorization"]["parent_runtime"]["path"]
+    parent = _parent_manifest(_load_json(parent_path))
+    if parent_protocol.manifest_sha256(parent) != PARENT_CANONICAL_SHA256:
+        raise ProtocolError("authorized parent runtime no longer matches")
+    for relative_path, expected in manifest["forge"]["component_sha256"].items():
+        if _file_sha256(repo_root / relative_path) != expected:
+            raise ProtocolError(f"frozen Forge component drifted: {relative_path}")
+    for relative_path, expected in manifest["protocol_artifact_sha256"].items():
+        if _file_sha256(repo_root / relative_path) != expected:
+            raise ProtocolError(f"protocol artifact drifted: {relative_path}")
+    for relative_path, expected in manifest["prompt_sha256"].items():
+        if _file_sha256(repo_root / relative_path) != expected:
+            raise ProtocolError(f"frozen prompt drifted: {relative_path}")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path, nargs="?", default=DEFAULT_MANIFEST)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            _write_json(args.schema, schema_document())
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+    except (OSError, ProtocolError, parent_protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "authorized_complete_pairs": 6,
+                "authorized_slots": 12,
+                "collection_authorized": True,
+                "manifest_sha256": manifest_sha256(manifest),
+                "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+                "status": "valid",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_authorized_report.py
+++ b/scripts/forge_verifier_repair_authorized_report.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""从主 ledger 与 repair sidecar 生成确定性配对 pilot 报告。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+HARNESS_ROOT = REPO_ROOT / "backend" / "packages" / "harness"
+for import_root in (SCRIPT_ROOT, HARNESS_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+import forge_verifier_repair_authorized_protocol as protocol  # noqa: E402
+import forge_verifier_repair_pilot_analyzer as analyzer  # noqa: E402
+import forge_verifier_repair_pilot_protocol as parent_protocol  # noqa: E402
+import forge_verifier_repair_runtime as repair_runtime  # noqa: E402
+
+from deerflow.compile.evidence import EvidenceError, ExperimentLedger  # noqa: E402
+
+REPORT_VERSION = "verifier-driven-repair-pilot-authorized-report-1.0.0"
+DEFAULT_EVIDENCE_DIR = Path(protocol.EVIDENCE_DIRECTORY)
+DEFAULT_JSON_REPORT = DEFAULT_EVIDENCE_DIR / "verifier-repair-pilot-report.json"
+DEFAULT_MARKDOWN_REPORT = DEFAULT_EVIDENCE_DIR / "verifier-repair-pilot-report.md"
+
+
+class ReportError(ValueError):
+    pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"cannot read JSON document: {path}") from exc
+    if not isinstance(value, dict):
+        raise ReportError(f"JSON document must be an object: {path}")
+    return value
+
+
+def load_manifest(path: Path = protocol.DEFAULT_MANIFEST) -> dict[str, Any]:
+    try:
+        return protocol.validate_manifest(_load_json(path))
+    except protocol.ProtocolError as exc:
+        raise ReportError(str(exc)) from exc
+
+
+def _event_payload(events: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    for event in reversed(events):
+        if event.get("event") == name and isinstance(event.get("payload"), dict):
+            return event["payload"]
+    return None
+
+
+def _slot_for_events(manifest: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not events:
+        return None
+    policy = events[0].get("payload", {}).get("policy")
+    if not isinstance(policy, dict):
+        return None
+    if policy.get("benchmark_id") != manifest["benchmark"]["id"] or policy.get("manifest_sha256") != protocol.manifest_sha256(manifest):
+        return None
+    matches = [slot for slot in manifest["collection_plan"] if slot["case_id"] == policy.get("case_id") and slot["condition_id"] == policy.get("condition") and slot["repetition"] == policy.get("repetition")]
+    if len(matches) != 1:
+        raise ReportError("physical ledger does not map to one authorized slot")
+    return matches[0]
+
+
+def _sidecar_path(ledger_path: Path) -> Path:
+    return ledger_path.with_name(ledger_path.stem + ".repair-sidecar.json")
+
+
+def _read_completed_sidecar(path: Path, *, manifest: dict[str, Any], slot: dict[str, Any], events: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    try:
+        records = repair_runtime.RepairEvidenceLedger(path).read()
+    except repair_runtime.RepairRuntimeError as exc:
+        raise ReportError(f"invalid repair sidecar: {path}") from exc
+    if not records or records[-1].get("event") != "repair.context_completed":
+        raise ReportError("repair sidecar is not terminal")
+    context = records[0]["payload"]
+    expected = {
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "thread_id": events[0]["payload"]["thread_id"],
+        "physical_attempt_id": events[0]["physical_attempt_id"],
+        "order": slot["order"],
+        "pair_id": slot["pair_id"],
+        "case_id": slot["case_id"],
+        "provider_condition": slot["provider_condition"],
+        "treatment": slot["treatment"],
+        "repetition": slot["repetition"],
+    }
+    if context != expected:
+        raise ReportError("repair sidecar identity drifted from the physical ledger")
+    fidelity = repair_runtime.evaluate_treatment_fidelity(records)
+    return records, fidelity
+
+
+def _recorded_tokens(events: list[dict[str, Any]]) -> int:
+    total = 0
+    for event in events:
+        if event.get("event") != "model.request_completed":
+            continue
+        usage = event.get("payload", {}).get("token_usage")
+        value = usage.get("total_tokens") if isinstance(usage, dict) else None
+        if type(value) is int and value >= 0:
+            total += value
+    return total
+
+
+def _wall_clock_seconds(events: list[dict[str, Any]]) -> float:
+    try:
+        started = datetime.fromisoformat(events[0]["occurred_at"])
+        completed = datetime.fromisoformat(events[-1]["occurred_at"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ReportError("physical ledger timestamps are invalid") from exc
+    return round(max(0.0, (completed - started).total_seconds()), 6)
+
+
+def _feedback_labels(records: list[dict[str, Any]]) -> list[str]:
+    labels: list[str] = []
+    for record in records:
+        if record.get("event") != "repair.feedback_observed":
+            continue
+        payload = record["payload"]
+        label = payload["primary_classification"] if payload["actionable"] else payload["status"]
+        if isinstance(label, str):
+            labels.append(label)
+    return labels
+
+
+def _failure_transitions(labels: list[str]) -> list[dict[str, str]]:
+    return [{"from": previous, "to": current} for previous, current in zip(labels, labels[1:], strict=False) if previous != current]
+
+
+def _repair_conversions(transitions: list[dict[str, str]]) -> int:
+    return sum(transition["from"] in repair_runtime.REPAIR_GOALS and transition["to"] == "passed" for transition in transitions)
+
+
+def summarize_attempt(
+    manifest: dict[str, Any],
+    slot: dict[str, Any],
+    events: list[dict[str, Any]],
+    sidecar_records: list[dict[str, Any]],
+    fidelity: dict[str, Any],
+) -> dict[str, Any]:
+    completed = _event_payload(events, "experiment.completed")
+    oracle = _event_payload(events, "oracle.completed")
+    if completed is None or oracle is None or events[-1]["event"] != "experiment.completed":
+        raise ReportError("attempt summary requires a terminal physical ledger")
+    labels = _feedback_labels(sidecar_records)
+    transitions = _failure_transitions(labels)
+    return {
+        "order": slot["order"],
+        "pair_id": slot["pair_id"],
+        "case_id": slot["case_id"],
+        "provider_condition": slot["provider_condition"],
+        "treatment": slot["treatment"],
+        "repetition": slot["repetition"],
+        "oracle_passed": oracle.get("passed") is True,
+        "terminal_passed": completed.get("status") == "passed",
+        "fidelity_status": fidelity["status"],
+        "recorded_tokens": _recorded_tokens(events),
+        "model_requests": sum(event.get("event") == "model.request_started" for event in events),
+        "wall_clock_seconds": _wall_clock_seconds(events),
+        "actionable_verifier_failures": sum(record.get("event") == "repair.feedback_observed" and record["payload"]["actionable"] is True for record in sidecar_records),
+        "repair_conversions": _repair_conversions(transitions),
+        "submit_attempts": sum(event.get("event") == "submit.started" for event in events),
+        "clean_replay_attempts": sum(event.get("event") == "replay.started" for event in events),
+        "failure_transitions": transitions,
+    }
+
+
+def _load_canary(evidence_dir: Path, manifest: dict[str, Any]) -> dict[str, Any] | None:
+    canary_dir = evidence_dir / "provider-canaries"
+    for path in sorted(canary_dir.glob("provider_canary_*.json"), reverse=True):
+        value = _load_json(path)
+        if value.get("document_type") == "formal_provider_canary" and value.get("manifest_sha256") == protocol.manifest_sha256(manifest):
+            return value
+    return None
+
+
+def build_report(manifest: dict[str, Any], evidence_dir: Path) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    observed: list[tuple[dict[str, Any], Path, list[dict[str, Any]]]] = []
+    for ledger_path in sorted(evidence_dir.rglob("*.jsonl")):
+        try:
+            events = ExperimentLedger.verify_path(ledger_path)
+        except EvidenceError as exc:
+            raise ReportError(f"invalid physical ledger: {ledger_path}") from exc
+        slot = _slot_for_events(manifest, events)
+        if slot is not None:
+            observed.append((slot, ledger_path, events))
+    observed.sort(key=lambda item: item[0]["order"])
+    orders = [slot["order"] for slot, _path, _events in observed]
+    if len(orders) != len(set(orders)) or orders != list(range(1, len(orders) + 1)):
+        raise ReportError("observed physical ledgers are not the frozen schedule prefix")
+
+    attempt_summaries: list[dict[str, Any]] = []
+    attempt_evidence: list[dict[str, Any]] = []
+    for slot, ledger_path, events in observed:
+        sidecar_path = _sidecar_path(ledger_path)
+        records, fidelity = _read_completed_sidecar(
+            sidecar_path,
+            manifest=manifest,
+            slot=slot,
+            events=events,
+        )
+        summary = summarize_attempt(manifest, slot, events, records, fidelity)
+        attempt_summaries.append(summary)
+        attempt_evidence.append(
+            {
+                "order": slot["order"],
+                "physical_attempt_id": events[0]["physical_attempt_id"],
+                "ledger": str(ledger_path),
+                "repair_sidecar": str(sidecar_path),
+                "fidelity": fidelity,
+                "summary": summary,
+            }
+        )
+
+    parent = parent_protocol.validate_manifest(parent_protocol._load_json(protocol.DEFAULT_PARENT_MANIFEST))
+    paired = analyzer.build_report(parent, attempt_summaries)
+    canary = _load_canary(evidence_dir, manifest)
+    if attempt_summaries and (canary is None or canary.get("passed") is not True):
+        raise ReportError("physical evidence requires a successful frozen provider canary")
+    return {
+        "report_version": REPORT_VERSION,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "parent_runtime_manifest_sha256": protocol.PARENT_CANONICAL_SHA256,
+        "scope": {
+            "descriptive_only": True,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+        },
+        "canary": canary,
+        "collection": {
+            "planned_slots": 12,
+            "observed_slots": len(attempt_summaries),
+            "complete_pairs": len(attempt_summaries) // 2,
+            "recorded_tokens": sum(attempt["recorded_tokens"] for attempt in attempt_summaries),
+            "recorded_token_limit": protocol.RECORDED_TOKEN_LIMIT,
+            "model_requests": sum(attempt["model_requests"] for attempt in attempt_summaries),
+            "wall_clock_seconds": round(
+                sum(attempt["wall_clock_seconds"] for attempt in attempt_summaries),
+                6,
+            ),
+        },
+        "paired_analysis": paired,
+        "attempts": attempt_evidence,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    collection = report["collection"]
+    paired = report["paired_analysis"]
+    lines = [
+        "# Verifier-driven repair 配对 pilot 报告",
+        "",
+        f"- 协议：`{report['benchmark_id']}`",
+        f"- 授权 manifest SHA-256：`{report['manifest_sha256']}`",
+        f"- 已观察：{collection['observed_slots']}/12 slots，{collection['complete_pairs']}/6 complete pairs",
+        f"- recorded tokens：{collection['recorded_tokens']}/{collection['recorded_token_limit']}",
+        f"- 模型请求：{collection['model_requests']}",
+        f"- physical-attempt 墙钟合计：{collection['wall_clock_seconds']:.3f} 秒",
+        "",
+        "## 配对结果",
+        "",
+        f"- paired primary eligible：`{str(paired['scope']['paired_primary_eligible']).lower()}`",
+        f"- Oracle discordance：`{json.dumps(paired['oracle_discordance'], ensure_ascii=False, sort_keys=True)}`",
+        f"- 不完整 pairs：`{json.dumps(paired['collection']['incomplete_pairs'], ensure_ascii=False)}`",
+        "",
+        "本报告只做配对描述，不计算 p-value，不按单个项目或不完整 block 排名模型。",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_reports(report: dict[str, Any], *, json_path: Path, markdown_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    markdown_path.write_text(render_markdown(report), encoding="utf-8", newline="\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument("--json", type=Path, default=DEFAULT_JSON_REPORT)
+    parser.add_argument("--markdown", type=Path, default=DEFAULT_MARKDOWN_REPORT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        report = build_report(manifest, args.evidence_dir)
+        write_reports(report, json_path=args.json, markdown_path=args.markdown)
+    except (OSError, ReportError, analyzer.AnalyzerError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "complete_pairs": report["collection"]["complete_pairs"],
+                "json_report": str(args.json),
+                "markdown_report": str(args.markdown),
+                "observed_slots": report["collection"]["observed_slots"],
+                "status": "written",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_authorized_runner.py
+++ b/scripts/forge_verifier_repair_authorized_runner.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""执行已授权的 verifier-driven repair 配对 pilot。"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_authorized_protocol as protocol  # noqa: E402
+import forge_verifier_repair_runtime as repair_runtime  # noqa: E402
+
+# 协议模块先建立仓库导入根，再加载 Ubuntu daemon 门禁。
+# isort: split
+import forge_formal_collection_v4_ubuntu_runner as ubuntu_runner  # noqa: E402
+
+
+def _load_private_base_runner():
+    module_name = f"{__name__}_base"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_formal_collection_v2_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the formal collection base runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_runner = _load_private_base_runner()
+_original_manifest_protocol = _runner._manifest_protocol
+_original_collect_provider_canary = _runner.collect_provider_canary
+_original_create_attempt = _runner.create_attempt
+_original_run_attempt = _runner.run_attempt
+
+_runner.protocol_formal_collection = protocol
+
+RunnerError = _runner.RunnerError
+REPO_ROOT = _runner.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+_CANARY_ATTEMPT_MARKER = "verifier-repair-provider-canary-attempt.json"
+_SIDECAR_SUFFIX = ".repair-sidecar.json"
+_NETWORK_ACCESS_MEDIA = {"mobile_hotspot", "wifi", "ethernet", "other"}
+
+
+def _manifest_protocol(manifest: dict[str, Any]):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        return protocol
+    return _original_manifest_protocol(manifest)
+
+
+def collect_runtime_launch_preflight(
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    return ubuntu_runner.collect_runtime_launch_preflight(
+        output_dir,
+        repo_root=repo_root,
+    )
+
+
+def _authorized_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["collection_constraints"]["evidence_directory"])
+
+
+def _require_authorized_output_dir(manifest: dict[str, Any], output_dir: Path) -> None:
+    expected = _authorized_output_dir(manifest).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise RunnerError("Verifier-repair evidence must use the frozen authorized directory")
+
+
+def _authorized_slots(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    return sorted(manifest["collection_plan"], key=lambda slot: slot["order"])
+
+
+def _slot_identity(slot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "case_id": slot["case_id"],
+        "condition_id": slot["condition_id"],
+        "repetition": slot["repetition"],
+    }
+
+
+def _observed_ledgers(manifest: dict[str, Any], *, output_dir: Path) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    return _runner._observed_collection_ledgers(manifest, output_dir=output_dir)
+
+
+def _recorded_total_tokens(
+    observed: list[tuple[dict[str, Any], list[dict[str, Any]]]],
+) -> int:
+    total = 0
+    for _slot, events in observed:
+        for event in events:
+            if event.get("event") != "model.request_completed":
+                continue
+            payload = event.get("payload")
+            usage = payload.get("token_usage") if isinstance(payload, dict) else None
+            value = usage.get("total_tokens") if isinstance(usage, dict) else None
+            if type(value) is int and value >= 0:
+                total += value
+    return total
+
+
+def _token_limit(manifest: dict[str, Any]) -> int:
+    return int(manifest["authorization"]["budget_confirmation"]["maximum_recorded_tokens"])
+
+
+def _ensure_pair_budget_remaining(manifest: dict[str, Any], *, output_dir: Path, observed_count: int) -> int:
+    recorded = _recorded_total_tokens(_observed_ledgers(manifest, output_dir=output_dir))
+    # 已开始 pair 的第二个 arm 必须先闭合；新 pair 只能在边界以下开始。
+    if observed_count % 2 == 0 and recorded >= _token_limit(manifest):
+        raise RunnerError("The authorized recorded-token boundary blocks a new complete pair")
+    return recorded
+
+
+def _enforce_authorized_order(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+) -> int:
+    plan = [_slot_identity(slot) for slot in _authorized_slots(manifest)]
+    observed = _observed_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    if observed_slots != plan[: len(observed_slots)]:
+        raise RunnerError("Existing physical evidence does not match the authorized schedule")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous authorized slot must complete before the next slot")
+    if len(observed_slots) >= len(plan):
+        raise RunnerError("All 12 authorized slots already have physical evidence")
+    requested = {
+        "case_id": case_id,
+        "condition_id": condition_id,
+        "repetition": repetition,
+    }
+    if requested != plan[len(observed_slots)]:
+        raise RunnerError("The requested slot is not next in the authorized schedule")
+    _ensure_pair_budget_remaining(manifest, output_dir=output_dir, observed_count=len(observed_slots))
+    return len(observed_slots)
+
+
+def _formal_container_ids() -> list[str] | None:
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-aq",
+                "--filter",
+                "label=deerflow.compile.physical_attempt_id",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _canary_marker_path(output_dir: Path) -> Path:
+    return output_dir / "provider-canaries" / _CANARY_ATTEMPT_MARKER
+
+
+def _write_json_atomic(path: Path, value: dict[str, Any]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _write_canary_marker(
+    path: Path,
+    *,
+    manifest: dict[str, Any],
+    status: str,
+    error_class: str | None = None,
+) -> None:
+    _write_json_atomic(
+        path,
+        {
+            "schema_version": "verifier-repair-canary-attempt-1.0.0",
+            "document_type": "verifier_repair_provider_canary_attempt",
+            "benchmark_id": manifest["benchmark"]["id"],
+            "manifest_sha256": protocol.manifest_sha256(manifest),
+            "status": status,
+            "error_class": error_class,
+            "updated_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _model_response_text(response: Any) -> str:
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(item if isinstance(item, str) else item.get("text", "") for item in content if isinstance(item, (str, dict)))
+
+
+def _invoke_provider_canary(profile: dict[str, Any]) -> dict[str, Any]:
+    from deerflow.models.factory import create_chat_model
+
+    started = time.perf_counter()
+    error_class: str | None = None
+    response_text = ""
+    try:
+        model = create_chat_model(
+            name=profile["roles"]["lead"],
+            thinking_enabled=False,
+        )
+        response = model.invoke("Reply with exactly CANARY_OK and nothing else.")
+        response_text = _model_response_text(response)
+    except Exception as exc:
+        error_class = type(exc).__name__
+    return {
+        "model": profile["roles"]["lead"],
+        "endpoint": profile["endpoint"].rstrip("/"),
+        "credential_env": profile["credential_env"],
+        "duration_ms": round((time.perf_counter() - started) * 1000),
+        "response_nonempty": bool(response_text.strip()),
+        "response_sha256": (hashlib.sha256(response_text.encode("utf-8")).hexdigest() if response_text else None),
+        "error_class": error_class,
+        "passed": error_class is None and bool(response_text.strip()),
+    }
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Provider canary requires the authorized repair protocol")
+    _require_authorized_output_dir(manifest, output_dir)
+    access_medium = os.environ.get("FORGE_NETWORK_ACCESS_MEDIUM")
+    if access_medium not in _NETWORK_ACCESS_MEDIA:
+        raise RunnerError("Provider canary requires a confirmed FORGE_NETWORK_ACCESS_MEDIUM")
+    if any(output_dir.rglob("*.jsonl")) or any(output_dir.rglob(f"*{_SIDECAR_SUFFIX}")):
+        raise RunnerError("Provider canary requires an empty evidence directory")
+    if _observed_ledgers(manifest, output_dir=output_dir):
+        raise RunnerError("Provider canary must precede the first pilot ledger")
+    container_ids = _formal_container_ids()
+    if container_ids is None:
+        raise RunnerError("Formal container reconciliation failed before canary")
+    if container_ids:
+        raise RunnerError("Residual formal containers block provider canary")
+    if not _runner._running_inside_compose_dood(repo_root):
+        raise RunnerError("Provider canary must run inside the Compose/DooD control plane")
+
+    marker_path = _canary_marker_path(output_dir)
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with marker_path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(
+                {
+                    "schema_version": "verifier-repair-canary-attempt-1.0.0",
+                    "document_type": "verifier_repair_provider_canary_attempt",
+                    "benchmark_id": manifest["benchmark"]["id"],
+                    "manifest_sha256": protocol.manifest_sha256(manifest),
+                    "status": "started",
+                    "error_class": None,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                },
+                stream,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            stream.write("\n")
+    except FileExistsError as exc:
+        raise RunnerError("The one authorized provider-canary attempt is consumed") from exc
+
+    try:
+        preflight = _runner.collect_preflight(
+            manifest,
+            repo_root=repo_root,
+            manifest_path=manifest_path,
+            output_dir=output_dir,
+            check_endpoint=False,
+        )
+        if preflight["ready"] is not True:
+            raise RunnerError("Provider canary preflight is not ready")
+        provider_results = {provider: {"id": provider, **_invoke_provider_canary(profile)} for provider, profile in manifest["model_profiles"].items()}
+        condition_results = [
+            {
+                "id": condition["id"],
+                "provider_condition": condition["provider_condition"],
+                "treatment": condition["treatment"],
+                **{key: value for key, value in provider_results[condition["provider_condition"]].items() if key != "id"},
+            }
+            for condition in manifest["conditions"]
+        ]
+        report = {
+            "schema_version": "formal-provider-canary-1.0.0",
+            "document_type": "formal_provider_canary",
+            "canary_id": _runner.new_evidence_id("provider_canary"),
+            "benchmark_id": manifest["benchmark"]["id"],
+            "manifest_sha256": protocol.manifest_sha256(manifest),
+            "manifest_file_sha256": _runner._sha256_file(manifest_path),
+            "completed_at": datetime.now(UTC).isoformat(),
+            "control_plane_topology": protocol.CONTROL_PLANE_TOPOLOGY,
+            "preflight_ready": True,
+            "network_access_medium": access_medium,
+            "provider_request_count": len(provider_results),
+            "providers": list(provider_results.values()),
+            "conditions": condition_results,
+            "passed": all(result["passed"] for result in provider_results.values()),
+        }
+        report_path = output_dir / "provider-canaries" / f"{report['canary_id']}.json"
+        with report_path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(report, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+    except BaseException as exc:
+        _write_canary_marker(
+            marker_path,
+            manifest=manifest,
+            status="failed",
+            error_class=type(exc).__name__,
+        )
+        raise
+    _write_canary_marker(
+        marker_path,
+        manifest=manifest,
+        status="passed" if report["passed"] else "failed",
+    )
+    return {**report, "report_path": str(report_path)}
+
+
+def create_attempt(
+    manifest: dict[str, Any],
+    *,
+    case_id: str,
+    condition_id: str,
+    repetition: int,
+    output_dir: Path,
+    **kwargs: Any,
+):
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        return _original_create_attempt(
+            manifest,
+            case_id=case_id,
+            condition_id=condition_id,
+            repetition=repetition,
+            output_dir=output_dir,
+            **kwargs,
+        )
+    _require_authorized_output_dir(manifest, output_dir)
+    if kwargs.get("replacement_for") is not None:
+        raise RunnerError("Verifier-repair authorization forbids replacement")
+    _enforce_authorized_order(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        output_dir=output_dir,
+    )
+    return _original_create_attempt(
+        manifest,
+        case_id=case_id,
+        condition_id=condition_id,
+        repetition=repetition,
+        output_dir=output_dir,
+        **kwargs,
+    )
+
+
+def _slot_for_policy(manifest: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    matches = [slot for slot in manifest["collection_plan"] if slot["case_id"] == policy.get("case_id") and slot["condition_id"] == policy.get("condition") and slot["repetition"] == policy.get("repetition")]
+    if len(matches) != 1:
+        raise RunnerError("The physical-attempt policy has no unique repair slot")
+    return matches[0]
+
+
+def repair_sidecar_path(ledger_path: Path) -> Path:
+    return ledger_path.with_name(ledger_path.stem + _SIDECAR_SUFFIX)
+
+
+def _feedback_context(
+    manifest: dict[str, Any],
+    ledger: Any,
+    slot: dict[str, Any],
+    evidence: repair_runtime.RepairEvidenceLedger,
+) -> repair_runtime.RepairFeedbackContext:
+    case = next(item for item in manifest["cases"] if item["id"] == slot["case_id"])
+    expected_artifacts = tuple((artifact["relative_path"], artifact["artifact_type"]) for artifact in case["oracle"]["required_artifacts"])
+    thread_id = ledger.read()[0]["payload"]["thread_id"]
+    return repair_runtime.RepairFeedbackContext(
+        thread_id=thread_id,
+        pair_id=slot["pair_id"],
+        case_id=slot["case_id"],
+        provider_condition=slot["provider_condition"],
+        treatment=slot["treatment"],
+        repetition=slot["repetition"],
+        expected_build_system=case["build_system"],
+        expected_artifacts=expected_artifacts,
+        event_reader=ledger.read,
+        evidence=evidence,
+    )
+
+
+def run_attempt(manifest: dict[str, Any], ledger_path: Path, **kwargs: Any) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        return _original_run_attempt(manifest, ledger_path, **kwargs)
+    expected = _authorized_output_dir(manifest).resolve(strict=False)
+    try:
+        ledger_path.resolve(strict=False).relative_to(expected)
+    except ValueError as exc:
+        raise RunnerError("Repair pilot ledger is outside the authorized directory") from exc
+    ledger = _runner.ExperimentLedger.open(ledger_path)
+    events = ledger.read()
+    if any(event["event"].startswith("model.") for event in events):
+        raise RunnerError("A physical attempt cannot issue model calls twice")
+    slot = _slot_for_policy(manifest, events[0]["payload"]["policy"])
+    sidecar_path = repair_sidecar_path(ledger_path)
+    evidence = repair_runtime.RepairEvidenceLedger.create(
+        sidecar_path,
+        {
+            "manifest_sha256": protocol.manifest_sha256(manifest),
+            "thread_id": events[0]["payload"]["thread_id"],
+            "physical_attempt_id": ledger.physical_attempt_id,
+            "order": slot["order"],
+            "pair_id": slot["pair_id"],
+            "case_id": slot["case_id"],
+            "provider_condition": slot["provider_condition"],
+            "treatment": slot["treatment"],
+            "repetition": slot["repetition"],
+        },
+    )
+    context = _feedback_context(manifest, ledger, slot, evidence)
+    kwargs["attempt_budget"] = _runner.ExperimentAttemptBudget.from_mapping(manifest["attempt_budget"])
+    from deerflow.tools import bound_compile_tools
+
+    try:
+        with repair_runtime.submit_feedback_scope(context, bound_compile_tools):
+            result = _original_run_attempt(manifest, ledger_path, **kwargs)
+    except BaseException:
+        evidence.append("repair.context_completed", {"status": "interrupted"})
+        raise
+    evidence.append("repair.context_completed", {"status": str(result["status"])})
+    result["repair_sidecar"] = str(sidecar_path)
+    result["repair_fidelity"] = repair_runtime.evaluate_treatment_fidelity(evidence.read())
+    return result
+
+
+def run_repair_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Repair batch requires the authorized protocol identity")
+    _require_authorized_output_dir(manifest, output_dir)
+    slots = _authorized_slots(manifest)
+    observed = _observed_ledgers(manifest, output_dir=output_dir)
+    observed_slots = [slot for slot, _events in observed]
+    planned = [_slot_identity(slot) for slot in slots]
+    if observed_slots != planned[: len(observed_slots)]:
+        raise RunnerError("Existing evidence does not match the authorized schedule")
+    if observed and observed[-1][1][-1]["event"] != "experiment.completed":
+        raise RunnerError("The previous slot must complete before batch resume")
+    start_index = len(observed_slots)
+    if start_index >= len(slots):
+        raise RunnerError("The authorized 12-slot boundary has been reached")
+    if max_attempts < 1 or max_attempts > len(slots) - start_index:
+        raise RunnerError("Requested batch crosses the authorized 12-slot boundary")
+    if (start_index + max_attempts) % 2 != 0:
+        raise RunnerError("Requested batch must stop on a complete-pair boundary")
+
+    results: list[dict[str, Any]] = []
+    stop_reason = "requested_attempt_boundary_reached"
+    with asyncio.Runner() as async_runner:
+        for slot_index in range(start_index, start_index + max_attempts):
+            recorded_before = _ensure_pair_budget_remaining(
+                manifest,
+                output_dir=output_dir,
+                observed_count=slot_index,
+            )
+            slot = slots[slot_index]
+            ledger, _preflight = create_attempt(
+                manifest,
+                case_id=slot["case_id"],
+                condition_id=slot["condition_id"],
+                repetition=slot["repetition"],
+                output_dir=output_dir,
+                manifest_path=manifest_path,
+                check_endpoint=check_endpoint,
+            )
+            result = run_attempt(
+                manifest,
+                ledger.path,
+                async_runner=async_runner,
+            )
+            recorded_after = _recorded_total_tokens(_observed_ledgers(manifest, output_dir=output_dir))
+            results.append(
+                {
+                    "schedule_order": slot["order"],
+                    "pair_id": slot["pair_id"],
+                    "case_id": slot["case_id"],
+                    "provider_condition": slot["provider_condition"],
+                    "treatment": slot["treatment"],
+                    "condition_id": slot["condition_id"],
+                    "physical_attempt_id": ledger.physical_attempt_id,
+                    "ledger": str(ledger.path),
+                    "repair_sidecar": result["repair_sidecar"],
+                    "status": result["status"],
+                    "fidelity_status": result["repair_fidelity"]["status"],
+                    "recorded_tokens_before": recorded_before,
+                    "recorded_tokens_after": recorded_after,
+                }
+            )
+            next_index = slot_index + 1
+            if next_index == len(slots):
+                stop_reason = "authorized_six_complete_pairs_reached"
+                break
+            if next_index % 2 == 0 and recorded_after >= _token_limit(manifest):
+                stop_reason = "recorded_token_pair_boundary_reached"
+                break
+    return {
+        "status": stop_reason,
+        "benchmark_id": manifest["benchmark"]["id"],
+        "manifest_sha256": protocol.manifest_sha256(manifest),
+        "start_slot_index": start_index,
+        "next_slot_index": start_index + len(results),
+        "authorized_slot_count": len(slots),
+        "attempts_completed": len(results),
+        "complete_pairs_observed": (start_index + len(results)) // 2,
+        "recorded_total_tokens": (results[-1]["recorded_tokens_after"] if results else _recorded_total_tokens(observed)),
+        "recorded_token_limit": _token_limit(manifest),
+        "results": results,
+    }
+
+
+_runner.collect_runtime_launch_preflight = collect_runtime_launch_preflight
+_runner._manifest_protocol = _manifest_protocol
+_runner.collect_provider_canary = collect_provider_canary
+_runner.create_attempt = create_attempt
+_runner.run_attempt = run_attempt
+_runner.run_formal_batch = run_repair_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_runner, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 派生 `verifier-driven-repair-pilot-authorized-1.0.0`，绑定父 runtime canonical SHA-256 `880af017…045`、12 slots / 6 complete pairs 与 2,400,000 recorded-token 上限。
- 将 provider×arm 展开为四个唯一 condition，复用已验证的 formal physical-attempt 生命周期；双 provider canary 仍严格每家只请求一次。
- 每个 attempt 在 `submit_feedback_scope` 内执行并生成独立 hash-chain repair sidecar；baseline 字节一致性、treatment packet 与 fidelity gate 沿用已评审 runtime。
- 新增只读报告器，按冻结 schedule 合并主 ledger 与 sidecar，复算 Oracle、terminal、repair conversion、false acceptance、submit/replay、请求、token、墙钟与 failure transition。
- 运行时硬门禁要求唯一 evidence 目录、空 evidence、0 orphan、已确认网络介质、一次双 provider canary、完整 pair 停止边界，并继续禁止 retry、fallback、replacement 和 backfill。

## 验证

- repair runtime + authorized 聚焦回归：`26 passed`
- Ruff check / format：通过
- `py_compile`：通过
- JSON Schema 实例校验：通过
- protocol validate 与确定性再生成：通过
- 父 runtime、共享 compile 字节与敏感值扫描：通过
- authorized manifest canonical SHA-256：`ad54858ad8cc938e823170bece020b21a7ab221788d5c36ac45c5213d78b56d0`

## 边界

本 PR 没有启动 Docker、没有调用 provider、没有消耗模型 token、没有创建 physical-attempt evidence。合并后仍须依次通过 Ubuntu 原生 Docker gate、非模型 preflight、空 evidence/0 orphan 和唯一双 provider canary，任一失败立即停止。

Closes #127