### PR TITLE
研究：验证预算 checkpoint 双臂重建

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-15 — 验证 failure checkpoint 预算重建与双臂隔离
+  - GitHub: 中文 Issue #139 已创建并回读；分支为 `research/139-budget-checkpoint-prototype`，基线为 `main@ffb3475c`。
+  - 实现: 新增实验专用 `forge-budget-checkpoint-1.0.0` manifest、deterministic fake clock/counters 与预注册；不修改生产 `_ACTIVE_EXPERIMENTS` 或历史 evidence。
+  - 当前验证: 父 manifest 固定 limits、capture 前累计成本、remaining、attempt/compiler work/total deadline 与 post-build；两臂初始 canonical budget 相同，后续五类 claim 独立，预算耗尽不阻塞 finalize/cleanup。
+  - 证据: fixture manifest SHA-256 为 `7a19ec82b058587656dd3c93d7f935e274f9560cb4e0beac863f6acd88043730`；聚焦与相邻消息/环境 checkpoint 回归 `27 passed, 1 skipped`，Ruff check/format 与 `py_compile` 通过。
+  - 边界: 0 provider、0 Docker、0 formal physical attempt、0 model token；下一步是中文提交、WSL helper 推送、中文 PR 与 CI，不授权组合 runner 或 mechanism slots。
+  - 文件: `scripts/forge_budget_checkpoint_prototype.py`, `backend/tests/test_forge_budget_checkpoint_prototype.py`, `benchmarks/preregistrations/cpp-verifier-budget-checkpoint-prototype.md`
+
 - 2026-08-15 — 验证 verifier failure checkpoint 的非模型分支可行性
   - GitHub: 中文 Issue #135 已创建并回读；分支为 `research/135-failure-checkpoint-prototype`，基线为 `main@1f944c8c`。
   - 实现: 从冻结 pilot Slot 7/10 派生两份脱敏只读 fixture，固定 Schema/canonical SHA-256；实验专用 fake compiler graph 使用 SQLite checkpointer，在 actionable submit 后、下一模型节点前暂停并派生 baseline/treatment。

--- a/backend/tests/test_forge_budget_checkpoint_prototype.py
+++ b/backend/tests/test_forge_budget_checkpoint_prototype.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOTYPE_PATH = REPO_ROOT / "scripts" / "forge_budget_checkpoint_prototype.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_budget_checkpoint_prototype_test", PROTOTYPE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+prototype = _load_module()
+
+
+def _manifest(*, post_build_started: bool = True):
+    return prototype.build_manifest(
+        checkpoint_id="fixture-budget-parent",
+        limits={
+            "provider_requests": 8,
+            "compiler_invocations": 3,
+            "compiler_model_turns": 12,
+            "graph_recursion_steps": 48,
+            "attempt_wall_clock_seconds": 200,
+            "attempt_cleanup_reserve_seconds": 20,
+            "compiler_wall_clock_seconds": 100,
+            "compiler_post_build_reserve_seconds": 20,
+            "post_build_commands": 3,
+        },
+        consumed_before_capture={
+            "provider_requests": 5,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 7,
+            "graph_recursion_steps": 30,
+            "attempt_wall_clock_seconds": 40,
+            "compiler_wall_clock_seconds": 60,
+            "post_build_commands": 1,
+            "tokens": 12345,
+        },
+        post_build_started=post_build_started,
+    )
+
+
+def test_manifest_freezes_remaining_deadlines_parent_cost_and_hash() -> None:
+    manifest = _manifest()
+
+    assert manifest["remaining_at_capture"] == {
+        "provider_requests": 3,
+        "compiler_invocations": 2,
+        "compiler_model_turns": 5,
+        "graph_recursion_steps": 18,
+        "attempt_wall_clock_seconds": 160,
+        "compiler_wall_clock_seconds": 40,
+        "post_build_commands": 2,
+    }
+    assert manifest["continuation_clock"] == {
+        "clock_kind": "deterministic_monotonic_offset",
+        "attempt_elapsed_before_capture_seconds": 40,
+        "attempt_total_remaining_seconds": 160,
+        "attempt_work_remaining_seconds": 140,
+        "compiler_elapsed_before_capture_seconds": 60,
+        "compiler_total_remaining_seconds": 40,
+        "compiler_exploration_remaining_seconds": 20,
+    }
+    assert manifest["parent_cost"] == {
+        "compiler_invocations": 1,
+        "provider_requests": 5,
+        "tokens": 12345,
+    }
+    assert manifest["manifest_sha256"] == "7a19ec82b058587656dd3c93d7f935e274f9560cb4e0beac863f6acd88043730"
+    assert manifest["manifest_sha256"] == prototype.manifest_payload_sha256(manifest)
+
+
+def test_same_parent_derives_equal_initial_budgets_and_independent_claims() -> None:
+    manifest = _manifest()
+    baseline = prototype.BudgetCheckpointRuntime(manifest, prototype.BASELINE_ARM, prototype.FakeClock(10))
+    treatment = prototype.BudgetCheckpointRuntime(manifest, prototype.TREATMENT_ARM, prototype.FakeClock(80))
+
+    assert prototype.canonical_initial_budget(baseline) == prototype.canonical_initial_budget(treatment)
+
+    baseline.claim("provider_requests")
+    baseline.claim("compiler_model_turns")
+    assert baseline.snapshot()["remaining"]["provider_requests"] == 2
+    assert baseline.snapshot()["remaining"]["compiler_model_turns"] == 4
+    assert treatment.snapshot()["remaining"]["provider_requests"] == 3
+    assert treatment.snapshot()["remaining"]["compiler_model_turns"] == 5
+
+
+@pytest.mark.parametrize("resource", prototype.DISCRETE_RESOURCES)
+def test_each_discrete_budget_exhausts_and_rejects_new_work(resource: str) -> None:
+    runtime = prototype.BudgetCheckpointRuntime(_manifest(), prototype.BASELINE_ARM, prototype.FakeClock())
+    initial = runtime.snapshot()["remaining"][resource]
+
+    for _ in range(initial):
+        runtime.claim(resource)
+
+    with pytest.raises(prototype.BudgetCheckpointExceeded, match=f"{resource}_limit_reached"):
+        runtime.claim(resource)
+
+
+def test_compiler_exploration_and_total_deadlines_are_distinct() -> None:
+    clock = prototype.FakeClock()
+    runtime = prototype.BudgetCheckpointRuntime(_manifest(), prototype.TREATMENT_ARM, clock)
+
+    clock.advance(20)
+    with pytest.raises(prototype.BudgetCheckpointExceeded, match="compiler_exploration_deadline_reached"):
+        runtime.claim("compiler_model_turns")
+    runtime.claim("post_build_commands")
+
+    clock.advance(20)
+    with pytest.raises(prototype.BudgetCheckpointExceeded, match="compiler_total_deadline_reached"):
+        runtime.claim("post_build_commands")
+
+
+def test_attempt_work_deadline_rejects_new_work_but_not_finalize_or_cleanup() -> None:
+    clock = prototype.FakeClock()
+    runtime = prototype.BudgetCheckpointRuntime(_manifest(), prototype.BASELINE_ARM, clock)
+
+    clock.advance(140)
+    for resource in prototype.DISCRETE_RESOURCES:
+        with pytest.raises(prototype.BudgetCheckpointExceeded, match="attempt_work_deadline_reached"):
+            runtime.claim(resource)
+
+    assert runtime.allow_terminal_action("finalize")["remaining"]["attempt_work_wall_clock_seconds"] == 0
+    clock.advance(40)
+    assert runtime.allow_terminal_action("cleanup")["remaining"]["attempt_total_wall_clock_seconds"] == 0
+
+
+def test_post_build_must_start_before_command_claim() -> None:
+    runtime = prototype.BudgetCheckpointRuntime(
+        _manifest(post_build_started=False),
+        prototype.BASELINE_ARM,
+        prototype.FakeClock(),
+    )
+
+    with pytest.raises(prototype.BudgetCheckpointExceeded, match="post_build_not_started"):
+        runtime.claim("post_build_commands")
+
+
+def test_cost_report_preserves_parent_and_separates_arm_increment() -> None:
+    baseline = prototype.BudgetCheckpointRuntime(_manifest(), prototype.BASELINE_ARM, prototype.FakeClock())
+    treatment = prototype.BudgetCheckpointRuntime(_manifest(), prototype.TREATMENT_ARM, prototype.FakeClock())
+
+    baseline.claim("provider_requests")
+    baseline.record_tokens(500)
+    treatment.claim("provider_requests")
+    treatment.claim("provider_requests")
+    treatment.claim("compiler_invocations")
+    treatment.record_tokens(900)
+
+    baseline_report = baseline.cost_report()
+    treatment_report = treatment.cost_report()
+    assert (
+        baseline_report["parent_cost"]
+        == treatment_report["parent_cost"]
+        == {
+            "compiler_invocations": 1,
+            "provider_requests": 5,
+            "tokens": 12345,
+        }
+    )
+    assert baseline_report["continuation_cost"] == {
+        "tokens": 500,
+        "provider_requests": 1,
+        "compiler_invocations": 0,
+    }
+    assert treatment_report["total_cost"] == {
+        "compiler_invocations": 2,
+        "provider_requests": 7,
+        "tokens": 13245,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda manifest: manifest["remaining_at_capture"].__setitem__("provider_requests", 99),
+            "remaining_at_capture",
+        ),
+        (
+            lambda manifest: manifest["continuation_clock"].__setitem__("attempt_work_remaining_seconds", 999),
+            "continuation_clock",
+        ),
+        (
+            lambda manifest: manifest["parent_cost"].__setitem__("tokens", 0),
+            "parent_cost",
+        ),
+        (
+            lambda manifest: manifest["limits"].__setitem__("provider_requests", -1),
+            "non-negative",
+        ),
+        (
+            lambda manifest: manifest.__setitem__("unexpected", True),
+            "fields",
+        ),
+    ],
+)
+def test_manifest_rejects_arithmetic_schema_and_cost_drift(mutate, message: str) -> None:
+    manifest = copy.deepcopy(_manifest())
+    mutate(manifest)
+    manifest["manifest_sha256"] = prototype.manifest_payload_sha256(manifest)
+
+    with pytest.raises(prototype.BudgetCheckpointError, match=message):
+        prototype.validate_manifest(manifest)
+
+
+def test_manifest_rejects_hash_tampering() -> None:
+    manifest = copy.deepcopy(_manifest())
+    manifest["manifest_sha256"] = "0" * 64
+
+    with pytest.raises(prototype.BudgetCheckpointError, match="SHA-256"):
+        prototype.validate_manifest(manifest)
+
+
+def test_clock_cannot_move_backwards() -> None:
+    clock = prototype.FakeClock(10)
+    runtime = prototype.BudgetCheckpointRuntime(_manifest(), prototype.BASELINE_ARM, clock)
+    clock.current = 9
+
+    with pytest.raises(prototype.BudgetCheckpointError, match="backwards"):
+        runtime.snapshot()
+
+
+def test_prototype_has_no_provider_docker_or_formal_runner_imports() -> None:
+    source = PROTOTYPE_PATH.read_text(encoding="utf-8")
+    assert "deerflow.models" not in source
+    assert "deerflow.compile.docker_runtime" not in source
+    assert "forge_benchmark_runner" not in source
+    assert "forge_verifier_repair_authorized_runner" not in source

--- a/benchmarks/preregistrations/cpp-verifier-budget-checkpoint-prototype.md
+++ b/benchmarks/preregistrations/cpp-verifier-budget-checkpoint-prototype.md
@@ -1,0 +1,59 @@
+# Verifier-driven repair budget checkpoint 非模型原型预注册
+
+## 研究问题
+
+Issue #135 / PR #136 已证明 compiler 消息 checkpoint 的中性分支与冷恢复；Issue #137 / PR #138 已证明合成环境的 rootfs + bind-mount 同源双臂恢复。本门禁只回答：能否从同一个父预算 checkpoint 确定性重建 baseline/treatment 的相同 continuation budget，同时隔离两臂后续消耗并保留 capture 前累计成本。
+
+## 冻结范围
+
+- 跟踪 Issue：#139。
+- Provider、Docker、formal physical attempt、model token：实际调用或消耗均为 0。
+- 只新增实验专用 manifest、deterministic fake clock/counters 与聚焦测试。
+- 不修改生产 `_ACTIVE_EXPERIMENTS`，不提供从历史 ledger 恢复生产 runtime 的入口。
+- 不修改 Oracle、clean replay、verifier-driven repair runtime、自然任务 ITT runner 或冻结 evidence。
+- 不接入组合 continuation runner，不授权 provider canary 或 mechanism slots。
+
+## Manifest 契约
+
+版本 `forge-budget-checkpoint-1.0.0` 固定以下层次，并以 canonical JSON 的 SHA-256 拒绝漂移：
+
+- `limits`：provider requests、compiler invocations、compiler model turns、graph recursion steps、attempt/compiler wall-clock、cleanup/post-build reserve 与 post-build commands。
+- `consumed_before_capture`：上述可消耗资源在 capture 前的累计值，以及累计 tokens。
+- `remaining_at_capture`：每项限制减去 capture 前累计值；不允许调用方自行声明不一致的剩余额度。
+- `continuation_clock`：attempt total/work 与 compiler total/exploration 的 capture 前 elapsed 和 continuation remaining。
+- `post_build`：是否已进入 post-build、reserve、command limit/consumed/remaining。
+- `parent_cost`：capture 前 tokens、provider requests 与 compiler invocations，后续报告不得隐藏。
+- `arm_identity`：父 manifest 固定为 neutral；baseline/treatment identity 属于各自 runtime，不改变父 manifest。
+
+## 双臂规则
+
+1. baseline/treatment 均深拷贝并重验同一个父 manifest。
+2. 两臂的 canonical initial budget 必须完全相同；绝对 fake-clock 起点不进入比较。
+3. 每臂独立记录 provider request、compiler invocation、model turn、graph step、post-build command 与 token 增量。
+4. 任一臂 claim 不得改变另一臂或父 manifest。
+5. 普通新工作受 attempt work deadline 约束；model turn/graph step 还受 compiler exploration deadline 约束；post-build command 使用预留时间但受 compiler total deadline 约束。
+6. finalize 与 cleanup 不被新工作预算耗尽阻塞；报告仍显式显示 total deadline 是否归零。
+
+## 通过条件
+
+- 所有离散预算满足 `limits - consumed_before_capture = remaining_at_capture`。
+- attempt 与 compiler 墙钟均能区分 work/exploration deadline 和 total deadline。
+- 两臂初始 canonical budget 相同，后续 claim 相互独立。
+- 五类离散预算均能耗尽并拒绝下一次 claim。
+- compiler exploration reserve、post-build total deadline 和 attempt cleanup reserve 的边界行为由 fake clock 固定。
+- finalize/cleanup 在预算耗尽后仍可调用。
+- 最终 cost report 同时保留 parent cost、arm continuation cost 与两者总和。
+- 未知字段、负数、超限、算术漂移、parent cost 漂移、clock 漂移和 hash 篡改均失败关闭。
+- 聚焦 pytest、消息/环境 checkpoint 相邻非 Docker 回归与 Ruff check/format 通过。
+
+## 失效条件
+
+- 原型导入 provider、Docker runtime 或 formal runner。
+- 任一实际 provider request、Docker 命令、formal physical attempt 或 model token 消耗。
+- 两臂初始预算不一致，或一臂 claim 污染另一臂。
+- capture 前成本未进入最终报告，或 remaining/deadline 可被不一致输入伪造。
+- 预算耗尽阻止 finalize/cleanup，导致资源清理语义倒置。
+
+## 解释边界
+
+通过只证明实验专用预算 manifest 和 continuation 计数器可以确定性重建并隔离，不证明生产 attempt runtime、真实 compiler transcript、provider client 或端到端 continuation runner 已可恢复，也不产生 verifier repair 的因果效果结论。消息、环境、预算三层均通过后，下一阶段仍需单独评审组合 runner；任何真实模型请求和机制实验预算继续由实验负责人另行授权。

--- a/scripts/forge_budget_checkpoint_prototype.py
+++ b/scripts/forge_budget_checkpoint_prototype.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""验证 failure checkpoint 预算重建与双臂隔离的非模型原型。"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = "forge-budget-checkpoint-1.0.0"
+BASELINE_ARM = "baseline"
+TREATMENT_ARM = "treatment"
+ALLOWED_ARMS = frozenset({BASELINE_ARM, TREATMENT_ARM})
+
+DISCRETE_RESOURCES = (
+    "provider_requests",
+    "compiler_invocations",
+    "compiler_model_turns",
+    "graph_recursion_steps",
+    "post_build_commands",
+)
+LIMIT_FIELDS = set(DISCRETE_RESOURCES) | {
+    "attempt_wall_clock_seconds",
+    "attempt_cleanup_reserve_seconds",
+    "compiler_wall_clock_seconds",
+    "compiler_post_build_reserve_seconds",
+}
+CONSUMED_FIELDS = set(DISCRETE_RESOURCES) | {
+    "attempt_wall_clock_seconds",
+    "compiler_wall_clock_seconds",
+    "tokens",
+}
+REMAINING_FIELDS = set(DISCRETE_RESOURCES) | {
+    "attempt_wall_clock_seconds",
+    "compiler_wall_clock_seconds",
+}
+PARENT_COST_FIELDS = {"tokens", "provider_requests", "compiler_invocations"}
+_IDENTIFIER_RE = re.compile(r"[a-z][a-z0-9-]{0,95}")
+
+
+class BudgetCheckpointError(ValueError):
+    pass
+
+
+class BudgetCheckpointExceeded(RuntimeError):
+    def __init__(self, resource: str, classification: str):
+        self.resource = resource
+        self.classification = classification
+        super().__init__(f"Budget checkpoint rejected {resource}: {classification}")
+
+
+def canonical_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise BudgetCheckpointError(f"value is not canonical JSON: {exc}") from exc
+    return encoded.encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def manifest_payload_sha256(manifest: dict[str, Any]) -> str:
+    payload = {key: value for key, value in manifest.items() if key != "manifest_sha256"}
+    return sha256_bytes(canonical_bytes(payload))
+
+
+def _require_exact_fields(value: Any, fields: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != fields:
+        raise BudgetCheckpointError(f"{label} fields do not match the frozen schema")
+    return value
+
+
+def _require_non_negative_integer(value: Any, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise BudgetCheckpointError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _require_non_negative_number(value: Any, label: str) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+        raise BudgetCheckpointError(f"{label} must be a finite non-negative number")
+    return value
+
+
+def _subtract(limit: int | float, consumed: int | float) -> int | float:
+    result = limit - consumed
+    return 0 if result == 0 else result
+
+
+def _expected_remaining(limits: dict[str, Any], consumed: dict[str, Any]) -> dict[str, Any]:
+    return {resource: _subtract(limits[resource], consumed[resource]) for resource in REMAINING_FIELDS}
+
+
+def _expected_clock(limits: dict[str, Any], consumed: dict[str, Any]) -> dict[str, Any]:
+    attempt_elapsed = consumed["attempt_wall_clock_seconds"]
+    compiler_elapsed = consumed["compiler_wall_clock_seconds"]
+    return {
+        "clock_kind": "deterministic_monotonic_offset",
+        "attempt_elapsed_before_capture_seconds": attempt_elapsed,
+        "attempt_total_remaining_seconds": _subtract(limits["attempt_wall_clock_seconds"], attempt_elapsed),
+        "attempt_work_remaining_seconds": max(
+            0,
+            limits["attempt_wall_clock_seconds"] - limits["attempt_cleanup_reserve_seconds"] - attempt_elapsed,
+        ),
+        "compiler_elapsed_before_capture_seconds": compiler_elapsed,
+        "compiler_total_remaining_seconds": _subtract(limits["compiler_wall_clock_seconds"], compiler_elapsed),
+        "compiler_exploration_remaining_seconds": max(
+            0,
+            limits["compiler_wall_clock_seconds"] - limits["compiler_post_build_reserve_seconds"] - compiler_elapsed,
+        ),
+    }
+
+
+def _expected_post_build(limits: dict[str, Any], consumed: dict[str, Any], *, started: bool) -> dict[str, Any]:
+    return {
+        "started": started,
+        "reserve_seconds": limits["compiler_post_build_reserve_seconds"],
+        "commands_limit": limits["post_build_commands"],
+        "commands_consumed": consumed["post_build_commands"],
+        "commands_remaining": limits["post_build_commands"] - consumed["post_build_commands"],
+    }
+
+
+def build_manifest(
+    *,
+    checkpoint_id: str,
+    limits: dict[str, Any],
+    consumed_before_capture: dict[str, Any],
+    post_build_started: bool,
+) -> dict[str, Any]:
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "manifest_sha256": "",
+        "checkpoint_id": checkpoint_id,
+        "limits": copy.deepcopy(limits),
+        "consumed_before_capture": copy.deepcopy(consumed_before_capture),
+        "remaining_at_capture": _expected_remaining(limits, consumed_before_capture),
+        "continuation_clock": _expected_clock(limits, consumed_before_capture),
+        "post_build": _expected_post_build(limits, consumed_before_capture, started=post_build_started),
+        "parent_cost": {field_name: consumed_before_capture[field_name] for field_name in sorted(PARENT_COST_FIELDS)},
+        "arm_identity": {
+            "parent_checkpoint_id": checkpoint_id,
+            "arm": "neutral",
+        },
+    }
+    manifest["manifest_sha256"] = manifest_payload_sha256(manifest)
+    return validate_manifest(manifest)
+
+
+def validate_manifest(value: Any) -> dict[str, Any]:
+    manifest = _require_exact_fields(
+        value,
+        {
+            "schema_version",
+            "manifest_sha256",
+            "checkpoint_id",
+            "limits",
+            "consumed_before_capture",
+            "remaining_at_capture",
+            "continuation_clock",
+            "post_build",
+            "parent_cost",
+            "arm_identity",
+        },
+        "manifest",
+    )
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise BudgetCheckpointError("manifest schema version is invalid")
+    checkpoint_id = manifest["checkpoint_id"]
+    if not isinstance(checkpoint_id, str) or _IDENTIFIER_RE.fullmatch(checkpoint_id) is None:
+        raise BudgetCheckpointError("checkpoint identity is invalid")
+
+    limits = _require_exact_fields(manifest["limits"], LIMIT_FIELDS, "limits")
+    consumed = _require_exact_fields(manifest["consumed_before_capture"], CONSUMED_FIELDS, "consumed_before_capture")
+    remaining = _require_exact_fields(manifest["remaining_at_capture"], REMAINING_FIELDS, "remaining_at_capture")
+    for resource in DISCRETE_RESOURCES:
+        limit = _require_non_negative_integer(limits[resource], f"limits.{resource}")
+        used = _require_non_negative_integer(consumed[resource], f"consumed_before_capture.{resource}")
+        _require_non_negative_integer(remaining[resource], f"remaining_at_capture.{resource}")
+        if used > limit:
+            raise BudgetCheckpointError(f"consumed_before_capture.{resource} exceeds its limit")
+    if limits["provider_requests"] < 1 or limits["compiler_invocations"] < 1:
+        raise BudgetCheckpointError("provider and compiler invocation limits must be positive")
+
+    for resource in ("attempt_wall_clock_seconds", "compiler_wall_clock_seconds"):
+        limit = _require_non_negative_number(limits[resource], f"limits.{resource}")
+        used = _require_non_negative_number(consumed[resource], f"consumed_before_capture.{resource}")
+        _require_non_negative_number(remaining[resource], f"remaining_at_capture.{resource}")
+        if limit <= 0 or used > limit:
+            raise BudgetCheckpointError(f"{resource} limit/consumption is invalid")
+    attempt_reserve = _require_non_negative_number(limits["attempt_cleanup_reserve_seconds"], "limits.attempt_cleanup_reserve_seconds")
+    compiler_reserve = _require_non_negative_number(
+        limits["compiler_post_build_reserve_seconds"],
+        "limits.compiler_post_build_reserve_seconds",
+    )
+    if attempt_reserve >= limits["attempt_wall_clock_seconds"]:
+        raise BudgetCheckpointError("attempt cleanup reserve must be smaller than its wall-clock limit")
+    if compiler_reserve >= limits["compiler_wall_clock_seconds"]:
+        raise BudgetCheckpointError("compiler post-build reserve must be smaller than its wall-clock limit")
+    _require_non_negative_integer(consumed["tokens"], "consumed_before_capture.tokens")
+
+    if remaining != _expected_remaining(limits, consumed):
+        raise BudgetCheckpointError("remaining_at_capture does not equal limits minus consumed_before_capture")
+
+    clock = _require_exact_fields(
+        manifest["continuation_clock"],
+        {
+            "clock_kind",
+            "attempt_elapsed_before_capture_seconds",
+            "attempt_total_remaining_seconds",
+            "attempt_work_remaining_seconds",
+            "compiler_elapsed_before_capture_seconds",
+            "compiler_total_remaining_seconds",
+            "compiler_exploration_remaining_seconds",
+        },
+        "continuation_clock",
+    )
+    if clock != _expected_clock(limits, consumed):
+        raise BudgetCheckpointError("continuation_clock does not match the frozen limits and consumption")
+
+    post_build = _require_exact_fields(
+        manifest["post_build"],
+        {"started", "reserve_seconds", "commands_limit", "commands_consumed", "commands_remaining"},
+        "post_build",
+    )
+    if type(post_build["started"]) is not bool:
+        raise BudgetCheckpointError("post_build.started must be boolean")
+    if post_build != _expected_post_build(limits, consumed, started=post_build["started"]):
+        raise BudgetCheckpointError("post_build does not match the frozen limits and consumption")
+
+    parent_cost = _require_exact_fields(manifest["parent_cost"], PARENT_COST_FIELDS, "parent_cost")
+    if parent_cost != {field_name: consumed[field_name] for field_name in sorted(PARENT_COST_FIELDS)}:
+        raise BudgetCheckpointError("parent_cost does not preserve capture-before cost")
+    identity = _require_exact_fields(manifest["arm_identity"], {"parent_checkpoint_id", "arm"}, "arm_identity")
+    if identity != {"parent_checkpoint_id": checkpoint_id, "arm": "neutral"}:
+        raise BudgetCheckpointError("parent manifest arm identity is invalid")
+
+    digest = manifest_payload_sha256(manifest)
+    if manifest["manifest_sha256"] != digest:
+        raise BudgetCheckpointError("manifest SHA-256 does not match canonical payload")
+    return manifest
+
+
+@dataclass
+class FakeClock:
+    current: float = 0.0
+
+    def __call__(self) -> float:
+        return self.current
+
+    def advance(self, seconds: float) -> None:
+        _require_non_negative_number(seconds, "clock advance")
+        self.current += seconds
+
+
+@dataclass
+class BudgetCheckpointRuntime:
+    manifest: dict[str, Any]
+    arm: str
+    clock: Callable[[], float]
+    started_monotonic: float = field(init=False)
+    claims: dict[str, int] = field(init=False)
+    continuation_tokens: int = 0
+    lock: threading.RLock = field(default_factory=threading.RLock)
+
+    def __post_init__(self) -> None:
+        if self.arm not in ALLOWED_ARMS:
+            raise BudgetCheckpointError("continuation arm is invalid")
+        self.manifest = copy.deepcopy(validate_manifest(self.manifest))
+        self.started_monotonic = self.clock()
+        self.claims = {resource: 0 for resource in DISCRETE_RESOURCES}
+
+    def _elapsed(self) -> float:
+        elapsed = self.clock() - self.started_monotonic
+        if elapsed < 0:
+            raise BudgetCheckpointError("continuation clock moved backwards")
+        return elapsed
+
+    def snapshot(self) -> dict[str, Any]:
+        with self.lock:
+            elapsed = self._elapsed()
+            initial = self.manifest["remaining_at_capture"]
+            clock = self.manifest["continuation_clock"]
+            return {
+                "checkpoint_id": self.manifest["checkpoint_id"],
+                "manifest_sha256": self.manifest["manifest_sha256"],
+                "arm": self.arm,
+                "continuation_elapsed_seconds": elapsed,
+                "remaining": {
+                    **{resource: initial[resource] - self.claims[resource] for resource in DISCRETE_RESOURCES},
+                    "attempt_total_wall_clock_seconds": max(0, clock["attempt_total_remaining_seconds"] - elapsed),
+                    "attempt_work_wall_clock_seconds": max(0, clock["attempt_work_remaining_seconds"] - elapsed),
+                    "compiler_total_wall_clock_seconds": max(0, clock["compiler_total_remaining_seconds"] - elapsed),
+                    "compiler_exploration_wall_clock_seconds": max(0, clock["compiler_exploration_remaining_seconds"] - elapsed),
+                },
+                "post_build_started": self.manifest["post_build"]["started"],
+            }
+
+    def claim(self, resource: str) -> dict[str, Any]:
+        if resource not in DISCRETE_RESOURCES:
+            raise BudgetCheckpointError(f"unknown budget resource: {resource}")
+        with self.lock:
+            snapshot = self.snapshot()
+            remaining = snapshot["remaining"]
+            if remaining["attempt_work_wall_clock_seconds"] <= 0:
+                raise BudgetCheckpointExceeded(resource, "attempt_work_deadline_reached")
+            if resource in {"compiler_model_turns", "graph_recursion_steps"} and remaining["compiler_exploration_wall_clock_seconds"] <= 0:
+                raise BudgetCheckpointExceeded(resource, "compiler_exploration_deadline_reached")
+            if resource == "post_build_commands":
+                if not snapshot["post_build_started"]:
+                    raise BudgetCheckpointExceeded(resource, "post_build_not_started")
+                if remaining["compiler_total_wall_clock_seconds"] <= 0:
+                    raise BudgetCheckpointExceeded(resource, "compiler_total_deadline_reached")
+            if remaining[resource] <= 0:
+                raise BudgetCheckpointExceeded(resource, f"{resource}_limit_reached")
+            self.claims[resource] += 1
+            return self.snapshot()
+
+    def record_tokens(self, tokens: int) -> None:
+        _require_non_negative_integer(tokens, "continuation tokens")
+        with self.lock:
+            self.continuation_tokens += tokens
+
+    def allow_terminal_action(self, action: str) -> dict[str, Any]:
+        if action not in {"finalize", "cleanup"}:
+            raise BudgetCheckpointError("unknown terminal action")
+        return self.snapshot()
+
+    def cost_report(self) -> dict[str, Any]:
+        with self.lock:
+            parent = copy.deepcopy(self.manifest["parent_cost"])
+            continuation = {
+                "tokens": self.continuation_tokens,
+                "provider_requests": self.claims["provider_requests"],
+                "compiler_invocations": self.claims["compiler_invocations"],
+            }
+            return {
+                "checkpoint_id": self.manifest["checkpoint_id"],
+                "arm": self.arm,
+                "parent_cost": parent,
+                "continuation_cost": continuation,
+                "total_cost": {field_name: parent[field_name] + continuation[field_name] for field_name in sorted(PARENT_COST_FIELDS)},
+            }
+
+
+def canonical_initial_budget(runtime: BudgetCheckpointRuntime) -> dict[str, Any]:
+    snapshot = runtime.snapshot()
+    return {
+        "checkpoint_id": snapshot["checkpoint_id"],
+        "manifest_sha256": snapshot["manifest_sha256"],
+        "continuation_elapsed_seconds": snapshot["continuation_elapsed_seconds"],
+        "remaining": snapshot["remaining"],
+        "post_build_started": snapshot["post_build_started"],
+    }


### PR DESCRIPTION
## 变更

- 新增版本化 budget checkpoint manifest，冻结 limits、capture 前累计成本、remaining、attempt/compiler work/total deadline 与 post-build 状态
- 新增 deterministic fake clock/counters，从同一父 manifest 派生 baseline/treatment，并隔离五类后续 claim
- 预算耗尽拒绝新工作，但不阻塞 finalize/cleanup；最终报告保留 parent、continuation 与 total cost
- 新增预注册与严格负例，拒绝字段、算术、clock、parent cost 和 canonical SHA-256 漂移
- 更新项目状态快照

## 边界

- 不修改生产 `_ACTIVE_EXPERIMENTS` 或历史 ledger 恢复路径
- 不接入组合 continuation runner
- 0 provider、0 Docker、0 formal physical attempt、0 model token
- 不授权 provider canary 或 mechanism slots

## 验证

- `27 passed, 1 skipped`：预算、消息、环境 checkpoint 非 Docker 回归
- Ruff check 通过
- Ruff format check 通过
- `py_compile` 通过
- `git diff --check` 通过
- 敏感信息扫描无命中

固定 fixture manifest SHA-256：`7a19ec82b058587656dd3c93d7f935e274f9560cb4e0beac863f6acd88043730`

Closes #139