### PR TITLE
研究：验证三层 checkpoint 组合恢复

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-15 — 验证 failure checkpoint 三层组合恢复
+  - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
+  - 实现: 新增实验专用 `forge-combined-checkpoint-1.0.0` manifest，把 message、environment、budget 绑定到同一 `capture_id` 与 message state SHA-256；三层全部校验后才发布父 manifest。
+  - 当前验证: 两臂同步切换 message thread/session、environment identity 与独立 budget runtime；SQLite 冷恢复不重新 capture。固定组合 manifest SHA-256 为 `bb1f6f4da5868e2e33ef1caf8c34a4645fc06641b5577669edf94f75f8449738`。
+  - 证据: 聚焦测试 `10 passed`；消息/环境/预算相邻非 Docker 回归 `37 passed, 1 skipped`；Ruff check/format、`py_compile` 与 `git diff --check` 通过。
+  - 边界: 0 provider、0 Docker、0 formal physical attempt、0 model token；不修改生产 Compiler、Compile Session、`_ACTIVE_EXPERIMENTS`、Oracle、clean replay 或自然任务 ITT runner。
+  - 下一步: 中文提交、通过 WSL helper 推送、创建中文 PR 并等待 CI；未经新授权不合并，也不进入 provider canary 或真实实验。
+  - 文件: `scripts/forge_combined_checkpoint_prototype.py`, `backend/tests/test_forge_combined_checkpoint_prototype.py`, `benchmarks/preregistrations/cpp-verifier-combined-checkpoint-prototype.md`
+
 - 2026-08-15 — 验证 failure checkpoint 预算重建与双臂隔离
   - GitHub: 中文 Issue #139 已创建并回读；分支为 `research/139-budget-checkpoint-prototype`，基线为 `main@ffb3475c`。
   - 实现: 新增实验专用 `forge-budget-checkpoint-1.0.0` manifest、deterministic fake clock/counters 与预注册；不修改生产 `_ACTIVE_EXPERIMENTS` 或历史 evidence。

--- a/backend/tests/test_forge_combined_checkpoint_prototype.py
+++ b/backend/tests/test_forge_combined_checkpoint_prototype.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+PROTOTYPE_PATH = SCRIPTS_DIR / "forge_combined_checkpoint_prototype.py"
+FIXTURE_PATH = REPO_ROOT / "benchmarks" / "fixtures" / "failure-checkpoints" / "slot-007-openthread.json"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location("forge_combined_checkpoint_prototype_test", PROTOTYPE_PATH)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+prototype = _load_module()
+
+
+def _fixture():
+    return prototype.message_checkpoint.load_fixture(FIXTURE_PATH)
+
+
+def _arm_plan(capture_id: str):
+    return {
+        "baseline": {
+            "thread_id": f"{capture_id}-baseline-thread",
+            "session_id": f"{capture_id}-baseline-session",
+            "environment_id": f"{capture_id}-baseline-environment",
+        },
+        "treatment": {
+            "thread_id": f"{capture_id}-treatment-thread",
+            "session_id": f"{capture_id}-treatment-session",
+            "environment_id": f"{capture_id}-treatment-environment",
+        },
+    }
+
+
+def _environment_manifest(capture_id: str):
+    image_id = "sha256:" + "1" * 64
+    plan = _arm_plan(capture_id)
+    manifest = {
+        "schema_version": prototype.environment_checkpoint.SCHEMA_VERSION,
+        "manifest_sha256": "",
+        "run_id": capture_id,
+        "capture_method": "explicit-pause+docker-commit+bind-tar",
+        "base_image_id": image_id,
+        "continuation_image_id": image_id,
+        "rootfs": {
+            "sentinel_path": prototype.environment_checkpoint.ROOTFS_SENTINEL,
+            "content_sha256": "2" * 64,
+        },
+        "bind_mounts": {
+            "workspace": {"archive_sha256": "3" * 64, "entries": []},
+            "artifacts": {"archive_sha256": "4" * 64, "entries": []},
+        },
+        "identities": {
+            "parent": f"{capture_id}-parent-environment",
+            "baseline": plan["baseline"]["environment_id"],
+            "treatment": plan["treatment"]["environment_id"],
+        },
+        "budget": {"reconstructed": False, "scope": "deferred-separate-gate"},
+    }
+    manifest["manifest_sha256"] = prototype.environment_checkpoint.checkpoint_payload_sha256(manifest)
+    return prototype.environment_checkpoint.validate_checkpoint_manifest(manifest)
+
+
+def _budget_manifest(capture_id: str):
+    return prototype.budget_checkpoint.build_manifest(
+        checkpoint_id=capture_id,
+        limits={
+            "provider_requests": 8,
+            "compiler_invocations": 3,
+            "compiler_model_turns": 12,
+            "graph_recursion_steps": 48,
+            "attempt_wall_clock_seconds": 200,
+            "attempt_cleanup_reserve_seconds": 20,
+            "compiler_wall_clock_seconds": 100,
+            "compiler_post_build_reserve_seconds": 20,
+            "post_build_commands": 3,
+        },
+        consumed_before_capture={
+            "provider_requests": 5,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 7,
+            "graph_recursion_steps": 30,
+            "attempt_wall_clock_seconds": 40,
+            "compiler_wall_clock_seconds": 60,
+            "post_build_commands": 1,
+            "tokens": 12345,
+        },
+        post_build_started=True,
+    )
+
+
+def _callbacks(capture_id: str, events: list[tuple]):
+    def capture_environment(observed_capture_id: str, message_sha256: str):
+        events.append(("environment", observed_capture_id, message_sha256))
+        return _environment_manifest(capture_id)
+
+    def capture_budget(observed_capture_id: str, message_sha256: str):
+        events.append(("budget", observed_capture_id, message_sha256))
+        return _budget_manifest(capture_id)
+
+    return capture_environment, capture_budget
+
+
+def test_atomic_capture_binds_three_components_after_message_pause(tmp_path: Path) -> None:
+    capture_id = "combined-fixture"
+    events: list[tuple] = []
+    counters = prototype.message_checkpoint.PrototypeCounters()
+    environment_capture, budget_capture = _callbacks(capture_id, events)
+
+    with SqliteSaver.from_conn_string(str(tmp_path / "combined.sqlite")) as saver:
+        saver.setup()
+        runtime = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=environment_capture,
+            budget_capture=budget_capture,
+            counters=counters,
+        )
+        manifest = runtime.capture(capture_id, _arm_plan(capture_id))
+
+        assert [event[0] for event in events] == ["environment", "budget"]
+        assert {event[1] for event in events} == {capture_id}
+        assert len({event[2] for event in events}) == 1
+        assert counters.submit_calls == 1
+        assert counters.fake_model_calls == 0
+        assert manifest["components"]["message"]["canonical_state_sha256"] == events[0][2]
+        assert manifest["manifest_sha256"] == "bb1f6f4da5868e2e33ef1caf8c34a4645fc06641b5577669edf94f75f8449738"
+        assert manifest["manifest_sha256"] == prototype.manifest_payload_sha256(manifest)
+
+
+@pytest.mark.parametrize("failing_component", ["environment", "budget"])
+def test_capture_failure_does_not_publish_parent_or_derive_arm(tmp_path: Path, failing_component: str) -> None:
+    capture_id = f"combined-fail-{failing_component}"
+    events: list[tuple] = []
+
+    def fail(_capture_id: str, _message_sha256: str):
+        raise prototype.CombinedCheckpointError(f"synthetic {failing_component} failure")
+
+    environment_capture, budget_capture = _callbacks(capture_id, events)
+    if failing_component == "environment":
+        environment_capture = fail
+    else:
+        budget_capture = fail
+
+    with SqliteSaver.from_conn_string(str(tmp_path / f"{failing_component}.sqlite")) as saver:
+        saver.setup()
+        runtime = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=environment_capture,
+            budget_capture=budget_capture,
+        )
+        with pytest.raises(prototype.CombinedCheckpointError, match=f"synthetic {failing_component}"):
+            runtime.capture(capture_id, _arm_plan(capture_id))
+
+        assert runtime.combined_manifest is None
+        assert runtime.arms == {}
+        assert runtime.counters.submit_calls == 1
+        assert runtime.counters.fake_model_calls == 0
+        assert runtime.external_counts() == {
+            "provider_calls": 0,
+            "docker_calls": 0,
+            "formal_physical_attempts": 0,
+            "model_tokens": 0,
+        }
+
+
+def test_cold_restore_derives_equal_isolated_arms_and_resumes_once(tmp_path: Path) -> None:
+    capture_id = "combined-cold-restore"
+    database = tmp_path / "combined.sqlite"
+    events: list[tuple] = []
+    counters = prototype.message_checkpoint.PrototypeCounters()
+    environment_capture, budget_capture = _callbacks(capture_id, events)
+
+    with SqliteSaver.from_conn_string(str(database)) as saver:
+        saver.setup()
+        runtime = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=environment_capture,
+            budget_capture=budget_capture,
+            counters=counters,
+        )
+        manifest = runtime.capture(capture_id, _arm_plan(capture_id))
+        environment_manifest = copy.deepcopy(runtime.environment_manifest)
+        budget_manifest = copy.deepcopy(runtime.budget_manifest)
+
+    assert environment_manifest is not None
+    assert budget_manifest is not None
+    with SqliteSaver.from_conn_string(str(database)) as saver:
+        saver.setup()
+        restored = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=lambda *_args: pytest.fail("cold restore must not recapture environment"),
+            budget_capture=lambda *_args: pytest.fail("cold restore must not recapture budget"),
+            counters=counters,
+        )
+        restored.restore_parent(
+            combined_manifest=manifest,
+            environment_manifest=environment_manifest,
+            budget_manifest=budget_manifest,
+        )
+        baseline = restored.derive_arm("baseline")
+        treatment = restored.derive_arm("treatment")
+
+        assert restored.canonical_initial_state("baseline") == restored.canonical_initial_state("treatment")
+        assert baseline.session_id != treatment.session_id
+        assert baseline.environment.identity != treatment.environment.identity
+
+        parent_environment_before = copy.deepcopy(restored.environment_manifest)
+        baseline.environment.write("workspace", "repo/generated.txt", "baseline")
+        baseline.budget.claim("provider_requests")
+        assert treatment.environment.workspace_overlay == {}
+        assert treatment.budget.snapshot()["remaining"]["provider_requests"] == 3
+        assert restored.environment_manifest == parent_environment_before
+
+        restored.resume_arm("baseline")
+        restored.resume_arm("treatment")
+        with pytest.raises(prototype.CombinedCheckpointError, match="already resumed"):
+            restored.resume_arm("baseline")
+
+        assert counters.submit_calls == 1
+        assert counters.fake_model_calls == 2
+        assert baseline.budget.snapshot()["remaining"]["compiler_model_turns"] == 4
+        assert treatment.budget.snapshot()["remaining"]["compiler_model_turns"] == 4
+        assert restored.external_counts() == {
+            "provider_calls": 0,
+            "docker_calls": 0,
+            "formal_physical_attempts": 0,
+            "model_tokens": 0,
+        }
+
+
+@pytest.mark.parametrize("drift", ["combined", "message", "environment", "budget"])
+def test_component_drift_before_resume_rejects_without_budget_claim(tmp_path: Path, drift: str) -> None:
+    capture_id = f"combined-drift-{drift}"
+    events: list[tuple] = []
+    environment_capture, budget_capture = _callbacks(capture_id, events)
+
+    with SqliteSaver.from_conn_string(str(tmp_path / f"{drift}.sqlite")) as saver:
+        saver.setup()
+        runtime = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=environment_capture,
+            budget_capture=budget_capture,
+        )
+        runtime.capture(capture_id, _arm_plan(capture_id))
+        arm = runtime.derive_arm("baseline")
+        before = copy.deepcopy(arm.budget.snapshot())
+
+        if drift == "combined":
+            runtime.combined_manifest["arm_plan"]["baseline"]["session_id"] = "drifted-session"
+            runtime.combined_manifest["manifest_sha256"] = prototype.manifest_payload_sha256(runtime.combined_manifest)
+        elif drift == "message":
+            runtime.message_runtime.fixture["fixture_sha256"] = "0" * 64
+        elif drift == "environment":
+            runtime.environment_manifest["run_id"] = "drifted-capture"
+        else:
+            runtime.budget_manifest["parent_cost"]["tokens"] += 1
+
+        expected_errors = (
+            prototype.CombinedCheckpointError,
+            prototype.message_checkpoint.FailureCheckpointPrototypeError,
+            prototype.environment_checkpoint.EnvironmentCheckpointError,
+            prototype.budget_checkpoint.BudgetCheckpointError,
+        )
+        with pytest.raises(expected_errors):
+            runtime.resume_arm("baseline")
+        assert arm.budget.snapshot() == before
+        assert runtime.counters.fake_model_calls == 0
+
+
+def test_capture_rejects_environment_arm_identity_drift(tmp_path: Path) -> None:
+    capture_id = "combined-identity-drift"
+
+    def environment_capture(_capture_id: str, _message_sha256: str):
+        manifest = copy.deepcopy(_environment_manifest(capture_id))
+        manifest["identities"]["baseline"] = "wrong-environment"
+        manifest["manifest_sha256"] = prototype.environment_checkpoint.checkpoint_payload_sha256(manifest)
+        return manifest
+
+    with SqliteSaver.from_conn_string(str(tmp_path / "identity.sqlite")) as saver:
+        saver.setup()
+        runtime = prototype.CombinedCheckpointPrototype(
+            _fixture(),
+            saver,
+            environment_capture=environment_capture,
+            budget_capture=lambda *_args: _budget_manifest(capture_id),
+        )
+        with pytest.raises(prototype.CombinedCheckpointError, match="environment identity drifted"):
+            runtime.capture(capture_id, _arm_plan(capture_id))
+        assert runtime.combined_manifest is None
+
+
+def test_combined_prototype_does_not_invoke_external_runtimes() -> None:
+    source = PROTOTYPE_PATH.read_text(encoding="utf-8")
+    assert "DockerCLI(" not in source
+    assert "deerflow.models" not in source
+    assert "forge_benchmark_runner" not in source
+    assert "forge_verifier_repair_authorized_runner" not in source

--- a/benchmarks/preregistrations/cpp-verifier-combined-checkpoint-prototype.md
+++ b/benchmarks/preregistrations/cpp-verifier-combined-checkpoint-prototype.md
@@ -1,0 +1,63 @@
+# Verifier-driven repair 三层 combined checkpoint 非模型原型预注册
+
+## 研究问题
+
+消息、环境和预算三个独立 feasibility gate 已分别进入主干。本门禁只回答：能否在 actionable submit 后、下一 continuation 前，以一次 neutral capture 原子绑定三层状态，并从同一父 checkpoint 派生身份同步、可写状态隔离且可冷恢复的 baseline/treatment。
+
+## 冻结范围
+
+- 跟踪 Issue：#141。
+- 只新增组合 manifest、组合编排原型和聚焦测试；三个既有原型及其固定 hash 保持不变。
+- 使用 SQLite message checkpointer、deterministic environment manifest/overlay 与 fake budget clock/counters。
+- Provider、Docker、formal physical attempt、model token：实际调用或消耗均为 0。
+- 不修改生产 Compiler、Compile Session、`_ACTIVE_EXPERIMENTS`、Oracle、clean replay、自然任务 ITT runner 或冻结 evidence。
+- 不授权 provider canary、mechanism slots、随机顺序、样本量或 token ceiling。
+
+## 原子 capture 契约
+
+1. message graph 先执行一次 fake actionable submit，并暂停在 `continue_model` 前。
+2. 对冻结的完整 message state 计算 canonical SHA-256。
+3. environment 与 budget capture callback 按固定顺序执行，二者接收同一个 `capture_id` 和 message state SHA-256。
+4. environment `run_id`、budget `checkpoint_id` 必须等于组合 `capture_id`；environment arm identities 必须与组合 arm plan 相同。
+5. 只有三个组件全部通过各自校验后，才发布 `forge-combined-checkpoint-1.0.0` manifest；失败路径不发布父 manifest 或 arm。
+
+## 组合 manifest
+
+- 固定 capture point 为 `after-actionable-submit-before-continuation`，父状态必须为 neutral。
+- message 组件固定 fixture identity/hash、neutral thread 和 canonical state hash。
+- environment 组件固定 run identity、manifest hash 与 continuation image ID。
+- budget 组件固定 checkpoint identity 与 manifest hash。
+- arm plan 同时固定 baseline/treatment 的 message thread、session 与 environment identity。
+- manifest 使用 canonical JSON SHA-256；运行时另保留 committed digest，拒绝重算 hash 后替换 arm plan。
+
+## 派生与恢复规则
+
+- 派生前和恢复前重新验证组合 manifest、三个组件 hash、neutral message next node 与 arm identity。
+- 每臂使用独立 message thread/session、environment overlay 和 budget runtime。
+- canonical initial combined state 屏蔽允许的 arm identity 与 feedback 差异后必须相同。
+- 任一臂环境写入、预算 claim 或恢复不得改变另一臂和只读父 manifest。
+- SQLite 关闭重开后从父 manifest 派生两臂，不重新 capture message/environment/budget。
+- fake continuation 前分别 claim 一个 graph step 和 compiler model turn；这只是预算计数，不构成 provider 请求或 token 消耗。
+
+## 通过条件
+
+- capture callback 顺序、共同 identity 与共同 message hash 被测试固定。
+- environment/budget 任一 callback 失败时不发布组合父状态或 arm。
+- baseline/treatment 初始 canonical combined state 相同，三层身份同步派生。
+- 冷恢复不重复 capture 前 submit；两臂 fake continuation 各执行一次且不能二次恢复。
+- environment overlay、预算 claim 和 message continuation 跨臂隔离，父 manifest 字节不变。
+- 组合 manifest、message fixture、environment manifest 或 budget manifest 在恢复前漂移时，先拒绝再消费预算。
+- provider calls、Docker calls、formal physical attempts 与 model tokens 均为 0。
+- 聚焦 pytest、消息/环境/预算原型相邻非 Docker 回归与 Ruff check/format 通过。
+
+## 失效条件
+
+- 三个组件只是独立调用，没有共同 capture identity/message state hash 或原子发布边界。
+- callback 失败后仍能派生 arm，或 arm identity 只修改消息层而未同步环境/预算层。
+- 任一臂写入或 claim 污染另一臂或父状态。
+- 组件漂移后仍执行 fake continuation或消费 continuation budget。
+- 发生真实 provider、Docker、formal attempt 或 model token 消耗。
+
+## 解释边界
+
+通过只证明三层实验原型可在一个确定性组合契约中原子绑定、派生和冷恢复；不证明真实 Compile Session/container 生命周期、provider client、网络连接或历史 actionable failure 可以端到端续跑，也不产生 verifier repair 因果效果。通过并合并后，下一阶段才评审真实生命周期接线，任何模型实验仍需独立预注册和授权。

--- a/scripts/forge_combined_checkpoint_prototype.py
+++ b/scripts/forge_combined_checkpoint_prototype.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""验证消息、环境与预算 checkpoint 原子绑定的非模型组合原型。"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import forge_budget_checkpoint_prototype as budget_checkpoint
+import forge_environment_checkpoint_prototype as environment_checkpoint
+import forge_failure_checkpoint_prototype as message_checkpoint
+
+SCHEMA_VERSION = "forge-combined-checkpoint-1.0.0"
+CAPTURE_POINT = "after-actionable-submit-before-continuation"
+ARMS = (message_checkpoint.BASELINE_ARM, message_checkpoint.TREATMENT_ARM)
+_IDENTIFIER_RE = re.compile(r"[a-z][a-z0-9-]{0,95}")
+
+CaptureCallback = Callable[[str, str], dict[str, Any]]
+
+
+class CombinedCheckpointError(RuntimeError):
+    pass
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def manifest_payload_sha256(manifest: dict[str, Any]) -> str:
+    payload = {key: value for key, value in manifest.items() if key != "manifest_sha256"}
+    return sha256_bytes(canonical_bytes(payload))
+
+
+def _require_exact_fields(value: Any, fields: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != fields:
+        raise CombinedCheckpointError(f"{label} fields do not match the frozen schema")
+    return value
+
+
+def _require_identifier(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER_RE.fullmatch(value) is None:
+        raise CombinedCheckpointError(f"{label} is invalid")
+    return value
+
+
+def _validate_arm_plan(value: Any) -> dict[str, Any]:
+    plan = _require_exact_fields(value, set(ARMS), "arm_plan")
+    seen: dict[str, set[str]] = {
+        "thread_id": set(),
+        "session_id": set(),
+        "environment_id": set(),
+    }
+    for arm in ARMS:
+        identity = _require_exact_fields(
+            plan[arm],
+            {"thread_id", "session_id", "environment_id"},
+            f"arm_plan.{arm}",
+        )
+        for field_name in seen:
+            value = _require_identifier(identity[field_name], f"arm_plan.{arm}.{field_name}")
+            if value in seen[field_name]:
+                raise CombinedCheckpointError(f"arm_plan {field_name} values must be unique")
+            seen[field_name].add(value)
+    return plan
+
+
+def validate_combined_manifest(value: Any) -> dict[str, Any]:
+    manifest = _require_exact_fields(
+        value,
+        {
+            "schema_version",
+            "manifest_sha256",
+            "capture_id",
+            "capture_point",
+            "neutral",
+            "components",
+            "arm_plan",
+        },
+        "combined manifest",
+    )
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise CombinedCheckpointError("combined manifest schema version is invalid")
+    capture_id = _require_identifier(manifest["capture_id"], "capture_id")
+    if manifest["capture_point"] != CAPTURE_POINT or manifest["neutral"] is not True:
+        raise CombinedCheckpointError("combined capture boundary is invalid")
+
+    components = _require_exact_fields(
+        manifest["components"],
+        {"message", "environment", "budget"},
+        "components",
+    )
+    message = _require_exact_fields(
+        components["message"],
+        {"fixture_id", "fixture_sha256", "canonical_state_sha256", "neutral_thread_id"},
+        "components.message",
+    )
+    for field_name in ("fixture_id", "fixture_sha256", "canonical_state_sha256", "neutral_thread_id"):
+        if not isinstance(message[field_name], str) or not message[field_name]:
+            raise CombinedCheckpointError(f"components.message.{field_name} is invalid")
+
+    environment = _require_exact_fields(
+        components["environment"],
+        {"run_id", "manifest_sha256", "continuation_image_id"},
+        "components.environment",
+    )
+    budget = _require_exact_fields(
+        components["budget"],
+        {"checkpoint_id", "manifest_sha256"},
+        "components.budget",
+    )
+    if environment["run_id"] != capture_id or budget["checkpoint_id"] != capture_id:
+        raise CombinedCheckpointError("component capture identities do not match capture_id")
+    if message["neutral_thread_id"] != f"{capture_id}-neutral":
+        raise CombinedCheckpointError("neutral message thread does not match capture_id")
+    for component, fields in ((environment, ("manifest_sha256", "continuation_image_id")), (budget, ("manifest_sha256",))):
+        for field_name in fields:
+            if not isinstance(component[field_name], str) or not component[field_name]:
+                raise CombinedCheckpointError(f"component {field_name} is invalid")
+
+    _validate_arm_plan(manifest["arm_plan"])
+    if manifest["manifest_sha256"] != manifest_payload_sha256(manifest):
+        raise CombinedCheckpointError("combined manifest SHA-256 does not match its payload")
+    return manifest
+
+
+@dataclass
+class ArmEnvironment:
+    identity: str
+    parent_manifest_sha256: str
+    rootfs_overlay: dict[str, str] = field(default_factory=dict)
+    workspace_overlay: dict[str, str] = field(default_factory=dict)
+    artifacts_overlay: dict[str, str] = field(default_factory=dict)
+
+    def write(self, layer: str, path: str, content: str) -> None:
+        if layer not in {"rootfs", "workspace", "artifacts"}:
+            raise CombinedCheckpointError(f"unknown environment layer: {layer}")
+        if not isinstance(path, str) or not path or path.startswith("/") or ".." in path.split("/"):
+            raise CombinedCheckpointError("environment overlay path is invalid")
+        getattr(self, f"{layer}_overlay")[path] = content
+
+    def canonical_state(self) -> dict[str, Any]:
+        return {
+            "parent_manifest_sha256": self.parent_manifest_sha256,
+            "rootfs_overlay": copy.deepcopy(self.rootfs_overlay),
+            "workspace_overlay": copy.deepcopy(self.workspace_overlay),
+            "artifacts_overlay": copy.deepcopy(self.artifacts_overlay),
+        }
+
+
+@dataclass
+class CombinedArm:
+    arm: str
+    message_config: dict[str, Any]
+    session_id: str
+    environment: ArmEnvironment
+    budget: budget_checkpoint.BudgetCheckpointRuntime
+    resumed: bool = False
+
+
+class CombinedCheckpointPrototype:
+    def __init__(
+        self,
+        fixture: dict[str, Any],
+        checkpointer: Any,
+        *,
+        environment_capture: CaptureCallback,
+        budget_capture: CaptureCallback,
+        counters: message_checkpoint.PrototypeCounters | None = None,
+    ) -> None:
+        self.counters = counters or message_checkpoint.PrototypeCounters()
+        self.message_runtime = message_checkpoint.FailureCheckpointPrototype(fixture, checkpointer, self.counters)
+        self.environment_capture = environment_capture
+        self.budget_capture = budget_capture
+        self.combined_manifest: dict[str, Any] | None = None
+        self.environment_manifest: dict[str, Any] | None = None
+        self.budget_manifest: dict[str, Any] | None = None
+        self.source_config: dict[str, Any] | None = None
+        self.arms: dict[str, CombinedArm] = {}
+        self._committed_manifest_sha256: str | None = None
+
+    @staticmethod
+    def _message_state_sha256(state: dict[str, Any]) -> str:
+        return sha256_bytes(canonical_bytes(message_checkpoint.serialize_checkpoint_state(state)))
+
+    @staticmethod
+    def _build_manifest(
+        *,
+        capture_id: str,
+        fixture: dict[str, Any],
+        message_state_sha256: str,
+        environment_manifest: dict[str, Any],
+        budget_manifest: dict[str, Any],
+        arm_plan: dict[str, Any],
+    ) -> dict[str, Any]:
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "manifest_sha256": "",
+            "capture_id": capture_id,
+            "capture_point": CAPTURE_POINT,
+            "neutral": True,
+            "components": {
+                "message": {
+                    "fixture_id": fixture["fixture_id"],
+                    "fixture_sha256": fixture["fixture_sha256"],
+                    "canonical_state_sha256": message_state_sha256,
+                    "neutral_thread_id": f"{capture_id}-neutral",
+                },
+                "environment": {
+                    "run_id": environment_manifest["run_id"],
+                    "manifest_sha256": environment_manifest["manifest_sha256"],
+                    "continuation_image_id": environment_manifest["continuation_image_id"],
+                },
+                "budget": {
+                    "checkpoint_id": budget_manifest["checkpoint_id"],
+                    "manifest_sha256": budget_manifest["manifest_sha256"],
+                },
+            },
+            "arm_plan": copy.deepcopy(arm_plan),
+        }
+        manifest["manifest_sha256"] = manifest_payload_sha256(manifest)
+        return validate_combined_manifest(manifest)
+
+    def capture(self, capture_id: str, arm_plan: dict[str, Any]) -> dict[str, Any]:
+        if self.combined_manifest is not None:
+            raise CombinedCheckpointError("combined checkpoint was already captured")
+        _require_identifier(capture_id, "capture_id")
+        _validate_arm_plan(arm_plan)
+
+        source_config = self.message_runtime.capture(f"{capture_id}-neutral")
+        source = self.message_runtime.graph.get_state(source_config)
+        if tuple(source.next) != (message_checkpoint.CONTINUATION_NODE,):
+            raise CombinedCheckpointError("message graph is not paused at the continuation boundary")
+        message_state_sha256 = self._message_state_sha256(source.values)
+
+        environment_manifest = environment_checkpoint.validate_checkpoint_manifest(self.environment_capture(capture_id, message_state_sha256))
+        budget_manifest = budget_checkpoint.validate_manifest(self.budget_capture(capture_id, message_state_sha256))
+        if environment_manifest["run_id"] != capture_id or budget_manifest["checkpoint_id"] != capture_id:
+            raise CombinedCheckpointError("capture callback identity drifted")
+        for arm in ARMS:
+            if environment_manifest["identities"].get(arm) != arm_plan[arm]["environment_id"]:
+                raise CombinedCheckpointError(f"environment identity drifted for {arm}")
+
+        manifest = self._build_manifest(
+            capture_id=capture_id,
+            fixture=self.message_runtime.fixture,
+            message_state_sha256=message_state_sha256,
+            environment_manifest=environment_manifest,
+            budget_manifest=budget_manifest,
+            arm_plan=arm_plan,
+        )
+        self.source_config = source_config
+        self.environment_manifest = copy.deepcopy(environment_manifest)
+        self.budget_manifest = copy.deepcopy(budget_manifest)
+        self.combined_manifest = copy.deepcopy(manifest)
+        self._committed_manifest_sha256 = manifest["manifest_sha256"]
+        return copy.deepcopy(manifest)
+
+    def restore_parent(
+        self,
+        *,
+        combined_manifest: dict[str, Any],
+        environment_manifest: dict[str, Any],
+        budget_manifest: dict[str, Any],
+    ) -> None:
+        if self.combined_manifest is not None:
+            raise CombinedCheckpointError("combined checkpoint was already restored")
+        combined = copy.deepcopy(validate_combined_manifest(combined_manifest))
+        environment = copy.deepcopy(environment_checkpoint.validate_checkpoint_manifest(environment_manifest))
+        budget = copy.deepcopy(budget_checkpoint.validate_manifest(budget_manifest))
+        self.combined_manifest = combined
+        self.environment_manifest = environment
+        self.budget_manifest = budget
+        self.source_config = self.message_runtime.config(combined["components"]["message"]["neutral_thread_id"])
+        self._committed_manifest_sha256 = combined["manifest_sha256"]
+        self._verify_parent()
+
+    def _verify_parent(self) -> None:
+        if any(
+            value is None
+            for value in (
+                self.combined_manifest,
+                self.environment_manifest,
+                self.budget_manifest,
+                self.source_config,
+                self._committed_manifest_sha256,
+            )
+        ):
+            raise CombinedCheckpointError("combined checkpoint is not committed")
+        assert self.combined_manifest is not None
+        assert self.environment_manifest is not None
+        assert self.budget_manifest is not None
+        assert self.source_config is not None
+        combined = validate_combined_manifest(self.combined_manifest)
+        if combined["manifest_sha256"] != self._committed_manifest_sha256:
+            raise CombinedCheckpointError("committed combined manifest drifted")
+        environment = environment_checkpoint.validate_checkpoint_manifest(self.environment_manifest)
+        budget = budget_checkpoint.validate_manifest(self.budget_manifest)
+        components = combined["components"]
+        if environment["manifest_sha256"] != components["environment"]["manifest_sha256"]:
+            raise CombinedCheckpointError("environment component drifted")
+        if budget["manifest_sha256"] != components["budget"]["manifest_sha256"]:
+            raise CombinedCheckpointError("budget component drifted")
+        fixture = message_checkpoint.validate_fixture(self.message_runtime.fixture)
+        if fixture["fixture_sha256"] != components["message"]["fixture_sha256"]:
+            raise CombinedCheckpointError("message fixture drifted")
+        source = self.message_runtime.graph.get_state(self.source_config)
+        if tuple(source.next) != (message_checkpoint.CONTINUATION_NODE,):
+            raise CombinedCheckpointError("neutral message checkpoint cannot resume")
+        if self._message_state_sha256(source.values) != components["message"]["canonical_state_sha256"]:
+            raise CombinedCheckpointError("neutral message state drifted")
+
+    def derive_arm(self, arm: str) -> CombinedArm:
+        if arm not in ARMS:
+            raise CombinedCheckpointError("combined checkpoint arm is invalid")
+        if arm in self.arms:
+            raise CombinedCheckpointError(f"combined checkpoint arm already exists: {arm}")
+        self._verify_parent()
+        assert self.combined_manifest is not None
+        assert self.environment_manifest is not None
+        assert self.budget_manifest is not None
+        assert self.source_config is not None
+        identity = self.combined_manifest["arm_plan"][arm]
+
+        environment = ArmEnvironment(
+            identity=identity["environment_id"],
+            parent_manifest_sha256=self.environment_manifest["manifest_sha256"],
+        )
+        budget = budget_checkpoint.BudgetCheckpointRuntime(
+            self.budget_manifest,
+            arm,
+            budget_checkpoint.FakeClock(),
+        )
+        message_config = self.message_runtime.derive_arm(
+            self.source_config,
+            arm=arm,
+            session_id=identity["session_id"],
+            thread_id=identity["thread_id"],
+        )
+        combined_arm = CombinedArm(
+            arm=arm,
+            message_config=message_config,
+            session_id=identity["session_id"],
+            environment=environment,
+            budget=budget,
+        )
+        self.arms[arm] = combined_arm
+        self._verify_arm(combined_arm)
+        return combined_arm
+
+    def _verify_arm(self, combined_arm: CombinedArm) -> None:
+        self._verify_parent()
+        assert self.combined_manifest is not None
+        identity = self.combined_manifest["arm_plan"][combined_arm.arm]
+        state = self.message_runtime.graph.get_state(combined_arm.message_config)
+        if state.values.get("arm") != combined_arm.arm or state.values.get("session_id") != identity["session_id"]:
+            raise CombinedCheckpointError("message arm identity drifted")
+        if combined_arm.message_config["configurable"]["thread_id"] != identity["thread_id"]:
+            raise CombinedCheckpointError("message thread identity drifted")
+        if combined_arm.environment.identity != identity["environment_id"]:
+            raise CombinedCheckpointError("environment arm identity drifted")
+        if combined_arm.budget.arm != combined_arm.arm:
+            raise CombinedCheckpointError("budget arm identity drifted")
+        if combined_arm.budget.manifest["manifest_sha256"] != self.combined_manifest["components"]["budget"]["manifest_sha256"]:
+            raise CombinedCheckpointError("arm budget parent drifted")
+
+    def canonical_initial_state(self, arm: str) -> dict[str, Any]:
+        combined_arm = self.arms[arm]
+        self._verify_arm(combined_arm)
+        message_state = self.message_runtime.graph.get_state(combined_arm.message_config).values
+        return {
+            "combined_manifest_sha256": self._committed_manifest_sha256,
+            "message": message_checkpoint.canonical_state_for_pairing(message_state),
+            "environment": combined_arm.environment.canonical_state(),
+            "budget": budget_checkpoint.canonical_initial_budget(combined_arm.budget),
+        }
+
+    def resume_arm(self, arm: str) -> dict[str, Any]:
+        combined_arm = self.arms[arm]
+        if combined_arm.resumed:
+            raise CombinedCheckpointError(f"combined checkpoint arm already resumed: {arm}")
+        self._verify_arm(combined_arm)
+        combined_arm.budget.claim("graph_recursion_steps")
+        combined_arm.budget.claim("compiler_model_turns")
+        result = self.message_runtime.resume(combined_arm.message_config)
+        combined_arm.resumed = True
+        return result
+
+    def external_counts(self) -> dict[str, int]:
+        return {
+            "provider_calls": self.counters.provider_calls,
+            "docker_calls": self.counters.docker_calls,
+            "formal_physical_attempts": self.counters.physical_attempts,
+            "model_tokens": 0,
+        }


### PR DESCRIPTION
## 概要

- 新增实验专用三层 combined checkpoint 原型，将 message、environment、budget 绑定到同一 neutral capture
- 只有三个组件全部校验成功后才发布组合 manifest，并同步派生两臂的 message/session/environment/budget identity
- 验证 SQLite 冷恢复、跨臂隔离、capture 前副作用不重复和组件漂移失败关闭
- 新增预注册与项目状态快照

## 研究边界

- 0 provider calls
- 0 Docker calls
- 0 formal physical attempts
- 0 model tokens
- 不修改生产 Compiler、Compile Session、_ACTIVE_EXPERIMENTS、Oracle、clean replay 或自然任务 ITT runner
- 本 PR 不授权 provider canary、mechanism slots、样本量、随机顺序或 token ceiling

## 验证

- 聚焦测试：10 passed
- 消息、环境、预算、组合 checkpoint 相邻非 Docker 回归：37 passed, 1 skipped
- Ruff check：通过
- Ruff format check：通过
- py_compile：通过
- git diff --check：通过

固定组合 manifest SHA-256：

bb1f6f4da5868e2e33ef1caf8c34a4645fc06641b5577669edf94f75f8449738

Closes #141