### PR TITLE
研究：预注册 failure checkpoint primary canary amendment 候选

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-19 — 修复 checkpoint canary 在 Windows bind 上的 CMake 构建目录冲突
-  - GitHub: 中文 Issue #151 已在修改前创建并回读；当前分支为 `fix/151-checkpoint-windows-build-dir`，基线为 `main@1ae32b50`。
-  - 实现: 新增版本化 build-layout adapter，只在私有加载的 v1 runner 上把三条已审计 parent 命令和 `BUILD_OUTPUT` 切换到 `.forge-cmake-build`，退出上下文后恢复；Issue #149 冻结 runner、测试、manifest 与 evidence 逐字不变。
-  - 证据: 新单元与相邻回归 `31 passed`，Ruff check/format 通过；真实 Compose + Windows bind gate 先确认 `BUILD`/`build` 冲突，再以 fake model 完成 parent build、checkpoint、两臂恢复、candidate verification、clean replay 和 cleanup，结果为 `1 passed in 126.91s`。
-  - 资源: 结束后 compile/checkpoint/prototype/paused container 与 checkpoint/prototype image 均为 0，测试目录已精确清理；实际 0 provider calls、0 model tokens、0 formal physical attempts，未读取 AK。
-  - 发布: 中文修复提交 `c0dd7b28` 已通过 `scripts/push-via-wsl.ps1` 第一次推送成功；本地 HEAD、远端跟踪分支与 GitHub ref 已核验一致。
-  - 下一步: 等待实验负责人单独授权创建中文 PR；合并仍需另行确认。工程修复合并后另开中文 Issue 预注册 amendment，不能复用 Issue #149 已消费的 reachability/pair marker。
-  - 文件: `scripts/forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py`
+- 2026-08-19 — 预注册 failure checkpoint primary canary amendment 候选
+  - GitHub: 中文 Issue #153 已在修改前创建并回读；当前分支为 `research/153-checkpoint-primary-canary-amendment`，基线为 `main@c7217e20`。
+  - 决策: Issue #149 的 reachability 绑定旧 manifest 与 `main@1ae32b50`，不在新 amendment 中复用。候选提出独立的一次 reachability、一个 controlled pair 和 245,000 recorded-token maximum，但全部授权位保持 `false`。
+  - 实现: 新 candidate manifest、预注册与只读 validator 固定旧四文件 evidence identity、新目录/marker、PR #152 build-layout adapter 和父协议；CLI 只有 `generate`、`validate`、`validate-evidence`，没有 provider 执行入口。
+  - 证据: candidate canonical SHA-256 为 `d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704`；真实旧 evidence 只读核验 4/4 通过，相邻回归 `17 passed`，Ruff check/format、diff 与敏感信息检查通过。
+  - 边界: 0 provider calls、0 model tokens、0 formal physical attempts、0 Docker，未读取 AK；不创建新 marker/ledger/report，不授权 6-pair pilot。
+  - 下一步: 中文本地提交已完成，等待实验负责人单独授权推送；PR、合并与后续 245,000-token provider canary 仍分别确认。
+  - 文件: `scripts/forge_checkpoint_primary_canary_amendment.py`, `backend/tests/test_forge_checkpoint_primary_canary_amendment.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -72,6 +72,11 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-19 — 合并 Windows bind checkpoint 构建目录修复
+  - 文件: `scripts/forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py`
+  - 动机: tracked `BUILD` 与 CMake 小写 `build` 在 Windows bind 上冲突，使 Issue #149 pair 在 arm/provider 前环境删失。
+  - 结果: 中文 PR #152 三项 CI 全绿后 squash 合并为 `main@c7217e20`，Issue #151 自动关闭；本地主干与 `origin/main` 同步一致。
 
 - 2026-08-19 — 终结 Issue #149 primary mechanism canary
   - 文件: `scripts/forge_checkpoint_primary_canary.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-authorized.json`

--- a/backend/tests/test_forge_checkpoint_primary_canary_amendment.py
+++ b/backend/tests/test_forge_checkpoint_primary_canary_amendment.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_checkpoint_primary_canary_amendment.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-candidate.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_checkpoint_primary_canary_amendment_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+amendment = _load_module()
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_candidate_is_deterministic_unauthorized_and_parent_frozen() -> None:
+    manifest = _manifest()
+
+    assert amendment.validate_manifest(manifest) == manifest
+    assert amendment.generate_manifest() == manifest
+    amendment.verify_frozen_components(manifest)
+    assert manifest["scope"]["provider_canary_authorized"] is False
+    assert manifest["scope"]["mechanism_canary_authorized"] is False
+    assert manifest["scope"]["pilot_collection_authorized"] is False
+    assert manifest["amendment"]["budget"]["stage_maximum_tokens"] == 245_000
+    assert manifest["amendment"]["reachability_policy"] == "new_request_required_after_separate_authorization"
+
+
+def test_candidate_rejects_authorization_reuse_or_budget_expansion() -> None:
+    manifest = _manifest()
+    manifest["scope"]["provider_canary_authorized"] = True
+    with pytest.raises(amendment.AmendmentError, match="冻结候选协议"):
+        amendment.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["amendment"]["reachability_policy"] = "reuse_parent"
+    with pytest.raises(amendment.AmendmentError, match="冻结候选协议"):
+        amendment.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["amendment"]["budget"]["stage_maximum_tokens"] += 1
+    with pytest.raises(amendment.AmendmentError, match="冻结候选协议"):
+        amendment.validate_manifest(manifest)
+
+
+def test_new_evidence_and_markers_are_isolated_from_parent() -> None:
+    manifest = _manifest()
+    parent = manifest["parent"]["terminal_evidence"]
+    execution = manifest["amendment"]["execution"]
+
+    assert execution["evidence_directory"] != parent["directory"]
+    parent_names = {Path(item["path"]).name for item in parent["files"]}
+    assert execution["reachability_marker"] not in parent_names
+    assert execution["controlled_pair_marker"] not in parent_names
+
+
+def test_superseded_evidence_requires_exact_files_hashes_and_semantics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    expected_files = {item["path"]: item["sha256"] for item in manifest["parent"]["terminal_evidence"]["files"]}
+    marker_identity = {
+        "manifest_sha256": amendment.PARENT_MANIFEST_SHA256,
+        "release_revision": amendment.PARENT_RELEASE_REVISION,
+    }
+    documents = {
+        "markers/reachability-attempt.json": {**marker_identity, "status": "passed", "error_class": None},
+        "markers/controlled-pair-attempt.json": {**marker_identity, "status": "failed", "error_class": "CanaryError"},
+        "reports/reachability.json": {
+            **marker_identity,
+            "passed": True,
+            "actual_model": "deepseek-v4-flash",
+            "request_count": 1,
+            "recorded_tokens": 17,
+        },
+        "ledgers/parent.jsonl": {},
+    }
+    for relative_path, document in documents.items():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(document) + "\n", encoding="utf-8")
+
+    original_file_sha256 = amendment.file_sha256
+
+    def evidence_sha256(path: Path) -> str:
+        if path.is_relative_to(tmp_path):
+            return expected_files[path.relative_to(tmp_path).as_posix()]
+        return original_file_sha256(path)
+
+    monkeypatch.setattr(amendment, "file_sha256", evidence_sha256)
+    assert amendment.verify_superseded_evidence(manifest, tmp_path)["file_count"] == 4
+
+    extra = tmp_path / "reports" / "unexpected.json"
+    extra.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(amendment.AmendmentError, match="文件集合"):
+        amendment.verify_superseded_evidence(manifest, tmp_path)
+    extra.unlink()
+
+    pair_path = tmp_path / "markers" / "controlled-pair-attempt.json"
+    pair = copy.deepcopy(documents["markers/controlled-pair-attempt.json"])
+    pair["status"] = "passed"
+    pair_path.write_text(json.dumps(pair) + "\n", encoding="utf-8")
+    with pytest.raises(amendment.AmendmentError, match="controlled pair marker"):
+        amendment.verify_superseded_evidence(manifest, tmp_path)
+
+
+def test_cli_does_not_expose_provider_execution_commands() -> None:
+    parser = amendment._parser()
+    choices = parser._subparsers._group_actions[0].choices
+    assert set(choices) == {"generate", "validate", "validate-evidence"}

--- a/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "forge-checkpoint-primary-canary-amendment-candidate-1.0.0",
+  "document_type": "forge_checkpoint_primary_canary_amendment_candidate",
+  "scope": {
+    "provider_canary_authorized": false,
+    "mechanism_canary_authorized": false,
+    "pilot_collection_authorized": false,
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false,
+    "provider_calls": 0,
+    "formal_physical_attempts": 0,
+    "model_tokens": 0
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-authorized.json",
+    "manifest_sha256": "2771e72eee45ca6eac7bc1e7d5040cf5633bb3bf7e24a186a44071d9a98ce579",
+    "release_revision": "1ae32b501db4f4e1c35cec84b93e02267239b051",
+    "terminal_evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary",
+      "expected_file_count": 4,
+      "files": [
+        {
+          "path": "ledgers/parent.jsonl",
+          "sha256": "1f6378867058261d6849436fe8077fdbb33ce74b82bd960f4045aa945b79dcf4"
+        },
+        {
+          "path": "markers/controlled-pair-attempt.json",
+          "sha256": "93160bddd375dfc6574bf8294876a75f0052a6bf96a22b38d5b174a607bcccf8"
+        },
+        {
+          "path": "markers/reachability-attempt.json",
+          "sha256": "d9aa041027140bae3473977ae66a570dc743e207d184cf20e6914846108890ac"
+        },
+        {
+          "path": "reports/reachability.json",
+          "sha256": "5eac49ff35e868fc3d307d9cf4ea5accc5cfa365858fdcc771aa1bd4df33ab14"
+        }
+      ],
+      "reachability": {
+        "status": "passed",
+        "actual_model": "deepseek-v4-flash",
+        "request_count": 1,
+        "recorded_tokens": 17
+      },
+      "controlled_pair": {
+        "status": "failed",
+        "error_class": "CanaryError",
+        "arm_ledger_count": 0,
+        "pair_report_count": 0,
+        "pair_provider_calls": 0,
+        "pair_model_tokens": 0
+      },
+      "reuse_policy": "forbidden_new_manifest_and_revision_required"
+    }
+  },
+  "amendment": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/153",
+    "implementation_baseline_commit": "c7217e201bb1cb35217482e184fb1d51ec5d8d18",
+    "reachability_policy": "new_request_required_after_separate_authorization",
+    "build_layout": {
+      "adapter_path": "scripts/forge_checkpoint_windows_build_layout.py",
+      "cmake_binary_dir": ".forge-cmake-build",
+      "build_output": ".forge-cmake-build/accumulate_examples"
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden"
+    },
+    "fault": {
+      "version": "controlled-fault-v1",
+      "family": "artifact_staging_missing",
+      "expected_classification": "candidate_verification_failed",
+      "capture_point": "after-neutral-tool-message-before-continuation",
+      "replay_attempts_required": 0
+    },
+    "continuation": {
+      "checkpoint_pairs": 1,
+      "arms_per_pair": 2,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "budget": {
+      "reachability_requests": 1,
+      "reachability_expected_tokens": 5000,
+      "reachability_maximum_tokens": 5000,
+      "mechanism_canary_expected_tokens": 120000,
+      "mechanism_canary_maximum_tokens": 240000,
+      "stage_expected_tokens": 125000,
+      "stage_maximum_tokens": 245000
+    },
+    "stopping": {
+      "provider_timeout_stops_canary": true,
+      "incomplete_pair_stops_canary": true,
+      "cleanup_or_identity_failure_stops_canary": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "canary_pass_does_not_authorize_pilot": true
+    },
+    "execution": {
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+      "reachability_marker": "amendment-reachability-attempt.json",
+      "controlled_pair_marker": "amendment-controlled-pair-attempt.json",
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true
+    }
+  },
+  "protocol_artifacts": [
+    {
+      "path": "scripts/forge_checkpoint_windows_build_layout.py",
+      "sha256": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+    },
+    {
+      "path": "benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md",
+      "sha256": "9d9a4a59d9b58b8abaf73131a847c71e9240ccf045b0ad2870544c9a0d318ae8"
+    }
+  ]
+}

--- a/benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md
+++ b/benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md
@@ -1,0 +1,34 @@
+# Failure checkpoint primary canary amendment 候选预注册
+
+本阶段只形成新的 amendment 候选协议，不授权或执行 provider 请求。Issue #149 的 reachability 与 controlled pair 已终态关闭；Issue #151 / PR #152 只修复 Windows bind 的 CMake binary dir parity，不改变旧实验终态。
+
+## 旧终态
+
+- 父授权 manifest canonical SHA-256 为 `2771e72eee45ca6eac7bc1e7d5040cf5633bb3bf7e24a186a44071d9a98ce579`，release revision 为 `1ae32b501db4f4e1c35cec84b93e02267239b051`。
+- 唯一 reachability 为 `passed`，actual model 为 `deepseek-v4-flash`，记录 1 request / 17 tokens。
+- 唯一 controlled pair 为 `failed/CanaryError`，失败发生在 checkpoint capture、arm provisioning 和 pair provider request 之前；没有 arm ledger 或 pair report。
+- 旧 marker、report 与 parent ledger 保持 append-only，不允许重试、replacement、backfill、删除或改写。
+
+## Amendment 决策
+
+- 旧 reachability 不复用。它绑定旧 manifest hash 与旧 release revision，不能满足新 amendment 的同身份前置门禁。
+- 新候选提出独立的一次 reachability 和一个 controlled checkpoint pair，仍固定 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、禁止 fallback/replacement/backfill。
+- 新 CMake binary dir 固定为 `.forge-cmake-build`，只通过 `forge_checkpoint_windows_build_layout.py` 适配；父 runner、父 manifest 和父测试逐字不变。
+- 新 evidence 目录为 `/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment`，marker 使用 `amendment-reachability-attempt.json` 与 `amendment-controlled-pair-attempt.json`，不得与旧目录或文件名重合。
+
+## 候选预算
+
+- Reachability：最多 1 request / 5,000 recorded tokens。
+- Controlled pair：每臂最多 8 requests、8 turns、24 graph steps、600 秒 work、120 秒 cleanup、120,000 recorded tokens。
+- Pair maximum 为 240,000 recorded tokens，阶段 maximum 为 245,000 recorded tokens。
+- 这些数值只是拟议 ceiling；`provider_canary_authorized=false`、`mechanism_canary_authorized=false`、`pilot_collection_authorized=false`。
+
+## 本阶段门禁
+
+- 只允许生成和校验候选 manifest，以及只读核对旧 evidence identity。
+- 不读取 AK，不创建 marker/ledger/report，不调用 provider，不启动 Docker，不创建 formal physical attempt。
+- 旧 evidence、父 manifest、父 protocol artifacts、build-layout adapter 或候选授权位发生漂移时失败关闭。
+
+## 后续停止点
+
+候选合并后，实验负责人仍需单独确认 1 次新 reachability、1 个 controlled checkpoint pair 和最多 245,000 recorded tokens。随后必须形成新的 authorized amendment manifest 并在干净 `main == origin/main` 上通过零调用 preflight；canary 通过也不自动授权 6-pair pilot。

--- a/scripts/forge_checkpoint_primary_canary_amendment.py
+++ b/scripts/forge_checkpoint_primary_canary_amendment.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""生成并校验 failure checkpoint primary canary amendment 候选。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-candidate.json"
+PARENT_MANIFEST = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-authorized.json"
+
+SCHEMA_VERSION = "forge-checkpoint-primary-canary-amendment-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_checkpoint_primary_canary_amendment_candidate"
+PARENT_MANIFEST_SHA256 = "2771e72eee45ca6eac7bc1e7d5040cf5633bb3bf7e24a186a44071d9a98ce579"
+PARENT_RELEASE_REVISION = "1ae32b501db4f4e1c35cec84b93e02267239b051"
+IMPLEMENTATION_BASELINE = "c7217e201bb1cb35217482e184fb1d51ec5d8d18"
+SUPERSEDED_EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary"
+AMENDMENT_EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment"
+REACHABILITY_MARKER = "amendment-reachability-attempt.json"
+PAIR_MARKER = "amendment-controlled-pair-attempt.json"
+
+SUPERSEDED_FILES = {
+    "ledgers/parent.jsonl": "1f6378867058261d6849436fe8077fdbb33ce74b82bd960f4045aa945b79dcf4",
+    "markers/controlled-pair-attempt.json": "93160bddd375dfc6574bf8294876a75f0052a6bf96a22b38d5b174a607bcccf8",
+    "markers/reachability-attempt.json": "d9aa041027140bae3473977ae66a570dc743e207d184cf20e6914846108890ac",
+    "reports/reachability.json": "5eac49ff35e868fc3d307d9cf4ea5accc5cfa365858fdcc771aa1bd4df33ab14",
+}
+PROTOCOL_ARTIFACT_PATHS = (
+    "scripts/forge_checkpoint_windows_build_layout.py",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md",
+)
+
+
+class AmendmentError(RuntimeError):
+    """候选协议、父协议或旧 evidence 发生漂移。"""
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AmendmentError(f"无法加载协议模块: {path.name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AmendmentError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise AmendmentError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def canonical_sha256(value: Any) -> str:
+    raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _protocol_artifacts(repo_root: Path) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    for relative_path in PROTOCOL_ARTIFACT_PATHS:
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise AmendmentError(f"候选协议文件缺失: {relative_path}")
+        artifacts.append({"path": relative_path, "sha256": file_sha256(path)})
+    return artifacts
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "scope": {
+            "provider_canary_authorized": False,
+            "mechanism_canary_authorized": False,
+            "pilot_collection_authorized": False,
+            "natural_collection_authorized": False,
+            "secondary_provider_authorized": False,
+            "provider_calls": 0,
+            "formal_physical_attempts": 0,
+            "model_tokens": 0,
+        },
+        "parent": {
+            "manifest_path": "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-authorized.json",
+            "manifest_sha256": PARENT_MANIFEST_SHA256,
+            "release_revision": PARENT_RELEASE_REVISION,
+            "terminal_evidence": {
+                "directory": SUPERSEDED_EVIDENCE_DIRECTORY,
+                "expected_file_count": len(SUPERSEDED_FILES),
+                "files": [{"path": path, "sha256": digest} for path, digest in SUPERSEDED_FILES.items()],
+                "reachability": {
+                    "status": "passed",
+                    "actual_model": "deepseek-v4-flash",
+                    "request_count": 1,
+                    "recorded_tokens": 17,
+                },
+                "controlled_pair": {
+                    "status": "failed",
+                    "error_class": "CanaryError",
+                    "arm_ledger_count": 0,
+                    "pair_report_count": 0,
+                    "pair_provider_calls": 0,
+                    "pair_model_tokens": 0,
+                },
+                "reuse_policy": "forbidden_new_manifest_and_revision_required",
+            },
+        },
+        "amendment": {
+            "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/153",
+            "implementation_baseline_commit": IMPLEMENTATION_BASELINE,
+            "reachability_policy": "new_request_required_after_separate_authorization",
+            "build_layout": {
+                "adapter_path": "scripts/forge_checkpoint_windows_build_layout.py",
+                "cmake_binary_dir": ".forge-cmake-build",
+                "build_output": ".forge-cmake-build/accumulate_examples",
+            },
+            "provider": {
+                "id": "deepseek-v4-flash",
+                "endpoint": "https://api.deepseek.com",
+                "credential_env": "DEEPSEEK_API_KEY",
+                "model": "deepseek-v4-flash",
+                "request_timeout_seconds": 300,
+                "max_retries": 0,
+                "fallback": "forbidden",
+            },
+            "fault": {
+                "version": "controlled-fault-v1",
+                "family": "artifact_staging_missing",
+                "expected_classification": "candidate_verification_failed",
+                "capture_point": "after-neutral-tool-message-before-continuation",
+                "replay_attempts_required": 0,
+            },
+            "continuation": {
+                "checkpoint_pairs": 1,
+                "arms_per_pair": 2,
+                "arm_order": ["baseline", "treatment"],
+                "maximum_requests_per_arm": 8,
+                "maximum_model_turns_per_arm": 8,
+                "maximum_graph_steps_per_arm": 24,
+                "work_wall_clock_seconds_per_arm": 600,
+                "cleanup_reserve_seconds_per_arm": 120,
+                "maximum_recorded_tokens_per_arm": 120000,
+            },
+            "budget": {
+                "reachability_requests": 1,
+                "reachability_expected_tokens": 5000,
+                "reachability_maximum_tokens": 5000,
+                "mechanism_canary_expected_tokens": 120000,
+                "mechanism_canary_maximum_tokens": 240000,
+                "stage_expected_tokens": 125000,
+                "stage_maximum_tokens": 245000,
+            },
+            "stopping": {
+                "provider_timeout_stops_canary": True,
+                "incomplete_pair_stops_canary": True,
+                "cleanup_or_identity_failure_stops_canary": True,
+                "retry_forbidden": True,
+                "replacement_forbidden": True,
+                "backfill_forbidden": True,
+                "canary_pass_does_not_authorize_pilot": True,
+            },
+            "execution": {
+                "control_plane": "compose-dood-on-ubuntu-native-docker",
+                "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+                "evidence_directory": AMENDMENT_EVIDENCE_DIRECTORY,
+                "reachability_marker": REACHABILITY_MARKER,
+                "controlled_pair_marker": PAIR_MARKER,
+                "release_branch": "main",
+                "require_clean_worktree": True,
+                "require_origin_main_identity": True,
+            },
+        },
+        "protocol_artifacts": _protocol_artifacts(repo_root),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AmendmentError("amendment candidate manifest 必须是对象")
+    expected = generate_manifest(repo_root)
+    if value != expected:
+        raise AmendmentError("amendment candidate manifest 与冻结候选协议不一致")
+    return value
+
+
+def _parent_modules() -> tuple[ModuleType, ModuleType]:
+    primary = _load_module("forge_checkpoint_primary_canary_amendment_parent", SCRIPT_ROOT / "forge_checkpoint_primary_canary.py")
+    layout = _load_module("forge_checkpoint_primary_canary_amendment_layout", SCRIPT_ROOT / "forge_checkpoint_windows_build_layout.py")
+    return primary, layout
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    primary, layout = _parent_modules()
+    parent = primary.load_manifest(repo_root / manifest["parent"]["manifest_path"])
+    if primary.canonical_sha256(parent) != PARENT_MANIFEST_SHA256:
+        raise AmendmentError("父授权 manifest identity 发生漂移")
+    primary.verify_frozen_artifacts(parent, repo_root)
+    build_layout = manifest["amendment"]["build_layout"]
+    if layout.CMAKE_BINARY_DIR != build_layout["cmake_binary_dir"] or layout.BUILD_OUTPUT_RELATIVE_PATH != build_layout["build_output"]:
+        raise AmendmentError("Windows bind build-layout adapter 发生漂移")
+
+
+def _assert_fields(value: dict[str, Any], expected: dict[str, Any], label: str) -> None:
+    if any(value.get(key) != expected_value for key, expected_value in expected.items()):
+        raise AmendmentError(f"旧 {label} 语义发生漂移")
+
+
+def verify_superseded_evidence(manifest: dict[str, Any], output_dir: Path) -> dict[str, Any]:
+    validate_manifest(manifest)
+    terminal = manifest["parent"]["terminal_evidence"]
+    files = {path.relative_to(output_dir).as_posix(): path for path in output_dir.rglob("*") if path.is_file()}
+    expected_files = {item["path"]: item["sha256"] for item in terminal["files"]}
+    if set(files) != set(expected_files) or len(files) != terminal["expected_file_count"]:
+        raise AmendmentError("旧 evidence 文件集合发生漂移")
+    for relative_path, expected_digest in expected_files.items():
+        if file_sha256(files[relative_path]) != expected_digest:
+            raise AmendmentError(f"旧 evidence SHA-256 发生漂移: {relative_path}")
+
+    reachability_marker = _load_json(output_dir / "markers" / "reachability-attempt.json")
+    pair_marker = _load_json(output_dir / "markers" / "controlled-pair-attempt.json")
+    reachability_report = _load_json(output_dir / "reports" / "reachability.json")
+    marker_identity = {"manifest_sha256": PARENT_MANIFEST_SHA256, "release_revision": PARENT_RELEASE_REVISION}
+    _assert_fields(reachability_marker, {**marker_identity, "status": "passed", "error_class": None}, "reachability marker")
+    _assert_fields(pair_marker, {**marker_identity, "status": "failed", "error_class": "CanaryError"}, "controlled pair marker")
+    _assert_fields(
+        reachability_report,
+        {
+            **marker_identity,
+            "passed": True,
+            "actual_model": terminal["reachability"]["actual_model"],
+            "request_count": terminal["reachability"]["request_count"],
+            "recorded_tokens": terminal["reachability"]["recorded_tokens"],
+        },
+        "reachability report",
+    )
+    return {"status": "valid", "file_count": len(files), "manifest_sha256": PARENT_MANIFEST_SHA256}
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    evidence = subparsers.add_parser("validate-evidence")
+    evidence.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    evidence.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            result = {"status": "generated", "manifest_sha256": canonical_sha256(manifest)}
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+            result = {
+                "status": "valid",
+                "provider_canary_authorized": False,
+                "mechanism_canary_authorized": False,
+                "stage_maximum_tokens": manifest["amendment"]["budget"]["stage_maximum_tokens"],
+                "manifest_sha256": canonical_sha256(manifest),
+            }
+            if args.command == "validate-evidence":
+                result["superseded_evidence"] = verify_superseded_evidence(manifest, args.output_dir)
+    except (AmendmentError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更概述

- 新增 failure checkpoint primary canary amendment candidate manifest、预注册、只读 validator 和聚焦测试。
- 固定 Issue #149 的父 manifest identity、旧 release revision，以及 reachability marker/report、failed pair marker、parent ledger 四个终态 evidence 文件。
- 显式绑定 PR #152 的 `.forge-cmake-build` adapter，并为后续 amendment 预留独立 evidence 目录和两个新 marker 名称。
- validator 只提供 `generate`、`validate`、`validate-evidence`，不暴露 reachability 或 controlled-pair 执行命令。

## 研究决策

- 不复用 Issue #149 的成功 reachability，因为它绑定旧 manifest SHA-256 与 `main@1ae32b50`，不能满足新 amendment 的同身份门禁。
- 候选提出独立的 1 次 reachability、1 个 controlled checkpoint pair 和 245,000 recorded-token maximum。
- `provider_canary_authorized=false`、`mechanism_canary_authorized=false`、`pilot_collection_authorized=false`；该 ceiling 只是后续授权候选，不是本 PR 的执行权限。
- Issue #149 的 marker/evidence 不重试、不 replacement、不 backfill，也不删除或改写。

## 验证

- Candidate canonical SHA-256：`d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704`。
- 真实 superseded evidence 只读核验：4/4 文件集合、SHA-256 与语义通过。
- 新候选、父 primary canary 与 Windows build-layout adapter 相邻回归：`17 passed`。
- Ruff check/format、`git diff --check` 与敏感信息检查通过。

## 实验边界

本阶段实际为 0 provider calls、0 model tokens、0 formal physical attempts、0 Docker，未读取 AK，也未创建新的 marker、ledger 或 report。合并后仍需实验负责人单独授权 1 次新 reachability、1 个 controlled pair 和最多 245,000 recorded tokens，并形成 authorized amendment manifest；canary 通过也不自动授权 6-pair pilot。

Closes #153