### PR TITLE
修复 verifier-driven repair canary 冻结请求超时

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,13 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-14 — 执行 verifier-driven repair 六对授权 pilot
-  - GitHub: 中文 Issue #127 已创建并回读；实现分支为 `research/issue-127-verifier-repair-authorized`，基线为 `main@fb24fa2b`。
-  - 授权: RichLab `gpt-5.5`、DeepSeek `deepseek-v4-flash`，3 cases × 2 providers × 2 arms × 1 repetition，共 12 slots / 6 complete pairs；expected 800,000、maximum 2,400,000 recorded tokens，禁止 retry、fallback、replacement 和 backfill。
-  - 实现: 新 authorized manifest/Schema 把 provider×arm 展开为四个唯一 condition，同时保持 canary 每个 provider 只请求一次；真实 attempt 在 `submit_feedback_scope` 内运行，独立 sidecar 不使用 `.jsonl` 后缀，避免被主 ledger 扫描器误识别；只读报告器按冻结 order 合并主 ledger 与 sidecar。
-  - 门禁: 合并前禁止模型与 evidence；合并后依次要求 Ubuntu 原生 Docker、非模型 preflight、空 evidence、0 orphan、已确认的 `FORGE_NETWORK_ACCESS_MEDIUM` 与唯一双 provider canary。batch 只能在完整 pair 边界停止，token 在新 pair 前检查。
-  - 验证: 聚焦 repair runtime/authorized 回归 `26 passed`；Ruff check/format、`py_compile`、Schema 实例校验、protocol validate、确定性再生成、父 runtime/共享 compile 与敏感值扫描通过。authorized manifest canonical SHA-256 为 `ad54858ad8cc938e823170bece020b21a7ab221788d5c36ac45c5213d78b56d0`。
-  - 边界与下一步: 当前 0 Docker、0 provider request、0 model token、0 physical attempt。下一步中文提交、WSL helper 推送、中文 PR/CI/合并；canary 前需实验负责人确认当前网络介质。
-  - 文件: `scripts/forge_verifier_repair_authorized_protocol.py`, `scripts/forge_verifier_repair_authorized_runner.py`, `scripts/forge_verifier_repair_authorized_report.py`, `backend/tests/test_forge_verifier_repair_authorized.py`, `benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json`, `benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json`
+- 2026-08-14 — 修复 verifier-driven repair canary 冻结超时接线
+  - GitHub: Issue #127 / PR #128 已完成 12-slot 授权实现；新中文 Issue #129 跟踪 canary 未应用 300 秒冻结超时，修复分支为 `fix/issue-129-canary-timeout`。
+  - 真实证据: 经授权的完整 canary 中 RichLab `gpt-5.5` 4.767 秒通过，DeepSeek `deepseek-v4-flash` 在 120.246 秒以 `APITimeoutError` 失败；0 formal JSONL、0 physical attempt，12-slot batch 未启动。失败 marker/report 与此前两次操作事故 marker 均保留，未经新授权不得再次 canary。
+  - 根因与修复: authorized runner 的 canary 未进入 `ExperimentPolicy`，沿用本地 120 秒配置。新 helper 在独立串行 runner 进程的模型构造临界区应用 profile 的 300 秒/0 retry，验证模型对象的有效策略后在 `finally` 恢复原配置；报告新增有效 timeout/retry 字段，不修改共享 factory、Oracle、clean replay 或历史 evidence。
+  - 验证: repair 相关回归 `27 passed`，Ruff 与测试格式通过；真实无请求模型对象探针确认 RichLab/DeepSeek 的模型和 OpenAI client 均为 300 秒、0 retry，构造后本地配置恢复为 120 秒。协议组件验证通过，新 canonical manifest SHA-256 为 `ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875`。
+  - 下一步: 完成中文提交、WSL helper 推送、中文 PR 与 CI；修复合并后只运行非模型门禁。新的 provider canary 与 12-slot batch 仍需实验负责人重新明确授权。
+  - 文件: `scripts/forge_verifier_repair_authorized_runner.py`, `backend/tests/test_forge_verifier_repair_authorized.py`, `benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json`, `benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json`
 
 - 2026-08-13 — 完成 formal v4 有限诊断与新 canary amendment
   - GitHub: 中文 Issue #115 已创建并回读；实现分支为 `research/formal-v4-canary-amendment`，PR 尚未创建。
@@ -337,6 +336,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 一次性正式入口必须先用最终完全相同的 `/app/backend/.venv/bin/python` 完成零请求 import、runner `--help` 与挂载内 preflight；双 provider canary 外层等待不得短于 700 秒。manifest 声明 300 秒不等于模型对象已生效，必须在请求前验证模型及底层 client 的有效 timeout/retry；调试级短超时、系统 `python` 和仅核对 endpoint 的 preflight 都不能作为放行依据。
 - Windows `docker` CLI 的 `desktop-linux` context 只反映 Docker Desktop daemon，不能据此判断 Forge 状态。Forge 容器实际属于 WSL2 Ubuntu 原生 `dockerd`；所有项目 Docker 命令必须先通过 `scripts/require-ubuntu-native-docker.sh`，并从 `wsl.exe -d Ubuntu` 或该发行版内执行。门禁失败时请求用户恢复服务，不得启动 Docker Desktop 作为回退。
 - LangGraph 容器内 `/repo` 是只读挂载。可在容器中使用 Ruff `--check --no-cache`，但不能直接格式化文件；写入格式化必须在可写工作树中使用相同 `backend/ruff.toml`，不要修改挂载权限或重建服务来绕过只读边界。
 

--- a/backend/tests/test_forge_verifier_repair_authorized.py
+++ b/backend/tests/test_forge_verifier_repair_authorized.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -92,6 +93,77 @@ def test_canary_invokes_each_provider_once_and_projects_four_conditions(tmp_path
     assert len(result["conditions"]) == 4
     assert result["network_access_medium"] == "mobile_hotspot"
     assert result["passed"] is True
+
+
+def test_canary_applies_frozen_request_policy_and_restores_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    from deerflow import config as config_module
+    from deerflow.models import factory as factory_module
+
+    profile = _manifest()["model_profiles"]["deepseek-v4-flash"]
+
+    class FakeModelConfig:
+        model = "deepseek-v4-flash"
+        base_url = "https://api.deepseek.com"
+        request_timeout = 120.0
+        max_retries = 4
+
+        def model_dump(self, *, exclude_none: bool) -> dict:
+            assert exclude_none is True
+            return {
+                "model": self.model,
+                "base_url": self.base_url,
+                "request_timeout": self.request_timeout,
+                "max_retries": self.max_retries,
+            }
+
+    configured = FakeModelConfig()
+    observed: list[tuple[float, int]] = []
+
+    class FakeModel:
+        request_timeout = configured.request_timeout
+        max_retries = configured.max_retries
+
+        def invoke(self, prompt: str):
+            assert prompt == "Reply with exactly CANARY_OK and nothing else."
+            return SimpleNamespace(content="CANARY_OK")
+
+    def fake_create_chat_model(*, name: str, thinking_enabled: bool):
+        assert name == "deepseek-v4-flash"
+        assert thinking_enabled is False
+        observed.append((configured.request_timeout, configured.max_retries))
+        model = FakeModel()
+        model.request_timeout = configured.request_timeout
+        model.max_retries = configured.max_retries
+        return model
+
+    monkeypatch.setattr(
+        config_module,
+        "get_app_config",
+        lambda: SimpleNamespace(get_model_config=lambda name: configured if name == configured.model else None),
+    )
+    monkeypatch.setattr(factory_module, "create_chat_model", fake_create_chat_model)
+
+    result = runner._invoke_provider_canary(profile)
+
+    assert result["passed"] is True
+    assert result["request_timeout_seconds"] == 300
+    assert result["max_retries"] == 0
+    assert observed == [(300.0, 0)]
+    assert configured.request_timeout == 120.0
+    assert configured.max_retries == 4
+
+    def failing_create_chat_model(*, name: str, thinking_enabled: bool):
+        assert name == "deepseek-v4-flash"
+        assert thinking_enabled is False
+        observed.append((configured.request_timeout, configured.max_retries))
+        raise RuntimeError("model construction failed")
+
+    monkeypatch.setattr(factory_module, "create_chat_model", failing_create_chat_model)
+    with pytest.raises(RuntimeError, match="model construction failed"):
+        runner._create_provider_canary_model(profile)
+    assert observed[-1] == (300.0, 0)
+    assert configured.request_timeout == 120.0
+    assert configured.max_retries == 4
 
 
 def test_canary_rejects_unconfirmed_network_before_consuming_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json
+++ b/benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json
@@ -90,7 +90,7 @@
   "protocol_artifact_sha256": {
     "scripts/forge_verifier_repair_authorized_protocol.py": "48f2e91a2ac97c143e9233e966cae5506d7a3cea30cbd8d03719764fc421f0e6",
     "scripts/forge_verifier_repair_authorized_report.py": "17b08d96838d364c192dcf27ac21a62af7b1217807d4377f46ef27d32a006ae6",
-    "scripts/forge_verifier_repair_authorized_runner.py": "b1651cbd7b7413a7d5234662c826238e0fdf8b39980bec9025b8609f87dbb2d8"
+    "scripts/forge_verifier_repair_authorized_runner.py": "2a708b59b9dfe5a33b96c29c0a79c7285c7a26360292048015140a933fa85f86"
   },
   "prompt_sha256": {
     "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",

--- a/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json
+++ b/benchmarks/schemas/forge-verifier-repair-pilot-authorized-v1.schema.json
@@ -94,7 +94,7 @@
     "protocol_artifact_sha256": {
       "scripts/forge_verifier_repair_authorized_protocol.py": "48f2e91a2ac97c143e9233e966cae5506d7a3cea30cbd8d03719764fc421f0e6",
       "scripts/forge_verifier_repair_authorized_report.py": "17b08d96838d364c192dcf27ac21a62af7b1217807d4377f46ef27d32a006ae6",
-      "scripts/forge_verifier_repair_authorized_runner.py": "b1651cbd7b7413a7d5234662c826238e0fdf8b39980bec9025b8609f87dbb2d8"
+      "scripts/forge_verifier_repair_authorized_runner.py": "2a708b59b9dfe5a33b96c29c0a79c7285c7a26360292048015140a933fa85f86"
     },
     "prompt_sha256": {
       "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",

--- a/scripts/forge_verifier_repair_authorized_runner.py
+++ b/scripts/forge_verifier_repair_authorized_runner.py
@@ -55,6 +55,7 @@ DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
 _CANARY_ATTEMPT_MARKER = "verifier-repair-provider-canary-attempt.json"
 _SIDECAR_SUFFIX = ".repair-sidecar.json"
 _NETWORK_ACCESS_MEDIA = {"mobile_hotspot", "wifi", "ethernet", "other"}
+_MISSING = object()
 
 
 def _manifest_protocol(manifest: dict[str, Any]):
@@ -222,17 +223,62 @@ def _model_response_text(response: Any) -> str:
     return "".join(item if isinstance(item, str) else item.get("text", "") for item in content if isinstance(item, (str, dict)))
 
 
-def _invoke_provider_canary(profile: dict[str, Any]) -> dict[str, Any]:
+def _restore_model_config_value(configured: Any, name: str, value: Any) -> None:
+    if value is _MISSING:
+        try:
+            delattr(configured, name)
+        except AttributeError:
+            pass
+        return
+    setattr(configured, name, value)
+
+
+def _create_provider_canary_model(profile: dict[str, Any]):
+    from deerflow.config import get_app_config
     from deerflow.models.factory import create_chat_model
 
+    model_name = profile["roles"]["lead"]
+    configured = get_app_config().get_model_config(model_name)
+    if configured is None or configured.model != model_name:
+        raise RunnerError(
+            "Provider canary model configuration does not match the frozen profile"
+        )
+    settings = configured.model_dump(exclude_none=True)
+    endpoint = settings.get("base_url", settings.get("openai_api_base"))
+    if endpoint is None or str(endpoint).rstrip("/") != profile["endpoint"].rstrip("/"):
+        raise RunnerError("Provider canary endpoint does not match the frozen profile")
+
+    expected_timeout = float(profile["request_timeout_seconds"])
+    original_timeout = getattr(configured, "request_timeout", _MISSING)
+    original_retries = getattr(configured, "max_retries", _MISSING)
+    try:
+        configured.request_timeout = expected_timeout
+        configured.max_retries = 0
+        model = create_chat_model(name=model_name, thinking_enabled=False)
+    finally:
+        _restore_model_config_value(configured, "request_timeout", original_timeout)
+        _restore_model_config_value(configured, "max_retries", original_retries)
+
+    try:
+        effective_timeout = float(model.request_timeout)
+        effective_retries = int(model.max_retries)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise RunnerError(
+            "Provider canary model does not expose its effective request policy"
+        ) from exc
+    if effective_timeout != expected_timeout or effective_retries != 0:
+        raise RunnerError(
+            "Provider canary model did not apply the frozen request policy"
+        )
+    return model
+
+
+def _invoke_provider_canary(profile: dict[str, Any]) -> dict[str, Any]:
     started = time.perf_counter()
     error_class: str | None = None
     response_text = ""
     try:
-        model = create_chat_model(
-            name=profile["roles"]["lead"],
-            thinking_enabled=False,
-        )
+        model = _create_provider_canary_model(profile)
         response = model.invoke("Reply with exactly CANARY_OK and nothing else.")
         response_text = _model_response_text(response)
     except Exception as exc:
@@ -241,6 +287,8 @@ def _invoke_provider_canary(profile: dict[str, Any]) -> dict[str, Any]:
         "model": profile["roles"]["lead"],
         "endpoint": profile["endpoint"].rstrip("/"),
         "credential_env": profile["credential_env"],
+        "request_timeout_seconds": profile["request_timeout_seconds"],
+        "max_retries": 0,
         "duration_ms": round((time.perf_counter() - started) * 1000),
         "response_nonempty": bool(response_text.strip()),
         "response_sha256": (hashlib.sha256(response_text.encode("utf-8")).hexdigest() if response_text else None),


### PR DESCRIPTION
## 变更摘要

- 在 authorized canary 的串行模型构造临界区应用 profile 冻结的 `request_timeout_seconds=300` 与 `max_retries=0`。
- 构造后核验模型对象的有效 timeout/retry，并在 `finally` 中恢复本地模型配置，避免污染下一家 provider。
- canary 报告新增实际请求策略字段；重新生成 manifest/Schema 绑定最终 runner 哈希。
- 增加成功与模型构造异常路径测试，覆盖策略生效及配置恢复。

## 根因

canary 直接调用模型 factory，但不在 `ExperimentPolicy` scope 内，因此此前沿用 `config.yaml` 的 120 秒，而不是 manifest 冻结的 300 秒。现有测试完全 mock 了 `_invoke_provider_canary()`，未覆盖有效模型构造参数。

## 验证

- verifier repair 相关回归：`27 passed`
- Ruff check：通过
- 测试文件 Ruff format：通过
- authorized protocol validate：通过
- 提交后 Compose/DooD 非模型 preflight：`ready=true`
- 真实无请求对象探针：RichLab 与 DeepSeek 的模型/client timeout 均为 300 秒、retry 为 0，构造后本地配置恢复为 120 秒

## 实验边界

本 PR 没有发起 provider 请求、canary 重试或 formal attempt；历史 marker/report 与 12-slot evidence 均未修改。合并后新的 canary 仍需实验负责人另行明确授权。

Closes #129