### PR TITLE
研究：授权 checkpoint primary canary amendment

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-19 — 预注册 failure checkpoint primary canary amendment 候选
-  - GitHub: 中文 Issue #153 已在修改前创建并回读；当前分支为 `research/153-checkpoint-primary-canary-amendment`，基线为 `main@c7217e20`。
-  - 决策: Issue #149 的 reachability 绑定旧 manifest 与 `main@1ae32b50`，不在新 amendment 中复用。候选提出独立的一次 reachability、一个 controlled pair 和 245,000 recorded-token maximum，但全部授权位保持 `false`。
-  - 实现: 新 candidate manifest、预注册与只读 validator 固定旧四文件 evidence identity、新目录/marker、PR #152 build-layout adapter 和父协议；CLI 只有 `generate`、`validate`、`validate-evidence`，没有 provider 执行入口。
-  - 证据: candidate canonical SHA-256 为 `d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704`；真实旧 evidence 只读核验 4/4 通过，相邻回归 `17 passed`，Ruff check/format、diff 与敏感信息检查通过。
-  - 边界: 0 provider calls、0 model tokens、0 formal physical attempts、0 Docker，未读取 AK；不创建新 marker/ledger/report，不授权 6-pair pilot。
-  - 下一步: 中文本地提交已完成，等待实验负责人单独授权推送；PR、合并与后续 245,000-token provider canary 仍分别确认。
-  - 文件: `scripts/forge_checkpoint_primary_canary_amendment.py`, `backend/tests/test_forge_checkpoint_primary_canary_amendment.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md`
+- 2026-08-19 — 授权 failure checkpoint primary canary amendment
+  - GitHub: 中文 Issue #155 已在修改前创建并回读；当前分支为 `research/155-checkpoint-primary-canary-authorized`，授权 baseline 为 `main@9feb832d`。
+  - 授权: 1 次 DeepSeek `deepseek-v4-flash` reachability、1 个 controlled pair，以及合计最多 245,000 recorded tokens；不授权 6-pair pilot、secondary/natural、retry、replacement、fallback 或 backfill。
+  - 实现: 新 authorized adapter 私有加载冻结 parent runner，先核验 Issue #149 四份旧 evidence，再使用独立 evidence 目录和 marker；controlled pair 期间临时启用 `.forge-cmake-build` 布局，退出后恢复 parent module。
+  - 证据: authorized manifest canonical SHA-256 为 `f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356`；真实旧 evidence 4/4 通过，primary/checkpoint 相邻回归 `23 passed`，Ruff check/format、`py_compile`、diff 与敏感信息检查通过。
+  - 边界: 当前仍为 0 provider、0 token、0 formal physical attempt、0 Docker，未读取 AK或创建新 marker/ledger/report。
+  - 下一步: 已获 WSL helper 推送授权；远端 SHA 核验后停在 PR 创建边界，PR、合并与真实 provider 执行仍分别确认。
+  - 文件: `scripts/forge_checkpoint_primary_canary_amendment_authorized.py`, `backend/tests/test_forge_checkpoint_primary_canary_amendment_authorized.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment-authorized.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -72,6 +72,11 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-19 — 合并 checkpoint primary canary amendment 候选
+  - 文件: `scripts/forge_checkpoint_primary_canary_amendment.py`, `backend/tests/test_forge_checkpoint_primary_canary_amendment.py`, `benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment.md`
+  - 动机: 旧 reachability 绑定旧 manifest/revision，Windows bind parity 修复后必须用独立 identity、目录和 marker 再申请一次受控机制 canary。
+  - 结果: 中文 PR #154 三项 CI 全绿后 squash 合并为 `main@9feb832d`，Issue #153 自动关闭；本地 `main` 与 `origin/main` 同步一致，远端研究分支保留。
 
 - 2026-08-19 — 合并 Windows bind checkpoint 构建目录修复
   - 文件: `scripts/forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_build_layout.py`, `backend/tests/test_forge_checkpoint_windows_bind_parity_docker.py`

--- a/backend/tests/test_forge_checkpoint_primary_canary_amendment_authorized.py
+++ b/backend/tests/test_forge_checkpoint_primary_canary_amendment_authorized.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_checkpoint_primary_canary_amendment_authorized.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-authorized.json"
+CANDIDATE_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-candidate.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_checkpoint_primary_canary_amendment_authorized_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+authorized = _load_module()
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_authorized_manifest_is_deterministic_bounded_and_parent_frozen() -> None:
+    manifest = _manifest()
+
+    assert authorized.generate_manifest() == manifest
+    assert authorized.validate_manifest(manifest) == manifest
+    authorized.verify_frozen_artifacts(manifest)
+    assert manifest["scope"] == {
+        "provider_canary_authorized": True,
+        "mechanism_canary_authorized": True,
+        "pilot_collection_authorized": False,
+        "natural_collection_authorized": False,
+        "secondary_provider_authorized": False,
+    }
+    assert manifest["authorization"]["authorized_reachability_attempts"] == 1
+    assert manifest["authorization"]["authorized_controlled_pairs"] == 1
+    assert manifest["budget"]["stage_maximum_tokens"] == 245_000
+    assert manifest["parent_candidate"]["canonical_sha256"] == authorized.CANDIDATE_CANONICAL_SHA256
+    assert "scripts/forge_checkpoint_primary_canary_amendment.py" in {artifact["path"] for artifact in manifest["protocol_artifacts"]}
+
+
+def test_authorized_manifest_rejects_budget_pilot_and_candidate_drift() -> None:
+    manifest = _manifest()
+    manifest["budget"]["stage_maximum_tokens"] += 1
+    with pytest.raises(authorized.AuthorizedAmendmentError, match="冻结授权协议"):
+        authorized.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["scope"]["pilot_collection_authorized"] = True
+    with pytest.raises(authorized.AuthorizedAmendmentError, match="冻结授权协议"):
+        authorized.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["parent_candidate"]["canonical_sha256"] = "0" * 64
+    with pytest.raises(authorized.AuthorizedAmendmentError, match="冻结授权协议"):
+        authorized.validate_manifest(manifest)
+
+
+def test_candidate_manifest_cannot_pass_authorized_validation() -> None:
+    candidate = json.loads(CANDIDATE_PATH.read_text(encoding="utf-8"))
+    with pytest.raises(authorized.AuthorizedAmendmentError, match="冻结授权协议"):
+        authorized.validate_manifest(candidate)
+
+
+def test_release_identity_requires_authorization_baseline_ancestor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    monkeypatch.setattr(
+        authorized,
+        "_parent_release_identity",
+        lambda _manifest, _repo_root: {
+            "branch": "main",
+            "revision": "a" * 40,
+            "origin_main": "a" * 40,
+        },
+    )
+    monkeypatch.setattr(
+        authorized.primary_canary,
+        "_git",
+        lambda _repo_root, *_arguments: authorized.AUTHORIZATION_BASELINE,
+    )
+    assert authorized.require_release_identity(manifest)["branch"] == "main"
+
+    monkeypatch.setattr(
+        authorized.primary_canary,
+        "_git",
+        lambda _repo_root, *_arguments: "b" * 40,
+    )
+    with pytest.raises(authorized.AuthorizedAmendmentError, match="不是授权 baseline 的后代"):
+        authorized.require_release_identity(manifest)
+
+
+def test_execution_wrappers_require_old_evidence_and_apply_build_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+    calls: list[str] = []
+
+    monkeypatch.setattr(authorized, "verify_superseded_evidence", lambda _manifest: calls.append("evidence"))
+    monkeypatch.setattr(
+        authorized.primary_canary,
+        "run_reachability",
+        lambda *_args, **_kwargs: {"passed": True},
+    )
+
+    def pair(*_args, **_kwargs):
+        calls.append(authorized.primary_canary.BUILD_OUTPUT)
+        return {"passed": True}
+
+    monkeypatch.setattr(authorized.primary_canary, "run_controlled_pair", pair)
+    assert authorized.run_reachability(manifest)["passed"] is True
+    assert authorized.run_controlled_pair(manifest)["passed"] is True
+    assert calls == ["evidence", "evidence", ".forge-cmake-build/accumulate_examples"]
+    assert authorized.primary_canary.BUILD_OUTPUT == "build/accumulate_examples"
+
+
+def test_authorized_cli_exposes_only_bounded_execution_commands() -> None:
+    parser = authorized._parser()
+    action = next(action for action in parser._actions if action.dest == "command")
+    assert set(action.choices) == {
+        "generate",
+        "validate",
+        "validate-evidence",
+        "reachability",
+        "controlled-pair",
+    }
+
+    candidate_choices = authorized.candidate_protocol._parser()._subparsers._group_actions[0].choices
+    assert set(candidate_choices) == {"generate", "validate", "validate-evidence"}

--- a/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "forge-checkpoint-primary-canary-amendment-authorized-1.0.0",
+  "document_type": "forge_checkpoint_primary_canary_amendment_authorized",
+  "scope": {
+    "provider_canary_authorized": true,
+    "mechanism_canary_authorized": true,
+    "pilot_collection_authorized": false,
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden"
+  },
+  "fault": {
+    "version": "controlled-fault-v1",
+    "family": "artifact_staging_missing",
+    "expected_classification": "candidate_verification_failed",
+    "capture_point": "after-neutral-tool-message-before-continuation",
+    "replay_attempts_required": 0
+  },
+  "continuation": {
+    "checkpoint_pairs": 1,
+    "arms_per_pair": 2,
+    "arm_order": [
+      "baseline",
+      "treatment"
+    ],
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "budget": {
+    "reachability_requests": 1,
+    "reachability_expected_tokens": 5000,
+    "reachability_maximum_tokens": 5000,
+    "mechanism_canary_expected_tokens": 120000,
+    "mechanism_canary_maximum_tokens": 240000,
+    "stage_expected_tokens": 125000,
+    "stage_maximum_tokens": 245000
+  },
+  "stopping": {
+    "provider_timeout_stops_canary": true,
+    "incomplete_pair_stops_canary": true,
+    "cleanup_or_identity_failure_stops_canary": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "canary_pass_does_not_authorize_pilot": true
+  },
+  "execution": {
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+    "reachability_marker": "amendment-reachability-attempt.json",
+    "controlled_pair_marker": "amendment-controlled-pair-attempt.json",
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "authorization_baseline_commit": "9feb832da1f4b124694260de1b487ea645ae55af",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/155",
+    "authorized_reachability_attempts": 1,
+    "authorized_controlled_pairs": 1,
+    "stage_maximum_tokens": 245000,
+    "pilot_collection_authorized": false
+  },
+  "parent_candidate": {
+    "path": "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json",
+    "sha256": "b955771db614b9789ab7ccf3447d066881644f545cfa42a32143f3945b32a995",
+    "canonical_sha256": "d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704"
+  },
+  "protocol_artifacts": [
+    {
+      "path": "scripts/forge_checkpoint_primary_canary_amendment.py",
+      "sha256": "879dafca2290ad1abdb2330e2090717a90bbbf82b65085cf1da7b640674c824a"
+    },
+    {
+      "path": "scripts/forge_checkpoint_primary_canary_amendment_authorized.py",
+      "sha256": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba"
+    },
+    {
+      "path": "backend/tests/test_forge_checkpoint_primary_canary_amendment_authorized.py",
+      "sha256": "cc27924694b5497745431995545a73dc470461e707aa011518b2d228b4a061b2"
+    },
+    {
+      "path": "benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment-authorized.md",
+      "sha256": "935304623140dc95c716d86c6f8cd5a2b23db3adb1575fef655f087c38427a33"
+    }
+  ]
+}

--- a/benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment-authorized.md
+++ b/benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment-authorized.md
@@ -1,0 +1,34 @@
+# Failure checkpoint primary canary amendment 授权预注册
+
+本协议承接 Issue #153 / PR #154 的不可执行候选。实验负责人在 Issue #155 明确授权 1 次新 reachability、1 个 controlled checkpoint pair，以及合计最多 245,000 recorded tokens。
+
+## 授权 identity
+
+- 授权 baseline 为 `main@9feb832da1f4b124694260de1b487ea645ae55af`；真实执行 revision 必须位于其后代、分支为 `main`、与 `origin/main` 一致且工作树干净。
+- 父 candidate canonical SHA-256 为 `d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704`。
+- provider 固定为 DeepSeek `deepseek-v4-flash`，endpoint 为 `https://api.deepseek.com`，凭据环境变量为 `DEEPSEEK_API_KEY`，请求策略为 300 秒 timeout、0 retry、禁止 fallback。
+- 运行拓扑固定为 WSL2 Ubuntu 原生 Docker 上的 Compose/DooD；不使用 Docker Desktop。
+
+## 唯一授权范围
+
+- Reachability：最多 1 request / 5,000 recorded tokens，使用独立 marker `amendment-reachability-attempt.json`。
+- Controlled pair：只允许 1 pair，严格按 `baseline`、`treatment` 顺序各一次；每臂最多 8 requests、8 turns、24 graph steps、600 秒 work、120 秒 cleanup 和 120,000 recorded tokens。
+- Pair maximum 为 240,000 recorded tokens，reachability 与 pair 的阶段总上限为 245,000 recorded tokens。
+- `pilot_collection_authorized=false`、`natural_collection_authorized=false`、`secondary_provider_authorized=false`。
+
+## 前置门禁
+
+- Issue #149 的四份终态 evidence 必须保持文件集合、SHA-256 和语义不变；旧 reachability 不复用。
+- 新 evidence 只写入 `/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment`。
+- Controlled pair 必须读取同一 authorized manifest、同一 release revision 下已通过的 reachability marker 与 report。
+- Windows bind 构建布局固定为 `.forge-cmake-build`；旧 runner 仅通过版本化 adapter 私有加载，不修改冻结文件。
+
+## 停止条件
+
+- Reachability 超时、模型 identity/token 门禁失败或 evidence/identity 漂移时立即停止，唯一机会不得重试。
+- Controlled pair 任一臂失败、pair 不完整或 cleanup 未闭合时立即停止，禁止 replacement、backfill 和 fallback。
+- Pair 通过只说明可以申请后续 6-pair pilot，不构成 pilot 自动授权，也不计入 pilot denominator。
+
+## 发布前边界
+
+authorized manifest 合并前只允许生成、校验和零 provider 测试；不得读取 AK、创建 marker/ledger/report、启动 Docker 或执行 physical attempt。真实 reachability 和 controlled pair 必须等待授权实现合入干净主干后再单独启动。

--- a/scripts/forge_checkpoint_primary_canary_amendment_authorized.py
+++ b/scripts/forge_checkpoint_primary_canary_amendment_authorized.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Issue #155 checkpoint primary canary amendment 授权协议与执行适配器。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+DEFAULT_MANIFEST = (
+    REPO_ROOT
+    / "benchmarks"
+    / "manifests"
+    / "cpp-verifier-checkpoint-primary-canary-amendment-authorized.json"
+)
+DEFAULT_OUTPUT_DIR = Path(
+    "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment"
+)
+SUPERSEDED_OUTPUT_DIR = Path(
+    "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary"
+)
+
+SCHEMA_VERSION = "forge-checkpoint-primary-canary-amendment-authorized-1.0.0"
+DOCUMENT_TYPE = "forge_checkpoint_primary_canary_amendment_authorized"
+AUTHORIZATION_BASELINE = "9feb832da1f4b124694260de1b487ea645ae55af"
+CANDIDATE_PATH = "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-candidate.json"
+CANDIDATE_CANONICAL_SHA256 = (
+    "d0598b549301a2efbe431e2bfa7f6f21c4ba32e2c3eae1b078935630f1ffb704"
+)
+REACHABILITY_MARKER = "amendment-reachability-attempt.json"
+PAIR_MARKER = "amendment-controlled-pair-attempt.json"
+PROTOCOL_ARTIFACT_PATHS = (
+    "scripts/forge_checkpoint_primary_canary_amendment.py",
+    "scripts/forge_checkpoint_primary_canary_amendment_authorized.py",
+    "backend/tests/test_forge_checkpoint_primary_canary_amendment_authorized.py",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-primary-canary-amendment-authorized.md",
+)
+
+
+class AuthorizedAmendmentError(RuntimeError):
+    """授权 identity、冻结组件或历史 evidence 发生漂移。"""
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AuthorizedAmendmentError(f"无法加载协议模块: {path.name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+candidate_protocol = _load_module(
+    "forge_checkpoint_primary_canary_amendment_authorized_candidate",
+    SCRIPT_ROOT / "forge_checkpoint_primary_canary_amendment.py",
+)
+primary_canary = _load_module(
+    "forge_checkpoint_primary_canary_amendment_authorized_parent",
+    SCRIPT_ROOT / "forge_checkpoint_primary_canary.py",
+)
+build_layout = _load_module(
+    "forge_checkpoint_primary_canary_amendment_authorized_layout",
+    SCRIPT_ROOT / "forge_checkpoint_windows_build_layout.py",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuthorizedAmendmentError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise AuthorizedAmendmentError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def canonical_sha256(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _candidate_manifest(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CANDIDATE_PATH
+    candidate = candidate_protocol.validate_manifest(_load_json(path), repo_root)
+    if candidate_protocol.canonical_sha256(candidate) != CANDIDATE_CANONICAL_SHA256:
+        raise AuthorizedAmendmentError(
+            "amendment candidate canonical identity 发生漂移"
+        )
+    return candidate
+
+
+def _protocol_artifacts(repo_root: Path) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    for relative_path in PROTOCOL_ARTIFACT_PATHS:
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise AuthorizedAmendmentError(f"授权协议文件缺失: {relative_path}")
+        artifacts.append({"path": relative_path, "sha256": file_sha256(path)})
+    return artifacts
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    candidate = _candidate_manifest(repo_root)
+    amendment = candidate["amendment"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "scope": {
+            "provider_canary_authorized": True,
+            "mechanism_canary_authorized": True,
+            "pilot_collection_authorized": False,
+            "natural_collection_authorized": False,
+            "secondary_provider_authorized": False,
+        },
+        "provider": amendment["provider"],
+        "fault": amendment["fault"],
+        "continuation": amendment["continuation"],
+        "budget": amendment["budget"],
+        "stopping": amendment["stopping"],
+        "execution": {
+            **amendment["execution"],
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "authorization": {
+            "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/155",
+            "authorized_reachability_attempts": 1,
+            "authorized_controlled_pairs": 1,
+            "stage_maximum_tokens": 245000,
+            "pilot_collection_authorized": False,
+        },
+        "parent_candidate": {
+            "path": CANDIDATE_PATH,
+            "sha256": file_sha256(repo_root / CANDIDATE_PATH),
+            "canonical_sha256": CANDIDATE_CANONICAL_SHA256,
+        },
+        "protocol_artifacts": _protocol_artifacts(repo_root),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AuthorizedAmendmentError("authorized amendment manifest 必须是对象")
+    if value != generate_manifest(repo_root):
+        raise AuthorizedAmendmentError(
+            "authorized amendment manifest 与冻结授权协议不一致"
+        )
+    return value
+
+
+def verify_frozen_artifacts(
+    manifest: dict[str, Any], repo_root: Path = REPO_ROOT
+) -> None:
+    validate_manifest(manifest, repo_root)
+    candidate = _candidate_manifest(repo_root)
+    candidate_protocol.verify_frozen_components(candidate, repo_root)
+    parent = manifest["parent_candidate"]
+    if file_sha256(repo_root / parent["path"]) != parent["sha256"]:
+        raise AuthorizedAmendmentError("amendment candidate 文件 identity 发生漂移")
+    for artifact in manifest["protocol_artifacts"]:
+        if file_sha256(repo_root / artifact["path"]) != artifact["sha256"]:
+            raise AuthorizedAmendmentError(f"授权协议制品发生漂移: {artifact['path']}")
+
+
+def verify_superseded_evidence(
+    manifest: dict[str, Any], output_dir: Path = SUPERSEDED_OUTPUT_DIR
+) -> dict[str, Any]:
+    verify_frozen_artifacts(manifest)
+    candidate = _candidate_manifest(REPO_ROOT)
+    return candidate_protocol.verify_superseded_evidence(candidate, output_dir)
+
+
+_parent_release_identity = primary_canary.require_release_identity
+
+
+def require_release_identity(
+    manifest: dict[str, Any], repo_root: Path = REPO_ROOT
+) -> dict[str, str]:
+    result = _parent_release_identity(manifest, repo_root)
+    merge_base = primary_canary._git(
+        repo_root,
+        "merge-base",
+        manifest["execution"]["authorization_baseline_commit"],
+        result["revision"],
+    )
+    if merge_base != manifest["execution"]["authorization_baseline_commit"]:
+        raise AuthorizedAmendmentError("当前 release 不是授权 baseline 的后代")
+    return result
+
+
+primary_canary.DEFAULT_MANIFEST = DEFAULT_MANIFEST
+primary_canary.DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIR
+primary_canary.REACHABILITY_MARKER = REACHABILITY_MARKER
+primary_canary.PAIR_MARKER = PAIR_MARKER
+primary_canary.validate_manifest = validate_manifest
+primary_canary.verify_frozen_artifacts = verify_frozen_artifacts
+primary_canary.require_release_identity = require_release_identity
+
+
+def run_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Callable[[dict[str, Any]], Any] | None = None,
+) -> dict[str, Any]:
+    validate_manifest(manifest, repo_root)
+    verify_superseded_evidence(manifest)
+    return primary_canary.run_reachability(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        model_factory=model_factory,
+    )
+
+
+def run_controlled_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Callable[[dict[str, Any], str], Any] | None = None,
+) -> dict[str, Any]:
+    validate_manifest(manifest, repo_root)
+    verify_superseded_evidence(manifest)
+    with build_layout.use_windows_safe_build_layout(primary_canary):
+        return primary_canary.run_controlled_pair(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        )
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=(
+            "generate",
+            "validate",
+            "validate-evidence",
+            "reachability",
+            "controlled-pair",
+        ),
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--superseded-output-dir", type=Path, default=SUPERSEDED_OUTPUT_DIR
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            result = {
+                "status": "generated",
+                "manifest_sha256": canonical_sha256(manifest),
+            }
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_artifacts(manifest)
+            if args.command == "validate":
+                result = {
+                    "status": "valid",
+                    "provider_calls": 0,
+                    "provider_canary_authorized": True,
+                    "mechanism_canary_authorized": True,
+                    "pilot_collection_authorized": False,
+                    "stage_maximum_tokens": manifest["budget"]["stage_maximum_tokens"],
+                    "manifest_sha256": canonical_sha256(manifest),
+                }
+            elif args.command == "validate-evidence":
+                result = {
+                    "status": "valid",
+                    "provider_calls": 0,
+                    "superseded_evidence": verify_superseded_evidence(
+                        manifest, args.superseded_output_dir
+                    ),
+                    "manifest_sha256": canonical_sha256(manifest),
+                }
+            elif args.command == "reachability":
+                result = run_reachability(manifest, output_dir=args.output_dir)
+            else:
+                result = run_controlled_pair(manifest, output_dir=args.output_dir)
+    except (
+        AuthorizedAmendmentError,
+        candidate_protocol.AmendmentError,
+        primary_canary.CanaryError,
+        build_layout.BuildLayoutError,
+        OSError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更概述

- 从 PR #154 的不可执行候选派生独立 authorized manifest，固定候选 canonical identity、候选 validator、父授权协议和 Issue #149 的四份终态 evidence。
- 新增版本化执行 adapter：私有加载冻结 parent runner，使用独立 evidence 目录与一次性 marker；controlled pair 期间临时应用 `.forge-cmake-build` 布局，退出后恢复 parent module。
- release 必须位于 `main@9feb832d` 的后代、分支为干净 `main`，并与 `origin/main` 一致。
- candidate CLI 继续不暴露 provider；只有 authorized CLI 提供有界的 `reachability` 与 `controlled-pair` 入口。

## 授权边界

- DeepSeek `deepseek-v4-flash` reachability：最多 1 次请求、5,000 recorded tokens。
- Controlled checkpoint pair：最多 1 pair，严格按 `baseline`、`treatment` 顺序；pair 最多 240,000 recorded tokens。
- 阶段总上限：245,000 recorded tokens。
- 不授权 6-pair pilot、secondary/natural、retry、replacement、fallback 或 backfill。
- 任一步失败立即停止；pair 通过也不自动授权 pilot。

## 验证

- authorized manifest canonical SHA-256：`f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356`
- 真实旧 evidence：4/4 文件、SHA-256 与语义校验通过
- primary/checkpoint 相邻回归：`23 passed`
- Ruff check/format、`py_compile`、`git diff --check`、确定性再生成与敏感信息检查通过

## 研究边界

本 PR 的开发与验证阶段实际为 0 provider、0 model token、0 formal physical attempt、0 Docker；未读取 AK，也未创建新的 marker、ledger 或 report。合并和真实 provider 执行仍需分别确认。

Closes #155