### PR TITLE
修复：兼容 Windows bind 的 checkpoint 构建目录

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,15 +5,13 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-18 — 完成 Issue #149 primary mechanism canary 的本地实现与零 provider 门禁
-  - GitHub: PR #148 已 squash 合并为 `main@fd89d1e6`，Issue #147 自动关闭；中文 Issue #149 已创建并回读，当前分支为 `research/149-checkpoint-primary-canary`。
-  - 实现: 新增授权 manifest、预注册和实验专用 runner；一次性 reachability marker 通过后才允许一个 baseline/treatment controlled checkpoint pair，真实 provider 又受 clean `main == origin/main`、Compose/DooD、冻结 evidence 目录和 protocol artifact hash 门禁。
-  - 预算: DeepSeek `deepseek-v4-flash`、`https://api.deepseek.com`、`DEEPSEEK_API_KEY`、300 秒 timeout、0 retry；每臂 8 requests/8 turns/24 graph steps、600 秒 work + 120 秒 cleanup、120,000 tokens，阶段总上限 245,000 tokens；禁止 fallback/replacement/backfill。
-  - 机制: treatment 只比 baseline 多 schema-valid repair packet；两个 arm 从同一 message/environment/budget checkpoint 派生，使用独立 Session/container/ledger 和内存 checkpointer。runner 强制 actual-model、endpoint、timeout/retry、token、pair completeness 和 cleanup 终态。
-  - 证据: 聚焦 `9 passed, 1 skipped`、相邻回归 `48 passed`、Ruff 通过；Ubuntu 原生 Docker fake-model pair 最终代码复验通过，结果为 `1 passed in 93.18s`，checkpoint container/image/paused 均为 0。manifest SHA-256 为 `2771e72eee45ca6eac7bc1e7d5040cf5633bb3bf7e24a186a44071d9a98ce579`。
-  - 边界: 实际 0 provider calls、0 model tokens、0 formal physical attempts，未读取 AK；本地分支不能通过 release identity 门禁。后续 6-pair pilot、RichLab、natural stratum 均未授权。
-  - 下一步: 中文本地提交已完成，等待实验负责人单独确认推送；创建 PR 和后续合并仍分别确认。只有授权内容进入干净主干后才执行唯一 reachability，失败立即停止，通过才执行唯一 pair。
-  - 文件: `scripts/forge_checkpoint_primary_canary.py`, `backend/tests/test_forge_checkpoint_primary_canary.py`, `backend/tests/test_forge_checkpoint_primary_canary_docker.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-authorized.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary.md`
+- 2026-08-19 — 修复 checkpoint canary 在 Windows bind 上的 CMake 构建目录冲突
+  - GitHub: 中文 Issue #151 已在修改前创建并回读；当前分支为 `fix/151-checkpoint-windows-build-dir`，基线为 `main@1ae32b50`。
+  - 实现: 新增版本化 build-layout adapter，只在私有加载的 v1 runner 上把三条已审计 parent 命令和 `BUILD_OUTPUT` 切换到 `.forge-cmake-build`，退出上下文后恢复；Issue #149 冻结 runner、测试、manifest 与 evidence 逐字不变。
+  - 证据: 新单元与相邻回归 `31 passed`，Ruff check/format 通过；真实 Compose + Windows bind gate 先确认 `BUILD`/`build` 冲突，再以 fake model 完成 parent build、checkpoint、两臂恢复、candidate verification、clean replay 和 cleanup，结果为 `1 passed in 126.91s`。
+  - 资源: 结束后 compile/checkpoint/prototype/paused container 与 checkpoint/prototype image 均为 0，测试目录已精确清理；实际 0 provider calls、0 model tokens、0 formal physical attempts，未读取 AK。
+  - 下一步: 中文本地提交已完成，等待实验负责人单独确认推送；PR 与合并仍分别确认。工程修复合并后另开中文 Issue 预注册 amendment，不能复用 Issue #149 已消费的 reachability/pair marker。
+  - 文件: `scripts/forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -73,6 +71,10 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-19 — 终结 Issue #149 primary mechanism canary
+  - 文件: `scripts/forge_checkpoint_primary_canary.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-authorized.json`
+  - 动机: 唯一 reachability 已通过；唯一 controlled pair 在 parent configure、任何 arm/provider 请求之前因 Windows bind 上 `BUILD`/`build` 冲突失败关闭。原 marker、ledger、report 与 workflow evidence 保持不变，不重试、replacement 或 backfill。
 
 - 2026-08-18 — 冻结并合并 controlled fault v1 零 provider gate
   - 文件: `scripts/forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_gate.py`, `backend/tests/test_forge_controlled_fault_v1_docker.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-candidate.json`
@@ -390,6 +392,8 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- Windows bind/DrvFS 目录大小写不敏感；上游若跟踪 `BUILD`，CMake `-B build` 会解析到同一普通文件。checkpoint canary 使用 `.forge-cmake-build`，并必须在真实 Compose `/workspace/.compile-sessions` 挂载上做 parity gate，不能再用 WSL ext4 `tmp_path` 代替。
+- Issue #149 runner 和测试的 SHA-256 已冻结在授权 manifest。跨阶段修复必须新增版本化 adapter/test，不能原地修改冻结文件或更新旧 manifest hash；后续 provider 运行还需要独立 amendment identity 与新授权。
 - Windows 工作树中的 `backend/.venv` 是 Linux 虚拟环境布局，没有 `Scripts/python.exe`；不要直接把它当 Windows venv，也不要省略 PowerShell 相对可执行路径所需的 `./`。先用 `Get-Command`/`Test-Path` 确认，再固定通过 WSL 调用 `./backend/.venv/bin/python` 和 `ruff`。
 - Compose/DooD checkpoint 同时存在服务容器路径 `/workspace/.compile-sessions/...` 与 Docker daemon 可见的 WSL 宿主路径 `$HOST_PROJECT_ROOT/.compile-sessions/...`；snapshot bind 必须显式做相对路径转换，不能把容器路径原样交给 daemon。
 - controlled parent 通过脚手架直接执行 build 时不会自动进入 bound tool 的 post-build phase；派生 arm 前必须持久化成功 build 的 `supporting_command_id`、开始时间和剩余命令预算，否则模型恢复 artifact 后无法自动触发 submit/clean replay。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -10,7 +10,8 @@
   - 实现: 新增版本化 build-layout adapter，只在私有加载的 v1 runner 上把三条已审计 parent 命令和 `BUILD_OUTPUT` 切换到 `.forge-cmake-build`，退出上下文后恢复；Issue #149 冻结 runner、测试、manifest 与 evidence 逐字不变。
   - 证据: 新单元与相邻回归 `31 passed`，Ruff check/format 通过；真实 Compose + Windows bind gate 先确认 `BUILD`/`build` 冲突，再以 fake model 完成 parent build、checkpoint、两臂恢复、candidate verification、clean replay 和 cleanup，结果为 `1 passed in 126.91s`。
   - 资源: 结束后 compile/checkpoint/prototype/paused container 与 checkpoint/prototype image 均为 0，测试目录已精确清理；实际 0 provider calls、0 model tokens、0 formal physical attempts，未读取 AK。
-  - 下一步: 中文本地提交已完成，等待实验负责人单独确认推送；PR 与合并仍分别确认。工程修复合并后另开中文 Issue 预注册 amendment，不能复用 Issue #149 已消费的 reachability/pair marker。
+  - 发布: 中文修复提交 `c0dd7b28` 已通过 `scripts/push-via-wsl.ps1` 第一次推送成功；本地 HEAD、远端跟踪分支与 GitHub ref 已核验一致。
+  - 下一步: 等待实验负责人单独授权创建中文 PR；合并仍需另行确认。工程修复合并后另开中文 Issue 预注册 amendment，不能复用 Issue #149 已消费的 reachability/pair marker。
   - 文件: `scripts/forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复

--- a/backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py
+++ b/backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py
@@ -1,0 +1,202 @@
+"""Issue #151 的 opt-in Compose + Windows bind 零 provider parity gate。"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-authorized.json"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_CHECKPOINT_WINDOWS_BIND_PARITY") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_CHECKPOINT_WINDOWS_BIND_PARITY=1 inside Forge Compose",
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+primary = _load_module(
+    "forge_checkpoint_primary_canary_windows_bind_test",
+    SCRIPTS_ROOT / "forge_checkpoint_primary_canary.py",
+)
+layout = _load_module(
+    "forge_checkpoint_windows_build_layout_docker_test",
+    SCRIPTS_ROOT / "forge_checkpoint_windows_build_layout.py",
+)
+
+
+class RestoreAndSubmitModel(BaseChatModel):
+    model_name: str = "deepseek-v4-flash"
+    base_url: str = "https://api.deepseek.com"
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "checkpoint-windows-bind-fake"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("successful automatic submit 后不应再次调用 fake model")
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "run_container_bash",
+                                "args": {
+                                    "command": ("cp .forge-cmake-build/accumulate_examples /artifacts/accumulate_examples"),
+                                    "timeout_seconds": 60,
+                                    "workdir": "/workspace/repo",
+                                    "command_role": "artifact_stage",
+                                },
+                                "id": "restore-controlled-artifact",
+                                "type": "tool_call",
+                            }
+                        ],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={
+                            "input_tokens": 100,
+                            "output_tokens": 20,
+                            "total_tokens": 120,
+                        },
+                    )
+                )
+            ]
+        )
+
+
+class ReachabilityModel:
+    def invoke(self, _prompt: str) -> AIMessage:
+        return AIMessage(
+            content="CANARY_OK",
+            response_metadata={"model_name": "deepseek-v4-flash"},
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "total_tokens": 12,
+            },
+        )
+
+
+def test_safe_layout_matches_real_compose_windows_bind_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary.require_compose_dood()
+    paths = Paths()
+    shared_root = paths.compile_sessions_dir
+    run_suffix = uuid.uuid4().hex[:12]
+    output_dir = shared_root / f"issue-151-parity-{run_suffix}"
+    probe_dir = shared_root / f"issue-151-casefold-probe-{run_suffix}"
+    created_session_dirs: list[Path] = []
+    manager = CompileSessionManager(paths=paths, default_image=primary.COMPILE_IMAGE)
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_session_dirs.append(Path(session.metadata_path).parent)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    release = {
+        "branch": "main",
+        "revision": "d" * 40,
+        "origin_main": "d" * 40,
+    }
+    monkeypatch.setattr(primary, "require_release_identity", lambda *_args: release)
+    monkeypatch.setattr(primary, "require_authorized_output_dir", lambda *_args: None)
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+
+    try:
+        probe_dir.mkdir(parents=True)
+        tracked_build = probe_dir / "BUILD"
+        tracked_build.write_text("tracked Bazel file\n", encoding="utf-8")
+        legacy_binary_dir = probe_dir / "build"
+        assert legacy_binary_dir.is_file()
+        with pytest.raises(FileExistsError):
+            legacy_binary_dir.mkdir()
+
+        manifest = primary.load_manifest(MANIFEST_PATH)
+        with layout.use_windows_safe_build_layout(primary):
+            primary.run_reachability(
+                manifest,
+                output_dir=output_dir,
+                model_factory=lambda _provider: ReachabilityModel(),
+            )
+            result = primary.run_controlled_pair(
+                manifest,
+                output_dir=output_dir,
+                model_factory=lambda _provider, _thread_id: RestoreAndSubmitModel(),
+            )
+
+        assert result["passed"] is True
+        assert result["complete_pair"] is True
+        assert result["cleanup_succeeded"] is True
+        assert result["pilot_denominator_contribution"] == 0
+        assert [arm["recorded_tokens"] for arm in result["arms"]] == [120, 120]
+        assert result["stage_recorded_tokens"] == 252
+    finally:
+        for session_dir in reversed(created_session_dirs):
+            shutil.rmtree(session_dir, ignore_errors=True)
+            thread_dir = session_dir.parent
+            try:
+                thread_dir.rmdir()
+            except OSError:
+                pass
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(probe_dir, ignore_errors=True)

--- a/backend/tests/test_forge_checkpoint_windows_build_layout.py
+++ b/backend/tests/test_forge_checkpoint_windows_build_layout.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+PRIMARY_SCRIPT = SCRIPTS_ROOT / "forge_checkpoint_primary_canary.py"
+LAYOUT_SCRIPT = SCRIPTS_ROOT / "forge_checkpoint_windows_build_layout.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-authorized.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+primary = _load_module("forge_checkpoint_primary_canary_layout_test", PRIMARY_SCRIPT)
+layout = _load_module("forge_checkpoint_windows_build_layout_test", LAYOUT_SCRIPT)
+
+
+def test_frozen_v1_artifacts_remain_byte_identical() -> None:
+    manifest = primary.load_manifest(MANIFEST_PATH)
+    primary.verify_frozen_artifacts(manifest, REPO_ROOT)
+
+
+def test_layout_adapter_rewrites_only_the_frozen_parent_commands() -> None:
+    calls: list[str] = []
+
+    def fake_record_command(*_args: Any, **kwargs: Any) -> str:
+        calls.append(kwargs["command"])
+        return kwargs["command"]
+
+    original_record_command = primary._record_command
+    primary._record_command = fake_record_command
+    try:
+        with layout.use_windows_safe_build_layout(primary):
+            assert primary.BUILD_OUTPUT == ".forge-cmake-build/accumulate_examples"
+            primary._record_command(command="cmake -S examples -B build -DCMAKE_BUILD_TYPE=Release")
+            primary._record_command(command="cmake --build build --target accumulate_examples -j2")
+            primary._record_command(command="cp build/accumulate_examples /artifacts/accumulate_examples")
+            primary._record_command(command="git status --short")
+        assert primary.BUILD_OUTPUT == "build/accumulate_examples"
+        assert primary._record_command is fake_record_command
+    finally:
+        primary._record_command = original_record_command
+
+    assert calls == [
+        "cmake -S examples -B .forge-cmake-build -DCMAKE_BUILD_TYPE=Release",
+        "cmake --build .forge-cmake-build --target accumulate_examples -j2",
+        ("cp .forge-cmake-build/accumulate_examples /artifacts/accumulate_examples"),
+        "git status --short",
+    ]
+
+
+def test_layout_updates_policy_and_fault_output_without_changing_manifest() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest_before = primary.canonical_sha256(manifest)
+
+    with layout.use_windows_safe_build_layout(primary):
+        policy = primary._policy(
+            manifest,
+            arm="baseline",
+            image_id="sha256:" + "1" * 64,
+        )
+        assert policy.artifact_instructions == (
+            (
+                "accumulate_examples",
+                ".forge-cmake-build/accumulate_examples",
+                "executable",
+            ),
+        )
+
+    assert primary.canonical_sha256(manifest) == manifest_before

--- a/scripts/forge_checkpoint_windows_build_layout.py
+++ b/scripts/forge_checkpoint_windows_build_layout.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""为 checkpoint primary canary 提供 Windows bind 安全的 CMake 构建布局。"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any
+
+CMAKE_BINARY_DIR = ".forge-cmake-build"
+BUILD_OUTPUT_RELATIVE_PATH = f"{CMAKE_BINARY_DIR}/accumulate_examples"
+LEGACY_BUILD_OUTPUT_RELATIVE_PATH = "build/accumulate_examples"
+
+_COMMAND_REWRITES = {
+    "cmake -S examples -B build -DCMAKE_BUILD_TYPE=Release": (f"cmake -S examples -B {CMAKE_BINARY_DIR} -DCMAKE_BUILD_TYPE=Release"),
+    "cmake --build build --target accumulate_examples -j2": (f"cmake --build {CMAKE_BINARY_DIR} --target accumulate_examples -j2"),
+    "cp build/accumulate_examples /artifacts/accumulate_examples": (f"cp {BUILD_OUTPUT_RELATIVE_PATH} /artifacts/accumulate_examples"),
+}
+
+
+class BuildLayoutError(RuntimeError):
+    """冻结 parent runner 与适配器的预期不一致。"""
+
+
+def rewrite_parent_build_command(command: str) -> str:
+    """只替换冻结 v1 runner 中已审计的三条 parent 构建命令。"""
+
+    return _COMMAND_REWRITES.get(command, command)
+
+
+@contextmanager
+def use_windows_safe_build_layout(primary_canary: ModuleType) -> Iterator[ModuleType]:
+    """在私有加载的 v1 runner 上临时应用新布局，并在退出时恢复。"""
+
+    original_output = getattr(primary_canary, "BUILD_OUTPUT", None)
+    original_record_command = getattr(primary_canary, "_record_command", None)
+    if original_output != LEGACY_BUILD_OUTPUT_RELATIVE_PATH or not callable(original_record_command):
+        raise BuildLayoutError("checkpoint primary canary v1 build layout drifted")
+
+    def record_command(*args: Any, **kwargs: Any) -> Any:
+        command = kwargs.get("command")
+        if not isinstance(command, str):
+            raise BuildLayoutError("parent build command must be passed by keyword")
+        kwargs["command"] = rewrite_parent_build_command(command)
+        return original_record_command(*args, **kwargs)
+
+    primary_canary.BUILD_OUTPUT = BUILD_OUTPUT_RELATIVE_PATH
+    primary_canary._record_command = record_command
+    try:
+        yield primary_canary
+    finally:
+        primary_canary.BUILD_OUTPUT = original_output
+        primary_canary._record_command = original_record_command


### PR DESCRIPTION
## 变更概述

- 新增版本化 build-layout adapter，将 controlled parent 的 CMake binary dir 从 `build` 切换为 `.forge-cmake-build`，同步更新构建、产物暂存、fault source 与双臂恢复路径。
- adapter 只在私有加载的 v1 runner 上精确替换三条已审计命令和 `BUILD_OUTPUT`，退出上下文后恢复原状态。
- 新增单元门禁与真实 Compose + Windows bind parity gate，覆盖 tracked `BUILD` 与小写 `build` 在大小写不敏感宿主挂载上的冲突。
- Issue #149 的冻结 runner、测试、authorized manifest、marker、ledger、report 与 evidence 保持不变。

## 验证

- 新单元与 checkpoint 相邻回归：`31 passed`。
- Ruff check/format 通过，`git diff --check` 通过。
- 真实 `deer-flow-dev` Compose + Windows bind gate：`1 passed in 126.91s`。
- gate 先确定性复现 `BUILD`/`build` 冲突，再完成 parent build、checkpoint capture、baseline/treatment 恢复、candidate verification、clean replay 与 cleanup。
- 最终 compile/checkpoint/prototype/paused container 与 checkpoint/prototype image 均为 0。

## 实验边界

本变更实际为 0 provider calls、0 formal physical attempts、0 model tokens，未读取 AK，也没有创建或消费新的 provider marker。该门禁只证明 Windows bind 环境 parity 已修复，不提供模型或 verifier-driven repair 效果证据。

合并后如需新的 provider canary，必须另开中文 Issue，版本化预注册 amendment、独立 evidence 目录、一次性 marker 与 token ceiling，并重新取得明确授权；不得复用或回填 Issue #149 已消费的机会，6-pair pilot 仍未授权。

Closes #151