### PR TITLE
研究：验证 verifier repair failure checkpoint 的非模型分支

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,13 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-15 — 验证 verifier failure checkpoint 的非模型分支可行性
+  - GitHub: 中文 Issue #135 已创建并回读；分支为 `research/135-failure-checkpoint-prototype`，基线为 `main@1f944c8c`。
+  - 实现: 从冻结 pilot Slot 7/10 派生两份脱敏只读 fixture，固定 Schema/canonical SHA-256；实验专用 fake compiler graph 使用 SQLite checkpointer，在 actionable submit 后、下一模型节点前暂停并派生 baseline/treatment。
+  - 当前验证: 两臂仅 feedback ToolMessage content 与 arm/session identity 不同；SQLite 关闭重开后从 `continue_model` 恢复，capture 前 fake submit 不重复；相邻回归 `40 passed`，完整 backend Ruff check/format 通过，全程 0 provider、0 Docker、0 physical attempt。
+  - 下一步: 完成中文提交、WSL helper 推送、中文 PR 与 CI；本原型不授权或实现 container rootfs/workspace 恢复。
+  - 文件: `scripts/forge_failure_checkpoint_prototype.py`, `backend/tests/test_forge_failure_checkpoint_prototype.py`, `benchmarks/fixtures/failure-checkpoints/`, `benchmarks/schemas/forge-failure-checkpoint-fixture-v1.schema.json`, `benchmarks/preregistrations/cpp-verifier-failure-checkpoint-prototype.md`
+
 - 2026-08-14 — 派生 verifier-driven repair 单次 canary amendment
   - GitHub: 中文 Issue #131 已创建并回读；分支为 `research/issue-131-verifier-repair-canary-amendment`，基线为 `main@9a63bc0a`。
   - 边界: 原失败 canary report/marker 与 authorized identity 保持不变；新 identity 使用独立 evidence 目录，只新增一次双 provider canary，成功才允许原 12 slots/6 complete pairs/2,400,000 recorded-token ceiling。

--- a/backend/tests/test_forge_failure_checkpoint_prototype.py
+++ b/backend/tests/test_forge_failure_checkpoint_prototype.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOTYPE_PATH = REPO_ROOT / "scripts" / "forge_failure_checkpoint_prototype.py"
+FIXTURE_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-failure-checkpoint-fixture-v1.schema.json"
+PACKET_SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-verifier-repair-packet-v1.schema.json"
+FIXTURE_DIR = REPO_ROOT / "benchmarks" / "fixtures" / "failure-checkpoints"
+FIXTURE_DIGESTS = {
+    "slot-007-openthread.json": "9a4a73173cf41d7cfd457133e23184f1685dcb9b2efe9ca64883e73e085bef27",
+    "slot-010-mupdf.json": "b7dc968fa484320250a985ee094fdc4660b7778ca1320281100b3a334a3d7fa1",
+}
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_failure_checkpoint_prototype_test", PROTOTYPE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+prototype = _load_module()
+
+
+def _fixture_paths() -> list[Path]:
+    return [FIXTURE_DIR / name for name in sorted(FIXTURE_DIGESTS)]
+
+
+def _assert_sanitized(value) -> None:
+    forbidden_keys = {
+        "api_key",
+        "credential_env",
+        "endpoint",
+        "physical_attempt_id",
+        "thread_id",
+        "session_id",
+    }
+    if isinstance(value, dict):
+        assert forbidden_keys.isdisjoint(value)
+        for child in value.values():
+            _assert_sanitized(child)
+    elif isinstance(value, list):
+        for child in value:
+            _assert_sanitized(child)
+    elif isinstance(value, str):
+        assert not value.startswith(("sk-", "thread_", "physical_attempt_"))
+
+
+def test_fixtures_have_frozen_schema_hash_and_no_runtime_identity() -> None:
+    fixture_schema = json.loads(FIXTURE_SCHEMA_PATH.read_text(encoding="utf-8"))
+    packet_schema = json.loads(PACKET_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    for path in _fixture_paths():
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        jsonschema.validate(fixture, fixture_schema)
+        jsonschema.validate(fixture["repair_packet"], packet_schema)
+        assert prototype.load_fixture(path)["fixture_sha256"] == FIXTURE_DIGESTS[path.name]
+        assert prototype.fixture_payload_sha256(fixture) == FIXTURE_DIGESTS[path.name]
+        _assert_sanitized(fixture)
+
+
+@pytest.mark.parametrize("fixture_path", _fixture_paths(), ids=lambda path: path.stem)
+def test_sqlite_checkpoint_branches_and_resumes_without_repeating_submit(
+    fixture_path: Path,
+    tmp_path: Path,
+) -> None:
+    fixture_bytes_before = fixture_path.read_bytes()
+    fixture = prototype.load_fixture(fixture_path)
+    counters = prototype.PrototypeCounters()
+    database = tmp_path / "failure-checkpoint.sqlite"
+    source_thread = f"{fixture['fixture_id']}-neutral"
+    baseline_thread = f"{fixture['fixture_id']}-baseline"
+    treatment_thread = f"{fixture['fixture_id']}-treatment"
+
+    with SqliteSaver.from_conn_string(str(database)) as saver:
+        saver.setup()
+        runtime = prototype.FailureCheckpointPrototype(fixture, saver, counters)
+        source_config = runtime.capture(source_thread)
+        source = runtime.graph.get_state(source_config)
+
+        assert tuple(source.next) == (prototype.CONTINUATION_NODE,)
+        assert source.config["configurable"]["checkpoint_id"]
+        assert [type(message) for message in source.values["messages"]] == [
+            HumanMessage,
+            AIMessage,
+            ToolMessage,
+        ]
+        request = source.values["messages"][1]
+        feedback = source.values["messages"][2]
+        assert request.tool_calls[0] == {
+            "name": "submit_build_result",
+            "args": {},
+            "id": "fixture-submit-call",
+            "type": "tool_call",
+        }
+        assert feedback.tool_call_id == "fixture-submit-call"
+
+        baseline_config = runtime.derive_arm(
+            source_config,
+            arm=prototype.BASELINE_ARM,
+            session_id="fixture-baseline-session",
+            thread_id=baseline_thread,
+        )
+        treatment_config = runtime.derive_arm(
+            source_config,
+            arm=prototype.TREATMENT_ARM,
+            session_id="fixture-treatment-session",
+            thread_id=treatment_thread,
+        )
+        baseline = runtime.graph.get_state(baseline_config)
+        treatment = runtime.graph.get_state(treatment_config)
+
+        assert tuple(baseline.next) == tuple(treatment.next) == (prototype.CONTINUATION_NODE,)
+        assert prototype.state_difference_paths(baseline.values, treatment.values) == {
+            "arm",
+            "messages[2].data.content",
+            "session_id",
+        }
+        assert prototype.canonical_state_for_pairing(baseline.values) == prototype.canonical_state_for_pairing(treatment.values)
+        assert counters.submit_calls == 1
+        assert counters.fake_model_calls == 0
+
+    # 重新打开 SQLite 模拟进程级冷恢复，不能依赖前一个 graph 对象的内存状态。
+    with SqliteSaver.from_conn_string(str(database)) as saver:
+        saver.setup()
+        recovered = prototype.FailureCheckpointPrototype(fixture, saver, counters)
+        baseline_result = recovered.resume(recovered.config(baseline_thread))
+        treatment_result = recovered.resume(recovered.config(treatment_thread))
+
+        assert recovered.graph.get_state(recovered.config(baseline_thread)).next == ()
+        assert recovered.graph.get_state(recovered.config(treatment_thread)).next == ()
+        assert len(baseline_result["messages"]) == len(treatment_result["messages"]) == 4
+        assert counters.submit_calls == 1
+        assert counters.fake_model_calls == 2
+        assert counters.provider_calls == counters.docker_calls == counters.physical_attempts == 0
+
+    assert fixture_path.read_bytes() == fixture_bytes_before
+    assert hashlib.sha256(fixture_path.read_bytes()).hexdigest() == hashlib.sha256(fixture_bytes_before).hexdigest()
+
+
+def test_prototype_has_no_provider_docker_or_attempt_imports() -> None:
+    source = PROTOTYPE_PATH.read_text(encoding="utf-8")
+    assert "deerflow.models" not in source
+    assert "deerflow.compile.docker_runtime" not in source
+    assert "forge_benchmark_runner" not in source

--- a/benchmarks/fixtures/failure-checkpoints/slot-007-openthread.json
+++ b/benchmarks/fixtures/failure-checkpoints/slot-007-openthread.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "forge-failure-checkpoint-fixture-1.0.0",
+  "fixture_id": "slot-007-openthread",
+  "fixture_sha256": "9a4a73173cf41d7cfd457133e23184f1685dcb9b2efe9ca64883e73e085bef27",
+  "read_only": true,
+  "instruction": "Continue the frozen C/C++ build from the actionable submit failure.",
+  "source": {
+    "benchmark_id": "forge-verifier-driven-repair-pilot-canary-amendment",
+    "manifest_sha256": "4ac87955e85bd7a0ed8465268ae42c2b0d2ce598bf7119c129364cba3fc87915",
+    "slot_order": 7,
+    "case_id": "openthread",
+    "source_event_sequence": 105,
+    "source_feedback_sha256": "a8db6363e815ff3727a76db7b5d2f4a483f76a1a55e3c2d78b1170a9e38eb2d3",
+    "evidence_scope": "sanitized_contract_only",
+    "model_transcript_available": false
+  },
+  "session": {
+    "session_alias": "fixture-parent-session",
+    "build_system": "cmake",
+    "command_cutoff": 17,
+    "artifacts": [
+      {
+        "path": "libopenthread-ftd.a",
+        "artifact_type": "static_library",
+        "size_bytes": 1902972,
+        "sha256": "d9f25840f9f36f1c50900cf01bc9e6b5ab74279943a213b0a4c91aea7ffd5e5b"
+      }
+    ]
+  },
+  "neutral_feedback": {
+    "status": "failed",
+    "actionable": true,
+    "evidence_complete": true,
+    "primary_classification": "build_system_unproven",
+    "submit_attempt_alias": "fixture-submit-attempt",
+    "supporting_command_alias": "fixture-supporting-command"
+  },
+  "repair_packet": {
+    "schema_version": "forge-verifier-repair-packet-1.0.0",
+    "failure_domain": "submit_replay",
+    "primary_classification": "build_system_unproven",
+    "failed_checks": [
+      {
+        "name": "benchmark_constraints",
+        "exit_code": 1
+      }
+    ],
+    "build_system_identity": {
+      "expected": "cmake",
+      "observed": "cmake",
+      "selected": "cmake",
+      "matches": true
+    },
+    "artifact_identity_diff": {
+      "expected_only": [],
+      "observed_only": [],
+      "mismatches": [],
+      "truncated": false
+    },
+    "replay_status": "not_run",
+    "repair_goal": "Run a successful non-housekeeping build command with the frozen build system before resubmitting.",
+    "supporting_command_id": "fixture-supporting-command",
+    "submit_attempt_id": "fixture-submit-attempt",
+    "replay_attempt_id": null
+  }
+}

--- a/benchmarks/fixtures/failure-checkpoints/slot-010-mupdf.json
+++ b/benchmarks/fixtures/failure-checkpoints/slot-010-mupdf.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "forge-failure-checkpoint-fixture-1.0.0",
+  "fixture_id": "slot-010-mupdf",
+  "fixture_sha256": "b7dc968fa484320250a985ee094fdc4660b7778ca1320281100b3a334a3d7fa1",
+  "read_only": true,
+  "instruction": "Continue the frozen C/C++ build from the actionable submit failure.",
+  "source": {
+    "benchmark_id": "forge-verifier-driven-repair-pilot-canary-amendment",
+    "manifest_sha256": "4ac87955e85bd7a0ed8465268ae42c2b0d2ce598bf7119c129364cba3fc87915",
+    "slot_order": 10,
+    "case_id": "mupdf",
+    "source_event_sequence": 78,
+    "source_feedback_sha256": "1c862cc379fd7dac0b5b152a4599273efcfef1e10f2a3da9bc7bcb0eadf02bf5",
+    "evidence_scope": "sanitized_contract_only",
+    "model_transcript_available": false
+  },
+  "session": {
+    "session_alias": "fixture-parent-session",
+    "build_system": "make",
+    "command_cutoff": 11,
+    "artifacts": []
+  },
+  "neutral_feedback": {
+    "status": "failed",
+    "actionable": true,
+    "evidence_complete": true,
+    "primary_classification": "candidate_verification_failed",
+    "submit_attempt_alias": "fixture-submit-attempt",
+    "supporting_command_alias": "fixture-supporting-command"
+  },
+  "repair_packet": {
+    "schema_version": "forge-verifier-repair-packet-1.0.0",
+    "failure_domain": "submit_replay",
+    "primary_classification": "candidate_verification_failed",
+    "failed_checks": [],
+    "build_system_identity": {
+      "expected": "make",
+      "observed": "make",
+      "selected": "make",
+      "matches": true
+    },
+    "artifact_identity_diff": {
+      "expected_only": [
+        "libmupdf.a"
+      ],
+      "observed_only": [],
+      "mismatches": [],
+      "truncated": false
+    },
+    "replay_status": "not_run",
+    "repair_goal": "Stage recognized compiled artifacts in /artifacts and submit the corrected candidate.",
+    "supporting_command_id": "fixture-supporting-command",
+    "submit_attempt_id": "fixture-submit-attempt",
+    "replay_attempt_id": null
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-failure-checkpoint-prototype.md
+++ b/benchmarks/preregistrations/cpp-verifier-failure-checkpoint-prototype.md
@@ -1,0 +1,23 @@
+# Verifier failure checkpoint 非模型可行性原型
+
+## 目的
+
+本原型只验证一个机制前提：在 actionable `submit_build_result` 已完成、下一次模型步骤尚未开始时，SQLite checkpoint 能否保存完整消息与下一节点，并从同一个中性状态派生 baseline/treatment 两臂。
+
+## Evidence 边界
+
+- `slot-007-openthread.json` 与 `slot-010-mupdf.json` 只保留冻结 pilot 中可公开审计的 submit 分类、构建系统、artifact identity 和内容哈希。
+- fixture 不包含真实 thread/session/attempt/command identity、provider 响应、prompt、日志、宿主路径或凭据。
+- 原始 Slot 7/10 没有完整 compiler transcript，因此 fixture 不是历史运行的可续跑 checkpoint。Human/AI/ToolMessage 由确定性 fake graph 构造，只用于验证 checkpoint 契约。
+
+## 通过条件
+
+1. 图在 fake submit 后暂停，checkpoint 的 `next` 固定为 `continue_model`。
+2. SQLite 关闭并重新打开后，两臂都能从 `continue_model` 恢复。
+3. 分支前的 HumanMessage、AI tool call 与 ToolMessage identity 完整；两臂只允许 feedback content 和 arm/session identity 不同。
+4. 恢复两臂不会再次执行 fake submit。
+5. 全程不导入或调用 provider、Docker runtime 与 physical-attempt runner。
+
+## 非目标
+
+本原型不证明 workspace、容器 rootfs、预算 monotonic clock 或真实 provider client 可以恢复。只有本门禁通过后，才能单独评审 rootfs 与 bind-mount 双重恢复；未通过该后续门禁前不得创建真实 mechanism slots。

--- a/benchmarks/schemas/forge-failure-checkpoint-fixture-v1.schema.json
+++ b/benchmarks/schemas/forge-failure-checkpoint-fixture-v1.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-failure-checkpoint-fixture-v1.schema.json",
+  "title": "Forge verifier failure checkpoint sanitized fixture",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "fixture_id",
+    "fixture_sha256",
+    "read_only",
+    "instruction",
+    "source",
+    "session",
+    "neutral_feedback",
+    "repair_packet"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "forge-failure-checkpoint-fixture-1.0.0"
+    },
+    "fixture_id": {
+      "type": "string",
+      "pattern": "^slot-[0-9]{3}-[a-z0-9-]+$"
+    },
+    "fixture_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "read_only": {
+      "const": true
+    },
+    "instruction": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "benchmark_id",
+        "manifest_sha256",
+        "slot_order",
+        "case_id",
+        "source_event_sequence",
+        "source_feedback_sha256",
+        "evidence_scope",
+        "model_transcript_available"
+      ],
+      "properties": {
+        "benchmark_id": {
+          "const": "forge-verifier-driven-repair-pilot-canary-amendment"
+        },
+        "manifest_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "slot_order": {
+          "enum": [7, 10]
+        },
+        "case_id": {
+          "enum": ["openthread", "mupdf"]
+        },
+        "source_event_sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source_feedback_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "evidence_scope": {
+          "const": "sanitized_contract_only"
+        },
+        "model_transcript_available": {
+          "const": false
+        }
+      }
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["session_alias", "build_system", "command_cutoff", "artifacts"],
+      "properties": {
+        "session_alias": {
+          "type": "string",
+          "pattern": "^fixture-[a-z0-9-]+$"
+        },
+        "build_system": {
+          "enum": ["cmake", "make"]
+        },
+        "command_cutoff": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "artifacts": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "artifact_type", "size_bytes", "sha256"],
+            "properties": {
+              "path": {"type": "string", "minLength": 1, "maxLength": 512},
+              "artifact_type": {
+                "enum": ["executable", "shared_library", "static_library", "object"]
+              },
+              "size_bytes": {"type": "integer", "minimum": 0},
+              "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+            }
+          }
+        }
+      }
+    },
+    "neutral_feedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "actionable",
+        "evidence_complete",
+        "primary_classification",
+        "submit_attempt_alias",
+        "supporting_command_alias"
+      ],
+      "properties": {
+        "status": {"const": "failed"},
+        "actionable": {"const": true},
+        "evidence_complete": {"const": true},
+        "primary_classification": {
+          "enum": ["build_system_unproven", "candidate_verification_failed"]
+        },
+        "submit_attempt_alias": {"const": "fixture-submit-attempt"},
+        "supporting_command_alias": {
+          "type": ["string", "null"],
+          "pattern": "^fixture-[a-z0-9-]+$"
+        }
+      }
+    },
+    "repair_packet": {
+      "type": "object"
+    }
+  }
+}

--- a/scripts/forge_failure_checkpoint_prototype.py
+++ b/scripts/forge_failure_checkpoint_prototype.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""验证 verifier failure checkpoint 分支语义的非模型原型。"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Any, TypedDict
+
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    ToolMessage,
+    message_to_dict,
+)
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+
+FIXTURE_SCHEMA_VERSION = "forge-failure-checkpoint-fixture-1.0.0"
+BASELINE_ARM = "baseline"
+TREATMENT_ARM = "treatment"
+ALLOWED_ARMS = frozenset({BASELINE_ARM, TREATMENT_ARM})
+CONTINUATION_NODE = "continue_model"
+
+
+class FailureCheckpointPrototypeError(ValueError):
+    pass
+
+
+class FailureCheckpointState(TypedDict):
+    messages: Annotated[list[BaseMessage], add_messages]
+    fixture_id: str
+    arm: str
+    session_id: str
+
+
+@dataclass
+class PrototypeCounters:
+    submit_calls: int = 0
+    fake_model_calls: int = 0
+    provider_calls: int = 0
+    docker_calls: int = 0
+    physical_attempts: int = 0
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def fixture_payload_sha256(fixture: dict[str, Any]) -> str:
+    payload = {key: value for key, value in fixture.items() if key != "fixture_sha256"}
+    return sha256(canonical_bytes(payload))
+
+
+def _require_exact_fields(value: Any, fields: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != fields:
+        raise FailureCheckpointPrototypeError(f"{label} fields do not match the frozen schema")
+    return value
+
+
+def validate_fixture(fixture: Any) -> dict[str, Any]:
+    fixture = _require_exact_fields(
+        fixture,
+        {
+            "schema_version",
+            "fixture_id",
+            "fixture_sha256",
+            "read_only",
+            "instruction",
+            "source",
+            "session",
+            "neutral_feedback",
+            "repair_packet",
+        },
+        "fixture",
+    )
+    if fixture["schema_version"] != FIXTURE_SCHEMA_VERSION:
+        raise FailureCheckpointPrototypeError("fixture schema version is invalid")
+    if fixture["read_only"] is not True:
+        raise FailureCheckpointPrototypeError("fixture must be marked read-only")
+    if not isinstance(fixture["fixture_id"], str) or not fixture["fixture_id"].startswith("slot-"):
+        raise FailureCheckpointPrototypeError("fixture identity is invalid")
+    if not isinstance(fixture["instruction"], str) or not fixture["instruction"]:
+        raise FailureCheckpointPrototypeError("fixture instruction is invalid")
+
+    source = _require_exact_fields(
+        fixture["source"],
+        {
+            "benchmark_id",
+            "manifest_sha256",
+            "slot_order",
+            "case_id",
+            "source_event_sequence",
+            "source_feedback_sha256",
+            "evidence_scope",
+            "model_transcript_available",
+        },
+        "fixture source",
+    )
+    if source["evidence_scope"] != "sanitized_contract_only" or source["model_transcript_available"] is not False:
+        raise FailureCheckpointPrototypeError("fixture source scope is invalid")
+
+    session = _require_exact_fields(
+        fixture["session"],
+        {"session_alias", "build_system", "command_cutoff", "artifacts"},
+        "fixture session",
+    )
+    if not isinstance(session["session_alias"], str) or not session["session_alias"].startswith("fixture-"):
+        raise FailureCheckpointPrototypeError("fixture session alias is invalid")
+
+    feedback = _require_exact_fields(
+        fixture["neutral_feedback"],
+        {
+            "status",
+            "actionable",
+            "evidence_complete",
+            "primary_classification",
+            "submit_attempt_alias",
+            "supporting_command_alias",
+        },
+        "neutral feedback",
+    )
+    if feedback["status"] != "failed" or feedback["actionable"] is not True or feedback["evidence_complete"] is not True:
+        raise FailureCheckpointPrototypeError("neutral feedback is not actionable")
+    if "repair_packet" in feedback:
+        raise FailureCheckpointPrototypeError("neutral feedback must not contain treatment data")
+    if fixture["repair_packet"].get("primary_classification") != feedback["primary_classification"]:
+        raise FailureCheckpointPrototypeError("repair packet classification drifted")
+
+    digest = fixture_payload_sha256(fixture)
+    if fixture["fixture_sha256"] != digest:
+        raise FailureCheckpointPrototypeError("fixture SHA-256 does not match canonical payload")
+    return fixture
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    return validate_fixture(json.loads(path.read_text(encoding="utf-8")))
+
+
+class DeterministicFakeModel:
+    def __init__(self, counters: PrototypeCounters):
+        self._counters = counters
+
+    def invoke(self, _messages: list[BaseMessage]) -> AIMessage:
+        self._counters.fake_model_calls += 1
+        return AIMessage(
+            content="deterministic checkpoint continuation completed",
+            id="fixture-continuation-response",
+        )
+
+
+class FailureCheckpointPrototype:
+    def __init__(self, fixture: dict[str, Any], checkpointer: Any, counters: PrototypeCounters):
+        self.fixture = copy.deepcopy(validate_fixture(fixture))
+        self.counters = counters
+        self.fake_model = DeterministicFakeModel(counters)
+        self.graph = self._build_graph(checkpointer)
+
+    def _build_graph(self, checkpointer: Any):
+        graph = StateGraph(FailureCheckpointState)
+        graph.add_node("request_submit", self._request_submit)
+        graph.add_node("submit_failure", self._submit_failure)
+        graph.add_node(CONTINUATION_NODE, self._continue_model)
+        graph.add_edge(START, "request_submit")
+        graph.add_edge("request_submit", "submit_failure")
+        graph.add_edge("submit_failure", CONTINUATION_NODE)
+        graph.add_edge(CONTINUATION_NODE, END)
+        return graph.compile(
+            checkpointer=checkpointer,
+            interrupt_before=[CONTINUATION_NODE],
+        )
+
+    def _request_submit(self, _state: FailureCheckpointState) -> dict[str, list[AIMessage]]:
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    id="fixture-submit-request",
+                    tool_calls=[
+                        {
+                            "name": "submit_build_result",
+                            "args": {},
+                            "id": "fixture-submit-call",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        }
+
+    def _submit_failure(self, state: FailureCheckpointState) -> dict[str, list[ToolMessage]]:
+        self.counters.submit_calls += 1
+        request = state["messages"][-1]
+        if not isinstance(request, AIMessage) or not request.tool_calls:
+            raise FailureCheckpointPrototypeError("submit request is missing")
+        return {
+            "messages": [
+                ToolMessage(
+                    content=canonical_bytes(self.fixture["neutral_feedback"]).decode("utf-8"),
+                    id="fixture-submit-feedback",
+                    name="submit_build_result",
+                    tool_call_id=request.tool_calls[0]["id"],
+                )
+            ]
+        }
+
+    def _continue_model(self, state: FailureCheckpointState) -> dict[str, list[AIMessage]]:
+        return {"messages": [self.fake_model.invoke(state["messages"])]}
+
+    @staticmethod
+    def config(thread_id: str) -> dict[str, dict[str, str]]:
+        return {"configurable": {"thread_id": thread_id}}
+
+    def capture(self, thread_id: str) -> dict[str, Any]:
+        config = self.config(thread_id)
+        self.graph.invoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content=self.fixture["instruction"],
+                        id="fixture-human-instruction",
+                    )
+                ],
+                "fixture_id": self.fixture["fixture_id"],
+                "arm": "neutral",
+                "session_id": self.fixture["session"]["session_alias"],
+            },
+            config,
+        )
+        snapshot = self.graph.get_state(config)
+        if tuple(snapshot.next) != (CONTINUATION_NODE,):
+            raise FailureCheckpointPrototypeError("graph did not pause before continuation")
+        return config
+
+    def derive_arm(
+        self,
+        source_config: dict[str, Any],
+        *,
+        arm: str,
+        session_id: str,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        if arm not in ALLOWED_ARMS:
+            raise FailureCheckpointPrototypeError("checkpoint arm is invalid")
+        source = self.graph.get_state(source_config)
+        if tuple(source.next) != (CONTINUATION_NODE,):
+            raise FailureCheckpointPrototypeError("source checkpoint is not resumable")
+        values = copy.deepcopy(source.values)
+        messages = list(values["messages"])
+        feedback = messages[-1]
+        if not isinstance(feedback, ToolMessage):
+            raise FailureCheckpointPrototypeError("source checkpoint feedback is missing")
+        content = copy.deepcopy(self.fixture["neutral_feedback"])
+        if arm == TREATMENT_ARM:
+            content["repair_packet"] = copy.deepcopy(self.fixture["repair_packet"])
+        messages[-1] = ToolMessage(
+            content=canonical_bytes(content).decode("utf-8"),
+            id=feedback.id,
+            name=feedback.name,
+            tool_call_id=feedback.tool_call_id,
+            status=feedback.status,
+        )
+        values.update(messages=messages, arm=arm, session_id=session_id)
+        target_config = self.config(thread_id)
+        self.graph.update_state(target_config, values, as_node="submit_failure")
+        target = self.graph.get_state(target_config)
+        if tuple(target.next) != (CONTINUATION_NODE,):
+            raise FailureCheckpointPrototypeError("derived checkpoint cannot resume at continuation")
+        return target_config
+
+    def resume(self, config: dict[str, Any]) -> dict[str, Any]:
+        self.graph.invoke(None, config)
+        return self.graph.get_state(config).values
+
+
+def serialize_checkpoint_state(state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "fixture_id": state["fixture_id"],
+        "arm": state["arm"],
+        "session_id": state["session_id"],
+        "messages": [message_to_dict(message) for message in state["messages"]],
+    }
+
+
+def canonical_state_for_pairing(state: dict[str, Any]) -> dict[str, Any]:
+    canonical = serialize_checkpoint_state(state)
+    canonical["arm"] = "<arm>"
+    canonical["session_id"] = "<session>"
+    for message in canonical["messages"]:
+        if message["type"] == "tool" and message["data"].get("name") == "submit_build_result":
+            message["data"]["content"] = "<feedback>"
+    return canonical
+
+
+def state_difference_paths(left: dict[str, Any], right: dict[str, Any]) -> set[str]:
+    differences: set[str] = set()
+
+    def walk(a: Any, b: Any, path: str) -> None:
+        if type(a) is not type(b):
+            differences.add(path)
+            return
+        if isinstance(a, dict):
+            for key in sorted(set(a) | set(b)):
+                child = f"{path}.{key}" if path else key
+                if key not in a or key not in b:
+                    differences.add(child)
+                else:
+                    walk(a[key], b[key], child)
+            return
+        if isinstance(a, list):
+            if len(a) != len(b):
+                differences.add(f"{path}.length")
+            for index, (a_item, b_item) in enumerate(zip(a, b, strict=False)):
+                walk(a_item, b_item, f"{path}[{index}]")
+            return
+        if a != b:
+            differences.add(path)
+
+    walk(serialize_checkpoint_state(left), serialize_checkpoint_state(right), "")
+    return differences


### PR DESCRIPTION
## 概要

- 从冻结 verifier-repair pilot 的 Slot 7/10 派生两份脱敏、只读 fixture，并固定 fixture Schema 与 canonical SHA-256
- 新增实验专用 fake compiler graph，在 actionable submit 完成后、下一模型节点前写入 SQLite checkpoint
- 从同一中性 checkpoint 派生 baseline/treatment，只允许 feedback ToolMessage content 与 arm/session identity 不同
- SQLite 关闭并重新打开后恢复两臂，验证 capture 前 fake submit 不会重复执行
- 增加非模型研究边界说明，明确历史 Slot 7/10 没有完整 compiler transcript，fixture 不是可直接续跑的历史 checkpoint

## 边界

- 未修改生产 compiler、Oracle、clean replay 或正式实验协议
- 未启动 Docker
- 未调用 RichLab、DeepSeek 或其他 provider
- 未创建 physical attempt，未消耗实验 token
- 未实现 container rootfs 或 bind-mount workspace 恢复

## 验证

- 聚焦及相邻回归：40 passed
- 完整 backend Ruff check：All checks passed
- 完整 backend Ruff format：294 files already formatted
- fixtures 的 Schema、repair packet Schema、canonical hash 与敏感字段扫描通过

Closes #135