### PR TITLE
研究：增加 controlled fault v1 零 provider 门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -11,7 +11,8 @@
   - 真实门禁: `cppitertools@531b3d7` 先生成并暂存 required artifact，再确定性删除 `/artifacts` 中唯一文件；真实 submit 产生 pre-replay `candidate_verification_failed`，同一 committed checkpoint 派生的 baseline/treatment 独立恢复后均通过 candidate verification 与 clean replay。
   - 证据: Ubuntu 原生 daemon gate 为 `provider=ubuntu-native`、`/var/run/docker.sock`；真实 Docker 用例 `1 passed in 90.23s`，相邻回归 `19 passed, 1 skipped`，Ruff check/format 通过，最终无 compile/checkpoint container、continuation image 或 snapshot 残留。
   - 边界: `provider_canary_authorized=false`、`collection_authorized=false`；实际 0 provider calls、0 formal physical attempts、0 model tokens，未读取或输出 AK。候选只描述最多 1 次 reachability request、1 个 controlled pair 和 245,000 tokens，不构成授权。
-  - 下一步: 完成中文本地提交；推送和创建中文 PR 前再次取得实验负责人授权。PR 合并后才单独申请最小 provider canary，canary 通过也不自动授权 6-pair pilot。
+  - 发布: 中文提交 `139f8de4` 已由 WSL helper 第一次推送成功；中文 PR #148 已创建并回读，`Closes #147`、base/head、提交 identity 和正文均正确，三项 CI 已启动。
+  - 下一步: 等待 PR #148 CI；CI 通过后请求实验负责人单独确认合并。合并后才单独申请最小 provider canary，canary 通过也不自动授权 6-pair pilot。
   - 文件: `scripts/forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_docker.py`, `benchmarks/preregistrations/cpp-verifier-controlled-fault-v1-gate.md`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-18 — 制定 Issue #145 failure checkpoint 机制实验决策包
-  - GitHub: PR #144 已 squash 合并为 `main@eb643c4d`，Issue #143 自动关闭；中文 Issue #145 已创建并回读，当前分支为 `research/145-checkpoint-mechanism-decision-package`。
-  - 决策: natural 与 controlled stratum 分开；推荐 primary 单 provider 6-pair controlled pilot，之后再用第二 provider 做 3-pair 独立复制，不做模型排名。
-  - 预算: 每 arm 最多 8 requests、8 turns、24 graph steps、600 秒 work、120 秒 cleanup、120,000 tokens；primary reachability + mechanism canary + pilot 的 expected/maximum ceiling 为 845,000/1,685,000 tokens。
-  - 边界: 当前 `collection_authorized=false`、`provider_canary_authorized=false`，实际 0 provider、0 formal attempt、0 model token、0 Docker；clean-replay mismatch 不纳入。
-  - 发布: 本地提交 `3d9fa5d5` 已由 WSL helper 一次推送；中文 PR #146 已创建并回读，`Closes #145`、base/head 与提交身份正确，backend unit tests、backend lint、frontend lint 三项 CI 全部通过。
-  - 下一步: 等待实验负责人单独确认合并 PR #146；合并后另开中文 Issue，先实现 controlled fault v1 的 0-provider 非模型 gate，任何 canary 仍需单独授权。
-  - 文件: `benchmarks/preregistrations/cpp-verifier-checkpoint-mechanism-decision-package.md`
+- 2026-08-18 — 完成 Issue #147 controlled fault v1 的零 provider 本地门禁
+  - GitHub: PR #146 已 squash 合并为 `main@b10a3857`，Issue #145 自动关闭；中文 Issue #147 已创建并回读，当前分支为 `research/147-controlled-fault-v1-gate`。
+  - 实现: 新增薄 controlled-fault adapter、非 Docker 契约测试、opt-in Ubuntu Docker gate、预注册和未授权 primary canary manifest；复用 #143 的真实 lifecycle checkpoint、真实 verifier、Compile Session 和 clean replay，不修改生产 Compiler、Oracle、自然任务 ITT runner、历史 evidence 或 `_ACTIVE_EXPERIMENTS`。
+  - 真实门禁: `cppitertools@531b3d7` 先生成并暂存 required artifact，再确定性删除 `/artifacts` 中唯一文件；真实 submit 产生 pre-replay `candidate_verification_failed`，同一 committed checkpoint 派生的 baseline/treatment 独立恢复后均通过 candidate verification 与 clean replay。
+  - 证据: Ubuntu 原生 daemon gate 为 `provider=ubuntu-native`、`/var/run/docker.sock`；真实 Docker 用例 `1 passed in 90.23s`，相邻回归 `19 passed, 1 skipped`，Ruff check/format 通过，最终无 compile/checkpoint container、continuation image 或 snapshot 残留。
+  - 边界: `provider_canary_authorized=false`、`collection_authorized=false`；实际 0 provider calls、0 formal physical attempts、0 model tokens，未读取或输出 AK。候选只描述最多 1 次 reachability request、1 个 controlled pair 和 245,000 tokens，不构成授权。
+  - 下一步: 完成中文本地提交；推送和创建中文 PR 前再次取得实验负责人授权。PR 合并后才单独申请最小 provider canary，canary 通过也不自动授权 6-pair pilot。
+  - 文件: `scripts/forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_docker.py`, `benchmarks/preregistrations/cpp-verifier-controlled-fault-v1-gate.md`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -384,6 +384,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- `CompileDockerRuntime.create_container()` 的 bind source 不会代替测试创建 `session.leadagent_repo_dir`；若目录缺失，容器能创建但首次以 `/workspace/repo` 为 cwd 的 exec 会在 OCI 层失败。真实 Docker fixture 必须在 create 前执行 `Path(session.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)`；这种失败发生在 fault、submit、checkpoint 和 replay 前，不能计入机制门禁结果。
 - WSL 冷启动或手动启动 `docker.service` 后，daemon 恢复已有容器可能需要 5-10 秒；启动命令返回后应等待 `systemctl is-active docker.service` 为 `active` 再运行正式 gate，不能把 `activating` 窗口误判为永久失败，也不能切换 Docker Desktop。
 - Docker 29 使用 `docker commit --no-pause`，旧的 `--pause=false` 会输出弃用提示并污染严格 SHA 解析。恢复后的 `0640 root:root` 文件由只读 helper tar 观测，不能为了测试方便 `chmod/chown` 被测目录。
 - 一次性正式入口必须先用最终完全相同的 `/app/backend/.venv/bin/python` 完成零请求 import、runner `--help` 与挂载内 preflight；双 provider canary 外层等待不得短于 700 秒。manifest 声明 300 秒不等于模型对象已生效，必须在请求前验证模型及底层 client 的有效 timeout/retry；调试级短超时、系统 `python` 和仅核对 endpoint 的 preflight 都不能作为放行依据。

--- a/backend/tests/test_forge_controlled_fault_v1_docker.py
+++ b/backend/tests/test_forge_controlled_fault_v1_docker.py
@@ -1,0 +1,377 @@
+"""Issue #147 controlled fault v1 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices, submit_build_result_impl
+from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_workspace_dir
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+COMPILE_IMAGE = "autocompiler:gcc13"
+CASE_ID = "cppitertools"
+REPOSITORY_URL = "https://github.com/ryanhaining/cppitertools"
+COMMIT_SHA = "531b3d753d2bbfe3b0ababe61c2e95e965c54a66"
+DOCKER_INTEGRATION_ENABLED = os.getenv("FORGE_RUN_CONTROLLED_FAULT_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_INTEGRATION_ENABLED,
+    reason="set FORGE_RUN_CONTROLLED_FAULT_DOCKER=1 to run the controlled fault Docker gate",
+)
+
+
+def _load_module(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+fault_module = _load_module("forge_controlled_fault_v1_gate_docker", "forge_controlled_fault_v1_gate.py")
+lifecycle_module = _load_module("forge_real_lifecycle_checkpoint_gate_controlled", "forge_real_lifecycle_checkpoint_gate.py")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_docker_and_compile_image():
+    if not DOCKER_INTEGRATION_ENABLED:
+        yield
+        return
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Docker daemon is unavailable: {daemon.stderr.strip()}")
+    image = subprocess.run(
+        ["docker", "image", "inspect", COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _budget_manifest(capture_id: str, _message_sha256: str) -> dict:
+    return lifecycle_module.budget_checkpoint.build_manifest(
+        checkpoint_id=capture_id,
+        limits={
+            "provider_requests": 8,
+            "compiler_invocations": 2,
+            "compiler_model_turns": 8,
+            "graph_recursion_steps": 24,
+            "attempt_wall_clock_seconds": 720,
+            "attempt_cleanup_reserve_seconds": 120,
+            "compiler_wall_clock_seconds": 720,
+            "compiler_post_build_reserve_seconds": 120,
+            "post_build_commands": 2,
+        },
+        consumed_before_capture={
+            "provider_requests": 0,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 1,
+            "graph_recursion_steps": 3,
+            "attempt_wall_clock_seconds": 10,
+            "compiler_wall_clock_seconds": 5,
+            "post_build_commands": 0,
+            "tokens": 0,
+        },
+        post_build_started=True,
+    )
+
+
+def _arm_plan(capture_id: str) -> dict:
+    return {
+        "baseline": {
+            "thread_id": f"baseline-{capture_id}-thread",
+            "session_id": f"baseline-{capture_id}-session",
+            "environment_id": f"baseline-{capture_id}-environment",
+        },
+        "treatment": {
+            "thread_id": f"treatment-{capture_id}-thread",
+            "session_id": f"treatment-{capture_id}-session",
+            "environment_id": f"treatment-{capture_id}-environment",
+        },
+    }
+
+
+def _record_command(*, manager, runtime, session, command: str, role: str) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(session, command, workdir="/workspace/repo", timeout_seconds=300)
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir="/workspace/repo",
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=300,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def test_controlled_fault_capture_two_arm_restore_and_cleanup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    capture_id = f"faultv1-{uuid.uuid4().hex[:12]}"
+    workspace = tmp_path / "workspace"
+    paths = Paths(base_dir=tmp_path / ".deer-flow", workspace_root=workspace, host_workspace_root=str(workspace))
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    runner = lifecycle_module.environment_checkpoint.DockerCLI()
+    session = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=REPOSITORY_URL,
+        image=COMPILE_IMAGE,
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "controlled-fault-ledger.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-147-controlled-fault-docker-gate"},
+    )
+    active = False
+    arm_sessions = []
+    continuation_images: set[str] = set()
+    snapshot = tmp_path / "snapshot"
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    try:
+        Path(session.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(session)
+        manager.save_session(session)
+        assert session.image_id is not None
+        clone = runtime.exec(
+            session,
+            "git config --global --add safe.directory /workspace/repo && "
+            "git init . && "
+            "git remote add origin https://github.com/ryanhaining/cppitertools && "
+            "git fetch --depth 1 origin 531b3d753d2bbfe3b0ababe61c2e95e965c54a66 && "
+            "git checkout --detach FETCH_HEAD",
+            workdir="/workspace/repo",
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        session.commit_sha = COMMIT_SHA
+        session.build_system = "cmake"
+        session.build_system_capabilities = ["cmake"]
+        session.selected_build_system = "cmake"
+        session.status = "inspected"
+        manager.save_session(session)
+
+        _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command="cmake -S examples -B build -DCMAKE_BUILD_TYPE=Release",
+            role="configure",
+        )
+        supporting = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command="cmake --build build --target accumulate_examples -j2",
+            role="build",
+        )
+        _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command="cp build/accumulate_examples /artifacts/accumulate_examples",
+            role="artifact_stage",
+        )
+
+        policy = ExperimentPolicy(
+            benchmark_id="forge-controlled-fault-v1-gate",
+            manifest_sha256="7" * 64,
+            case_id=CASE_ID,
+            condition="controlled-fault-v1",
+            repetition=1,
+            expected_repo_url=REPOSITORY_URL,
+            expected_commit_sha=COMMIT_SHA,
+            expected_build_system="cmake",
+            compile_image=COMPILE_IMAGE,
+            image_id=session.image_id,
+            model_name="deterministic-no-provider",
+            endpoint="https://example.invalid/v1",
+            credential_env="UNUSED_PROVIDER_KEY",
+            request_timeout_seconds=1,
+            model_max_retries=0,
+            compiler_max_turns=8,
+            subagent_timeout_seconds=600,
+            memory_enabled=False,
+            skills_enabled=False,
+            required_system_packages=(),
+            cmake_arguments=("-DCMAKE_BUILD_TYPE=Release",),
+            configure_arguments=(),
+            environment=(),
+            minimum_replay_delay_seconds=0,
+        )
+        activate_experiment(
+            thread_id=session.thread_id,
+            experiment_id=ledger.experiment_id,
+            physical_attempt_id=ledger.physical_attempt_id,
+            ledger=ledger,
+            policy=policy,
+        )
+        active = True
+        fault = fault_module.ControlledFaultV1(
+            fault_module.ControlledFaultSpec(
+                case_id=CASE_ID,
+                build_output_relative_path="build/accumulate_examples",
+                staged_relative_path="accumulate_examples",
+                artifact_type="executable",
+            )
+        )
+        fault_manifest = fault.inject(session=session, ledger=ledger, fault_id=new_evidence_id("fault"))
+        assert fault_manifest["state"]["staged_artifact_present"] is False
+
+        submit_results: list[str] = []
+
+        def submit() -> str:
+            result = submit_build_result_impl(session=session, supporting_command_id=supporting.command_id)
+            submit_results.append(result)
+            return result
+
+        def evidence() -> dict:
+            result = fault_module.validate_actionable_failure(ledger=ledger, session=session)
+            result["session_sha256"] = lifecycle_module.sha256_file(Path(session.metadata_path))
+            result["fault_state_sha256"] = fault_manifest["fault_state_sha256"]
+            return result
+
+        coordinator = lifecycle_module.CaptureCoordinator(tmp_path / "coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(tmp_path / "messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = lifecycle_module.LifecycleMessageRuntime(
+                saver,
+                submit,
+                repair_packet={
+                    "schema_version": "forge-verifier-repair-packet-1.0.0",
+                    "primary_classification": "candidate_verification_failed",
+                },
+            )
+            environment = lifecycle_module.LifecycleEnvironmentAdapter(
+                runner,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=str(snapshot),
+            )
+            gate = lifecycle_module.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=_budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="coordinator-controlled-fault",
+            )
+            manifest = gate.capture(
+                capture_id=capture_id,
+                session=session,
+                instruction="freeze the controlled artifact staging failure before continuation",
+                arm_plan=_arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(session.session_id, session.thread_id, paths),
+                    "artifacts": get_host_artifacts_dir(session.session_id, session.thread_id, paths),
+                    "logs": get_host_logs_dir(session.session_id, session.thread_id, paths),
+                    "repro": get_host_repro_dir(session.session_id, session.thread_id, paths),
+                },
+                evidence=evidence,
+            )
+            continuation_images.add(manifest["environment"]["continuation_image_id"])
+            assert len(submit_results) == 1
+            assert json.loads(submit_results[0])["candidate_status"] == "failed"
+            assert session.replay_attempts == []
+
+            baseline = gate.provision_arm(capture_id, "baseline", parent_session=session)
+            treatment = gate.provision_arm(capture_id, "treatment", parent_session=session)
+            arm_sessions.extend([baseline.session, treatment.session])
+            assert gate.canonical_arm_environment("baseline") == gate.canonical_arm_environment("treatment")
+            assert list(Path(baseline.session.leadagent_artifacts_dir).iterdir()) == []
+            assert list(Path(treatment.session.leadagent_artifacts_dir).iterdir()) == []
+
+            fault.restore_arm(session=baseline.session, runtime=runtime)
+            assert list(Path(treatment.session.leadagent_artifacts_dir).iterdir()) == []
+            fault.restore_arm(session=treatment.session, runtime=runtime)
+            baseline_result = fault_module.validate_arm_submit_result(submit_build_result_impl(session=baseline.session, supporting_command_id=supporting.command_id))
+            treatment_result = fault_module.validate_arm_submit_result(submit_build_result_impl(session=treatment.session, supporting_command_id=supporting.command_id))
+            assert baseline_result["artifacts"][0]["sha256"] == treatment_result["artifacts"][0]["sha256"]
+            assert len(baseline.session.replay_attempts) == 1
+            assert len(treatment.session.replay_attempts) == 1
+
+            cleaned = gate.cleanup(capture_id, parent_session=session)
+            assert cleaned.phase == "cleaned"
+            assert gate.external_counts() == {"provider_calls": 0, "formal_physical_attempts": 0, "model_tokens": 0}
+    finally:
+        if active:
+            deactivate_experiment(session.thread_id)
+        for arm_session in arm_sessions:
+            runtime.stop_and_remove_container(arm_session)
+        runtime.stop_and_remove_container(session)
+        for container_id in runner.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle_module.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split():
+            runner.run(["rm", "-f", container_id], check=False, timeout_seconds=30)
+        for image_id in continuation_images | set(
+            runner.run(
+                ["image", "ls", "-q", "--filter", f"label={lifecycle_module.CAPTURE_LABEL}={capture_id}"],
+                check=False,
+                timeout_seconds=30,
+            ).stdout.split()
+        ):
+            runner.run(["image", "rm", "-f", image_id], check=False, timeout_seconds=60)
+
+    assert (
+        runner.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle_module.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )
+    assert (
+        runner.run(
+            ["image", "ls", "-q", "--filter", f"label={lifecycle_module.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )
+    assert not snapshot.exists()

--- a/backend/tests/test_forge_controlled_fault_v1_gate.py
+++ b/backend/tests/test_forge_controlled_fault_v1_gate.py
@@ -1,0 +1,152 @@
+"""Issue #147 controlled fault v1 的非 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from deerflow.compile.evidence import ExperimentLedger, new_evidence_id
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+MODULE_PATH = SCRIPTS_DIR / "forge_controlled_fault_v1_gate.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_controlled_fault_v1_gate", MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate_module = _load_module()
+
+
+class Session:
+    def __init__(self, root: Path) -> None:
+        self.session_id = "session-controlled-fault"
+        self.leadagent_repo_dir = str(root / "workspace/repo")
+        self.leadagent_artifacts_dir = str(root / "artifacts")
+        self.replay_attempts = []
+
+
+def _fixture(tmp_path: Path) -> tuple[Session, ExperimentLedger]:
+    session = Session(tmp_path)
+    output = Path(session.leadagent_repo_dir) / "build/example.a"
+    staged = Path(session.leadagent_artifacts_dir) / "example.a"
+    output.parent.mkdir(parents=True)
+    staged.parent.mkdir(parents=True)
+    output.write_bytes(b"deterministic-static-library")
+    staged.write_bytes(output.read_bytes())
+    ledger = ExperimentLedger.create(
+        tmp_path / "controlled-fault.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-147-non-provider-gate"},
+    )
+    return session, ledger
+
+
+def _fault() -> object:
+    return gate_module.ControlledFaultV1(
+        gate_module.ControlledFaultSpec(
+            case_id="fixture",
+            build_output_relative_path="build/example.a",
+            staged_relative_path="example.a",
+            artifact_type="static_library",
+        ),
+        classifier=lambda _path: "static_library",
+    )
+
+
+def test_injects_only_staging_fault_and_records_safe_deterministic_state(tmp_path: Path) -> None:
+    session, ledger = _fixture(tmp_path)
+    manifest = _fault().inject(session=session, ledger=ledger, fault_id="fault_fixture")
+
+    assert (Path(session.leadagent_repo_dir) / "build/example.a").is_file()
+    assert list(Path(session.leadagent_artifacts_dir).iterdir()) == []
+    assert manifest["state"]["workspace_artifact_present"] is True
+    assert manifest["state"]["staged_artifact_present"] is False
+    assert manifest["fault_state_sha256"] == gate_module.sha256_bytes(gate_module.canonical_bytes(manifest["state"]))
+    event = ledger.read()[-1]
+    assert event["event"] == "controlled.fault_injected"
+    assert event["payload"]["fault_state_sha256"] == manifest["fault_state_sha256"]
+    encoded = json.dumps(event, ensure_ascii=False).lower()
+    for forbidden in ("stdout", "stderr", "authorization", "api_key", "secret", str(tmp_path).lower()):
+        assert forbidden not in encoded
+
+
+def test_rejects_mismatched_or_extra_staged_artifacts(tmp_path: Path) -> None:
+    session, ledger = _fixture(tmp_path)
+    staged = Path(session.leadagent_artifacts_dir) / "example.a"
+    staged.write_bytes(b"different")
+    with pytest.raises(gate_module.ControlledFaultGateError, match="differ"):
+        _fault().inject(session=session, ledger=ledger, fault_id="fault_mismatch")
+
+    staged.write_bytes((Path(session.leadagent_repo_dir) / "build/example.a").read_bytes())
+    (staged.parent / "extra.a").write_bytes(b"extra")
+    with pytest.raises(gate_module.ControlledFaultGateError, match="exactly"):
+        _fault().inject(session=session, ledger=ledger, fault_id="fault_extra")
+
+
+def test_actionable_failure_validation_requires_one_pre_replay_failure(tmp_path: Path) -> None:
+    session, ledger = _fixture(tmp_path)
+    submit_id = new_evidence_id("submit")
+    ledger.append(
+        "submit.completed",
+        {
+            "submit_attempt_id": submit_id,
+            "supporting_command_id": None,
+            "session_id": session.session_id,
+            "status": "failed",
+            "candidate_status": "failed",
+            "command_cutoff": 0,
+            "command_ids": [],
+            "artifacts": [],
+            "checks": [],
+            "recipe_sha256": None,
+            "replay": None,
+            "gates": {"exit_code": False, "candidate_only": False, "replay_ready": False, "clean_replay": False, "delivered": None},
+        },
+    )
+    failure_id = new_evidence_id("failure")
+    ledger.append(
+        "failure.recorded",
+        {
+            "failure_id": failure_id,
+            "submit_attempt_id": submit_id,
+            "replay_attempt_id": None,
+            "session_id": session.session_id,
+            "domain": "verification",
+            "classification": "candidate_verification_failed",
+            "primary": True,
+            "secondary_classifications": [],
+        },
+    )
+
+    evidence = gate_module.validate_actionable_failure(ledger=ledger, session=session)
+    assert evidence["submit_attempt_id"] == submit_id
+    assert evidence["failure_id"] == failure_id
+    assert evidence["classification"] == "candidate_verification_failed"
+
+
+def test_canary_candidate_is_strictly_unauthorized_and_hash_bound() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    gate_module.validate_canary_candidate(manifest)
+    for artifact in manifest["protocol_artifacts"]:
+        assert gate_module.sha256_file(REPO_ROOT / artifact["path"]) == artifact["sha256"]
+
+
+def test_source_does_not_import_provider_or_formal_runner() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert "create_chat_model" not in source
+    assert "formal_collection_runner" not in source
+    assert "DEEPSEEK_API_KEY" not in source

--- a/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "forge-checkpoint-primary-canary-candidate-1.0.0",
+  "document_type": "forge_checkpoint_primary_canary_candidate",
+  "scope": {
+    "provider_canary_authorized": false,
+    "collection_authorized": false,
+    "provider_calls": 0,
+    "formal_physical_attempts": 0,
+    "model_tokens": 0
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden"
+  },
+  "fault": {
+    "version": "controlled-fault-v1",
+    "family": "artifact_staging_missing",
+    "expected_classification": "candidate_verification_failed",
+    "capture_point": "after-neutral-tool-message-before-continuation",
+    "replay_attempts_required": 0
+  },
+  "continuation": {
+    "checkpoint_pairs": 1,
+    "arms_per_pair": 2,
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "budget": {
+    "reachability_requests": 1,
+    "reachability_expected_tokens": 5000,
+    "reachability_maximum_tokens": 5000,
+    "mechanism_canary_expected_tokens": 120000,
+    "mechanism_canary_maximum_tokens": 240000,
+    "stage_expected_tokens": 125000,
+    "stage_maximum_tokens": 245000
+  },
+  "stopping": {
+    "provider_timeout_stops_canary": true,
+    "incomplete_pair_stops_canary": true,
+    "cleanup_or_identity_failure_stops_canary": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "canary_pass_does_not_authorize_pilot": true
+  },
+  "protocol_artifacts": [
+    {
+      "path": "scripts/forge_controlled_fault_v1_gate.py",
+      "sha256": "3dd4b2495cb21594f9348aaf8416dc17c57f6aa850f14b739049b030bc4d9f2d"
+    },
+    {
+      "path": "backend/tests/test_forge_controlled_fault_v1_gate.py",
+      "sha256": "0ad92e10ca364c27247b7db2082a6fa8ecce0efa56f94524aefb32904f5dec54"
+    },
+    {
+      "path": "backend/tests/test_forge_controlled_fault_v1_docker.py",
+      "sha256": "e0d9b686e920ec4005c6300d2bbf068a1ca36b76831a6028a1f9b4540ca9665e"
+    },
+    {
+      "path": "benchmarks/preregistrations/cpp-verifier-controlled-fault-v1-gate.md",
+      "sha256": "5b0d5d2a2c3f7dc10447372a25614b639b7976e75f312f88c551af5abcf94fac"
+    }
+  ]
+}

--- a/benchmarks/preregistrations/cpp-verifier-controlled-fault-v1-gate.md
+++ b/benchmarks/preregistrations/cpp-verifier-controlled-fault-v1-gate.md
@@ -1,0 +1,41 @@
+# Verifier-driven repair controlled fault v1 零 provider 门禁预注册
+
+## 研究问题
+
+Issue #145 已冻结 checkpoint 机制实验设计。本门禁只回答：能否在真实、可恢复的 C/C++ build output 已存在时，确定性移除 `/artifacts` 中唯一 required artifact，由真实 verifier 产生 pre-replay `candidate_verification_failed`，再从同一 committed checkpoint 派生两个隔离 arm 并恢复正确 staging。
+
+## 冻结范围
+
+- 跟踪 Issue：#147。
+- fault family：`artifact_staging_missing`；expected classification：`candidate_verification_failed`。
+- Provider calls、formal physical attempts、model tokens 均为 0；不读取任何 AK。
+- Docker 只允许 WSL2 Ubuntu 原生 `docker.service`，不使用 Docker Desktop 或 Windows Docker CLI。
+- 不修改生产 Compiler、自然任务 ITT runner、Oracle、clean replay、历史 evidence 或 `_ACTIVE_EXPERIMENTS`。
+- 只新增薄的 controlled-fault adapter、聚焦测试和未授权 primary canary manifest 候选；复用 Issue #143 的真实 lifecycle gate。
+
+## Fault 契约
+
+1. 冻结 recipe 先生成真实 required artifact，并把同一字节复制到 `/artifacts`。
+2. 注入前，workspace output 与 staged artifact 的类型和 SHA-256 必须相同，`/artifacts` 只能包含该文件。
+3. fault 只删除 staged artifact，workspace output 和容器 rootfs 保持不变。
+4. 调用 verifier 前写入 `controlled.fault_injected`；payload 只含 case/session/fault identity、相对路径、artifact type、SHA-256 和布尔状态。
+5. 真实 submit 必须只发生一次，产生 `candidate_status=failed`、无 replay、`candidate_verification_failed`，且 `replay_attempts == 0`。
+
+## 恢复门禁
+
+- baseline/treatment 从同一个 committed message/environment/budget checkpoint 派生。
+- 两臂初始 canonical environment 相同，`/artifacts` 均为空，workspace output 均存在。
+- 非模型恢复动作只把 workspace output 复制到 arm-local `/artifacts`；任一臂不得污染另一臂或父 snapshot。
+- 两臂分别调用真实 submit，candidate verification 与 clean replay 均应通过。
+- cleanup 后无 paused/orphan container、continuation image、helper 或 snapshot。
+
+## Canary candidate 边界
+
+机器可读候选为 `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json`。它固定 primary provider 候选、1 次 reachability request、1 个 controlled pair 和 245,000 maximum tokens，但 `provider_canary_authorized=false`、`collection_authorized=false`。本 gate 通过不会自动授权任何请求。
+
+## 通过与停止
+
+- 聚焦非 Docker 测试、checkpoint/lifecycle 相邻回归和 Ruff 必须通过。
+- 唯一 opt-in Docker gate 使用冻结的 `cppitertools@531b3d7...` CMake recipe；网络/daemon/image preflight 失败时停止，不切换 Docker daemon，不把基础设施失败解释为 fault 失败。
+- submit 重复、classification/replay 漂移、arm 污染、敏感信息进入 evidence 或 cleanup 遗留均立即失败。
+- 通过只证明 controlled fault v1 与 checkpoint 生命周期可供后续 canary 使用，不产生 repair effect 结论。

--- a/scripts/forge_controlled_fault_v1_gate.py
+++ b/scripts/forge_controlled_fault_v1_gate.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""验证 controlled artifact-staging fault 的零 provider 门禁。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCHEMA_VERSION = "forge-controlled-fault-v1-1.0.0"
+FAULT_FAMILY = "artifact_staging_missing"
+EXPECTED_CLASSIFICATION = "candidate_verification_failed"
+CANARY_SCHEMA_VERSION = "forge-checkpoint-primary-canary-candidate-1.0.0"
+
+
+class ControlledFaultGateError(RuntimeError):
+    pass
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative_path(value: str, label: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ControlledFaultGateError(f"{label} must be a safe relative path")
+    return path.as_posix()
+
+
+@dataclass(frozen=True)
+class ControlledFaultSpec:
+    case_id: str
+    build_output_relative_path: str
+    staged_relative_path: str
+    artifact_type: str
+
+    def validate(self) -> ControlledFaultSpec:
+        if not self.case_id or not self.case_id.replace("-", "").isalnum():
+            raise ControlledFaultGateError("case_id is invalid")
+        _safe_relative_path(self.build_output_relative_path, "build_output_relative_path")
+        _safe_relative_path(self.staged_relative_path, "staged_relative_path")
+        if self.artifact_type not in {"executable", "shared_library", "static_library", "object"}:
+            raise ControlledFaultGateError("artifact_type is invalid")
+        return self
+
+
+class ControlledFaultV1:
+    """只移除 staged artifact，并将白名单事实写入现有实验 ledger。"""
+
+    def __init__(self, spec: ControlledFaultSpec, *, classifier: Callable[[Path], str | None] | None = None) -> None:
+        self.spec = spec.validate()
+        self.classifier = classifier or self._default_classifier
+
+    @staticmethod
+    def _default_classifier(path: Path) -> str | None:
+        from deerflow.compile.operations import _classify_compiled_artifact
+
+        return _classify_compiled_artifact(path)
+
+    def _paths(self, session: Any) -> tuple[Path, Path]:
+        workspace_artifact = Path(session.leadagent_repo_dir) / self.spec.build_output_relative_path
+        staged_artifact = Path(session.leadagent_artifacts_dir) / self.spec.staged_relative_path
+        return workspace_artifact, staged_artifact
+
+    def inject(self, *, session: Any, ledger: Any, fault_id: str) -> dict[str, Any]:
+        if not isinstance(fault_id, str) or not fault_id.startswith("fault_"):
+            raise ControlledFaultGateError("fault_id is invalid")
+        workspace_artifact, staged_artifact = self._paths(session)
+        if not workspace_artifact.is_file() or not staged_artifact.is_file():
+            raise ControlledFaultGateError("fault requires matching workspace and staged artifacts")
+        workspace_type = self.classifier(workspace_artifact)
+        staged_type = self.classifier(staged_artifact)
+        if workspace_type != self.spec.artifact_type or staged_type != self.spec.artifact_type:
+            raise ControlledFaultGateError("pre-fault artifact type does not match the frozen oracle")
+        workspace_sha256 = sha256_file(workspace_artifact)
+        staged_sha256 = sha256_file(staged_artifact)
+        if workspace_sha256 != staged_sha256:
+            raise ControlledFaultGateError("workspace and staged artifacts differ before fault injection")
+        artifact_root = Path(session.leadagent_artifacts_dir)
+        staged_files = sorted(path.relative_to(artifact_root).as_posix() for path in artifact_root.rglob("*") if path.is_file())
+        if staged_files != [self.spec.staged_relative_path]:
+            raise ControlledFaultGateError("fault v1 requires exactly the frozen staged artifact")
+
+        staged_artifact.unlink()
+        remaining_files = sorted(path.relative_to(artifact_root).as_posix() for path in artifact_root.rglob("*") if path.is_file())
+        if remaining_files:
+            raise ControlledFaultGateError("fault v1 did not produce an empty artifacts directory")
+
+        state = {
+            "fault_family": FAULT_FAMILY,
+            "case_id": self.spec.case_id,
+            "artifact_type": self.spec.artifact_type,
+            "build_output_relative_path": self.spec.build_output_relative_path,
+            "staged_relative_path": self.spec.staged_relative_path,
+            "workspace_artifact_sha256": workspace_sha256,
+            "staged_artifact_sha256_before_fault": staged_sha256,
+            "workspace_artifact_present": True,
+            "staged_artifact_present": False,
+        }
+        state_sha256 = sha256_bytes(canonical_bytes(state))
+        event = ledger.append(
+            "controlled.fault_injected",
+            {
+                "fault_id": fault_id,
+                "session_id": session.session_id,
+                **state,
+                "fault_state_sha256": state_sha256,
+            },
+        )
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "fault_id": fault_id,
+            "session_id": session.session_id,
+            "state": state,
+            "fault_state_sha256": state_sha256,
+            "evidence_sequence": event["sequence"],
+            "evidence_event_sha256": event["event_sha256"],
+        }
+        manifest["manifest_sha256"] = sha256_bytes(canonical_bytes(manifest))
+        return manifest
+
+    def restore_arm(self, *, session: Any, runtime: Any) -> None:
+        source = f"/workspace/repo/{self.spec.build_output_relative_path}"
+        target = f"/artifacts/{self.spec.staged_relative_path}"
+        command = f"mkdir -p -- {shlex.quote(str(PurePosixPath(target).parent))} && cp -- {shlex.quote(source)} {shlex.quote(target)}"
+        result = runtime.exec(session, command, workdir="/workspace/repo", timeout_seconds=60)
+        if result.exit_code != 0:
+            raise ControlledFaultGateError("failed to restore the arm artifact staging")
+        workspace_artifact, staged_artifact = self._paths(session)
+        if not staged_artifact.is_file() or sha256_file(staged_artifact) != sha256_file(workspace_artifact):
+            raise ControlledFaultGateError("restored arm artifact differs from the workspace output")
+
+
+def validate_actionable_failure(*, ledger: Any, session: Any) -> dict[str, Any]:
+    events = ledger.read()
+    submits = [event for event in events if event["event"] == "submit.completed"]
+    failures = [event for event in events if event["event"] == "failure.recorded"]
+    if len(submits) != 1 or len(failures) != 1:
+        raise ControlledFaultGateError("controlled fault must produce exactly one submit and one failure")
+    submit = submits[0]
+    failure = failures[0]
+    payload = submit["payload"]
+    if payload["status"] != "failed" or payload["candidate_status"] != "failed" or payload["replay"] is not None:
+        raise ControlledFaultGateError("controlled fault did not stop at a pre-replay candidate failure")
+    if failure["payload"]["classification"] != EXPECTED_CLASSIFICATION or failure["payload"]["submit_attempt_id"] != payload["submit_attempt_id"]:
+        raise ControlledFaultGateError("controlled fault classification or submit identity drifted")
+    if session.replay_attempts:
+        raise ControlledFaultGateError("controlled fault unexpectedly created a replay attempt")
+    return {
+        "submit_attempt_id": payload["submit_attempt_id"],
+        "failure_id": failure["payload"]["failure_id"],
+        "classification": EXPECTED_CLASSIFICATION,
+        "submit_sequence": submit["sequence"],
+        "failure_sequence": failure["sequence"],
+        "ledger_head_sha256": events[-1]["event_sha256"],
+        "ledger_sequence": events[-1]["sequence"],
+    }
+
+
+def validate_arm_submit_result(value: str) -> dict[str, Any]:
+    result = json.loads(value)
+    if result.get("status") != "passed" or result.get("candidate_status") != "passed" or result.get("replay_status") != "passed":
+        raise ControlledFaultGateError("restored arm did not pass candidate verification and clean replay")
+    return result
+
+
+def validate_canary_candidate(value: dict[str, Any]) -> dict[str, Any]:
+    required = {"schema_version", "document_type", "scope", "provider", "fault", "continuation", "budget", "stopping", "protocol_artifacts"}
+    if set(value) != required or value.get("schema_version") != CANARY_SCHEMA_VERSION:
+        raise ControlledFaultGateError("canary candidate schema is invalid")
+    scope = value["scope"]
+    if scope != {
+        "provider_canary_authorized": False,
+        "collection_authorized": False,
+        "provider_calls": 0,
+        "formal_physical_attempts": 0,
+        "model_tokens": 0,
+    }:
+        raise ControlledFaultGateError("canary candidate must remain completely unauthorized")
+    provider = value["provider"]
+    if provider.get("model") != "deepseek-v4-flash" or provider.get("request_timeout_seconds") != 300 or provider.get("max_retries") != 0:
+        raise ControlledFaultGateError("primary provider candidate drifted")
+    fault = value["fault"]
+    if fault.get("family") != FAULT_FAMILY or fault.get("expected_classification") != EXPECTED_CLASSIFICATION or fault.get("replay_attempts_required") != 0:
+        raise ControlledFaultGateError("controlled fault candidate drifted")
+    continuation = value["continuation"]
+    if continuation != {
+        "checkpoint_pairs": 1,
+        "arms_per_pair": 2,
+        "maximum_requests_per_arm": 8,
+        "maximum_model_turns_per_arm": 8,
+        "maximum_graph_steps_per_arm": 24,
+        "work_wall_clock_seconds_per_arm": 600,
+        "cleanup_reserve_seconds_per_arm": 120,
+        "maximum_recorded_tokens_per_arm": 120000,
+    }:
+        raise ControlledFaultGateError("continuation budget drifted")
+    budget = value["budget"]
+    if budget != {
+        "reachability_requests": 1,
+        "reachability_expected_tokens": 5000,
+        "reachability_maximum_tokens": 5000,
+        "mechanism_canary_expected_tokens": 120000,
+        "mechanism_canary_maximum_tokens": 240000,
+        "stage_expected_tokens": 125000,
+        "stage_maximum_tokens": 245000,
+    }:
+        raise ControlledFaultGateError("canary token budget drifted")
+    if (
+        budget["stage_expected_tokens"] != budget["reachability_expected_tokens"] + budget["mechanism_canary_expected_tokens"]
+        or budget["stage_maximum_tokens"] != budget["reachability_maximum_tokens"] + budget["mechanism_canary_maximum_tokens"]
+    ):
+        raise ControlledFaultGateError("canary token arithmetic drifted")
+    if value["stopping"].get("canary_pass_does_not_authorize_pilot") is not True:
+        raise ControlledFaultGateError("pilot authorization boundary is missing")
+    artifacts = value["protocol_artifacts"]
+    if not isinstance(artifacts, list) or not artifacts or any(set(item) != {"path", "sha256"} for item in artifacts):
+        raise ControlledFaultGateError("protocol artifact identities are invalid")
+    return value


### PR DESCRIPTION
## 变更概述

- 新增 controlled fault v1 薄适配层：保留真实 workspace build output，仅确定性删除 `/artifacts` 中唯一 required artifact。
- 复用 Issue #143 的真实 lifecycle checkpoint、Compile Session、预算、SQLite coordinator、verifier 与 clean replay，不修改生产 Compiler、Oracle、自然任务 ITT runner、历史 evidence 或 `_ACTIVE_EXPERIMENTS`。
- 真实 submit 在 replay 前产生 `candidate_verification_failed`；baseline/treatment 从同一 committed checkpoint 派生，各自恢复 artifact 后均通过 candidate verification 与 clean replay。
- 新增未授权 primary canary manifest 候选，固定最多 1 次 reachability request、1 个 controlled checkpoint pair 和 245,000 tokens；authorization flags 保持 false。

## 验证

- Ubuntu 原生 Docker 门禁：`provider=ubuntu-native`，endpoint 为 `/var/run/docker.sock`，未使用 Docker Desktop。
- 真实 opt-in Docker gate：`1 passed in 90.23s`。
- checkpoint/lifecycle 相邻回归：`19 passed, 1 skipped`。
- Ruff format/check 通过，协议文件哈希绑定与敏感信息检查通过。
- cleanup 后无 compile/checkpoint container、continuation image 或 snapshot 残留。

## 实验边界

本变更实际为 0 provider calls、0 formal physical attempts、0 model tokens，未读取或输出 AK。合并本 PR 不自动授权 reachability canary、mechanism canary 或后续 6-pair pilot。

Closes #147