### PR TITLE
研究：增加 verifier repair 单次 canary 修订

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-14 — 派生 verifier-driven repair 单次 canary amendment
+  - GitHub: 中文 Issue #131 已创建并回读；分支为 `research/issue-131-verifier-repair-canary-amendment`，基线为 `main@9a63bc0a`。
+  - 边界: 原失败 canary report/marker 与 authorized identity 保持不变；新 identity 使用独立 evidence 目录，只新增一次双 provider canary，成功才允许原 12 slots/6 complete pairs/2,400,000 recorded-token ceiling。
+  - 实现: 新 protocol/runner/report 在 canary、attempt 和 batch 前核对旧 marker/report 的完整 SHA-256 与 0 formal ledger；模型、300 秒/0 retry、treatment、Oracle、clean replay、顺序和分析规则均继承 parent。
+  - 当前验证: parent + amendment 聚焦回归 `15 passed`，Ruff check/format 与语法检查通过；canonical manifest SHA-256 为 `4ac87955e85bd7a0ed8465268ae42c2b0d2ce598bf7119c129364cba3fc87915`。
+  - 下一步: 完成最终审计、中文提交/推送/PR/CI；合并后通过 Ubuntu/Compose 非模型门禁并执行唯一新 canary，双通过才运行 batch。
+  - 文件: `scripts/forge_verifier_repair_canary_amendment_protocol.py`, `scripts/forge_verifier_repair_canary_amendment_runner.py`, `scripts/forge_verifier_repair_canary_amendment_report.py`, `backend/tests/test_forge_verifier_repair_canary_amendment.py`, `benchmarks/manifests/cpp-verifier-repair-pilot-canary-amendment.json`, `benchmarks/schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json`
+
 - 2026-08-14 — 修复 verifier-driven repair canary 冻结超时接线
   - GitHub: Issue #127 / PR #128 已完成 12-slot 授权实现；新中文 Issue #129 跟踪 canary 未应用 300 秒冻结超时，修复分支为 `fix/issue-129-canary-timeout`。
   - 真实证据: 经授权的完整 canary 中 RichLab `gpt-5.5` 4.767 秒通过，DeepSeek `deepseek-v4-flash` 在 120.246 秒以 `APITimeoutError` 失败；0 formal JSONL、0 physical attempt，12-slot batch 未启动。失败 marker/report 与此前两次操作事故 marker 均保留，未经新授权不得再次 canary。

--- a/backend/tests/test_forge_verifier_repair_canary_amendment.py
+++ b/backend/tests/test_forge_verifier_repair_canary_amendment.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_canary_amendment_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_canary_amendment_runner.py"
+REPORT_PATH = REPO_ROOT / "scripts" / "forge_verifier_repair_canary_amendment_report.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-canary-amendment.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-pilot-canary-amendment-v1.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_verifier_repair_canary_amendment_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_verifier_repair_canary_amendment_runner_test", RUNNER_PATH)
+report = _load_module("forge_verifier_repair_canary_amendment_report_test", REPORT_PATH)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, value: dict) -> bytes:
+    raw = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(raw)
+    return raw
+
+
+def test_manifest_is_deterministic_schema_valid_and_preserves_study() -> None:
+    manifest = _manifest()
+    parent = protocol._parent_manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert protocol.validate_manifest(manifest) == manifest
+    assert protocol.generate_manifest() == manifest
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(manifest, schema)
+    assert manifest["schema_version"] == "verifier-driven-repair-pilot-canary-amendment-1.0.0"
+    assert manifest["authorization"]["issue_url"].endswith("/131")
+    assert manifest["authorization"]["new_canary"] == {
+        "maximum_attempts": 1,
+        "authenticated_requests_per_provider": 1,
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "success_required_before_first_ledger": True,
+    }
+    for key in ("model_profiles", "conditions", "collection_plan", "cases", "repair_packet", "fidelity_gate", "outcomes", "analysis_plan"):
+        assert manifest[key] == parent[key]
+    assert manifest["authorization"]["budget_confirmation"] == parent["authorization"]["budget_confirmation"]
+
+
+def test_parent_identity_and_files_remain_frozen() -> None:
+    parent = protocol._parent_manifest()
+    assert protocol.parent_protocol.manifest_sha256(parent) == protocol.PARENT_CANONICAL_SHA256
+    assert protocol.SUPERSEDED_CANARY_TERMINAL["marker_sha256"] == "1a2b7bc7547e30ef56b1340420e435bd44b2f56df5e025a90653f5f88a39bcd7"
+    assert protocol.SUPERSEDED_CANARY_TERMINAL["provider_report_sha256"] == "a8cc041ba4213a9f35169e4c48273c4ba4911e84e467c7f55fd5143bff2283a5"
+
+
+def test_superseded_canary_requires_exact_marker_report_and_zero_ledgers(tmp_path: Path) -> None:
+    manifest = copy.deepcopy(_manifest())
+    frozen = manifest["authorization"]["superseded_canary_terminal"]
+    marker = {
+        "benchmark_id": frozen["benchmark_id"],
+        "manifest_sha256": frozen["manifest_sha256"],
+        "status": "failed",
+        "error_class": None,
+    }
+    provider_report = {
+        "benchmark_id": frozen["benchmark_id"],
+        "manifest_sha256": frozen["manifest_sha256"],
+        "passed": False,
+    }
+    marker_raw = _write_json(tmp_path / frozen["marker_relative_path"], marker)
+    report_path = tmp_path / frozen["provider_report_relative_path"]
+    report_raw = _write_json(report_path, provider_report)
+    frozen["marker_sha256"] = hashlib.sha256(marker_raw).hexdigest()
+    frozen["provider_report_sha256"] = hashlib.sha256(report_raw).hexdigest()
+
+    assert runner._verify_superseded_canary_terminal(manifest, output_dir=tmp_path) == {
+        "status": "failed",
+        "provider_report_count": 1,
+        "formal_ledger_count": 0,
+    }
+    report_path.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(runner.RunnerError, match="report changed"):
+        runner._verify_superseded_canary_terminal(manifest, output_dir=tmp_path)
+
+
+def test_canary_verifies_superseded_layer_before_delegating(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest()
+    calls: list[str] = []
+    monkeypatch.setattr(runner, "_verify_superseded_canary_terminal", lambda *_args, **_kwargs: calls.append("verify"))
+    monkeypatch.setattr(runner, "_original_collect_provider_canary", lambda *_args, **_kwargs: calls.append("canary") or {"passed": True})
+
+    assert runner.collect_provider_canary(manifest, manifest_path=MANIFEST_PATH, output_dir=tmp_path) == {"passed": True}
+    assert calls == ["verify", "canary"]
+
+
+def test_report_adapter_uses_amendment_identity() -> None:
+    manifest = _manifest()
+    assert report._parent.protocol.SCHEMA_VERSION == protocol.SCHEMA_VERSION
+    assert report._parent.protocol.DEFAULT_MANIFEST == protocol.DEFAULT_MANIFEST
+    assert report._parent.DEFAULT_EVIDENCE_DIR == Path(protocol.EVIDENCE_DIRECTORY)
+    assert report._parent.load_manifest(MANIFEST_PATH) == manifest

--- a/benchmarks/manifests/cpp-verifier-repair-pilot-canary-amendment.json
+++ b/benchmarks/manifests/cpp-verifier-repair-pilot-canary-amendment.json
@@ -1,0 +1,710 @@
+{
+  "$schema": "../schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json",
+  "schema_version": "verifier-driven-repair-pilot-canary-amendment-1.0.0",
+  "document_type": "forge_verifier_repair_pilot_authorization",
+  "benchmark": {
+    "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+    "name": "Forge C/C++ verifier-driven repair paired pilot canary amendment",
+    "purpose": "execute one new authenticated provider canary before the unchanged paired pilot"
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "phase": "verifier_driven_repair_pilot_canary_amendment",
+    "formal_comparison_enabled": false,
+    "collection_authorized": true,
+    "instrumentation_blocker": false
+  },
+  "authorization": {
+    "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+    "status": "authorized_single_canary_amendment",
+    "authorized_by": "experiment_owner",
+    "authorized_on": "2026-08-14",
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/131",
+    "implementation_baseline_commit": "9a63bc0ac07b71a531a5400197f0fb836b687fc1",
+    "parent_runtime": {
+      "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+      "path": "benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json",
+      "canonical_sha256": "880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045"
+    },
+    "network_observation": {
+      "access_medium_reconfirmation_required_before_canary": true,
+      "browser_ui_required": false,
+      "last_observed_access_medium": "wifi"
+    },
+    "budget_confirmation": {
+      "confirmed": true,
+      "expected_recorded_tokens": 800000,
+      "maximum_recorded_tokens": 2400000,
+      "enforcement": "check_before_each_complete_pair",
+      "complete_started_pair_before_next_boundary_check": true
+    },
+    "collection_constraints": {
+      "authorized_slot_count": 12,
+      "authorized_complete_pairs": 6,
+      "provider_canary_required_before_first_ledger": true,
+      "provider_canary_max_attempts": 1,
+      "provider_canary_requests_per_provider": 1,
+      "empty_evidence_required_before_canary": true,
+      "zero_residual_formal_containers_required_before_canary": true,
+      "replacement_forbidden": true,
+      "fallback_forbidden": true,
+      "retry_forbidden": true,
+      "backfill_forbidden": true,
+      "p_value_forbidden": true,
+      "model_ranking_forbidden": true,
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-canary-amendment"
+    },
+    "parent_manifest": {
+      "id": "forge-verifier-driven-repair-pilot-authorized",
+      "path": "benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json",
+      "canonical_sha256": "ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875"
+    },
+    "superseded_canary_terminal": {
+      "benchmark_id": "forge-verifier-driven-repair-pilot-authorized",
+      "manifest_sha256": "ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-authorized",
+      "marker_relative_path": "provider-canaries/verifier-repair-provider-canary-attempt.json",
+      "marker_sha256": "1a2b7bc7547e30ef56b1340420e435bd44b2f56df5e025a90653f5f88a39bcd7",
+      "status": "failed",
+      "error_class": null,
+      "provider_report_relative_path": "provider-canaries/provider_canary_2de75d5184664bb08d572e026161cef9.json",
+      "provider_report_sha256": "a8cc041ba4213a9f35169e4c48273c4ba4911e84e467c7f55fd5143bff2283a5",
+      "provider_report_count": 1,
+      "formal_ledger_count": 0
+    },
+    "nonformal_diagnostic": {
+      "provider_condition": "richlab-gpt-5.5",
+      "request_count": 1,
+      "request_timeout_seconds": 60,
+      "max_retries": 0,
+      "duration_ms": 5983,
+      "passed": true,
+      "excluded_from_formal_evidence": true,
+      "response_body_storage_forbidden": true
+    },
+    "new_canary": {
+      "maximum_attempts": 1,
+      "authenticated_requests_per_provider": 1,
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "success_required_before_first_ledger": true
+    }
+  },
+  "forge": {
+    "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+    "commit_sha": "9a63bc0ac07b71a531a5400197f0fb836b687fc1",
+    "revision_policy": "descendant-compatible",
+    "component_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+      "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+      "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+      "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+      "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+      "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+      "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+      "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+      "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+      "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+      "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+      "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+      "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+      "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+      "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+      "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+      "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+      "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+    }
+  },
+  "protocol_artifact_sha256": {
+    "scripts/forge_verifier_repair_canary_amendment_protocol.py": "139dc3d78fa0c3c91222bbf1a64dbdb2a079418cc9e3fe29c1633fa59f073a35",
+    "scripts/forge_verifier_repair_canary_amendment_report.py": "15500f2538aef69d0d771e51c25d44956146aabd7de23a633518e377e0eb0db2",
+    "scripts/forge_verifier_repair_canary_amendment_runner.py": "3737b6ec1877bf3b022a76dcf670bc6746e4bcacea02f1f4e326570cfe94986b"
+  },
+  "prompt_sha256": {
+    "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+    "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+    "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+  },
+  "model_profiles": {
+    "richlab-gpt-5.5": {
+      "endpoint": "https://rich-api.choosefire.com/v1",
+      "credential_env": "OpenAI_AK",
+      "roles": {
+        "lead": "gpt-5.5",
+        "compiler": "gpt-5.5"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    },
+    "deepseek-v4-flash": {
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "roles": {
+        "lead": "deepseek-v4-flash",
+        "compiler": "deepseek-v4-flash"
+      },
+      "fallback_policy": "forbidden",
+      "request_timeout_seconds": 300,
+      "max_retries": 0
+    }
+  },
+  "runtime": {
+    "compile_image": "autocompiler:gcc13",
+    "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+    "control_plane_topology": "compose-dood",
+    "replay_timeout_seconds": 1200,
+    "cleanup_timeout_seconds": 20,
+    "docker_control_timeout_seconds": 30,
+    "model_turn_limit": 36,
+    "graph_recursion_limit": 96,
+    "wall_clock_timeout_seconds": 900,
+    "post_build_reserve_seconds": 120,
+    "max_parallel_runs": 1,
+    "backend_processes": 1,
+    "network_policy": {
+      "network_name": "compile_network_wwf_v1",
+      "egress": "enabled_for_clone_and_dependencies"
+    },
+    "host": {
+      "wsl_distribution": "Ubuntu",
+      "cpu_count": 32,
+      "memory_kib": 7723024,
+      "kernel": "6.6.114.1-microsoft-standard-WSL2",
+      "architecture": "x86_64",
+      "docker_server_version": "29.5.3"
+    },
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "attempt_budget": {
+    "total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "enforcement_checkpoints": [
+      "before_provider_request",
+      "before_compiler_invocation",
+      "before_submit_or_replay",
+      "before_finalize",
+      "before_cleanup"
+    ],
+    "new_work_forbidden_after_limit": true,
+    "cleanup_mandatory_after_limit": true,
+    "terminal_classification": "attempt_budget_exhausted"
+  },
+  "resource_preflight": {
+    "minimum_available_memory_bytes": 2147483648,
+    "docker_daemon_timeout_seconds": 10,
+    "maximum_docker_daemon_latency_seconds": 5,
+    "required_checks": [
+      "host_available_memory_at_least_minimum",
+      "docker_daemon_responded",
+      "docker_daemon_latency_within_limit",
+      "docker_daemon_provider_matches",
+      "docker_socket_source_matches_native_path"
+    ],
+    "sensitive_host_identifiers_forbidden": true,
+    "docker_daemon_provider": "ubuntu-native",
+    "docker_socket_path": "/var/run/docker.sock"
+  },
+  "budget": {
+    "authorized": true,
+    "request_timeout_seconds": 300,
+    "provider_retries": 0,
+    "attempt_total_wall_clock_seconds": 1800,
+    "cleanup_reserve_seconds": 120,
+    "max_compiler_invocations": 2,
+    "max_model_requests": 48,
+    "model_turn_limit": 36,
+    "maximum_recorded_tokens": 2400000,
+    "expected_recorded_tokens": 800000,
+    "budget_check_boundary": "before_each_complete_pair",
+    "remaining_pairs_require_confirmation": true
+  },
+  "conditions": [
+    {
+      "id": "richlab-gpt-5.5-baseline",
+      "model_profile": "richlab-gpt-5.5",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "richlab-gpt-5.5-repair",
+      "model_profile": "richlab-gpt-5.5",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash-baseline",
+      "model_profile": "deepseek-v4-flash",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    },
+    {
+      "id": "deepseek-v4-flash-repair",
+      "model_profile": "deepseek-v4-flash",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "memory_enabled": false,
+      "skills_enabled": false,
+      "repetitions": 1,
+      "acceptance_gate": "clean_replay"
+    }
+  ],
+  "collection_plan": [
+    {
+      "order": 1,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 2,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 3,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 4,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    },
+    {
+      "order": 5,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 6,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 7,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    },
+    {
+      "order": 8,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 9,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-baseline"
+    },
+    {
+      "order": 10,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "richlab-gpt-5.5-repair"
+    },
+    {
+      "order": 11,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-repair"
+    },
+    {
+      "order": 12,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1,
+      "condition_id": "deepseek-v4-flash-baseline"
+    }
+  ],
+  "schedule_sha256": "588cfae514f827d8ff436285dee80bd2d2dd782cbab4dfd4992c0f99cd8c51b2",
+  "cases": [
+    {
+      "id": "liblouis",
+      "repository_url": "https://github.com/liblouis/liblouis",
+      "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+      "languages": [
+        "C"
+      ],
+      "build_system": "autotools",
+      "license": "LGPL-2.1",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [
+          "autoreconf -fi"
+        ],
+        "configure_arguments": [
+          "--disable-shared",
+          "--enable-static"
+        ],
+        "build_targets": [
+          "all"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "liblouis.a",
+            "build_output_path": "liblouis/.libs/liblouis.a",
+            "artifact_type": "static_library",
+            "producing_target": "all"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "autoconf",
+          "automake",
+          "build-essential",
+          "libtool",
+          "pkg-config"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": [
+            "--disable-shared",
+            "--enable-static"
+          ]
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "openthread",
+      "repository_url": "https://github.com/openthread/openthread",
+      "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "cmake",
+      "license": "BSD-3-Clause",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DOT_BUILD_EXECUTABLES=OFF",
+          "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+        ],
+        "build_targets": [
+          "openthread-ftd"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libopenthread-ftd.a",
+            "build_output_path": "build/src/core/libopenthread-ftd.a",
+            "artifact_type": "static_library",
+            "producing_target": "openthread-ftd"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "cmake",
+          "python3"
+        ],
+        "build_arguments": {
+          "cmake": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    },
+    {
+      "id": "mupdf",
+      "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+      "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+      "languages": [
+        "C++"
+      ],
+      "build_system": "make",
+      "license": "AGPL-3.0",
+      "protocol": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libs"
+        ]
+      },
+      "oracle": {
+        "expected_candidate_status": "pass",
+        "expected_clean_replay_status": "pass",
+        "required_artifacts": [
+          {
+            "relative_path": "libmupdf.a",
+            "build_output_path": "build/release/libmupdf.a",
+            "artifact_type": "static_library",
+            "producing_target": "libs"
+          }
+        ]
+      },
+      "constraints": {
+        "required_system_packages": [
+          "build-essential",
+          "libfreetype6-dev",
+          "libjpeg-dev",
+          "zlib1g-dev"
+        ],
+        "build_arguments": {
+          "cmake": [],
+          "configure": []
+        },
+        "environment": {},
+        "minimum_replay_delay_seconds": 0
+      }
+    }
+  ],
+  "pilot_schedule": [
+    {
+      "order": 1,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 2,
+      "pair_id": "liblouis-richlab-r1",
+      "case_id": "liblouis",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 3,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 4,
+      "pair_id": "liblouis-deepseek-r1",
+      "case_id": "liblouis",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 5,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 6,
+      "pair_id": "openthread-richlab-r1",
+      "case_id": "openthread",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 7,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 8,
+      "pair_id": "openthread-deepseek-r1",
+      "case_id": "openthread",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 9,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    },
+    {
+      "order": 10,
+      "pair_id": "mupdf-richlab-r1",
+      "case_id": "mupdf",
+      "provider_condition": "richlab-gpt-5.5",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 11,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "structured-verifier-repair-packet",
+      "repetition": 1
+    },
+    {
+      "order": 12,
+      "pair_id": "mupdf-deepseek-r1",
+      "case_id": "mupdf",
+      "provider_condition": "deepseek-v4-flash",
+      "treatment": "baseline-current-verifier-output",
+      "repetition": 1
+    }
+  ],
+  "repair_packet": {
+    "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+    "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+    "actionable_classifications": [
+      "artifact_set_mismatch",
+      "artifact_type_mismatch",
+      "build_system_mismatch",
+      "build_system_selection_mismatch",
+      "build_system_unproven",
+      "candidate_verification_failed",
+      "recipe_execution_failed",
+      "sha256_mismatch",
+      "size_mismatch",
+      "smoke_mismatch"
+    ],
+    "repair_goals": {
+      "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+      "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+      "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+      "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+      "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+      "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+      "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+      "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+      "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+    },
+    "forbidden_content": [
+      "stdout",
+      "stderr",
+      "prompt",
+      "model_body",
+      "credential",
+      "host_path",
+      "generated_repair_command"
+    ]
+  },
+  "fidelity_gate": {
+    "statuses": [
+      "passed",
+      "not_exposed",
+      "failed"
+    ],
+    "baseline_packet_count": 0,
+    "treatment_requires_packet_for_each_actionable_submit": true,
+    "paired_analysis_requires_both_arms": true,
+    "p_value_forbidden": true,
+    "model_ranking_forbidden": true
+  },
+  "outcomes": {
+    "primary": "oracle_passed",
+    "secondary": [
+      "terminal_passed",
+      "repair_conversion_after_actionable_verifier_failure",
+      "false_acceptance_count",
+      "submit_attempts",
+      "clean_replay_attempts",
+      "model_requests",
+      "recorded_tokens",
+      "attempt_wall_clock_seconds",
+      "failure_classification_transition"
+    ],
+    "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+    "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+  },
+  "analysis_plan": {
+    "descriptive_only": true,
+    "complete_pairs_required": 6,
+    "repair_conversion_definition": "adjacent_actionable_classification_to_passed_feedback",
+    "model_request_count_event": "model.request_started",
+    "submit_attempt_count_event": "submit.started",
+    "clean_replay_attempt_count_event": "replay.started",
+    "wall_clock_definition": "experiment_started_to_experiment_completed_ledger_time",
+    "p_value_computed": false,
+    "model_ranking_performed": false
+  }
+}

--- a/benchmarks/schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json
+++ b/benchmarks/schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json
@@ -1,0 +1,715 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json",
+  "title": "Forge verifier-driven repair pilot canary amendment",
+  "const": {
+    "$schema": "../schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json",
+    "schema_version": "verifier-driven-repair-pilot-canary-amendment-1.0.0",
+    "document_type": "forge_verifier_repair_pilot_authorization",
+    "benchmark": {
+      "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+      "name": "Forge C/C++ verifier-driven repair paired pilot canary amendment",
+      "purpose": "execute one new authenticated provider canary before the unchanged paired pilot"
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "phase": "verifier_driven_repair_pilot_canary_amendment",
+      "formal_comparison_enabled": false,
+      "collection_authorized": true,
+      "instrumentation_blocker": false
+    },
+    "authorization": {
+      "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+      "status": "authorized_single_canary_amendment",
+      "authorized_by": "experiment_owner",
+      "authorized_on": "2026-08-14",
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/131",
+      "implementation_baseline_commit": "9a63bc0ac07b71a531a5400197f0fb836b687fc1",
+      "parent_runtime": {
+        "id": "forge-cpp-verifier-driven-repair-pilot-runtime-candidate",
+        "path": "benchmarks/manifests/cpp-verifier-repair-pilot-runtime-candidate.json",
+        "canonical_sha256": "880af0175795e474d470fd483544296fc68cdb0e5e968cebd32d73ef183ab045"
+      },
+      "network_observation": {
+        "access_medium_reconfirmation_required_before_canary": true,
+        "browser_ui_required": false,
+        "last_observed_access_medium": "wifi"
+      },
+      "budget_confirmation": {
+        "confirmed": true,
+        "expected_recorded_tokens": 800000,
+        "maximum_recorded_tokens": 2400000,
+        "enforcement": "check_before_each_complete_pair",
+        "complete_started_pair_before_next_boundary_check": true
+      },
+      "collection_constraints": {
+        "authorized_slot_count": 12,
+        "authorized_complete_pairs": 6,
+        "provider_canary_required_before_first_ledger": true,
+        "provider_canary_max_attempts": 1,
+        "provider_canary_requests_per_provider": 1,
+        "empty_evidence_required_before_canary": true,
+        "zero_residual_formal_containers_required_before_canary": true,
+        "replacement_forbidden": true,
+        "fallback_forbidden": true,
+        "retry_forbidden": true,
+        "backfill_forbidden": true,
+        "p_value_forbidden": true,
+        "model_ranking_forbidden": true,
+        "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-canary-amendment"
+      },
+      "parent_manifest": {
+        "id": "forge-verifier-driven-repair-pilot-authorized",
+        "path": "benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json",
+        "canonical_sha256": "ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875"
+      },
+      "superseded_canary_terminal": {
+        "benchmark_id": "forge-verifier-driven-repair-pilot-authorized",
+        "manifest_sha256": "ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875",
+        "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-authorized",
+        "marker_relative_path": "provider-canaries/verifier-repair-provider-canary-attempt.json",
+        "marker_sha256": "1a2b7bc7547e30ef56b1340420e435bd44b2f56df5e025a90653f5f88a39bcd7",
+        "status": "failed",
+        "error_class": null,
+        "provider_report_relative_path": "provider-canaries/provider_canary_2de75d5184664bb08d572e026161cef9.json",
+        "provider_report_sha256": "a8cc041ba4213a9f35169e4c48273c4ba4911e84e467c7f55fd5143bff2283a5",
+        "provider_report_count": 1,
+        "formal_ledger_count": 0
+      },
+      "nonformal_diagnostic": {
+        "provider_condition": "richlab-gpt-5.5",
+        "request_count": 1,
+        "request_timeout_seconds": 60,
+        "max_retries": 0,
+        "duration_ms": 5983,
+        "passed": true,
+        "excluded_from_formal_evidence": true,
+        "response_body_storage_forbidden": true
+      },
+      "new_canary": {
+        "maximum_attempts": 1,
+        "authenticated_requests_per_provider": 1,
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "success_required_before_first_ledger": true
+      }
+    },
+    "forge": {
+      "repository_url": "https://github.com/WWFXL/Forge-AutoCompiler",
+      "commit_sha": "9a63bc0ac07b71a531a5400197f0fb836b687fc1",
+      "revision_policy": "descendant-compatible",
+      "component_sha256": {
+        "backend/packages/harness/deerflow/agents/lead_agent/agent.py": "ce3ee4d371d98982edfb054824ee9fa002e064d641e256b34c3ea281e93fb320",
+        "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+        "backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py": "6555b8921b7cbde9372d3025d5050ab7096fff8ac679d59395d844bc2db0cd77",
+        "backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py": "3a4da4a44e338fbe404e9e619635f49ef0bd4d12979090a984ea14aa157b9dcc",
+        "backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py": "6e7896fa9472086457cc69a5ea2a4a593485d4c9d6d324f8029b5ff70a113022",
+        "backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py": "017679304d7c9ad456d6a3050c87a0646d55641ae0d0e3a6ec6860535b0e9b79",
+        "backend/packages/harness/deerflow/client.py": "5b0e187027367a3adcd223403fb154f1f51d28f729e865026b224eb7f03d07f9",
+        "backend/packages/harness/deerflow/compile/__init__.py": "db4ca1b560d0b97d4a46574e29f1d44eaafb899b7473140aa1b3a8d640d81819",
+        "backend/packages/harness/deerflow/compile/docker_runtime.py": "55a25331969c231c32f36096f7a49a81ceac196e805514e041bd9a7ea1879ea9",
+        "backend/packages/harness/deerflow/compile/evidence.py": "7f43ac42464ba8a0bef22198e119c80572b2eb90c3c82451d75252751c273b58",
+        "backend/packages/harness/deerflow/compile/manager.py": "2413cf71e3cda47906f19121cdaea7edbb5352083a7ca15f98b8d882172d545d",
+        "backend/packages/harness/deerflow/compile/operations.py": "7689b8738a1c0e4981a0c72bf3b5632e6d5e339e38542c6875f0c163c8f4a361",
+        "backend/packages/harness/deerflow/compile/schemas.py": "fb68ae2d4a3ed5d6c5879b26f8d584f5604555a7ff2d14987a63c5418a07f563",
+        "backend/packages/harness/deerflow/models/factory.py": "804da24b5a3929df57251a0274dd690dcfa469c9c5c59024b100ae928dc0f5fc",
+        "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+        "backend/packages/harness/deerflow/subagents/executor.py": "6d1c8cd8395c6e849f51ebd9171ee06b0d5c8a4c9b6941628441792e0df402dd",
+        "backend/packages/harness/deerflow/tools/bound_compile_tools.py": "d06003920c9d4d9794237a165f5a743421647c0f03ef6aed49ea0156407f2140",
+        "backend/packages/harness/deerflow/tools/builtins/agent_compile_tools.py": "1e8d6216ce2aa070a8ec1a2e3b6a042b4ca1be76edc66632597bc7ac4eb6ee2d",
+        "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec",
+        "backend/uv.lock": "cd9271aa22af6ef37f1a81404b20cef2af0f3d302480e605f62e690f6cf8650d",
+        "config.example.yaml": "7f40b0a88a86a1344bff83e5e2f3ad9e4c20d88aa74e19a0ae11ae821dac6715",
+        "docker/compile/Dockerfile": "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628",
+        "docker/docker-compose-dev.yaml": "b41ba1165eee5975692f5636e39e0f0416d449cf33119d83e324d95c35b34752"
+      }
+    },
+    "protocol_artifact_sha256": {
+      "scripts/forge_verifier_repair_canary_amendment_protocol.py": "139dc3d78fa0c3c91222bbf1a64dbdb2a079418cc9e3fe29c1633fa59f073a35",
+      "scripts/forge_verifier_repair_canary_amendment_report.py": "15500f2538aef69d0d771e51c25d44956146aabd7de23a633518e377e0eb0db2",
+      "scripts/forge_verifier_repair_canary_amendment_runner.py": "3737b6ec1877bf3b022a76dcf670bc6746e4bcacea02f1f4e326570cfe94986b"
+    },
+    "prompt_sha256": {
+      "backend/packages/harness/deerflow/agents/lead_agent/prompt.py": "179b65b6cd386b56d2dbd8ae69003f1a708715b28681197d5f063b1a4c2f4b26",
+      "backend/packages/harness/deerflow/subagents/builtins/compiler_agent.py": "163024555882bbe7f106b77b78743bc05f4ddf6ae7e3994c471603db3aad975e",
+      "backend/packages/harness/deerflow/tools/builtins/task_tool.py": "5e8880181da032ade720b437a351c68f3d6e35e117e72fcee2f5f01acbc4f2ec"
+    },
+    "model_profiles": {
+      "richlab-gpt-5.5": {
+        "endpoint": "https://rich-api.choosefire.com/v1",
+        "credential_env": "OpenAI_AK",
+        "roles": {
+          "lead": "gpt-5.5",
+          "compiler": "gpt-5.5"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      },
+      "deepseek-v4-flash": {
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "roles": {
+          "lead": "deepseek-v4-flash",
+          "compiler": "deepseek-v4-flash"
+        },
+        "fallback_policy": "forbidden",
+        "request_timeout_seconds": 300,
+        "max_retries": 0
+      }
+    },
+    "runtime": {
+      "compile_image": "autocompiler:gcc13",
+      "image_id": "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554",
+      "control_plane_topology": "compose-dood",
+      "replay_timeout_seconds": 1200,
+      "cleanup_timeout_seconds": 20,
+      "docker_control_timeout_seconds": 30,
+      "model_turn_limit": 36,
+      "graph_recursion_limit": 96,
+      "wall_clock_timeout_seconds": 900,
+      "post_build_reserve_seconds": 120,
+      "max_parallel_runs": 1,
+      "backend_processes": 1,
+      "network_policy": {
+        "network_name": "compile_network_wwf_v1",
+        "egress": "enabled_for_clone_and_dependencies"
+      },
+      "host": {
+        "wsl_distribution": "Ubuntu",
+        "cpu_count": 32,
+        "memory_kib": 7723024,
+        "kernel": "6.6.114.1-microsoft-standard-WSL2",
+        "architecture": "x86_64",
+        "docker_server_version": "29.5.3"
+      },
+      "docker_daemon_provider": "ubuntu-native",
+      "docker_socket_path": "/var/run/docker.sock"
+    },
+    "attempt_budget": {
+      "total_wall_clock_seconds": 1800,
+      "cleanup_reserve_seconds": 120,
+      "max_compiler_invocations": 2,
+      "max_model_requests": 48,
+      "enforcement_checkpoints": [
+        "before_provider_request",
+        "before_compiler_invocation",
+        "before_submit_or_replay",
+        "before_finalize",
+        "before_cleanup"
+      ],
+      "new_work_forbidden_after_limit": true,
+      "cleanup_mandatory_after_limit": true,
+      "terminal_classification": "attempt_budget_exhausted"
+    },
+    "resource_preflight": {
+      "minimum_available_memory_bytes": 2147483648,
+      "docker_daemon_timeout_seconds": 10,
+      "maximum_docker_daemon_latency_seconds": 5,
+      "required_checks": [
+        "host_available_memory_at_least_minimum",
+        "docker_daemon_responded",
+        "docker_daemon_latency_within_limit",
+        "docker_daemon_provider_matches",
+        "docker_socket_source_matches_native_path"
+      ],
+      "sensitive_host_identifiers_forbidden": true,
+      "docker_daemon_provider": "ubuntu-native",
+      "docker_socket_path": "/var/run/docker.sock"
+    },
+    "budget": {
+      "authorized": true,
+      "request_timeout_seconds": 300,
+      "provider_retries": 0,
+      "attempt_total_wall_clock_seconds": 1800,
+      "cleanup_reserve_seconds": 120,
+      "max_compiler_invocations": 2,
+      "max_model_requests": 48,
+      "model_turn_limit": 36,
+      "maximum_recorded_tokens": 2400000,
+      "expected_recorded_tokens": 800000,
+      "budget_check_boundary": "before_each_complete_pair",
+      "remaining_pairs_require_confirmation": true
+    },
+    "conditions": [
+      {
+        "id": "richlab-gpt-5.5-baseline",
+        "model_profile": "richlab-gpt-5.5",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "richlab-gpt-5.5-repair",
+        "model_profile": "richlab-gpt-5.5",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "deepseek-v4-flash-baseline",
+        "model_profile": "deepseek-v4-flash",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      },
+      {
+        "id": "deepseek-v4-flash-repair",
+        "model_profile": "deepseek-v4-flash",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "memory_enabled": false,
+        "skills_enabled": false,
+        "repetitions": 1,
+        "acceptance_gate": "clean_replay"
+      }
+    ],
+    "collection_plan": [
+      {
+        "order": 1,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 2,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 3,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 4,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      },
+      {
+        "order": 5,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 6,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 7,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      },
+      {
+        "order": 8,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 9,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-baseline"
+      },
+      {
+        "order": 10,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "richlab-gpt-5.5-repair"
+      },
+      {
+        "order": 11,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-repair"
+      },
+      {
+        "order": 12,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1,
+        "condition_id": "deepseek-v4-flash-baseline"
+      }
+    ],
+    "schedule_sha256": "588cfae514f827d8ff436285dee80bd2d2dd782cbab4dfd4992c0f99cd8c51b2",
+    "cases": [
+      {
+        "id": "liblouis",
+        "repository_url": "https://github.com/liblouis/liblouis",
+        "commit_sha": "b52ab11ade4cf0917315991b54a8558a2589cf55",
+        "languages": [
+          "C"
+        ],
+        "build_system": "autotools",
+        "license": "LGPL-2.1",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [
+            "autoreconf -fi"
+          ],
+          "configure_arguments": [
+            "--disable-shared",
+            "--enable-static"
+          ],
+          "build_targets": [
+            "all"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "liblouis.a",
+              "build_output_path": "liblouis/.libs/liblouis.a",
+              "artifact_type": "static_library",
+              "producing_target": "all"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "autoconf",
+            "automake",
+            "build-essential",
+            "libtool",
+            "pkg-config"
+          ],
+          "build_arguments": {
+            "cmake": [],
+            "configure": [
+              "--disable-shared",
+              "--enable-static"
+            ]
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      },
+      {
+        "id": "openthread",
+        "repository_url": "https://github.com/openthread/openthread",
+        "commit_sha": "044aa98f1b5255731e0a6f2816e267b282299684",
+        "languages": [
+          "C++"
+        ],
+        "build_system": "cmake",
+        "license": "BSD-3-Clause",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DOT_BUILD_EXECUTABLES=OFF",
+            "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+          ],
+          "build_targets": [
+            "openthread-ftd"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "libopenthread-ftd.a",
+              "build_output_path": "build/src/core/libopenthread-ftd.a",
+              "artifact_type": "static_library",
+              "producing_target": "openthread-ftd"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "build-essential",
+            "cmake",
+            "python3"
+          ],
+          "build_arguments": {
+            "cmake": [
+              "-DCMAKE_BUILD_TYPE=Release",
+              "-DOT_BUILD_EXECUTABLES=OFF",
+              "-DOT_COMPILE_WARNING_AS_ERROR=OFF"
+            ],
+            "configure": []
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      },
+      {
+        "id": "mupdf",
+        "repository_url": "https://github.com/ArtifexSoftware/mupdf",
+        "commit_sha": "b29caae1ab8c602187d4fc36d7b540bac493635d",
+        "languages": [
+          "C++"
+        ],
+        "build_system": "make",
+        "license": "AGPL-3.0",
+        "protocol": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [],
+          "build_targets": [
+            "libs"
+          ]
+        },
+        "oracle": {
+          "expected_candidate_status": "pass",
+          "expected_clean_replay_status": "pass",
+          "required_artifacts": [
+            {
+              "relative_path": "libmupdf.a",
+              "build_output_path": "build/release/libmupdf.a",
+              "artifact_type": "static_library",
+              "producing_target": "libs"
+            }
+          ]
+        },
+        "constraints": {
+          "required_system_packages": [
+            "build-essential",
+            "libfreetype6-dev",
+            "libjpeg-dev",
+            "zlib1g-dev"
+          ],
+          "build_arguments": {
+            "cmake": [],
+            "configure": []
+          },
+          "environment": {},
+          "minimum_replay_delay_seconds": 0
+        }
+      }
+    ],
+    "pilot_schedule": [
+      {
+        "order": 1,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 2,
+        "pair_id": "liblouis-richlab-r1",
+        "case_id": "liblouis",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 3,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 4,
+        "pair_id": "liblouis-deepseek-r1",
+        "case_id": "liblouis",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 5,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 6,
+        "pair_id": "openthread-richlab-r1",
+        "case_id": "openthread",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 7,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 8,
+        "pair_id": "openthread-deepseek-r1",
+        "case_id": "openthread",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 9,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      },
+      {
+        "order": 10,
+        "pair_id": "mupdf-richlab-r1",
+        "case_id": "mupdf",
+        "provider_condition": "richlab-gpt-5.5",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 11,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "structured-verifier-repair-packet",
+        "repetition": 1
+      },
+      {
+        "order": 12,
+        "pair_id": "mupdf-deepseek-r1",
+        "case_id": "mupdf",
+        "provider_condition": "deepseek-v4-flash",
+        "treatment": "baseline-current-verifier-output",
+        "repetition": 1
+      }
+    ],
+    "repair_packet": {
+      "schema_path": "benchmarks/schemas/forge-verifier-repair-packet-v1.schema.json",
+      "schema_sha256": "81d51743e40e4c8e7d81328e598088524417615c2cdc99124e4aa3c44e9f2068",
+      "actionable_classifications": [
+        "artifact_set_mismatch",
+        "artifact_type_mismatch",
+        "build_system_mismatch",
+        "build_system_selection_mismatch",
+        "build_system_unproven",
+        "candidate_verification_failed",
+        "recipe_execution_failed",
+        "sha256_mismatch",
+        "size_mismatch",
+        "smoke_mismatch"
+      ],
+      "repair_goals": {
+        "artifact_set_mismatch": "Stage exactly the frozen artifact set and remove unexpected outputs before resubmitting.",
+        "artifact_type_mismatch": "Stage artifacts with the frozen compiled artifact types before resubmitting.",
+        "build_system_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_selection_mismatch": "Use the frozen expected build system and rebuild before resubmitting.",
+        "build_system_unproven": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+        "candidate_verification_failed": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+        "recipe_execution_failed": "Make the recorded successful build and staging commands replayable from a clean workspace.",
+        "sha256_mismatch": "Remove nondeterminism so staged artifacts reproduce with identical SHA-256 values.",
+        "size_mismatch": "Rebuild and stage artifacts whose sizes reproduce in clean replay.",
+        "smoke_mismatch": "Repair runtime behavior so executable smoke output reproduces in clean replay."
+      },
+      "forbidden_content": [
+        "stdout",
+        "stderr",
+        "prompt",
+        "model_body",
+        "credential",
+        "host_path",
+        "generated_repair_command"
+      ]
+    },
+    "fidelity_gate": {
+      "statuses": [
+        "passed",
+        "not_exposed",
+        "failed"
+      ],
+      "baseline_packet_count": 0,
+      "treatment_requires_packet_for_each_actionable_submit": true,
+      "paired_analysis_requires_both_arms": true,
+      "p_value_forbidden": true,
+      "model_ranking_forbidden": true
+    },
+    "outcomes": {
+      "primary": "oracle_passed",
+      "secondary": [
+        "terminal_passed",
+        "repair_conversion_after_actionable_verifier_failure",
+        "false_acceptance_count",
+        "submit_attempts",
+        "clean_replay_attempts",
+        "model_requests",
+        "recorded_tokens",
+        "attempt_wall_clock_seconds",
+        "failure_classification_transition"
+      ],
+      "pilot_analysis": "按 pair 描述 discordant outcome、成本与 treatment fidelity；不做 p-value 或模型排名。",
+      "formal_follow_up": "只有 pilot 证明 treatment 接线、预算和证据完整后，才预注册至少 3 次重复的正式配对实验。"
+    },
+    "analysis_plan": {
+      "descriptive_only": true,
+      "complete_pairs_required": 6,
+      "repair_conversion_definition": "adjacent_actionable_classification_to_passed_feedback",
+      "model_request_count_event": "model.request_started",
+      "submit_attempt_count_event": "submit.started",
+      "clean_replay_attempt_count_event": "replay.started",
+      "wall_clock_definition": "experiment_started_to_experiment_completed_ledger_time",
+      "p_value_computed": false,
+      "model_ranking_performed": false
+    }
+  }
+}

--- a/scripts/forge_verifier_repair_canary_amendment_protocol.py
+++ b/scripts/forge_verifier_repair_canary_amendment_protocol.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""生成并校验 verifier-driven repair 单次 canary 修订协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_authorized_protocol as parent_protocol  # noqa: E402
+
+SCHEMA_VERSION = "verifier-driven-repair-pilot-canary-amendment-1.0.0"
+BASELINE_COMMIT = "9a63bc0ac07b71a531a5400197f0fb836b687fc1"
+PARENT_CANONICAL_SHA256 = "ff30e38d643c211c3f2f6d33a6f9424d9410168d81ecb2c4f47ffb79e4a61875"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-verifier-repair-canary-amendment"
+SUPERSEDED_EVIDENCE_DIRECTORY = parent_protocol.EVIDENCE_DIRECTORY
+
+REVISION_POLICY = parent_protocol.REVISION_POLICY
+CONTROL_PLANE_TOPOLOGY = parent_protocol.CONTROL_PLANE_TOPOLOGY
+DOCKER_DAEMON_PROVIDER = parent_protocol.DOCKER_DAEMON_PROVIDER
+DOCKER_SOCKET_PATH = parent_protocol.DOCKER_SOCKET_PATH
+RECORDED_TOKEN_LIMIT = parent_protocol.RECORDED_TOKEN_LIMIT
+EXPECTED_RECORDED_TOKENS = parent_protocol.EXPECTED_RECORDED_TOKENS
+
+DEFAULT_PARENT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-authorized.json"
+DEFAULT_MANIFEST = REPOSITORY_ROOT / "benchmarks" / "manifests" / "cpp-verifier-repair-pilot-canary-amendment.json"
+DEFAULT_SCHEMA = REPOSITORY_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-pilot-canary-amendment-v1.schema.json"
+
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_verifier_repair_canary_amendment_protocol.py",
+    "scripts/forge_verifier_repair_canary_amendment_runner.py",
+    "scripts/forge_verifier_repair_canary_amendment_report.py",
+}
+
+SUPERSEDED_CANARY_TERMINAL = {
+    "benchmark_id": "forge-verifier-driven-repair-pilot-authorized",
+    "manifest_sha256": PARENT_CANONICAL_SHA256,
+    "evidence_directory": SUPERSEDED_EVIDENCE_DIRECTORY,
+    "marker_relative_path": "provider-canaries/verifier-repair-provider-canary-attempt.json",
+    "marker_sha256": "1a2b7bc7547e30ef56b1340420e435bd44b2f56df5e025a90653f5f88a39bcd7",
+    "status": "failed",
+    "error_class": None,
+    "provider_report_relative_path": "provider-canaries/provider_canary_2de75d5184664bb08d572e026161cef9.json",
+    "provider_report_sha256": "a8cc041ba4213a9f35169e4c48273c4ba4911e84e467c7f55fd5143bff2283a5",
+    "provider_report_count": 1,
+    "formal_ledger_count": 0,
+}
+
+ProtocolError = parent_protocol.ProtocolError
+canonical_json_bytes = parent_protocol.canonical_json_bytes
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return parent_protocol._load_json(path)
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"protocol artifact is missing: {relative_path}")
+        hashes[relative_path] = _file_sha256(path)
+    return hashes
+
+
+def _parent_manifest(document: dict[str, Any] | None = None) -> dict[str, Any]:
+    parent = parent_protocol.validate_manifest(document or _load_json(DEFAULT_PARENT_MANIFEST))
+    if parent_protocol.manifest_sha256(parent) != PARENT_CANONICAL_SHA256:
+        raise ProtocolError("parent authorized manifest canonical SHA-256 drifted")
+    return parent
+
+
+def _authorization(parent: dict[str, Any]) -> dict[str, Any]:
+    authorization = copy.deepcopy(parent["authorization"])
+    authorization.update(
+        {
+            "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+            "status": "authorized_single_canary_amendment",
+            "authorized_on": "2026-08-14",
+            "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/131",
+            "implementation_baseline_commit": BASELINE_COMMIT,
+            "parent_manifest": {
+                "id": parent["benchmark"]["id"],
+                "path": "benchmarks/manifests/cpp-verifier-repair-pilot-authorized.json",
+                "canonical_sha256": PARENT_CANONICAL_SHA256,
+            },
+            "superseded_canary_terminal": copy.deepcopy(SUPERSEDED_CANARY_TERMINAL),
+            "nonformal_diagnostic": {
+                "provider_condition": "richlab-gpt-5.5",
+                "request_count": 1,
+                "request_timeout_seconds": 60,
+                "max_retries": 0,
+                "duration_ms": 5983,
+                "passed": True,
+                "excluded_from_formal_evidence": True,
+                "response_body_storage_forbidden": True,
+            },
+            "new_canary": {
+                "maximum_attempts": 1,
+                "authenticated_requests_per_provider": 1,
+                "request_timeout_seconds": 300,
+                "max_retries": 0,
+                "success_required_before_first_ledger": True,
+            },
+        }
+    )
+    authorization["network_observation"] = {
+        **authorization["network_observation"],
+        "last_observed_access_medium": "wifi",
+    }
+    authorization["collection_constraints"]["evidence_directory"] = EVIDENCE_DIRECTORY
+    return authorization
+
+
+def generate_manifest(
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parent = _parent_manifest(parent)
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["benchmark"] = {
+        "id": "forge-verifier-driven-repair-pilot-canary-amendment",
+        "name": "Forge C/C++ verifier-driven repair paired pilot canary amendment",
+        "purpose": "execute one new authenticated provider canary before the unchanged paired pilot",
+    }
+    manifest["scope"] = {
+        **copy.deepcopy(parent["scope"]),
+        "phase": "verifier_driven_repair_pilot_canary_amendment",
+    }
+    manifest["authorization"] = _authorization(parent)
+    manifest["forge"] = {
+        **copy.deepcopy(parent["forge"]),
+        "commit_sha": BASELINE_COMMIT,
+    }
+    manifest["protocol_artifact_sha256"] = _hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS)
+    return manifest
+
+
+def validate_manifest(
+    document: Any,
+    repo_root: Path = REPOSITORY_ROOT,
+    *,
+    parent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise ProtocolError("canary amendment manifest must be an object")
+    expected = generate_manifest(repo_root, parent=parent)
+    if document != expected:
+        raise ProtocolError("canary amendment manifest does not match the frozen protocol")
+    return document
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(manifest)).hexdigest()
+
+
+def schema_document() -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-verifier-repair-pilot-canary-amendment-v1.schema.json",
+        "title": "Forge verifier-driven repair pilot canary amendment",
+        "const": generate_manifest(),
+    }
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPOSITORY_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    parent = _parent_manifest(_load_json(DEFAULT_PARENT_MANIFEST))
+    parent_protocol.verify_frozen_components(parent, repo_root)
+    for relative_path, expected in manifest["protocol_artifact_sha256"].items():
+        if _file_sha256(repo_root / relative_path) != expected:
+            raise ProtocolError(f"canary amendment protocol artifact drifted: {relative_path}")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    validate = subparsers.add_parser("validate-manifest")
+    validate.add_argument("manifest", type=Path, nargs="?", default=DEFAULT_MANIFEST)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            _write_json(args.schema, schema_document())
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+    except (OSError, ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "authorized_complete_pairs": 6,
+                "authorized_slots": 12,
+                "manifest_sha256": manifest_sha256(manifest),
+                "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+                "status": "valid",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_canary_amendment_report.py
+++ b/scripts/forge_verifier_repair_canary_amendment_report.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""生成 verifier-driven repair canary 修订的确定性配对报告。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_canary_amendment_protocol as protocol  # noqa: E402
+
+
+def _load_parent_report():
+    module_name = f"{__name__}_parent"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_verifier_repair_authorized_report.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the authorized verifier-repair report")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_parent = _load_parent_report()
+_parent.protocol = protocol
+_parent.REPORT_VERSION = "verifier-driven-repair-pilot-canary-amendment-report-1.0.0"
+_parent.DEFAULT_EVIDENCE_DIR = Path(protocol.EVIDENCE_DIRECTORY)
+_parent.DEFAULT_JSON_REPORT = _parent.DEFAULT_EVIDENCE_DIR / "verifier-repair-pilot-report.json"
+_parent.DEFAULT_MARKDOWN_REPORT = _parent.DEFAULT_EVIDENCE_DIR / "verifier-repair-pilot-report.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _parent.main(argv)
+
+
+def __getattr__(name: str):
+    return getattr(_parent, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_verifier_repair_canary_amendment_runner.py
+++ b/scripts/forge_verifier_repair_canary_amendment_runner.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""执行 verifier-driven repair 单次 canary 修订。"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_verifier_repair_canary_amendment_protocol as protocol  # noqa: E402
+
+
+def _load_parent_runner():
+    module_name = f"{__name__}_parent"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        SCRIPT_ROOT / "forge_verifier_repair_authorized_runner.py",
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load the authorized verifier-repair runner")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_parent = _load_parent_runner()
+_base_runner = _parent._runner
+_original_collect_provider_canary = _parent.collect_provider_canary
+_original_create_attempt = _parent.create_attempt
+_original_run_attempt = _parent.run_attempt
+_original_run_repair_batch = _parent.run_repair_batch
+
+_parent.protocol = protocol
+_base_runner.protocol_formal_collection = protocol
+
+RunnerError = _parent.RunnerError
+REPO_ROOT = _parent.REPO_ROOT
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+
+
+def _superseded_output_dir(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["authorization"]["superseded_canary_terminal"]["evidence_directory"])
+
+
+def _verify_superseded_canary_terminal(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    frozen = manifest["authorization"]["superseded_canary_terminal"]
+    directory = output_dir or _superseded_output_dir(manifest)
+    marker_path = directory / frozen["marker_relative_path"]
+    report_path = directory / frozen["provider_report_relative_path"]
+    try:
+        marker_raw = marker_path.read_bytes()
+        report_raw = report_path.read_bytes()
+        marker = json.loads(marker_raw)
+        report = json.loads(report_raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError("The superseded verifier-repair canary evidence is missing or invalid") from exc
+    if hashlib.sha256(marker_raw).hexdigest() != frozen["marker_sha256"]:
+        raise RunnerError("The superseded verifier-repair canary marker changed")
+    if hashlib.sha256(report_raw).hexdigest() != frozen["provider_report_sha256"]:
+        raise RunnerError("The superseded verifier-repair canary report changed")
+    expected_marker = {
+        "benchmark_id": frozen["benchmark_id"],
+        "manifest_sha256": frozen["manifest_sha256"],
+        "status": frozen["status"],
+        "error_class": frozen["error_class"],
+    }
+    if any(marker.get(key) != value for key, value in expected_marker.items()):
+        raise RunnerError("The superseded verifier-repair canary marker identity changed")
+    if report.get("benchmark_id") != frozen["benchmark_id"] or report.get("manifest_sha256") != frozen["manifest_sha256"] or report.get("passed") is not False:
+        raise RunnerError("The superseded verifier-repair canary report identity changed")
+    reports = [path for path in (directory / "provider-canaries").glob("*.json") if path != marker_path]
+    ledgers = list(directory.rglob("*.jsonl"))
+    if len(reports) != frozen["provider_report_count"] or len(ledgers) != frozen["formal_ledger_count"]:
+        raise RunnerError("The superseded verifier-repair evidence layer changed")
+    return {
+        "status": marker["status"],
+        "provider_report_count": len(reports),
+        "formal_ledger_count": len(ledgers),
+    }
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Provider canary requires the canary amendment protocol")
+    _verify_superseded_canary_terminal(manifest)
+    return _original_collect_provider_canary(
+        manifest,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        repo_root=repo_root,
+    )
+
+
+def create_attempt(manifest: dict[str, Any], **kwargs: Any):
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        _verify_superseded_canary_terminal(manifest)
+    return _original_create_attempt(manifest, **kwargs)
+
+
+def run_attempt(manifest: dict[str, Any], ledger_path: Path, **kwargs: Any) -> dict[str, Any]:
+    if manifest.get("schema_version") == protocol.SCHEMA_VERSION:
+        _verify_superseded_canary_terminal(manifest)
+    return _original_run_attempt(manifest, ledger_path, **kwargs)
+
+
+def run_repair_batch(
+    manifest: dict[str, Any],
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    max_attempts: int,
+    check_endpoint: bool = True,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != protocol.SCHEMA_VERSION:
+        raise RunnerError("Repair batch requires the canary amendment protocol")
+    _verify_superseded_canary_terminal(manifest)
+    return _original_run_repair_batch(
+        manifest,
+        manifest_path=manifest_path,
+        output_dir=output_dir,
+        max_attempts=max_attempts,
+        check_endpoint=check_endpoint,
+    )
+
+
+_base_runner.collect_provider_canary = collect_provider_canary
+_base_runner.create_attempt = create_attempt
+_base_runner.run_attempt = run_attempt
+_base_runner.run_formal_batch = run_repair_batch
+
+
+def _arguments_with_default_manifest(argv: list[str]) -> list[str]:
+    if not argv or argv[0] == "runtime-preflight" or "--manifest" in argv:
+        return argv
+    return [argv[0], "--manifest", str(DEFAULT_MANIFEST), *argv[1:]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return _base_runner.main(_arguments_with_default_manifest(arguments))
+
+
+def __getattr__(name: str):
+    return getattr(_parent, name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 派生 `verifier-driven-repair-pilot-canary-amendment-1.0.0`，使用独立 evidence 目录和唯一新双 provider canary。
- 在 canary、attempt 与 batch 前核验旧失败 marker 和 provider report 的完整 SHA-256、终态身份及 0 formal ledger，禁止覆盖历史证据。
- 保持原 12 slots、6 complete pairs、2,400,000 recorded-token ceiling、300 秒 timeout、0 retry、treatment、Oracle、clean replay、顺序和描述性分析规则不变。

## 研究边界

- 经授权的单次非正式 RichLab 诊断只记录为 amendment 背景，不进入 formal evidence 或实验分母。
- 新 canary 失败时立即停止；双 provider 通过后才允许原批次。
- 不允许 retry、fallback、replacement、backfill、p-value 或模型排名。

## 验证

- parent authorized + amendment 聚焦回归：`15 passed`
- Ruff check/format：通过
- `py_compile`：通过
- 真实 LangGraph 容器 runner `--help` 与协议组件校验：通过
- 新 canonical manifest SHA-256：`4ac87955e85bd7a0ed8465268ae42c2b0d2ce598bf7119c129364cba3fc87915`
- 敏感信息字面值扫描：0 命中
- 旧失败 report/marker SHA-256：保持不变

Closes #131