### PR TITLE
研究：实现 endpoint 删失容忍六配对 pilot

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-29 — 实现 endpoint 删失容忍 checkpoint 六配对 pilot
+  - GitHub: 中文 Issue #159 已创建并回读；分支为 `research/159-checkpoint-censored-pilot`，基线为 `main@fe9fb519`。
+  - 协议: 路线 B 固定 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、6 pair/12 arms、每臂 120,000 recorded tokens 和总计 1,440,000 上限；arm order 以 3:3 交叉平衡，禁止 fallback、replacement、backfill 和扩样。
+  - 实现: 新版本化 runner 复用冻结 controlled-pair 生命周期，只允许具备完整哈希链、唯一 `model_endpoint/timeout/retry_exhausted`、`cleanup.succeeded=true`、coordinator `cleaned` 与 0 orphan 的 pair 作为 endpoint 删失后继续；其余失败关闭。单一 `asyncio.Runner` 跨 12 个 arm 复用。
+  - Evidence: Issue #155 的 7 个核心文件与 2 个后验 SQLite sidecar 均固定集合和 SHA-256，sidecar 保留；coordinator 后验审计使用 `immutable=1`。
+  - 验证: 新增与相邻 checkpoint 回归 `38 passed`，Ruff check/format、manifest/Schema 确定性生成、Compose/DooD 零 provider 门禁和旧 9 文件 evidence 核验通过；canonical manifest SHA-256 为 `d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391`。
+  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；随后在干净 `main == origin/main` 上执行已授权 6-pair pilot，并形成 ITT/attrition 与 conditional mechanism 描述性报告。
+  - 文件: `scripts/forge_checkpoint_censored_pilot_protocol.py`, `scripts/forge_checkpoint_censored_pilot_runner.py`, `backend/tests/test_forge_checkpoint_censored_pilot.py`, `benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json`, `benchmarks/schemas/forge-checkpoint-censored-pilot-v1.schema.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md`
+
 - 2026-08-19 — 评审 checkpoint primary canary 超时终态与下一 amendment
   - GitHub: 中文 Issue #157 已创建并回读；Issue #155 的唯一 controlled pair 已失败关闭，6-pair pilot 未启动。
   - 终态: reachability 在 0.992 秒内通过并记录 17 tokens；baseline 第 1 次 compiler 请求在 300.165 秒 `ReadTimeout`，treatment 未调用模型，三个 Session 均已终结且 0 orphan。

--- a/backend/tests/test_forge_checkpoint_censored_pilot.py
+++ b/backend/tests/test_forge_checkpoint_censored_pilot.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPT_ROOT / "forge_checkpoint_censored_pilot_protocol.py"
+RUNNER_PATH = SCRIPT_ROOT / "forge_checkpoint_censored_pilot_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-censored-pilot-v1.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-censored-pilot-v1.schema.json"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load("forge_checkpoint_censored_pilot_protocol_test", PROTOCOL_PATH)
+runner = _load("forge_checkpoint_censored_pilot_runner_test", RUNNER_PATH)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_is_deterministic_balanced_and_bounded() -> None:
+    manifest = _manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert protocol.generate_manifest() == manifest
+    assert protocol.validate_manifest(manifest) == manifest
+    protocol.verify_frozen_components(manifest)
+    assert schema == protocol.schema_document(manifest)
+    assert len(manifest["schedule"]) == 6
+    assert [item["arm_order"][0] for item in manifest["schedule"]] == [
+        "baseline",
+        "treatment",
+    ] * 3
+    assert manifest["provider"]["request_timeout_seconds"] == 300
+    assert manifest["provider"]["max_retries"] == 0
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 1_440_000
+    assert manifest["stopping"] == {
+        "endpoint_timeout_censors_pair_and_continues": True,
+        "cleanup_or_identity_failure_stops_batch": True,
+        "non_endpoint_failure_stops_batch": True,
+        "retry_forbidden": True,
+        "replacement_forbidden": True,
+        "backfill_forbidden": True,
+        "schedule_extension_forbidden": True,
+    }
+
+
+def test_manifest_rejects_schedule_budget_and_transport_drift() -> None:
+    manifest = _manifest()
+    manifest["schedule"].reverse()
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["budget"]["stage_maximum_recorded_tokens"] += 1
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["provider"]["request_timeout_seconds"] = 600
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)
+
+
+def _patch_preflight(monkeypatch: pytest.MonkeyPatch, manifest: dict, output_dir: Path) -> dict:
+    candidate = copy.deepcopy(manifest)
+    candidate["execution"]["evidence_directory"] = str(output_dir)
+    monkeypatch.setattr(runner.protocol, "validate_manifest", lambda value, *_args: value)
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_args: None)
+    monkeypatch.setattr(runner.protocol, "verify_parent_evidence", lambda *_args: {})
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {
+            "branch": "main",
+            "revision": "a" * 40,
+            "origin_main": "a" * 40,
+        },
+    )
+    monkeypatch.setattr(runner, "require_network_medium", lambda *_args: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+    return candidate
+
+
+def _fake_outcome(manifest: dict, pair: dict, *, censored: bool) -> dict:
+    metrics = {
+        "model_requests": 1,
+        "submit_attempts": 1,
+        "clean_replay_attempts": 1,
+        "recorded_tokens": 10,
+        "ledger_wall_clock_seconds": 2.0,
+    }
+    return {
+        "schema_version": "forge-checkpoint-censored-pair-outcome-1.0.0",
+        "document_type": "forge_checkpoint_censored_pair_outcome",
+        "manifest_sha256": runner.protocol.canonical_sha256(manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "endpoint_censored" if censored else "complete",
+        "endpoint_timeout_arm": pair["arm_order"][0] if censored else None,
+        "recorded_tokens": 10 if censored else 20,
+        "metrics_by_arm": ({pair["arm_order"][0]: metrics} if censored else {"baseline": metrics, "treatment": metrics}),
+    }
+
+
+def test_schedule_continues_after_endpoint_censoring_without_replacement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _patch_preflight(monkeypatch, _manifest(), tmp_path)
+    calls: list[str] = []
+
+    def execute(value: dict, pair: dict, _pair_dir: Path) -> dict:
+        calls.append(pair["pair_id"])
+        return _fake_outcome(value, pair, censored=pair["order"] in {2, 5})
+
+    report = runner.run_pilot(manifest, output_dir=tmp_path, pair_executor=execute)
+
+    assert calls == [f"pair-{number:02d}" for number in range(1, 7)]
+    assert report["status"] == "completed_with_censoring"
+    assert report["itt_attrition"] == {
+        "scheduled_pairs": 6,
+        "observed_pairs": 6,
+        "complete_pairs": 4,
+        "endpoint_censored_pairs": 2,
+        "endpoint_censored_pair_ids": ["pair-02", "pair-05"],
+        "endpoint_timeout_arms": {"baseline": 1, "treatment": 1},
+        "observed_arm_attempts": {"baseline": 5, "treatment": 5},
+    }
+    assert report["conditional_mechanism"]["eligible_complete_pairs"] == 4
+    assert report["conditional_mechanism"]["mean_paired_deltas"]["recorded_tokens"] == 0
+    assert len(list((tmp_path / "pairs").glob("*/reports/pair-outcome.json"))) == 6
+
+    resumed = runner.run_pilot(
+        manifest,
+        output_dir=tmp_path,
+        pair_executor=lambda *_args: pytest.fail("终态 pair 不得重跑"),
+    )
+    assert resumed == report
+
+
+def test_non_endpoint_outcome_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _patch_preflight(monkeypatch, _manifest(), tmp_path)
+
+    with pytest.raises(runner.PilotError, match="非 endpoint"):
+        runner.run_pilot(
+            manifest,
+            output_dir=tmp_path,
+            pair_executor=lambda *_args: {"status": "runtime_failed"},
+        )
+    marker = json.loads((tmp_path / runner.BATCH_MARKER).read_text(encoding="utf-8"))
+    assert marker["status"] == "failed"
+    assert marker["error_class"] == "PilotError"
+
+
+def test_timeout_classifier_requires_hashed_endpoint_failure_and_cleanup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    pair = manifest["schedule"][0]
+    pair_manifest = runner._pair_manifest(manifest, pair)
+    pair_dir = tmp_path / pair["pair_id"]
+    pair_manifest["execution"]["evidence_directory"] = str(pair_dir)
+    marker = {
+        "status": "failed",
+        "manifest_sha256": protocol.canonical_sha256(pair_manifest),
+    }
+    runner._write_once(pair_dir / "markers" / runner.PAIR_MARKER, marker)
+
+    database = pair_dir / "checkpoint" / "coordinator.sqlite"
+    database.parent.mkdir(parents=True)
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE checkpoint_capture (capture_id TEXT, phase TEXT, payload_json TEXT)")
+        connection.execute(
+            "INSERT INTO checkpoint_capture VALUES (?, ?, ?)",
+            ("capture-1", "cleaned", json.dumps({"cleanup": {"succeeded": True}})),
+        )
+
+    ledger = runner.primary.ExperimentLedger.create(
+        pair_dir / "ledgers" / "baseline.jsonl",
+        experiment_id="experiment_1234567890abcdef1234567890abcdef",
+        physical_attempt_id="mechanism_attempt_1234567890abcdef1234567890abcdef",
+        context={"scope": "test"},
+    )
+    ledger.append(
+        "model.request_started",
+        {
+            "attempt": 1,
+            "configured_model": "deepseek-v4-flash",
+            "max_attempts": 1,
+            "model_call_id": "model_call_1234567890abcdef1234567890abcdef",
+            "model_request_id": "model_request_1234567890abcdef1234567890abcdef",
+            "observed_endpoint": "https://api.deepseek.com",
+            "provider_max_retries": 0,
+            "request_timeout_seconds": 300,
+            "role": "compiler",
+        },
+    )
+    ledger.append(
+        "model.request_failed",
+        {
+            "attempt": 1,
+            "classification": "timeout",
+            "latency_seconds": 300.1,
+            "max_attempts": 1,
+            "model_call_id": "model_call_1234567890abcdef1234567890abcdef",
+            "model_request_id": "model_request_1234567890abcdef1234567890abcdef",
+            "retriable": True,
+            "retry_exhausted": True,
+            "status_code": None,
+        },
+    )
+    ledger.append(
+        "failure.recorded",
+        {
+            "classification": "timeout",
+            "domain": "model_endpoint",
+            "failure_id": "failure_1234567890abcdef1234567890abcdef",
+            "model_call_id": "model_call_1234567890abcdef1234567890abcdef",
+            "model_request_id": "model_request_1234567890abcdef1234567890abcdef",
+            "primary": True,
+            "secondary_classifications": ["retry_exhausted"],
+        },
+    )
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+
+    outcome = runner._endpoint_timeout_outcome(
+        manifest,
+        pair,
+        pair_manifest,
+        pair_dir,
+        runner.primary.CanaryError("timeout"),
+    )
+    assert outcome["status"] == "endpoint_censored"
+    assert outcome["endpoint_timeout_arm"] == "baseline"
+    assert outcome["recorded_tokens"] == 0
+    assert outcome["metrics_by_arm"]["baseline"]["model_requests"] == 1
+
+    with sqlite3.connect(database) as connection:
+        connection.execute("UPDATE checkpoint_capture SET phase = 'cleanup_pending'")
+    with pytest.raises(runner.PilotError, match="cleanup 未闭合"):
+        runner._endpoint_timeout_outcome(
+            manifest,
+            pair,
+            pair_manifest,
+            pair_dir,
+            runner.primary.CanaryError("timeout"),
+        )
+
+
+def test_runtime_pair_manifest_binds_pair_identity_and_no_reachability() -> None:
+    manifest = _manifest()
+    first = runner._pair_manifest(manifest, manifest["schedule"][0])
+    second = runner._pair_manifest(manifest, manifest["schedule"][1])
+
+    assert first["pilot"]["pair_id"] == "pair-01"
+    assert second["pilot"]["pair_id"] == "pair-02"
+    assert first["continuation"]["arm_order"] == ["baseline", "treatment"]
+    assert second["continuation"]["arm_order"] == ["treatment", "baseline"]
+    assert first["budget"]["reachability_requests"] == 0
+    assert protocol.canonical_sha256(first) != protocol.canonical_sha256(second)

--- a/benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "../schemas/forge-checkpoint-censored-pilot-v1.schema.json",
+  "schema_version": "forge-checkpoint-censored-pilot-1.0.0",
+  "document_type": "forge_checkpoint_censored_pilot",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/159",
+    "authorized_by": "experiment_owner",
+    "route": "B",
+    "pilot_collection_authorized": true,
+    "authorized_pairs": 6,
+    "maximum_recorded_tokens": 1440000
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "mechanism": "failure_checkpoint",
+    "controlled_fault": "artifact_staging_missing",
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "pair-01",
+      "order": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-02",
+      "order": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "pair-03",
+      "order": 3,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-04",
+      "order": 4,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "pair-05",
+      "order": 5,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-06",
+      "order": 6,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    }
+  ],
+  "schedule_sha256": "274eb4ffd9c769301a5553f23f39ee26537a781d7e351a934908af8cebb982dd",
+  "budget": {
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 1440000,
+    "reachability_requests": 0,
+    "enforcement": "after_each_pair_before_next_pair"
+  },
+  "stopping": {
+    "endpoint_timeout_censors_pair_and_continues": true,
+    "cleanup_or_identity_failure_stops_batch": true,
+    "non_endpoint_failure_stops_batch": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "itt_attrition_includes_all_scheduled_pairs": true,
+    "conditional_mechanism_requires_complete_pair": true,
+    "descriptive_only": true,
+    "p_value_computed": false,
+    "model_ranking_performed": false
+  },
+  "execution": {
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "network_access_medium": "wifi",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+    "pair_directory_pattern": "pairs/pair-NN",
+    "batch_marker": "markers/pilot-attempt.json",
+    "pair_marker": "markers/pair-attempt.json",
+    "release_branch": "main",
+    "authorization_baseline_commit": "fe9fb519eb831e0795ef31f93cec0fb971a80fdf",
+    "release_revision_policy": "descendant-compatible",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_zero_managed_containers_between_pairs": true
+  },
+  "parent": {
+    "authorized_manifest_canonical_sha256": "f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356",
+    "components": {
+      "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+      "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+      "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+      "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+    },
+    "terminal_evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+      "expected_file_count": 9,
+      "files": {
+        "checkpoint/coordinator.sqlite": "dc2b426ceff514683ccec719fb064158b7bc58b3f5f01d1fc620571d6fb13956",
+        "checkpoint/messages.sqlite": "3091ebbe147af151ed9ad37aff3a5d14979bc187a0d69a685a72e8de3b6e14bb",
+        "checkpoint/messages.sqlite-shm": "fd4c9fda9cd3f9ae7c962b0ddf37232294d55580e1aa165aa06129b8549389eb",
+        "checkpoint/messages.sqlite-wal": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "ledgers/baseline.jsonl": "01137d096b55c447655946373afe517135f01306aaf54797aad700dfb69aece2",
+        "ledgers/parent.jsonl": "683c68dc1f2626915c9a7a722db11701dbef667a8fac3d187acf22c269644891",
+        "markers/amendment-controlled-pair-attempt.json": "0d7526bcd7c9af3d3d3349964d2df4cdf15c1503f53fd705c2fcbda16fe00cc0",
+        "markers/amendment-reachability-attempt.json": "51212cbfc00b887f2540343bef156d0e3b1bd680f760a65debcf2eddeee5fa23",
+        "reports/reachability.json": "ff664651aacea073cb8541594c1d443cd92654fe2c9d9767227788dd10adeb48"
+      },
+      "sqlite_sidecars_retained": true
+    }
+  },
+  "protocol_artifacts": {
+    "backend/tests/test_forge_checkpoint_censored_pilot.py": "68db510500f56dc778dd98fae063832f16b7fef52d1ec02a40da5693b55c8570",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md": "5e0b00ea13cb2446a4d65b7ae45dfdb587d3593409623eac0867e36760416989",
+    "scripts/forge_checkpoint_censored_pilot_protocol.py": "b48b43568d0a1f4c1c548e56aeb7e31a94ef6bb40c515fdcedf0edda5e650758",
+    "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768"
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md
+++ b/benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md
@@ -1,0 +1,43 @@
+# Endpoint 删失容忍 checkpoint 六配对 pilot 预注册
+
+本协议承接 Issue #157 的只读 timeout 审计和 Issue #159 的路线 B 授权。研究变量仍是 failure checkpoint 是否向 compiler continuation 提供结构化 verifier repair packet；本次只改变批次停止策略，不改变 provider、prompt、controlled fault、Oracle、candidate verification 或 clean replay。
+
+## 实验身份与预算
+
+- 语言范围固定为 C/C++，controlled fault 固定为 `artifact_staging_missing`。
+- provider 固定为 DeepSeek `deepseek-v4-flash` 与 `https://api.deepseek.com`；单请求 300 秒 timeout、0 retry、禁止 fallback，保持非 streaming。
+- 预注册 6 pair、12 arms；每臂最多 120,000 recorded tokens，总机械上限为 1,440,000 recorded tokens。
+- pair 1/3/5 按 `baseline -> treatment`，pair 2/4/6 按 `treatment -> baseline`，形成 3:3 交叉平衡。
+- 不允许 replacement、backfill、补跑或第 7 个 pair。timeout、streaming 和输出上限不能在本批次中另行改变。
+
+## 独立 evidence 与断点
+
+- 新 evidence 只写入 `/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1`。
+- 每个 pair 使用 `pairs/pair-NN` 独立目录、独立 checkpoint SQLite、ledger、report 和一次性 marker。
+- 已形成 `complete` 或 `endpoint_censored` outcome 的 pair 在批次恢复时只读跳过，不能重复执行。
+- 已出现内容但没有合法终态的 pair 视为中断，不自动重试；必须人工审计 cleanup 和 evidence 后另行决策。
+- Issue #155 的 7 个核心 evidence 与 2 个后验 SQLite sidecar 均固定文件集合和 SHA-256。sidecar 保留，不删除、不覆盖；SQLite 审计只使用 `immutable=1`。
+
+## Endpoint 删失定义
+
+只有同时满足以下条件的失败 pair 才标记为 `endpoint_censored` 并继续后续预注册 pair：
+
+1. 唯一请求失败事件为 `model.request_failed`；
+2. `classification=timeout`、`retry_exhausted=true`、`status_code=null`；
+3. 存在唯一匹配的 primary `failure.recorded`，其 `domain=model_endpoint`、`classification=timeout` 且 secondary 包含 `retry_exhausted`；
+4. ledger 哈希链完整，每臂 recorded tokens 未超过上限；
+5. coordinator 以 `immutable=1` 读取后为 `cleaned`，并记录 `cleanup.succeeded=true`；
+6. Docker daemon 中没有 `deerflow-compile-*` 或 `deerflow-replay-*` orphan。
+
+identity/evidence 漂移、cleanup 不闭合、预算超限、非 endpoint 请求失败、模型行为失败或其他异常仍立即关闭批次。删失不能解释为模型能力、checkpoint treatment、Oracle 或 clean replay 的失败。
+
+## 两个 estimand
+
+- ITT/attrition：分母固定为全部 6 个预注册 pair，报告 complete 与 endpoint-censored 数量、删失 pair/arm、请求数和 recorded tokens。
+- Conditional mechanism：只纳入双臂均形成完整可验证终态的 pair，描述 repair conversion、请求数、submit/replay 次数、token 和 wall-clock 差异。
+
+本 pilot 仅做描述性机制评估，不计算 p 值，不做模型排名或跨 provider 推断。单个 pair 或少量 complete pair 不支持确定性效应结论。
+
+## 发布与执行门禁
+
+实现合并前只允许 manifest/Schema 生成、零 provider 单测、Ruff 和冻结 evidence 只读核验。真实执行必须位于干净 `main == origin/main`，使用 WSL2 Ubuntu 原生 Docker 的既有 Compose/DooD control plane，网络介质记录为 `wifi`，并在每个 pair 前后核验 0 受管 orphan。

--- a/benchmarks/schemas/forge-checkpoint-censored-pilot-v1.schema.json
+++ b/benchmarks/schemas/forge-checkpoint-censored-pilot-v1.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-censored-pilot-v1.schema.json",
+  "title": "Forge endpoint-censored checkpoint pilot",
+  "const": {
+    "$schema": "../schemas/forge-checkpoint-censored-pilot-v1.schema.json",
+    "schema_version": "forge-checkpoint-censored-pilot-1.0.0",
+    "document_type": "forge_checkpoint_censored_pilot",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/159",
+      "authorized_by": "experiment_owner",
+      "route": "B",
+      "pilot_collection_authorized": true,
+      "authorized_pairs": 6,
+      "maximum_recorded_tokens": 1440000
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "mechanism": "failure_checkpoint",
+      "controlled_fault": "artifact_staging_missing",
+      "natural_collection_authorized": false,
+      "secondary_provider_authorized": false
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "pair-01",
+        "order": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-02",
+        "order": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "pair-03",
+        "order": 3,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-04",
+        "order": 4,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "pair-05",
+        "order": 5,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-06",
+        "order": 6,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "schedule_sha256": "274eb4ffd9c769301a5553f23f39ee26537a781d7e351a934908af8cebb982dd",
+    "budget": {
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 1440000,
+      "reachability_requests": 0,
+      "enforcement": "after_each_pair_before_next_pair"
+    },
+    "stopping": {
+      "endpoint_timeout_censors_pair_and_continues": true,
+      "cleanup_or_identity_failure_stops_batch": true,
+      "non_endpoint_failure_stops_batch": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "itt_attrition_includes_all_scheduled_pairs": true,
+      "conditional_mechanism_requires_complete_pair": true,
+      "descriptive_only": true,
+      "p_value_computed": false,
+      "model_ranking_performed": false
+    },
+    "execution": {
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "network_access_medium": "wifi",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+      "pair_directory_pattern": "pairs/pair-NN",
+      "batch_marker": "markers/pilot-attempt.json",
+      "pair_marker": "markers/pair-attempt.json",
+      "release_branch": "main",
+      "authorization_baseline_commit": "fe9fb519eb831e0795ef31f93cec0fb971a80fdf",
+      "release_revision_policy": "descendant-compatible",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_zero_managed_containers_between_pairs": true
+    },
+    "parent": {
+      "authorized_manifest_canonical_sha256": "f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356",
+      "components": {
+        "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+        "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+        "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+        "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+      },
+      "terminal_evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+        "expected_file_count": 9,
+        "files": {
+          "checkpoint/coordinator.sqlite": "dc2b426ceff514683ccec719fb064158b7bc58b3f5f01d1fc620571d6fb13956",
+          "checkpoint/messages.sqlite": "3091ebbe147af151ed9ad37aff3a5d14979bc187a0d69a685a72e8de3b6e14bb",
+          "checkpoint/messages.sqlite-shm": "fd4c9fda9cd3f9ae7c962b0ddf37232294d55580e1aa165aa06129b8549389eb",
+          "checkpoint/messages.sqlite-wal": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "ledgers/baseline.jsonl": "01137d096b55c447655946373afe517135f01306aaf54797aad700dfb69aece2",
+          "ledgers/parent.jsonl": "683c68dc1f2626915c9a7a722db11701dbef667a8fac3d187acf22c269644891",
+          "markers/amendment-controlled-pair-attempt.json": "0d7526bcd7c9af3d3d3349964d2df4cdf15c1503f53fd705c2fcbda16fe00cc0",
+          "markers/amendment-reachability-attempt.json": "51212cbfc00b887f2540343bef156d0e3b1bd680f760a65debcf2eddeee5fa23",
+          "reports/reachability.json": "ff664651aacea073cb8541594c1d443cd92654fe2c9d9767227788dd10adeb48"
+        },
+        "sqlite_sidecars_retained": true
+      }
+    },
+    "protocol_artifacts": {
+      "backend/tests/test_forge_checkpoint_censored_pilot.py": "68db510500f56dc778dd98fae063832f16b7fef52d1ec02a40da5693b55c8570",
+      "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md": "5e0b00ea13cb2446a4d65b7ae45dfdb587d3593409623eac0867e36760416989",
+      "scripts/forge_checkpoint_censored_pilot_protocol.py": "b48b43568d0a1f4c1c548e56aeb7e31a94ef6bb40c515fdcedf0edda5e650758",
+      "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768"
+    }
+  }
+}

--- a/scripts/forge_checkpoint_censored_pilot_protocol.py
+++ b/scripts/forge_checkpoint_censored_pilot_protocol.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Issue #159 endpoint 删失容忍 checkpoint 六配对 pilot 协议。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-censored-pilot-v1.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-censored-pilot-v1.schema.json"
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1")
+PARENT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment")
+
+SCHEMA_VERSION = "forge-checkpoint-censored-pilot-1.0.0"
+DOCUMENT_TYPE = "forge_checkpoint_censored_pilot"
+AUTHORIZATION_BASELINE = "fe9fb519eb831e0795ef31f93cec0fb971a80fdf"
+PAIR_COUNT = 6
+RECORDED_TOKENS_PER_ARM = 120_000
+RECORDED_TOKEN_LIMIT = PAIR_COUNT * 2 * RECORDED_TOKENS_PER_ARM
+
+PARENT_COMPONENTS = {
+    "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": ("fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776"),
+    "scripts/forge_checkpoint_primary_canary.py": ("031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282"),
+    "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": ("89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba"),
+    "scripts/forge_checkpoint_windows_build_layout.py": ("df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"),
+}
+
+PARENT_EVIDENCE = {
+    "checkpoint/coordinator.sqlite": ("dc2b426ceff514683ccec719fb064158b7bc58b3f5f01d1fc620571d6fb13956"),
+    "checkpoint/messages.sqlite": ("3091ebbe147af151ed9ad37aff3a5d14979bc187a0d69a685a72e8de3b6e14bb"),
+    "checkpoint/messages.sqlite-shm": ("fd4c9fda9cd3f9ae7c962b0ddf37232294d55580e1aa165aa06129b8549389eb"),
+    "checkpoint/messages.sqlite-wal": ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+    "ledgers/baseline.jsonl": ("01137d096b55c447655946373afe517135f01306aaf54797aad700dfb69aece2"),
+    "ledgers/parent.jsonl": ("683c68dc1f2626915c9a7a722db11701dbef667a8fac3d187acf22c269644891"),
+    "markers/amendment-controlled-pair-attempt.json": ("0d7526bcd7c9af3d3d3349964d2df4cdf15c1503f53fd705c2fcbda16fe00cc0"),
+    "markers/amendment-reachability-attempt.json": ("51212cbfc00b887f2540343bef156d0e3b1bd680f760a65debcf2eddeee5fa23"),
+    "reports/reachability.json": ("ff664651aacea073cb8541594c1d443cd92654fe2c9d9767227788dd10adeb48"),
+}
+
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_checkpoint_censored_pilot_protocol.py",
+    "scripts/forge_checkpoint_censored_pilot_runner.py",
+    "backend/tests/test_forge_checkpoint_censored_pilot.py",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-v1.md",
+}
+
+
+class ProtocolError(RuntimeError):
+    """协议、冻结组件或历史 evidence 发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_protocol_artifacts(repo_root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(PROTOCOL_ARTIFACT_PATHS):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"协议制品缺失: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def _schedule() -> list[dict[str, Any]]:
+    schedule: list[dict[str, Any]] = []
+    for number in range(1, PAIR_COUNT + 1):
+        arm_order = ["baseline", "treatment"] if number % 2 == 1 else ["treatment", "baseline"]
+        schedule.append(
+            {
+                "pair_id": f"pair-{number:02d}",
+                "order": number,
+                "arm_order": arm_order,
+            }
+        )
+    return schedule
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    schedule = _schedule()
+    return {
+        "$schema": "../schemas/forge-checkpoint-censored-pilot-v1.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/159",
+            "authorized_by": "experiment_owner",
+            "route": "B",
+            "pilot_collection_authorized": True,
+            "authorized_pairs": PAIR_COUNT,
+            "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+        },
+        "scope": {
+            "languages": ["C", "C++"],
+            "mechanism": "failure_checkpoint",
+            "controlled_fault": "artifact_staging_missing",
+            "natural_collection_authorized": False,
+            "secondary_provider_authorized": False,
+        },
+        "provider": {
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "continuation": {
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "budget": {
+            "recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+            "recorded_tokens_per_pair": RECORDED_TOKENS_PER_ARM * 2,
+            "stage_maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+            "reachability_requests": 0,
+            "enforcement": "after_each_pair_before_next_pair",
+        },
+        "stopping": {
+            "endpoint_timeout_censors_pair_and_continues": True,
+            "cleanup_or_identity_failure_stops_batch": True,
+            "non_endpoint_failure_stops_batch": True,
+            "retry_forbidden": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "analysis": {
+            "itt_attrition_includes_all_scheduled_pairs": True,
+            "conditional_mechanism_requires_complete_pair": True,
+            "descriptive_only": True,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+        },
+        "execution": {
+            "control_plane": "compose-dood-on-ubuntu-native-docker",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "network_access_medium": "wifi",
+            "evidence_directory": str(DEFAULT_OUTPUT_DIR),
+            "pair_directory_pattern": "pairs/pair-NN",
+            "batch_marker": "markers/pilot-attempt.json",
+            "pair_marker": "markers/pair-attempt.json",
+            "release_branch": "main",
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE,
+            "release_revision_policy": "descendant-compatible",
+            "require_clean_worktree": True,
+            "require_origin_main_identity": True,
+            "require_zero_managed_containers_between_pairs": True,
+        },
+        "parent": {
+            "authorized_manifest_canonical_sha256": ("f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356"),
+            "components": dict(sorted(PARENT_COMPONENTS.items())),
+            "terminal_evidence": {
+                "directory": str(PARENT_OUTPUT_DIR),
+                "expected_file_count": len(PARENT_EVIDENCE),
+                "files": dict(sorted(PARENT_EVIDENCE.items())),
+                "sqlite_sidecars_retained": True,
+            },
+        },
+        "protocol_artifacts": _hash_protocol_artifacts(repo_root),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("pilot manifest 必须是对象")
+    expected = generate_manifest(repo_root)
+    if value != expected:
+        raise ProtocolError("pilot manifest 与冻结协议不一致")
+    schedule = value["schedule"]
+    if len(schedule) != PAIR_COUNT:
+        raise ProtocolError("pilot schedule 必须包含 6 个 pair")
+    if [item["order"] for item in schedule] != list(range(1, PAIR_COUNT + 1)):
+        raise ProtocolError("pilot schedule order 不连续")
+    first_arms = [item["arm_order"][0] for item in schedule]
+    if first_arms != ["baseline", "treatment"] * 3:
+        raise ProtocolError("pilot arm order 未交叉平衡")
+    return value
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    for relative_path, expected in manifest["parent"]["components"].items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise ProtocolError(f"冻结父组件发生漂移: {relative_path}")
+    for relative_path, expected in manifest["protocol_artifacts"].items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise ProtocolError(f"pilot 协议制品发生漂移: {relative_path}")
+
+
+def verify_parent_evidence(manifest: dict[str, Any], output_dir: Path = PARENT_OUTPUT_DIR) -> dict[str, Any]:
+    terminal = manifest["parent"]["terminal_evidence"]
+    expected = terminal["files"]
+    actual_paths = {path.relative_to(output_dir).as_posix() for path in output_dir.rglob("*") if path.is_file()}
+    if actual_paths != set(expected):
+        raise ProtocolError("Issue #155 冻结 evidence 文件集合发生漂移")
+    for relative_path, digest in expected.items():
+        if file_sha256(output_dir / relative_path) != digest:
+            raise ProtocolError(f"Issue #155 冻结 evidence SHA-256 发生漂移: {relative_path}")
+    return {
+        "status": "valid",
+        "file_count": len(actual_paths),
+        "sqlite_sidecars_retained": terminal["sqlite_sidecars_retained"],
+    }
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": ("https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-censored-pilot-v1.schema.json"),
+        "title": "Forge endpoint-censored checkpoint pilot",
+        "const": manifest or generate_manifest(),
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "validate-evidence"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--parent-output-dir", type=Path, default=PARENT_OUTPUT_DIR)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            _write_json(args.schema, schema_document(manifest))
+            status = "generated"
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+            if args.command == "validate-evidence":
+                verify_parent_evidence(manifest, args.parent_output_dir)
+            status = "valid"
+    except (OSError, ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "manifest_sha256": canonical_sha256(manifest),
+                "authorized_pairs": PAIR_COUNT,
+                "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+                "provider_calls": 0,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_checkpoint_censored_pilot_runner.py
+++ b/scripts/forge_checkpoint_censored_pilot_runner.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""执行 Issue #159 endpoint 删失容忍 checkpoint 六配对 pilot。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import importlib.util
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_checkpoint_censored_pilot_protocol as protocol  # noqa: E402
+
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = protocol.DEFAULT_OUTPUT_DIR
+BATCH_MARKER = "markers/pilot-attempt.json"
+PAIR_MARKER = "pair-attempt.json"
+PAIR_OUTCOME = "reports/pair-outcome.json"
+PILOT_REPORT = "reports/pilot.json"
+MANAGED_CONTAINER_PREFIXES = ("deerflow-compile-", "deerflow-replay-")
+
+
+class PilotError(RuntimeError):
+    """pilot identity、evidence、cleanup 或停止规则失败。"""
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise PilotError(f"无法加载 runner 模块: {path.name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+parent_adapter = _load_module(
+    "forge_checkpoint_censored_pilot_parent_adapter",
+    SCRIPT_ROOT / "forge_checkpoint_primary_canary_amendment_authorized.py",
+)
+primary = parent_adapter.primary_canary
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PilotError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise PilotError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _write_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+    except FileExistsError as exc:
+        raise PilotError(f"不可覆盖已存在的 evidence: {path}") from exc
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo_root}", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise PilotError("无法验证 release Git identity")
+    return result.stdout.strip()
+
+
+def require_release_identity(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    branch = _git(repo_root, "branch", "--show-current")
+    revision = _git(repo_root, "rev-parse", "HEAD")
+    origin_main = _git(repo_root, "rev-parse", "origin/main")
+    dirty = _git(repo_root, "status", "--porcelain", "--untracked-files=normal")
+    execution = manifest["execution"]
+    if branch != execution["release_branch"]:
+        raise PilotError("真实 pilot 只能在合并后的 main 分支运行")
+    if revision != origin_main:
+        raise PilotError("HEAD 与 origin/main 不一致，禁止真实 pilot")
+    if dirty:
+        raise PilotError("工作树不干净，禁止真实 pilot")
+    baseline = execution["authorization_baseline_commit"]
+    if _git(repo_root, "merge-base", baseline, revision) != baseline:
+        raise PilotError("当前 release 不是授权 baseline 的后代")
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+def require_network_medium(manifest: dict[str, Any]) -> str:
+    execution = manifest["execution"]
+    name = execution["network_access_medium_env"]
+    medium = os.environ.get(name)
+    if medium != execution["network_access_medium"]:
+        raise PilotError(f"必须通过 {name}=wifi 确认当前网络介质")
+    return medium
+
+
+def managed_containers() -> list[str]:
+    result = subprocess.run(
+        ["docker", "ps", "-a", "--format", "{{.Names}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise PilotError("无法核验 Compile Session/replay 容器清单")
+    return sorted(name for name in result.stdout.splitlines() if name.startswith(MANAGED_CONTAINER_PREFIXES))
+
+
+def require_zero_managed_containers() -> None:
+    names = managed_containers()
+    if names:
+        raise PilotError("存在 Compile Session/replay orphan，禁止继续 pilot")
+
+
+def _pair_manifest(manifest: dict[str, Any], pair: dict[str, Any]) -> dict[str, Any]:
+    parent_path = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-authorized.json"
+    value = _load_json(parent_path)
+    value["schema_version"] = "forge-checkpoint-censored-pair-runtime-1.0.0"
+    value["document_type"] = "forge_checkpoint_censored_pair_runtime"
+    value["scope"]["pilot_collection_authorized"] = True
+    value["continuation"]["arm_order"] = copy.deepcopy(pair["arm_order"])
+    value["budget"] = {
+        "reachability_requests": 0,
+        "reachability_expected_tokens": 0,
+        "reachability_maximum_tokens": 0,
+        "mechanism_canary_expected_tokens": 120_000,
+        "mechanism_canary_maximum_tokens": 240_000,
+        "stage_expected_tokens": 120_000,
+        "stage_maximum_tokens": 240_000,
+    }
+    pair_dir = DEFAULT_OUTPUT_DIR / "pairs" / pair["pair_id"]
+    value["execution"]["evidence_directory"] = str(pair_dir)
+    value["execution"]["controlled_pair_marker"] = PAIR_MARKER
+    value["execution"]["authorization_baseline_commit"] = manifest["execution"]["authorization_baseline_commit"]
+    value["authorization"] = {
+        "issue_url": manifest["authorization"]["issue_url"],
+        "authorized_reachability_attempts": 0,
+        "authorized_controlled_pairs": 1,
+        "stage_maximum_tokens": 240_000,
+        "pilot_collection_authorized": True,
+    }
+    value["pilot"] = {
+        "parent_manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "endpoint_timeout_censors_pair_and_continues": True,
+    }
+    return value
+
+
+class _AsyncioProxy:
+    def __init__(self, runner: asyncio.Runner):
+        self._runner = runner
+
+    def run(self, coroutine: Any) -> Any:
+        return self._runner.run(coroutine)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(asyncio, name)
+
+
+@contextmanager
+def _adapt_parent_runner(
+    manifest: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    async_runner: asyncio.Runner,
+) -> Iterator[None]:
+    original = {
+        "validate_manifest": primary.validate_manifest,
+        "verify_frozen_artifacts": primary.verify_frozen_artifacts,
+        "require_release_identity": primary.require_release_identity,
+        "require_passed_reachability": primary.require_passed_reachability,
+        "PAIR_MARKER": primary.PAIR_MARKER,
+        "asyncio": primary.asyncio,
+    }
+
+    def validate(value: Any) -> dict[str, Any]:
+        if value != pair_manifest:
+            raise PilotError("pair runtime manifest 发生漂移")
+        return value
+
+    def verify(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+        validate(value)
+        protocol.verify_frozen_components(manifest, repo_root)
+
+    def release(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+        validate(value)
+        return require_release_identity(manifest, repo_root)
+
+    primary.validate_manifest = validate
+    primary.verify_frozen_artifacts = verify
+    primary.require_release_identity = release
+    primary.require_passed_reachability = lambda *_args, **_kwargs: {
+        "recorded_tokens": 0,
+        "inherited_reachability": False,
+    }
+    primary.PAIR_MARKER = PAIR_MARKER
+    primary.asyncio = _AsyncioProxy(async_runner)
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            setattr(primary, name, value)
+
+
+def _coordinator_terminal(pair_dir: Path) -> dict[str, Any]:
+    database = (pair_dir / "checkpoint" / "coordinator.sqlite").resolve()
+    if not database.is_file():
+        raise PilotError("pair 缺少 checkpoint coordinator evidence")
+    uri = f"file:{database.as_posix()}?immutable=1"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute("SELECT capture_id, phase, payload_json FROM checkpoint_capture").fetchall()
+    except (sqlite3.Error, OSError) as exc:
+        raise PilotError("无法以 immutable=1 审计 coordinator evidence") from exc
+    if len(rows) != 1:
+        raise PilotError("pair coordinator capture 数量不是 1")
+    capture_id, phase, payload_raw = rows[0]
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        raise PilotError("pair coordinator payload 不是有效 JSON") from exc
+    if phase != "cleaned" or payload.get("cleanup", {}).get("succeeded") is not True:
+        raise PilotError("pair cleanup 未闭合")
+    return {"capture_id": capture_id, "phase": phase, "cleanup_succeeded": True}
+
+
+def _ledger_events(pair_dir: Path) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for arm in ("baseline", "treatment"):
+        path = pair_dir / "ledgers" / f"{arm}.jsonl"
+        if path.is_file():
+            result[arm] = primary.ExperimentLedger.verify_path(path)
+    if not result:
+        raise PilotError("pair 没有 arm ledger")
+    return result
+
+
+def _recorded_tokens(events: list[dict[str, Any]]) -> int:
+    total = 0
+    for event in events:
+        if event["event"] != "model.request_completed":
+            continue
+        usage = event["payload"].get("token_usage")
+        tokens = usage.get("total_tokens") if isinstance(usage, dict) else None
+        if type(tokens) is not int or tokens < 0:
+            raise PilotError("完成请求缺少有效 recorded token usage")
+        total += tokens
+    return total
+
+
+def _arm_metrics(events: list[dict[str, Any]]) -> dict[str, Any]:
+    started_at = datetime.fromisoformat(events[0]["occurred_at"])
+    completed_at = datetime.fromisoformat(events[-1]["occurred_at"])
+    return {
+        "model_requests": sum(event["event"] == "model.request_started" for event in events),
+        "submit_attempts": sum(event["event"] == "submit.started" for event in events),
+        "clean_replay_attempts": sum(event["event"] == "replay.started" for event in events),
+        "recorded_tokens": _recorded_tokens(events),
+        "ledger_wall_clock_seconds": round((completed_at - started_at).total_seconds(), 6),
+    }
+
+
+def _endpoint_timeout_outcome(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    pair_dir: Path,
+    error: BaseException,
+) -> dict[str, Any]:
+    marker = _load_json(pair_dir / "markers" / PAIR_MARKER)
+    if marker.get("status") != "failed" or marker.get("manifest_sha256") != protocol.canonical_sha256(pair_manifest):
+        raise PilotError("失败 pair marker identity 或终态无效") from error
+    coordinator = _coordinator_terminal(pair_dir)
+    require_zero_managed_containers()
+    ledgers = _ledger_events(pair_dir)
+    failures: list[tuple[str, dict[str, Any]]] = []
+    classifications: list[tuple[str, dict[str, Any]]] = []
+    metrics_by_arm: dict[str, dict[str, Any]] = {}
+    for arm, events in ledgers.items():
+        metrics_by_arm[arm] = _arm_metrics(events)
+        failures.extend((arm, event) for event in events if event["event"] in {"model.request_failed", "model.request_cancelled"})
+        classifications.extend((arm, event) for event in events if event["event"] == "failure.recorded" and event["payload"].get("primary") is True)
+    if any(metrics["recorded_tokens"] > manifest["continuation"]["maximum_recorded_tokens_per_arm"] for metrics in metrics_by_arm.values()):
+        raise PilotError("endpoint-censored arm 超过 recorded-token 上限") from error
+    if len(failures) != 1 or failures[0][1]["event"] != "model.request_failed":
+        raise PilotError("失败 pair 不是唯一 endpoint timeout") from error
+    failed_arm, failed = failures[0]
+    payload = failed["payload"]
+    matching = [
+        item
+        for arm, item in classifications
+        if arm == failed_arm and item["payload"].get("domain") == "model_endpoint" and item["payload"].get("classification") == "timeout" and "retry_exhausted" in item["payload"].get("secondary_classifications", [])
+    ]
+    if payload.get("classification") != "timeout" or payload.get("retry_exhausted") is not True or payload.get("status_code") is not None or len(matching) != 1 or len(classifications) != 1:
+        raise PilotError("失败 pair 不满足预注册 endpoint timeout 删失定义") from error
+    return {
+        "schema_version": "forge-checkpoint-censored-pair-outcome-1.0.0",
+        "document_type": "forge_checkpoint_censored_pair_outcome",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_manifest_sha256": protocol.canonical_sha256(pair_manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "endpoint_censored",
+        "endpoint_timeout_arm": failed_arm,
+        "metrics_by_arm": metrics_by_arm,
+        "recorded_tokens": sum(metrics["recorded_tokens"] for metrics in metrics_by_arm.values()),
+        "conditional_mechanism_contribution": 0,
+        "itt_attrition_contribution": 1,
+        "coordinator": coordinator,
+        "error_class": type(error).__name__,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _passed_outcome(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    pair_dir: Path,
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    if report.get("passed") is not True or report.get("complete_pair") is not True or report.get("arm_order") != pair["arm_order"]:
+        raise PilotError("passed pair report 终态无效")
+    coordinator = _coordinator_terminal(pair_dir)
+    require_zero_managed_containers()
+    arms = report.get("arms")
+    if not isinstance(arms, list) or {item.get("arm") for item in arms} != {
+        "baseline",
+        "treatment",
+    }:
+        raise PilotError("passed pair 缺少双臂结果")
+    tokens_by_arm = {item["arm"]: item["recorded_tokens"] for item in arms}
+    if any(type(tokens) is not int or tokens < 0 or tokens > manifest["continuation"]["maximum_recorded_tokens_per_arm"] for tokens in tokens_by_arm.values()):
+        raise PilotError("passed pair arm token evidence 无效")
+    ledgers = _ledger_events(pair_dir)
+    if set(ledgers) != {"baseline", "treatment"}:
+        raise PilotError("passed pair 缺少双臂 ledger")
+    metrics_by_arm = {arm: _arm_metrics(events) for arm, events in ledgers.items()}
+    if any(metrics_by_arm[arm]["recorded_tokens"] != tokens_by_arm[arm] for arm in metrics_by_arm):
+        raise PilotError("passed pair report 与 ledger token 不一致")
+    return {
+        "schema_version": "forge-checkpoint-censored-pair-outcome-1.0.0",
+        "document_type": "forge_checkpoint_censored_pair_outcome",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_manifest_sha256": protocol.canonical_sha256(pair_manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "complete",
+        "arms": arms,
+        "metrics_by_arm": metrics_by_arm,
+        "recorded_tokens": sum(tokens_by_arm.values()),
+        "conditional_mechanism_contribution": 1,
+        "itt_attrition_contribution": 1,
+        "coordinator": coordinator,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def execute_real_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: asyncio.Runner,
+) -> dict[str, Any]:
+    pair_manifest = _pair_manifest(manifest, pair)
+    pair_manifest["execution"]["evidence_directory"] = str(pair_dir)
+    with _adapt_parent_runner(manifest, pair_manifest, async_runner):
+        try:
+            with parent_adapter.build_layout.use_windows_safe_build_layout(primary):
+                report = primary.run_controlled_pair(
+                    pair_manifest,
+                    output_dir=pair_dir,
+                    repo_root=REPO_ROOT,
+                )
+        except BaseException as exc:
+            return _endpoint_timeout_outcome(manifest, pair, pair_manifest, pair_dir, exc)
+    return _passed_outcome(manifest, pair, pair_manifest, pair_dir, report)
+
+
+def _claim_batch_marker(path: Path, manifest_sha256: str, revision: str) -> dict[str, Any]:
+    if path.exists():
+        marker = _load_json(path)
+        if marker.get("manifest_sha256") != manifest_sha256 or marker.get("release_revision") != revision:
+            raise PilotError("已有 batch marker identity 发生漂移")
+        if marker.get("status") not in {"started", "passed"}:
+            raise PilotError("已有 batch marker 已失败关闭")
+        return marker
+    value = {
+        "schema_version": "forge-checkpoint-censored-pilot-attempt-1.0.0",
+        "document_type": "forge_checkpoint_censored_pilot_attempt",
+        "manifest_sha256": manifest_sha256,
+        "release_revision": revision,
+        "status": "started",
+        "error_class": None,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    _write_once(path, value)
+    return value
+
+
+def summarize(
+    manifest: dict[str, Any],
+    release: dict[str, str],
+    outcomes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    complete = [item for item in outcomes if item["status"] == "complete"]
+    censored = [item for item in outcomes if item["status"] == "endpoint_censored"]
+    tokens = sum(item["recorded_tokens"] for item in outcomes)
+    metric_names = ("model_requests", "submit_attempts", "clean_replay_attempts", "recorded_tokens", "ledger_wall_clock_seconds")
+    paired_deltas = {name: [round(item["metrics_by_arm"]["treatment"][name] - item["metrics_by_arm"]["baseline"][name], 6) for item in complete] for name in metric_names}
+    return {
+        "schema_version": "forge-checkpoint-censored-pilot-report-1.0.0",
+        "document_type": "forge_checkpoint_censored_pilot_report",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": manifest["execution"]["network_access_medium"],
+        "status": "completed_with_censoring" if censored else "completed",
+        "itt_attrition": {
+            "scheduled_pairs": protocol.PAIR_COUNT,
+            "observed_pairs": len(outcomes),
+            "complete_pairs": len(complete),
+            "endpoint_censored_pairs": len(censored),
+            "endpoint_censored_pair_ids": [item["pair_id"] for item in censored],
+            "endpoint_timeout_arms": {arm: sum(item.get("endpoint_timeout_arm") == arm for item in censored) for arm in ("baseline", "treatment")},
+            "observed_arm_attempts": {arm: sum(arm in item.get("metrics_by_arm", {}) for item in outcomes) for arm in ("baseline", "treatment")},
+        },
+        "conditional_mechanism": {
+            "eligible_complete_pairs": len(complete),
+            "pair_ids": [item["pair_id"] for item in complete],
+            "repair_conversion": {"baseline_passed": len(complete), "treatment_passed": len(complete)},
+            "paired_deltas_treatment_minus_baseline": paired_deltas,
+            "mean_paired_deltas": {name: (round(sum(values) / len(values), 6) if values else None) for name, values in paired_deltas.items()},
+            "descriptive_only": True,
+            "model_ranking_performed": False,
+            "p_value_computed": False,
+        },
+        "recorded_tokens": tokens,
+        "maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+        "pairs": outcomes,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+PairExecutor = Callable[[dict[str, Any], dict[str, Any], Path], dict[str, Any]]
+
+
+def run_pilot(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    pair_executor: PairExecutor | None = None,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    expected = Path(manifest["execution"]["evidence_directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise PilotError("pilot evidence 必须写入冻结授权目录")
+    release = require_release_identity(manifest, repo_root)
+    require_network_medium(manifest)
+    primary.require_compose_dood()
+    protocol.verify_parent_evidence(manifest)
+    require_zero_managed_containers()
+    digest = protocol.canonical_sha256(manifest)
+    marker_path = output_dir / BATCH_MARKER
+    marker = _claim_batch_marker(marker_path, digest, release["revision"])
+    report_path = output_dir / PILOT_REPORT
+    if marker["status"] == "passed":
+        report = _load_json(report_path)
+        if report.get("manifest_sha256") != digest:
+            raise PilotError("已完成 pilot report identity 发生漂移")
+        return report
+
+    outcomes: list[dict[str, Any]] = []
+    try:
+        with asyncio.Runner() as async_runner:
+            for pair in manifest["schedule"]:
+                pair_dir = output_dir / "pairs" / pair["pair_id"]
+                outcome_path = pair_dir / PAIR_OUTCOME
+                if outcome_path.exists():
+                    outcome = _load_json(outcome_path)
+                    if outcome.get("manifest_sha256") != digest or outcome.get("pair_id") != pair["pair_id"] or outcome.get("status") not in {"complete", "endpoint_censored"}:
+                        raise PilotError("已有 pair outcome identity 或终态无效")
+                else:
+                    if pair_dir.exists() and any(pair_dir.iterdir()):
+                        raise PilotError(f"{pair['pair_id']} 已开始但没有终态，禁止自动补跑")
+                    require_zero_managed_containers()
+                    if pair_executor is None:
+                        outcome = execute_real_pair(manifest, pair, pair_dir, async_runner)
+                    else:
+                        outcome = pair_executor(manifest, pair, pair_dir)
+                    if outcome.get("status") not in {
+                        "complete",
+                        "endpoint_censored",
+                    }:
+                        raise PilotError("非 endpoint 失败关闭 pilot")
+                    _write_once(outcome_path, outcome)
+                outcomes.append(outcome)
+                recorded = sum(item["recorded_tokens"] for item in outcomes)
+                if recorded > manifest["budget"]["stage_maximum_recorded_tokens"]:
+                    raise PilotError("pilot 超过 recorded-token 机械上限")
+                require_zero_managed_containers()
+        if len(outcomes) != protocol.PAIR_COUNT:
+            raise PilotError("pilot 未形成 6 个预注册 pair 终态")
+        report = summarize(manifest, release, outcomes)
+        _write_once(report_path, report)
+        marker.update(
+            status="passed",
+            error_class=None,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write(marker_path, marker)
+        return report
+    except BaseException as exc:
+        marker.update(
+            status="failed",
+            error_class=type(exc).__name__,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write(marker_path, marker)
+        raise
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "run", "report"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = protocol.validate_manifest(_load_json(args.manifest))
+        if args.command == "validate":
+            protocol.verify_frozen_components(manifest)
+            result = {
+                "status": "valid",
+                "manifest_sha256": protocol.canonical_sha256(manifest),
+                "provider_calls": 0,
+            }
+        elif args.command == "report":
+            result = _load_json(args.output_dir / PILOT_REPORT)
+            if result.get("manifest_sha256") != protocol.canonical_sha256(manifest):
+                raise PilotError("pilot report identity 发生漂移")
+        else:
+            result = run_pilot(manifest, output_dir=args.output_dir)
+    except (OSError, PilotError, protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 冻结路线 B 的 6-pair/12-arm checkpoint mechanism pilot，arm order 以 3:3 交叉平衡；
- 固定 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、非 streaming 与 1,440,000 recorded-token 总上限；
- 新增版本化 runner：每个 pair 使用独立 evidence/marker，只有满足完整 ledger 哈希链、唯一 endpoint timeout、coordinator `cleaned`、`cleanup.succeeded=true` 和 0 orphan 时才作为删失继续；
- 复用既有 controlled-pair、checkpoint、Oracle、candidate verification 和 clean replay，不修改冻结父 runner 或 Forge 编译核心；
- 复用单一 `asyncio.Runner` 执行 12 个 arm，避免跨 arm 关闭事件循环；
- 报告同时输出全部预注册 pair 的 ITT/attrition，以及完整 pair 的 conditional mechanism 配对差值；
- 固定 Issue #155 的 7 个核心 evidence 与 2 个保留 SQLite sidecar，后验 SQLite 审计使用 `immutable=1`。

## 验证

- 新增与相邻 checkpoint 回归：`38 passed`；
- Ruff check/format：通过；
- manifest/Schema 确定性生成：通过；
- canonical manifest SHA-256：`d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391`；
- WSL Ubuntu 原生 Docker + Compose/DooD 零 provider 门禁：通过；
- Issue #155 旧 9 文件 evidence 集合与 SHA-256：通过；
- 研究分支 dry-run 在 release gate 失败关闭，未创建 evidence/marker/容器，0 provider。

## 边界

本 PR 只交付授权协议和执行能力，不包含真实 provider 调用或 pilot 结果。合并后才在干净 `main == origin/main` 上运行已授权 6-pair pilot；禁止 replacement、backfill、补跑和第 7 个 pair。

Closes #159