### PR TITLE
研究：验证 failure checkpoint 的环境双层恢复

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -47,6 +47,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-15 — 证明 failure checkpoint 的 rootfs 与 bind-mount 同源双臂恢复
+  - 文件: `scripts/forge_environment_checkpoint_prototype.py`, `backend/tests/test_forge_environment_checkpoint_prototype.py`, `benchmarks/preregistrations/cpp-verifier-environment-checkpoint-prototype.md`
+  - 动机: 消息 checkpoint 已通过，但真实 mechanism arm 还必须从同一 rootfs 与 bind snapshot 恢复，且不能共享可写状态。
+  - 结果: Issue #137 原型在同一显式 pause 窗口完成 rootfs commit 与只读 bind tar；两臂初始 canonical state 相同，rootfs/workspace/artifacts 交叉污染为 0，父 snapshot 不变。
+  - 证据: checkpoint manifest SHA-256 为 `e5c5a8c024339775f469fa889c441f028f099561fe3638ae54da5d02d9bf2375`，initial state SHA-256 为 `5c05c6ca919a0d39f23945ad4b72293153901733cc010a9720f54316b9700a47`；真实 Docker `1 passed in 28.38s`，相邻回归 `18 passed, 1 skipped`，Ruff 通过，cleanup 后 0 prototype container/image/temp。
+  - 边界: 0 provider、0 formal physical attempt、0 model token；budget reconstruction 继续作为下一独立 gate。
+
 - 2026-08-14 — 完成 verifier-driven repair 运行时与未授权证据门禁
   - GitHub: 中文 Issue #125 已创建并回读；实现分支为 `research/issue-125-verifier-repair-runtime`，基线为 `main@97f252b4`。
   - 实现: 新增版本化 submit feedback adapter、严格白名单 `repair_packet`、独立 hash-chain sidecar、treatment fidelity gate、硬拒绝 canary/attempt/batch 的未授权 runner，以及只做配对描述性统计的 analyzer。
@@ -351,6 +358,8 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- WSL 冷启动或手动启动 `docker.service` 后，daemon 恢复已有容器可能需要 5-10 秒；启动命令返回后应等待 `systemctl is-active docker.service` 为 `active` 再运行正式 gate，不能把 `activating` 窗口误判为永久失败，也不能切换 Docker Desktop。
+- Docker 29 使用 `docker commit --no-pause`，旧的 `--pause=false` 会输出弃用提示并污染严格 SHA 解析。恢复后的 `0640 root:root` 文件由只读 helper tar 观测，不能为了测试方便 `chmod/chown` 被测目录。
 - 一次性正式入口必须先用最终完全相同的 `/app/backend/.venv/bin/python` 完成零请求 import、runner `--help` 与挂载内 preflight；双 provider canary 外层等待不得短于 700 秒。manifest 声明 300 秒不等于模型对象已生效，必须在请求前验证模型及底层 client 的有效 timeout/retry；调试级短超时、系统 `python` 和仅核对 endpoint 的 preflight 都不能作为放行依据。
 - Windows `docker` CLI 的 `desktop-linux` context 只反映 Docker Desktop daemon，不能据此判断 Forge 状态。Forge 容器实际属于 WSL2 Ubuntu 原生 `dockerd`；所有项目 Docker 命令必须先通过 `scripts/require-ubuntu-native-docker.sh`，并从 `wsl.exe -d Ubuntu` 或该发行版内执行。门禁失败时请求用户恢复服务，不得启动 Docker Desktop 作为回退。
 - LangGraph 容器内 `/repo` 是只读挂载。可在容器中使用 Ruff `--check --no-cache`，但不能直接格式化文件；写入格式化必须在可写工作树中使用相同 `backend/ruff.toml`，不要修改挂载权限或重建服务来绕过只读边界。

--- a/backend/tests/test_forge_environment_checkpoint_prototype.py
+++ b/backend/tests/test_forge_environment_checkpoint_prototype.py
@@ -1,0 +1,188 @@
+"""Issue #137 的非模型 environment checkpoint 原型测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOTYPE_PATH = REPO_ROOT / "scripts" / "forge_environment_checkpoint_prototype.py"
+DOCKER_INTEGRATION_ENABLED = os.getenv("FORGE_RUN_ENVIRONMENT_CHECKPOINT_DOCKER") == "1"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_environment_checkpoint_prototype_test", PROTOTYPE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+prototype = _load_module()
+
+
+class FakeDockerRunner:
+    def __init__(self, *, fail_capture: bool = False) -> None:
+        self.command_count = 0
+        self.commands: list[list[str]] = []
+        self.fail_capture = fail_capture
+
+    def run(self, arguments, *, check=True, timeout_seconds=60):
+        del check, timeout_seconds
+        self.command_count += 1
+        self.commands.append(arguments)
+        if self.fail_capture and arguments[0] == "commit":
+            raise prototype.EnvironmentCheckpointError("synthetic capture failure")
+        return prototype.DockerCommandResult(0, "", "")
+
+
+def test_capture_uses_one_pause_window_and_unpauses_on_failure() -> None:
+    runner = FakeDockerRunner(fail_capture=True)
+
+    with pytest.raises(prototype.EnvironmentCheckpointError, match="synthetic capture failure"):
+        prototype.capture_parent_checkpoint(
+            runner,
+            "fixture-parent",
+            lambda: runner.run(["commit", "fixture-parent"]).stdout,
+        )
+
+    assert runner.commands == [
+        ["pause", "fixture-parent"],
+        ["commit", "fixture-parent"],
+        ["unpause", "fixture-parent"],
+    ]
+
+
+def test_commit_output_uses_the_final_strict_image_id_line() -> None:
+    image_id = "sha256:" + "a" * 64
+
+    assert prototype.committed_image_id(f"non-sensitive Docker notice\n{image_id}\n") == image_id
+
+    with pytest.raises(prototype.EnvironmentCheckpointError, match="Invalid immutable"):
+        prototype.committed_image_id("notice without an image ID")
+
+
+def test_tar_manifest_fixes_content_mode_mtime_and_symlink_metadata(tmp_path: Path) -> None:
+    archive_path = tmp_path / "fixture.tar"
+    content = b"checkpoint-content\n"
+    with tarfile.open(archive_path, "w") as archive:
+        directory = tarfile.TarInfo("./src")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o750
+        directory.mtime = prototype.FIXED_MTIME
+        directory.uid = directory.gid = 0
+        archive.addfile(directory)
+
+        regular = tarfile.TarInfo("./src/input.txt")
+        regular.size = len(content)
+        regular.mode = 0o640
+        regular.mtime = prototype.FIXED_MTIME
+        regular.uid = regular.gid = 0
+        archive.addfile(regular, io.BytesIO(content))
+
+        symlink = tarfile.TarInfo("./src/current")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "input.txt"
+        symlink.mode = 0o777
+        symlink.mtime = prototype.FIXED_MTIME
+        symlink.uid = symlink.gid = 0
+        archive.addfile(symlink)
+
+    assert prototype.manifest_from_tar(archive_path) == [
+        {
+            "path": "src",
+            "type": "directory",
+            "mode": 0o750,
+            "mtime": prototype.FIXED_MTIME,
+            "uid": 0,
+            "gid": 0,
+            "content_sha256": None,
+            "link_target": None,
+        },
+        {
+            "path": "src/current",
+            "type": "symlink",
+            "mode": 0o777,
+            "mtime": prototype.FIXED_MTIME,
+            "uid": 0,
+            "gid": 0,
+            "content_sha256": None,
+            "link_target": "input.txt",
+        },
+        {
+            "path": "src/input.txt",
+            "type": "file",
+            "mode": 0o640,
+            "mtime": prototype.FIXED_MTIME,
+            "uid": 0,
+            "gid": 0,
+            "content_sha256": prototype.sha256_bytes(content),
+            "link_target": None,
+        },
+    ]
+
+
+def test_checkpoint_manifest_rejects_budget_scope_or_hash_drift() -> None:
+    image_id = "sha256:" + "1" * 64
+    manifest = {
+        "schema_version": prototype.SCHEMA_VERSION,
+        "manifest_sha256": "",
+        "run_id": "fixture-run",
+        "capture_method": "explicit-pause+docker-commit+bind-tar",
+        "base_image_id": image_id,
+        "continuation_image_id": image_id,
+        "rootfs": {
+            "sentinel_path": prototype.ROOTFS_SENTINEL,
+            "content_sha256": "2" * 64,
+        },
+        "bind_mounts": {
+            "workspace": {"archive_sha256": "3" * 64, "entries": []},
+            "artifacts": {"archive_sha256": "4" * 64, "entries": []},
+        },
+        "identities": {"parent": "p", "baseline": "b", "treatment": "t"},
+        "budget": {"reconstructed": False, "scope": "deferred-separate-gate"},
+    }
+    manifest["manifest_sha256"] = prototype.checkpoint_payload_sha256(manifest)
+    assert prototype.validate_checkpoint_manifest(manifest) == manifest
+
+    manifest["budget"]["reconstructed"] = True
+    with pytest.raises(prototype.EnvironmentCheckpointError, match="Budget scope"):
+        prototype.validate_checkpoint_manifest(manifest)
+
+
+@pytest.mark.skipif(
+    not DOCKER_INTEGRATION_ENABLED,
+    reason="set FORGE_RUN_ENVIRONMENT_CHECKPOINT_DOCKER=1 to run the Ubuntu-native Docker gate",
+)
+def test_real_docker_rootfs_and_bind_mount_checkpoint() -> None:
+    if shutil.which("docker") is None:
+        pytest.fail("The opt-in environment checkpoint test requires the Docker CLI")
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Docker daemon is unavailable: {daemon.stderr.strip()}")
+
+    result = prototype.EnvironmentCheckpointPrototype().run()
+
+    assert result["base_image_id"] == "sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554"
+    assert result["continuation_image_id"].startswith("sha256:")
+    assert result["working_root_removed"] is True
+    assert all(result["checks"].values())
+    assert result["counts"]["provider_calls"] == 0
+    assert result["counts"]["formal_physical_attempts"] == 0
+    assert result["counts"]["model_tokens"] == 0

--- a/benchmarks/preregistrations/cpp-verifier-environment-checkpoint-prototype.md
+++ b/benchmarks/preregistrations/cpp-verifier-environment-checkpoint-prototype.md
@@ -1,0 +1,60 @@
+# Verifier-driven repair environment checkpoint 非模型原型预注册
+
+## 研究问题
+
+Issue #135 / PR #136 已证明 compiler 消息状态可以从同一个中性 SQLite checkpoint 派生两臂，但尚未证明编译环境可以从同一点恢复。本门禁只回答：显式暂停父容器后，分别冻结 rootfs 和 bind-mounted workspace/artifacts，能否恢复两个初始状态相同且可写层互不污染的 continuation arm。
+
+## 冻结范围
+
+- 跟踪 Issue：#137。
+- 语言与任务范围：合成 C/C++ 编译环境 fixture，不运行真实仓库构建。
+- Docker：仅使用 WSL2 Ubuntu 中由 `docker.service` 管理的原生 daemon；基础镜像使用本地 `autocompiler:gcc13`，运行时记录完整 image ID，不拉取镜像。
+- Provider、模型 token、formal physical attempt：均为 0。
+- 不修改生产 Compile Session、Oracle、clean replay、verifier-driven repair runner 或自然任务 ITT runner。
+- attempt budget reconstruction 不属于本门禁，通过后另开阶段评审。
+
+## 固定 capture 过程
+
+1. 创建一个带独立 workspace/artifacts bind mount 的合成父容器。
+2. 在父 rootfs 写 sentinel；在 bind mount 写普通文件、固定 mode/mtime 和符号链接。
+3. 显式 `docker pause` 父容器。
+4. 在同一个 pause 窗口内：
+   - 使用 `docker commit --pause=false` 冻结 rootfs，并记录不可变 continuation image ID；
+   - 使用只读 bind mount 的 helper container 分别生成 workspace/artifacts tar；
+   - 固定 archive SHA-256 和逐项 manifest。
+5. 无论 capture 成功或抛错，均在 `finally` 中执行 `docker unpause`。
+6. 将 tar 与 checkpoint manifest 改为只读父快照。
+
+## 固定恢复与比较过程
+
+- baseline/treatment 从同一个 continuation image ID 和同一组只读 tar 恢复。
+- 两臂使用不同 container identity 和不同可写 workspace/artifacts 目录。
+- canonical 初始状态包含 image ID、rootfs sentinel hash，以及文件 path/type/content SHA-256/mode/mtime/uid/gid/symlink target。
+- 初始 canonical 状态必须逐字相同，并与父快照 manifest 相同。
+- 向 baseline 的 rootfs 与 workspace 写入后，treatment 和父状态必须不变。
+- 向 treatment 的 artifacts 写入后，baseline 和父状态不得出现该文件。
+- capture tar 和 manifest 的文件 hash 在两臂运行后必须不变。
+
+## 通过条件
+
+- 显式 pause capture 与异常 unpause 单元测试通过。
+- tar manifest 固定普通文件内容、权限、mtime 与符号链接 metadata。
+- 两臂 rootfs sentinel 恢复，且容器实际 image ID 等于同一 continuation image ID。
+- 两臂初始 canonical 环境相同。
+- rootfs、workspace、artifacts 的跨臂与父状态污染均为 0。
+- 原型创建的 container、continuation image 和临时目录完成有界清理；不按宽泛 label 删除先前资源。
+- provider calls、formal physical attempts 与 model tokens 均为 0。
+- 聚焦单元测试、opt-in Ubuntu 原生 Docker 测试与 Ruff 通过。
+
+## 失效条件
+
+- Ubuntu 原生 Docker 门禁失败，或发现 Docker Desktop/其他 daemon 路径。
+- 运行前已有 prototype label 资源；原型必须停止，不得做宽泛清理。
+- 父容器未可靠 unpause，或 continuation image/任一容器未清理。
+- 任一 metadata、内容 hash、rootfs sentinel 或 canonical state 不一致。
+- 任一 arm 写入改变另一 arm、父目录或只读 snapshot。
+- 发生 provider 请求、token 消耗或 formal physical attempt。
+
+## 解释边界
+
+通过仅证明“rootfs commit + bind tar”足以恢复本合成环境，并为后续 failure checkpoint 提供环境分支候选；不证明进程内存、网络连接、真实 compiler transcript、attempt budget 或 provider client 可以恢复，也不产生 repair packet 的因果效果结论。

--- a/scripts/forge_environment_checkpoint_prototype.py
+++ b/scripts/forge_environment_checkpoint_prototype.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""验证 rootfs 与 bind mount 双层恢复的非模型环境 checkpoint 原型。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+SCHEMA_VERSION = "forge-environment-checkpoint-1.0.0"
+PROTOTYPE_LABEL = "forge.environment-checkpoint.prototype"
+RUN_LABEL = "forge.environment-checkpoint.run_id"
+DEFAULT_IMAGE = "autocompiler:gcc13"
+ROOTFS_SENTINEL = "/opt/forge-checkpoint/rootfs-sentinel.txt"
+FIXED_MTIME = 1_700_000_000
+
+
+class EnvironmentCheckpointError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DockerCommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class DockerRunner(Protocol):
+    command_count: int
+
+    def run(
+        self,
+        arguments: list[str],
+        *,
+        check: bool = True,
+        timeout_seconds: int = 60,
+    ) -> DockerCommandResult: ...
+
+
+class DockerCLI:
+    def __init__(self) -> None:
+        self.command_count = 0
+
+    def run(
+        self,
+        arguments: list[str],
+        *,
+        check: bool = True,
+        timeout_seconds: int = 60,
+    ) -> DockerCommandResult:
+        self.command_count += 1
+        command = ["docker", *arguments]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise EnvironmentCheckpointError(f"Docker command failed to complete: {arguments[0]}") from exc
+        result = DockerCommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout.strip(),
+            stderr=completed.stderr.strip(),
+        )
+        if check and result.returncode != 0:
+            detail = result.stderr or result.stdout or "unknown Docker error"
+            raise EnvironmentCheckpointError(f"Docker command failed ({arguments[0]}): {detail}")
+        return result
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def checkpoint_payload_sha256(manifest: dict[str, Any]) -> str:
+    payload = {key: value for key, value in manifest.items() if key != "manifest_sha256"}
+    return sha256_bytes(canonical_bytes(payload))
+
+
+def _normalize_archive_path(name: str) -> str | None:
+    while name.startswith("./"):
+        name = name[2:]
+    if not name or name == ".":
+        return None
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise EnvironmentCheckpointError(f"Unsafe archive member path: {name!r}")
+    return path.as_posix()
+
+
+def _entry(
+    *,
+    path: str,
+    entry_type: str,
+    mode: int,
+    mtime: int,
+    uid: int,
+    gid: int,
+    content_sha256: str | None = None,
+    link_target: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "path": path,
+        "type": entry_type,
+        "mode": mode,
+        "mtime": mtime,
+        "uid": uid,
+        "gid": gid,
+        "content_sha256": content_sha256,
+        "link_target": link_target,
+    }
+
+
+def manifest_from_tar(path: Path) -> list[dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    with tarfile.open(path, mode="r:") as archive:
+        for member in archive.getmembers():
+            normalized = _normalize_archive_path(member.name)
+            if normalized is None:
+                continue
+            if normalized in entries:
+                raise EnvironmentCheckpointError(f"Duplicate archive member path: {normalized}")
+            if member.isfile():
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise EnvironmentCheckpointError(f"Archive file cannot be read: {normalized}")
+                entries[normalized] = _entry(
+                    path=normalized,
+                    entry_type="file",
+                    mode=member.mode,
+                    mtime=int(member.mtime),
+                    uid=member.uid,
+                    gid=member.gid,
+                    content_sha256=sha256_bytes(stream.read()),
+                )
+            elif member.isdir():
+                entries[normalized] = _entry(
+                    path=normalized,
+                    entry_type="directory",
+                    mode=member.mode,
+                    mtime=int(member.mtime),
+                    uid=member.uid,
+                    gid=member.gid,
+                )
+            elif member.issym():
+                entries[normalized] = _entry(
+                    path=normalized,
+                    entry_type="symlink",
+                    mode=member.mode,
+                    mtime=int(member.mtime),
+                    uid=member.uid,
+                    gid=member.gid,
+                    link_target=member.linkname,
+                )
+            else:
+                raise EnvironmentCheckpointError(f"Unsupported archive member type: {normalized}")
+    return [entries[name] for name in sorted(entries)]
+
+
+def validate_checkpoint_manifest(manifest: Any) -> dict[str, Any]:
+    expected_fields = {
+        "schema_version",
+        "manifest_sha256",
+        "run_id",
+        "capture_method",
+        "base_image_id",
+        "continuation_image_id",
+        "rootfs",
+        "bind_mounts",
+        "identities",
+        "budget",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected_fields:
+        raise EnvironmentCheckpointError("Checkpoint manifest fields do not match the frozen schema")
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise EnvironmentCheckpointError("Checkpoint manifest schema version is invalid")
+    if manifest["capture_method"] != "explicit-pause+docker-commit+bind-tar":
+        raise EnvironmentCheckpointError("Checkpoint capture method is invalid")
+    if manifest["budget"] != {"reconstructed": False, "scope": "deferred-separate-gate"}:
+        raise EnvironmentCheckpointError("Budget scope drifted into the environment gate")
+    for image_field in ("base_image_id", "continuation_image_id"):
+        _validate_image_id(manifest[image_field])
+    for mount_name in ("workspace", "artifacts"):
+        mount = manifest["bind_mounts"].get(mount_name)
+        if not isinstance(mount, dict) or set(mount) != {"archive_sha256", "entries"}:
+            raise EnvironmentCheckpointError(f"Bind mount manifest is invalid: {mount_name}")
+        if not isinstance(mount["entries"], list):
+            raise EnvironmentCheckpointError(f"Bind mount entries are invalid: {mount_name}")
+    if manifest["manifest_sha256"] != checkpoint_payload_sha256(manifest):
+        raise EnvironmentCheckpointError("Checkpoint manifest SHA-256 does not match its payload")
+    return manifest
+
+
+def _validate_image_id(value: Any) -> str:
+    if not isinstance(value, str) or len(value) != 71 or not value.startswith("sha256:"):
+        raise EnvironmentCheckpointError(f"Invalid immutable Docker image ID: {value!r}")
+    try:
+        int(value[7:], 16)
+    except ValueError as exc:
+        raise EnvironmentCheckpointError(f"Invalid immutable Docker image ID: {value!r}") from exc
+    return value.lower()
+
+
+def committed_image_id(output: str) -> str:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not lines:
+        raise EnvironmentCheckpointError("Docker commit returned no immutable image ID")
+    return _validate_image_id(lines[-1])
+
+
+def capture_parent_checkpoint(
+    runner: DockerRunner,
+    parent_name: str,
+    capture: Callable[[], str],
+) -> str:
+    """在同一个显式暂停窗口执行 capture，并保证异常路径恢复父容器。"""
+
+    runner.run(["pause", parent_name])
+    try:
+        return capture()
+    finally:
+        runner.run(["unpause", parent_name])
+
+
+class EnvironmentCheckpointPrototype:
+    def __init__(
+        self,
+        *,
+        image: str = DEFAULT_IMAGE,
+        runner: DockerRunner | None = None,
+    ) -> None:
+        self.image = image
+        self.runner = runner or DockerCLI()
+        self.run_id = uuid.uuid4().hex[:12]
+        self.working_root = Path(tempfile.mkdtemp(prefix=f"forge-env-checkpoint-{self.run_id}-"))
+        self.container_names: list[str] = []
+        self.continuation_image_id: str | None = None
+        self.base_image_id: str | None = None
+
+    def _name(self, role: str) -> str:
+        return f"forge-env-checkpoint-{self.run_id}-{role}"
+
+    def _label_arguments(self) -> list[str]:
+        return [
+            "--label",
+            f"{PROTOTYPE_LABEL}=true",
+            "--label",
+            f"{RUN_LABEL}={self.run_id}",
+        ]
+
+    def _assert_no_preexisting_resources(self) -> None:
+        containers = self.runner.run(
+            ["ps", "-aq", "--filter", f"label={PROTOTYPE_LABEL}=true"],
+            timeout_seconds=30,
+        ).stdout
+        images = self.runner.run(
+            ["image", "ls", "-q", "--filter", f"label={PROTOTYPE_LABEL}=true"],
+            timeout_seconds=30,
+        ).stdout
+        if containers or images:
+            raise EnvironmentCheckpointError("Prototype-labeled Docker resources already exist; refusing broad cleanup")
+
+    def _image_id(self, reference: str) -> str:
+        result = self.runner.run(
+            ["image", "inspect", "--format", "{{.Id}}", reference],
+            timeout_seconds=30,
+        )
+        return _validate_image_id(result.stdout)
+
+    def _create_parent(self, workspace: Path, artifacts: Path) -> str:
+        parent_name = self._name("parent")
+        self.container_names.append(parent_name)
+        self.runner.run(
+            [
+                "create",
+                "--name",
+                parent_name,
+                *self._label_arguments(),
+                "--mount",
+                f"type=bind,src={workspace},dst=/workspace",
+                "--mount",
+                f"type=bind,src={artifacts},dst=/artifacts",
+                self.image,
+                "sh",
+                "-c",
+                "while :; do sleep 3600; done",
+            ],
+            timeout_seconds=60,
+        )
+        self.runner.run(["start", parent_name], timeout_seconds=30)
+        seed = f"""set -eu
+mkdir -p /opt/forge-checkpoint /workspace/src /artifacts/bin
+printf 'rootfs-before-checkpoint\n' > {ROOTFS_SENTINEL}
+printf 'workspace-before-checkpoint\n' > /workspace/src/input.txt
+printf 'artifact-before-checkpoint\n' > /artifacts/bin/output.bin
+chmod 0600 {ROOTFS_SENTINEL}
+chmod 0640 /workspace/src/input.txt
+chmod 0750 /artifacts/bin/output.bin
+ln -s input.txt /workspace/src/current
+touch -d @{FIXED_MTIME} {ROOTFS_SENTINEL} /workspace/src/input.txt /artifacts/bin/output.bin
+touch -h -d @{FIXED_MTIME} /workspace/src/current
+touch -d @{FIXED_MTIME} /workspace/src /artifacts/bin
+"""
+        self.runner.run(["exec", parent_name, "sh", "-c", seed], timeout_seconds=30)
+        return parent_name
+
+    def _archive_bind_mounts(
+        self,
+        *,
+        workspace: Path,
+        artifacts: Path,
+        snapshot: Path,
+    ) -> None:
+        helper_name = self._name("capture")
+        self.container_names.append(helper_name)
+        command = (
+            "set -eu; "
+            "tar --numeric-owner --format=posix -cpf /snapshot/workspace.tar -C /source/workspace .; "
+            "tar --numeric-owner --format=posix -cpf /snapshot/artifacts.tar -C /source/artifacts .; "
+            f"chown -R {os.getuid()}:{os.getgid()} /snapshot"
+        )
+        self.runner.run(
+            [
+                "run",
+                "--rm",
+                "--name",
+                helper_name,
+                *self._label_arguments(),
+                "--mount",
+                f"type=bind,src={workspace},dst=/source/workspace,readonly",
+                "--mount",
+                f"type=bind,src={artifacts},dst=/source/artifacts,readonly",
+                "--mount",
+                f"type=bind,src={snapshot},dst=/snapshot",
+                self.image,
+                "sh",
+                "-c",
+                command,
+            ],
+            timeout_seconds=120,
+        )
+
+    def _capture(self, parent_name: str, workspace: Path, artifacts: Path, snapshot: Path) -> str:
+        def commit_and_archive() -> str:
+            committed = self.runner.run(
+                [
+                    "commit",
+                    "--no-pause",
+                    "--change",
+                    f"LABEL {PROTOTYPE_LABEL}=true",
+                    "--change",
+                    f"LABEL {RUN_LABEL}={self.run_id}",
+                    parent_name,
+                ],
+                timeout_seconds=180,
+            )
+            self.continuation_image_id = committed_image_id(committed.stdout)
+            self._archive_bind_mounts(workspace=workspace, artifacts=artifacts, snapshot=snapshot)
+            return self.continuation_image_id
+
+        return capture_parent_checkpoint(self.runner, parent_name, commit_and_archive)
+
+    def _write_manifest(
+        self,
+        *,
+        snapshot: Path,
+        parent_name: str,
+        baseline_name: str,
+        treatment_name: str,
+        rootfs_content: str,
+    ) -> dict[str, Any]:
+        workspace_tar = snapshot / "workspace.tar"
+        artifacts_tar = snapshot / "artifacts.tar"
+        manifest: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "manifest_sha256": "",
+            "run_id": self.run_id,
+            "capture_method": "explicit-pause+docker-commit+bind-tar",
+            "base_image_id": self.base_image_id,
+            "continuation_image_id": self.continuation_image_id,
+            "rootfs": {
+                "sentinel_path": ROOTFS_SENTINEL,
+                "content_sha256": sha256_bytes(rootfs_content.encode("utf-8")),
+            },
+            "bind_mounts": {
+                "workspace": {
+                    "archive_sha256": sha256_file(workspace_tar),
+                    "entries": manifest_from_tar(workspace_tar),
+                },
+                "artifacts": {
+                    "archive_sha256": sha256_file(artifacts_tar),
+                    "entries": manifest_from_tar(artifacts_tar),
+                },
+            },
+            "identities": {
+                "parent": parent_name,
+                "baseline": baseline_name,
+                "treatment": treatment_name,
+            },
+            "budget": {"reconstructed": False, "scope": "deferred-separate-gate"},
+        }
+        manifest["manifest_sha256"] = checkpoint_payload_sha256(manifest)
+        validate_checkpoint_manifest(manifest)
+        manifest_path = snapshot / "checkpoint.json"
+        manifest_path.write_bytes(canonical_bytes(manifest) + b"\n")
+        for path in (workspace_tar, artifacts_tar, manifest_path):
+            path.chmod(0o444)
+        snapshot.chmod(0o555)
+        return manifest
+
+    def _restore_arm(self, role: str, snapshot: Path, workspace: Path, artifacts: Path) -> str:
+        helper_name = self._name(f"restore-{role}")
+        self.container_names.append(helper_name)
+        self.runner.run(
+            [
+                "run",
+                "--rm",
+                "--name",
+                helper_name,
+                *self._label_arguments(),
+                "--mount",
+                f"type=bind,src={snapshot},dst=/snapshot,readonly",
+                "--mount",
+                f"type=bind,src={workspace},dst=/restore/workspace",
+                "--mount",
+                f"type=bind,src={artifacts},dst=/restore/artifacts",
+                self.image,
+                "sh",
+                "-c",
+                "set -eu; tar -xpf /snapshot/workspace.tar -C /restore/workspace; tar -xpf /snapshot/artifacts.tar -C /restore/artifacts",
+            ],
+            timeout_seconds=120,
+        )
+
+        arm_name = self._name(role)
+        self.container_names.append(arm_name)
+        self.runner.run(
+            [
+                "create",
+                "--name",
+                arm_name,
+                *self._label_arguments(),
+                "--mount",
+                f"type=bind,src={workspace},dst=/workspace",
+                "--mount",
+                f"type=bind,src={artifacts},dst=/artifacts",
+                self.continuation_image_id or "",
+                "sh",
+                "-c",
+                "while :; do sleep 3600; done",
+            ],
+            timeout_seconds=60,
+        )
+        self.runner.run(["start", arm_name], timeout_seconds=30)
+        return arm_name
+
+    def _observe_bind_mounts(self, role: str, workspace: Path, artifacts: Path) -> dict[str, list[dict[str, Any]]]:
+        observation = self.working_root / "observations" / f"{role}-{uuid.uuid4().hex[:8]}"
+        observation.mkdir(parents=True)
+        observation.chmod(0o777)
+        helper_name = self._name(f"observe-{role}-{uuid.uuid4().hex[:6]}")
+        self.container_names.append(helper_name)
+        command = (
+            "set -eu; "
+            "tar --numeric-owner --format=posix -cpf /observation/workspace.tar -C /source/workspace .; "
+            "tar --numeric-owner --format=posix -cpf /observation/artifacts.tar -C /source/artifacts .; "
+            f"chown -R {os.getuid()}:{os.getgid()} /observation"
+        )
+        self.runner.run(
+            [
+                "run",
+                "--rm",
+                "--name",
+                helper_name,
+                *self._label_arguments(),
+                "--mount",
+                f"type=bind,src={workspace},dst=/source/workspace,readonly",
+                "--mount",
+                f"type=bind,src={artifacts},dst=/source/artifacts,readonly",
+                "--mount",
+                f"type=bind,src={observation},dst=/observation",
+                self.image,
+                "sh",
+                "-c",
+                command,
+            ],
+            timeout_seconds=120,
+        )
+        result = {
+            "workspace": manifest_from_tar(observation / "workspace.tar"),
+            "artifacts": manifest_from_tar(observation / "artifacts.tar"),
+        }
+        shutil.rmtree(observation)
+        return result
+
+    def _container_rootfs_content(self, container_name: str) -> str:
+        return (
+            self.runner.run(
+                ["exec", container_name, "cat", ROOTFS_SENTINEL],
+                timeout_seconds=30,
+            ).stdout
+            + "\n"
+        )
+
+    def _canonical_arm_state(
+        self,
+        container_name: str,
+        workspace: Path,
+        artifacts: Path,
+    ) -> dict[str, Any]:
+        image_id = _validate_image_id(
+            self.runner.run(
+                ["inspect", "--format", "{{.Image}}", container_name],
+                timeout_seconds=30,
+            ).stdout
+        )
+        bind_mounts = self._observe_bind_mounts(container_name.rsplit("-", 1)[-1], workspace, artifacts)
+        return {
+            "image_id": image_id,
+            "rootfs_content_sha256": sha256_bytes(self._container_rootfs_content(container_name).encode("utf-8")),
+            "workspace": bind_mounts["workspace"],
+            "artifacts": bind_mounts["artifacts"],
+        }
+
+    def _run_gate(self) -> dict[str, Any]:
+        self._assert_no_preexisting_resources()
+        self.base_image_id = self._image_id(self.image)
+
+        parent_workspace = self.working_root / "parent" / "workspace"
+        parent_artifacts = self.working_root / "parent" / "artifacts"
+        snapshot = self.working_root / "snapshot"
+        baseline_workspace = self.working_root / "baseline" / "workspace"
+        baseline_artifacts = self.working_root / "baseline" / "artifacts"
+        treatment_workspace = self.working_root / "treatment" / "workspace"
+        treatment_artifacts = self.working_root / "treatment" / "artifacts"
+        directories = (
+            parent_workspace,
+            parent_artifacts,
+            snapshot,
+            baseline_workspace,
+            baseline_artifacts,
+            treatment_workspace,
+            treatment_artifacts,
+        )
+        for directory in directories:
+            directory.mkdir(parents=True, exist_ok=True)
+            directory.chmod(0o777)
+
+        parent_name = self._create_parent(parent_workspace, parent_artifacts)
+        baseline_name = self._name("baseline")
+        treatment_name = self._name("treatment")
+        rootfs_content = self._container_rootfs_content(parent_name)
+        self._capture(parent_name, parent_workspace, parent_artifacts, snapshot)
+        manifest = self._write_manifest(
+            snapshot=snapshot,
+            parent_name=parent_name,
+            baseline_name=baseline_name,
+            treatment_name=treatment_name,
+            rootfs_content=rootfs_content,
+        )
+
+        baseline_name = self._restore_arm("baseline", snapshot, baseline_workspace, baseline_artifacts)
+        treatment_name = self._restore_arm("treatment", snapshot, treatment_workspace, treatment_artifacts)
+        baseline_initial = self._canonical_arm_state(baseline_name, baseline_workspace, baseline_artifacts)
+        treatment_initial = self._canonical_arm_state(treatment_name, treatment_workspace, treatment_artifacts)
+        if baseline_initial != treatment_initial:
+            raise EnvironmentCheckpointError("Baseline and treatment initial environments differ")
+        if baseline_initial["workspace"] != manifest["bind_mounts"]["workspace"]["entries"]:
+            raise EnvironmentCheckpointError("Restored workspace metadata differs from the immutable snapshot")
+        if baseline_initial["artifacts"] != manifest["bind_mounts"]["artifacts"]["entries"]:
+            raise EnvironmentCheckpointError("Restored artifact metadata differs from the immutable snapshot")
+        if baseline_initial["image_id"] != self.continuation_image_id:
+            raise EnvironmentCheckpointError("Arm container did not use the continuation image ID")
+
+        source_before = self._observe_bind_mounts("parent-before", parent_workspace, parent_artifacts)
+        archive_hashes_before = {
+            "workspace": sha256_file(snapshot / "workspace.tar"),
+            "artifacts": sha256_file(snapshot / "artifacts.tar"),
+            "manifest": sha256_file(snapshot / "checkpoint.json"),
+        }
+        self.runner.run(
+            [
+                "exec",
+                baseline_name,
+                "sh",
+                "-c",
+                f"printf 'baseline-rootfs-write\n' > {ROOTFS_SENTINEL}; printf 'baseline-workspace-write\n' > /workspace/src/input.txt",
+            ],
+            timeout_seconds=30,
+        )
+        if self._container_rootfs_content(treatment_name) != rootfs_content:
+            raise EnvironmentCheckpointError("Baseline rootfs write polluted treatment")
+        if self._container_rootfs_content(parent_name) != rootfs_content:
+            raise EnvironmentCheckpointError("Baseline rootfs write polluted parent")
+        treatment_after_baseline_write = self._observe_bind_mounts(
+            "treatment-after-baseline-write",
+            treatment_workspace,
+            treatment_artifacts,
+        )
+        if treatment_after_baseline_write["workspace"] != treatment_initial["workspace"]:
+            raise EnvironmentCheckpointError("Baseline bind write polluted treatment")
+        parent_after_baseline_write = self._observe_bind_mounts(
+            "parent-after-baseline-write",
+            parent_workspace,
+            parent_artifacts,
+        )
+        if parent_after_baseline_write["workspace"] != source_before["workspace"]:
+            raise EnvironmentCheckpointError("Baseline bind write polluted parent")
+        if parent_after_baseline_write["artifacts"] != source_before["artifacts"]:
+            raise EnvironmentCheckpointError("Parent artifact checkpoint changed")
+
+        self.runner.run(
+            ["exec", treatment_name, "sh", "-c", "printf 'treatment-only\n' > /artifacts/treatment-only.txt"],
+            timeout_seconds=30,
+        )
+        if (baseline_artifacts / "treatment-only.txt").exists() or (parent_artifacts / "treatment-only.txt").exists():
+            raise EnvironmentCheckpointError("Treatment artifact write crossed an arm boundary")
+        archive_hashes_after = {
+            "workspace": sha256_file(snapshot / "workspace.tar"),
+            "artifacts": sha256_file(snapshot / "artifacts.tar"),
+            "manifest": sha256_file(snapshot / "checkpoint.json"),
+        }
+        if archive_hashes_before != archive_hashes_after:
+            raise EnvironmentCheckpointError("Immutable parent snapshot was modified")
+
+        checks = {
+            "explicit_pause_capture_and_unpause": True,
+            "rootfs_sentinel_restored": True,
+            "bind_content_mode_mtime_symlink_restored": True,
+            "initial_canonical_state_equal": True,
+            "arm_rootfs_isolated": True,
+            "arm_bind_mounts_isolated": True,
+            "parent_snapshot_immutable": True,
+            "provider_calls_zero": True,
+            "formal_physical_attempts_zero": True,
+            "model_tokens_zero": True,
+            "budget_reconstruction_deferred": True,
+        }
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "base_image_id": self.base_image_id,
+            "continuation_image_id": self.continuation_image_id,
+            "checkpoint_manifest_sha256": manifest["manifest_sha256"],
+            "initial_state_sha256": sha256_bytes(canonical_bytes(baseline_initial)),
+            "checks": checks,
+            "counts": {
+                "provider_calls": 0,
+                "formal_physical_attempts": 0,
+                "model_tokens": 0,
+                "docker_commands_before_cleanup": self.runner.command_count,
+            },
+        }
+
+    def _cleanup(self) -> list[str]:
+        errors: list[str] = []
+        for name in reversed(self.container_names):
+            result = self.runner.run(["rm", "-f", name], check=False, timeout_seconds=20)
+            if result.returncode not in (0, 1):
+                errors.append(f"container cleanup failed: {name}")
+        if self.continuation_image_id:
+            result = self.runner.run(
+                ["image", "rm", "-f", self.continuation_image_id],
+                check=False,
+                timeout_seconds=60,
+            )
+            if result.returncode != 0:
+                errors.append("continuation image cleanup failed")
+
+        if self.working_root.exists():
+            try:
+                snapshot = self.working_root / "snapshot"
+                if snapshot.exists():
+                    snapshot.chmod(0o755)
+                    for child in snapshot.iterdir():
+                        child.chmod(0o644)
+                shutil.rmtree(self.working_root)
+            except OSError:
+                helper_name = self._name("cleanup-permissions")
+                result = self.runner.run(
+                    [
+                        "run",
+                        "--rm",
+                        "--name",
+                        helper_name,
+                        *self._label_arguments(),
+                        "--mount",
+                        f"type=bind,src={self.working_root},dst=/cleanup",
+                        self.image,
+                        "sh",
+                        "-c",
+                        "chmod -R a+rwX /cleanup",
+                    ],
+                    check=False,
+                    timeout_seconds=60,
+                )
+                if result.returncode == 0:
+                    shutil.rmtree(self.working_root, ignore_errors=True)
+                if self.working_root.exists():
+                    errors.append("temporary directory cleanup failed")
+
+        for kind, arguments in (
+            ("container", ["ps", "-aq", "--filter", f"label={RUN_LABEL}={self.run_id}"]),
+            ("image", ["image", "ls", "-q", "--filter", f"label={RUN_LABEL}={self.run_id}"]),
+        ):
+            result = self.runner.run(arguments, check=False, timeout_seconds=30)
+            if result.returncode != 0 or result.stdout:
+                errors.append(f"prototype-labeled {kind} cleanup was incomplete")
+        return errors
+
+    def run(self) -> dict[str, Any]:
+        result: dict[str, Any] | None = None
+        failure: BaseException | None = None
+        try:
+            result = self._run_gate()
+        except BaseException as exc:
+            failure = exc
+        cleanup_errors = self._cleanup()
+        if failure is not None:
+            if cleanup_errors:
+                failure.add_note("; ".join(cleanup_errors))
+            raise failure
+        if cleanup_errors:
+            raise EnvironmentCheckpointError("; ".join(cleanup_errors))
+        if result is None:
+            raise EnvironmentCheckpointError("Environment checkpoint gate produced no result")
+        result["checks"]["bounded_cleanup_complete"] = True
+        result["counts"]["docker_commands_total"] = self.runner.command_count
+        result["working_root_removed"] = not self.working_root.exists()
+        return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    result = EnvironmentCheckpointPrototype(image=arguments.image).run()
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if arguments.output:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增实验专用 environment checkpoint 原型，在同一显式 pause 窗口冻结 rootfs continuation image 与 workspace/artifacts bind archive。
- 从同一个不可变 image ID 和同一只读快照恢复 baseline/treatment，验证初始 canonical state、文件 metadata 与跨臂隔离。
- 新增预注册、异常 unpause/manifest 单元测试和 opt-in Ubuntu 原生 Docker 集成测试。
- 不修改生产 Compile Session、Oracle、clean replay、verifier runner 或自然任务 ITT runner。

## 证据

- checkpoint manifest SHA-256：`e5c5a8c024339775f469fa889c441f028f099561fe3638ae54da5d02d9bf2375`
- initial canonical state SHA-256：`5c05c6ca919a0d39f23945ad4b72293153901733cc010a9720f54316b9700a47`
- Ubuntu 原生 Docker 集成：`1 passed in 28.38s`
- 相邻回归：`18 passed, 1 skipped`
- Ruff check/format、py_compile、diff check：通过
- cleanup 后 prototype container/image/temp：0

## 边界

- 0 provider request
- 0 formal physical attempt
- 0 model token
- budget reconstruction 延后到独立 gate；本 PR 不授权 provider canary 或 mechanism slot

Closes #137