### PR TITLE
修复：避免 coordinator WAL 审计误判并恢复 pilot

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-29 — 修复 coordinator WAL 审计误判并恢复六配对 pilot
+  - GitHub: 中文 Issue #161 已创建并回读；分支为 `fix/161-coordinator-wal-recovery`，基线为 `main@95dafbe7`。
+  - v1 终态: `pair-01` 双臂均通过 candidate + clean replay，baseline/treatment 分别为 4 requests/11,996 tokens 与 4 requests/11,815 tokens；pair marker/report、三个 Session 终态、coordinator `cleaned` 和 0 orphan 均闭合，但 batch 因 `immutable=1` 未读取尚在 WAL 的最新 phase 而 false negative，pair-02 未启动。
+  - Recovery: 冻结 v1 的 8 个批次文件与 3 个 Session JSON 哈希，导入唯一 `pair-01` 且禁止重跑；新批次只执行原 schedule 的 `pair-02` 至 `pair-06`，新增上限 1,200,000 recorded tokens，总上限仍为 1,440,000。
+  - 修复: coordinator 审计复制 source main/WAL/SHM 到临时目录，只在副本恢复 WAL，并在读取前后核对源文件集合与 SHA-256 未变。
+  - 验证: WAL-only `cleaned` 回归、导入/剩余调度与相邻 checkpoint 共 `39 passed`；Ruff、实际 v1 8 文件/3 Session 哈希、copy-based 导入和零 provider 门禁通过；recovery manifest SHA-256 为 `4e26976373bd02937a55703081794bcb45c4e9d07f6eec27931a368a32174d89`。
+  - 下一步: 中文提交、WSL helper 推送、PR/CI/合并；随后执行剩余五 pair，不修改 v1 失败 marker 或 evidence。
+  - 文件: `scripts/forge_checkpoint_censored_pilot_recovery_protocol.py`, `scripts/forge_checkpoint_censored_pilot_recovery_runner.py`, `backend/tests/test_forge_checkpoint_censored_pilot_recovery.py`, `benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-recovery-v1.json`, `benchmarks/schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md`
+
 - 2026-08-29 — 实现 endpoint 删失容忍 checkpoint 六配对 pilot
   - GitHub: 中文 Issue #159 已创建并回读；分支为 `research/159-checkpoint-censored-pilot`，基线为 `main@fe9fb519`。
   - 协议: 路线 B 固定 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、6 pair/12 arms、每臂 120,000 recorded tokens 和总计 1,440,000 上限；arm order 以 3:3 交叉平衡，禁止 fallback、replacement、backfill 和扩样。

--- a/backend/tests/test_forge_checkpoint_censored_pilot_recovery.py
+++ b/backend/tests/test_forge_checkpoint_censored_pilot_recovery.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPT_ROOT / "forge_checkpoint_censored_pilot_recovery_protocol.py"
+RUNNER_PATH = SCRIPT_ROOT / "forge_checkpoint_censored_pilot_recovery_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-censored-pilot-recovery-v1.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-censored-pilot-recovery-v1.schema.json"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load("forge_checkpoint_censored_pilot_recovery_protocol_test", PROTOCOL_PATH)
+runner = _load("forge_checkpoint_censored_pilot_recovery_runner_test", RUNNER_PATH)
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _metrics() -> dict:
+    return {
+        "model_requests": 1,
+        "submit_attempts": 1,
+        "clean_replay_attempts": 1,
+        "recorded_tokens": 10,
+        "ledger_wall_clock_seconds": 2.0,
+    }
+
+
+def _outcome(manifest: dict, pair: dict, tokens: int = 20) -> dict:
+    return {
+        "schema_version": "forge-checkpoint-censored-pair-outcome-1.0.0",
+        "document_type": "forge_checkpoint_censored_pair_outcome",
+        "manifest_sha256": runner.protocol.canonical_sha256(manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "complete",
+        "recorded_tokens": tokens,
+        "metrics_by_arm": {"baseline": _metrics(), "treatment": _metrics()},
+    }
+
+
+def test_manifest_freezes_one_import_and_only_five_remaining_pairs() -> None:
+    manifest = _manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert protocol.generate_manifest() == manifest
+    assert protocol.validate_manifest(manifest) == manifest
+    protocol.verify_frozen_components(manifest)
+    assert schema == protocol.schema_document(manifest)
+    assert manifest["recovery"]["imported_pair"]["pair_id"] == "pair-01"
+    assert manifest["recovery"]["imported_pair"]["rerun_forbidden"] is True
+    assert manifest["execution"]["recovery_execution_pairs"] == [
+        "pair-02",
+        "pair-03",
+        "pair-04",
+        "pair-05",
+        "pair-06",
+    ]
+    assert manifest["budget"]["imported_recorded_tokens"] == 23_811
+    assert manifest["budget"]["additional_recorded_token_limit"] == 1_200_000
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 1_440_000
+
+
+def test_copy_auditor_reads_latest_wal_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    pair_dir = tmp_path / "pair-02"
+    database = pair_dir / "checkpoint" / "coordinator.sqlite"
+    database.parent.mkdir(parents=True)
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute("CREATE TABLE checkpoint_capture (capture_id TEXT, phase TEXT, payload_json TEXT)")
+        connection.execute(
+            "INSERT INTO checkpoint_capture VALUES (?, ?, ?)",
+            ("capture-1", "committed", json.dumps({"cleanup": {"succeeded": False}})),
+        )
+        connection.commit()
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        connection.execute(
+            "UPDATE checkpoint_capture SET phase = ?, payload_json = ?",
+            ("cleaned", json.dumps({"cleanup": {"succeeded": True}})),
+        )
+        connection.commit()
+        assert Path(f"{database}-wal").stat().st_size > 0
+        before = runner._file_snapshot(database)
+
+        result = runner.coordinator_terminal_from_copy(pair_dir)
+
+        assert runner._file_snapshot(database) == before
+        assert result["phase"] == "cleaned"
+        assert result["cleanup_succeeded"] is True
+        assert "coordinator.sqlite-wal" in result["source_files"]
+
+
+def _patch_preflight(monkeypatch: pytest.MonkeyPatch, manifest: dict, output_dir: Path) -> dict:
+    candidate = copy.deepcopy(manifest)
+    candidate["execution"]["evidence_directory"] = str(output_dir)
+    monkeypatch.setattr(runner.protocol, "validate_manifest", lambda value, *_args: value)
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_args: None)
+    monkeypatch.setattr(runner.protocol, "verify_v1_evidence", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(runner.v1_protocol, "verify_parent_evidence", lambda *_args: {})
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {
+            "branch": "main",
+            "revision": "a" * 40,
+            "origin_main": "a" * 40,
+        },
+    )
+    monkeypatch.setattr(runner.v1_runner, "require_network_medium", lambda *_args: "wifi")
+    monkeypatch.setattr(runner.v1_runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner.v1_runner, "require_zero_managed_containers", lambda: None)
+    pair_one = _outcome(candidate, candidate["schedule"][0], 23_811)
+    pair_one["source"] = {"kind": "frozen-v1-complete-pair", "rerun": False}
+    monkeypatch.setattr(runner, "_import_pair_one", lambda *_args: pair_one)
+    return candidate
+
+
+def test_recovery_imports_pair_one_and_executes_only_pairs_two_through_six(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _patch_preflight(monkeypatch, _manifest(), tmp_path)
+    calls: list[str] = []
+
+    def execute(value: dict, pair: dict, _pair_dir: Path) -> dict:
+        calls.append(pair["pair_id"])
+        return _outcome(value, pair)
+
+    report = runner.run_recovery(manifest, output_dir=tmp_path, pair_executor=execute)
+
+    assert calls == [f"pair-{number:02d}" for number in range(2, 7)]
+    assert report["itt_attrition"]["scheduled_pairs"] == 6
+    assert report["itt_attrition"]["complete_pairs"] == 6
+    assert report["recorded_tokens"] == 23_911
+    assert report["recovery"] == {
+        "imported_pair_ids": ["pair-01"],
+        "executed_pair_ids": [f"pair-{number:02d}" for number in range(2, 7)],
+        "replacement": False,
+        "backfill": False,
+        "coordinator_audit": "copy-main-wal-shm-then-read-copy",
+    }
+    assert not (tmp_path / "pairs" / "pair-01").exists()
+
+    resumed = runner.run_recovery(
+        manifest,
+        output_dir=tmp_path,
+        pair_executor=lambda *_args: pytest.fail("恢复终态不得重跑"),
+    )
+    assert resumed == report
+
+
+def test_manifest_rejects_pair_one_rerun_or_extra_budget() -> None:
+    manifest = _manifest()
+    manifest["execution"]["recovery_execution_pairs"].insert(0, "pair-01")
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["budget"]["additional_recorded_token_limit"] += 1
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)

--- a/benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-recovery-v1.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-recovery-v1.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "../schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json",
+  "schema_version": "forge-checkpoint-censored-pilot-recovery-1.0.0",
+  "document_type": "forge_checkpoint_censored_pilot_recovery",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/161",
+    "authorized_by": "experiment_owner",
+    "route": "B-recovery",
+    "pilot_collection_authorized": true,
+    "authorized_additional_pairs": 5,
+    "maximum_additional_recorded_tokens": 1200000,
+    "maximum_total_recorded_tokens": 1440000
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "mechanism": "failure_checkpoint",
+    "controlled_fault": "artifact_staging_missing",
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "pair-01",
+      "order": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-02",
+      "order": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "pair-03",
+      "order": 3,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-04",
+      "order": 4,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "pair-05",
+      "order": 5,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "pair-06",
+      "order": 6,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    }
+  ],
+  "schedule_sha256": "274eb4ffd9c769301a5553f23f39ee26537a781d7e351a934908af8cebb982dd",
+  "budget": {
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 1440000,
+    "reachability_requests": 0,
+    "enforcement": "after_each_pair_before_next_pair",
+    "imported_recorded_tokens": 23811,
+    "additional_recorded_token_limit": 1200000
+  },
+  "stopping": {
+    "endpoint_timeout_censors_pair_and_continues": true,
+    "cleanup_or_identity_failure_stops_batch": true,
+    "non_endpoint_failure_stops_batch": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "itt_attrition_includes_all_scheduled_pairs": true,
+    "conditional_mechanism_requires_complete_pair": true,
+    "descriptive_only": true,
+    "p_value_computed": false,
+    "model_ranking_performed": false
+  },
+  "execution": {
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "network_access_medium": "wifi",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1",
+    "pair_directory_pattern": "pairs/pair-NN",
+    "batch_marker": "markers/pilot-attempt.json",
+    "pair_marker": "markers/pair-attempt.json",
+    "release_branch": "main",
+    "authorization_baseline_commit": "95dafbe7ca2f69c2beb2b5a4c9779b8619c70736",
+    "release_revision_policy": "descendant-compatible",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_zero_managed_containers_between_pairs": true,
+    "recovery_import": "pair-01",
+    "recovery_execution_pairs": [
+      "pair-02",
+      "pair-03",
+      "pair-04",
+      "pair-05",
+      "pair-06"
+    ],
+    "coordinator_audit": "copy-main-wal-shm-then-read-copy"
+  },
+  "parent": {
+    "authorized_manifest_canonical_sha256": "f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356",
+    "components": {
+      "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+      "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+      "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+      "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+    },
+    "terminal_evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+      "expected_file_count": 9,
+      "files": {
+        "checkpoint/coordinator.sqlite": "dc2b426ceff514683ccec719fb064158b7bc58b3f5f01d1fc620571d6fb13956",
+        "checkpoint/messages.sqlite": "3091ebbe147af151ed9ad37aff3a5d14979bc187a0d69a685a72e8de3b6e14bb",
+        "checkpoint/messages.sqlite-shm": "fd4c9fda9cd3f9ae7c962b0ddf37232294d55580e1aa165aa06129b8549389eb",
+        "checkpoint/messages.sqlite-wal": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "ledgers/baseline.jsonl": "01137d096b55c447655946373afe517135f01306aaf54797aad700dfb69aece2",
+        "ledgers/parent.jsonl": "683c68dc1f2626915c9a7a722db11701dbef667a8fac3d187acf22c269644891",
+        "markers/amendment-controlled-pair-attempt.json": "0d7526bcd7c9af3d3d3349964d2df4cdf15c1503f53fd705c2fcbda16fe00cc0",
+        "markers/amendment-reachability-attempt.json": "51212cbfc00b887f2540343bef156d0e3b1bd680f760a65debcf2eddeee5fa23",
+        "reports/reachability.json": "ff664651aacea073cb8541594c1d443cd92654fe2c9d9767227788dd10adeb48"
+      },
+      "sqlite_sidecars_retained": true
+    }
+  },
+  "protocol_artifacts": {
+    "backend/tests/test_forge_checkpoint_censored_pilot_recovery.py": "0857c83fc14df4e49a4c73db0de5de41970e8bbf941d37307add82a0c6acba7d",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md": "401d58798235ce7905da15a8089f8bbfb8a2a1fbad6a12e40a768e1eb99e2b88",
+    "scripts/forge_checkpoint_censored_pilot_recovery_protocol.py": "be431981451b072c039bf9357b89cc7b4ea5031eb1b24073bde189dcb45446d4",
+    "scripts/forge_checkpoint_censored_pilot_recovery_runner.py": "336d9217c83ee60ebb479615200a0eddbcfb82233140bfaca6711baa0d79d786"
+  },
+  "recovery": {
+    "parent_manifest_canonical_sha256": "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391",
+    "parent_components": {
+      "benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json": "640c463331ab2eaded74417a1311fc841c6561fc98153dbed88a9754619a67ee",
+      "scripts/forge_checkpoint_censored_pilot_protocol.py": "b48b43568d0a1f4c1c548e56aeb7e31a94ef6bb40c515fdcedf0edda5e650758",
+      "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768"
+    },
+    "imported_pair": {
+      "pair_id": "pair-01",
+      "status": "complete",
+      "recorded_tokens": 23811,
+      "source_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+      "expected_file_count": 8,
+      "files": {
+        "markers/pilot-attempt.json": "90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575",
+        "pairs/pair-01/checkpoint/coordinator.sqlite": "304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c",
+        "pairs/pair-01/checkpoint/messages.sqlite": "7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9",
+        "pairs/pair-01/ledgers/baseline.jsonl": "717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea",
+        "pairs/pair-01/ledgers/parent.jsonl": "858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d",
+        "pairs/pair-01/ledgers/treatment.jsonl": "c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840",
+        "pairs/pair-01/markers/pair-attempt.json": "8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d",
+        "pairs/pair-01/reports/controlled-pair.json": "afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4"
+      },
+      "session_terminals": {
+        ".compile-sessions/baseline-primary-canary-a8d91e3243a3-thread/baseline-primary-canary-a8d91e3243a3-session/session.json": "39cc1947501b01b63afa25479d35e9e4531193a33b4923701f326d9dbf1f6847",
+        ".compile-sessions/parent-0f56a49c49ea/parent-7f16996f020f/session.json": "281308e574ce629a01026c3611397c7ceca47fc8a780cd71a140b5285d82337d",
+        ".compile-sessions/treatment-primary-canary-a8d91e3243a3-thread/treatment-primary-canary-a8d91e3243a3-session/session.json": "b0b94326e284456f5c0c8cc7272efc95a465d8c43680e6c49759f11e0fdc1bbf"
+      },
+      "rerun_forbidden": true
+    },
+    "failure_classification": "post_pair_coordinator_wal_visibility_race",
+    "replacement": false,
+    "backfill": false
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md
+++ b/benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md
@@ -1,0 +1,27 @@
+# Checkpoint 六配对 pilot coordinator WAL recovery amendment
+
+Issue #159 的 `pair-01` 已形成双臂 passed、clean replay passed、pair marker passed、controlled report passed、Session 全部终结与 0 orphan，但 v1 外层 `immutable=1` 审计在 WAL checkpoint 前读取到旧 coordinator phase，导致 batch marker false negative。Issue #161 授权一个不重跑 `pair-01` 的 recovery amendment。
+
+## 冻结输入
+
+- v1 manifest canonical SHA-256 固定为 `d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391`。
+- v1 输出目录的文件集合固定为 8 个文件；batch/pair marker、controlled report、parent/baseline/treatment ledger、coordinator 和 messages SQLite 均固定 SHA-256。
+- parent、baseline 与 treatment 的 Session JSON 固定 SHA-256；三者均已终结，当前 0 Compile Session/replay orphan。
+- 导入的 `pair-01` 记录 23,811 tokens，baseline/treatment 均为完整 pair，只计一次且禁止重跑、replacement 或 backfill。
+
+## 剩余执行
+
+- recovery 使用独立 manifest、batch marker 和 evidence 目录 `/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1`。
+- 只执行原预注册的 `pair-02` 至 `pair-06`，保持原 arm order；不创建新的 `pair-01`，不扩展到第 7 个 pair。
+- 新增执行最多 10 arms × 120,000 = 1,200,000 recorded tokens；与导入的 23,811 tokens 合并后仍受原 1,440,000 总上限约束。
+- provider、300 秒 timeout、0 retry、非 streaming、fallback 禁止、endpoint timeout 删失规则和双 estimand 均不改变。
+
+## Copy-based SQLite 审计
+
+pair 停止写入后，runner 枚举并哈希源 `coordinator.sqlite`、`-wal`、`-shm`，复制存在的文件到进程临时目录，在副本中重建 SHM/回放 WAL 并读取唯一 capture。读取后再次核对源文件集合与哈希未变。所有 SQLite recovery/checkpoint 和 sidecar 变化只能发生在临时副本，不得修改 evidence 源目录。
+
+只有副本中的 coordinator 为 `cleaned`、`cleanup.succeeded=true` 且 daemon 为 0 Compile Session/replay orphan 时，pair 才能进入 complete 或 endpoint-censored 终态。其他 cleanup、identity、evidence、预算与非 endpoint 错误仍失败关闭。
+
+## 分析边界
+
+最终报告固定分母为最初预注册的 6 pair：导入 `pair-01` 加 recovery 执行的 5 pair。ITT/attrition 包含所有六 pair；conditional mechanism 只包含完整双臂 pair。只做描述性分析，不计算 p 值，不做模型排名。

--- a/benchmarks/schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json
+++ b/benchmarks/schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json",
+  "title": "Forge checkpoint censored pilot recovery amendment",
+  "const": {
+    "$schema": "../schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json",
+    "schema_version": "forge-checkpoint-censored-pilot-recovery-1.0.0",
+    "document_type": "forge_checkpoint_censored_pilot_recovery",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/161",
+      "authorized_by": "experiment_owner",
+      "route": "B-recovery",
+      "pilot_collection_authorized": true,
+      "authorized_additional_pairs": 5,
+      "maximum_additional_recorded_tokens": 1200000,
+      "maximum_total_recorded_tokens": 1440000
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "mechanism": "failure_checkpoint",
+      "controlled_fault": "artifact_staging_missing",
+      "natural_collection_authorized": false,
+      "secondary_provider_authorized": false
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "pair-01",
+        "order": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-02",
+        "order": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "pair-03",
+        "order": 3,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-04",
+        "order": 4,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "pair-05",
+        "order": 5,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pair-06",
+        "order": 6,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "schedule_sha256": "274eb4ffd9c769301a5553f23f39ee26537a781d7e351a934908af8cebb982dd",
+    "budget": {
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 1440000,
+      "reachability_requests": 0,
+      "enforcement": "after_each_pair_before_next_pair",
+      "imported_recorded_tokens": 23811,
+      "additional_recorded_token_limit": 1200000
+    },
+    "stopping": {
+      "endpoint_timeout_censors_pair_and_continues": true,
+      "cleanup_or_identity_failure_stops_batch": true,
+      "non_endpoint_failure_stops_batch": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "itt_attrition_includes_all_scheduled_pairs": true,
+      "conditional_mechanism_requires_complete_pair": true,
+      "descriptive_only": true,
+      "p_value_computed": false,
+      "model_ranking_performed": false
+    },
+    "execution": {
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "network_access_medium": "wifi",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1",
+      "pair_directory_pattern": "pairs/pair-NN",
+      "batch_marker": "markers/pilot-attempt.json",
+      "pair_marker": "markers/pair-attempt.json",
+      "release_branch": "main",
+      "authorization_baseline_commit": "95dafbe7ca2f69c2beb2b5a4c9779b8619c70736",
+      "release_revision_policy": "descendant-compatible",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_zero_managed_containers_between_pairs": true,
+      "recovery_import": "pair-01",
+      "recovery_execution_pairs": [
+        "pair-02",
+        "pair-03",
+        "pair-04",
+        "pair-05",
+        "pair-06"
+      ],
+      "coordinator_audit": "copy-main-wal-shm-then-read-copy"
+    },
+    "parent": {
+      "authorized_manifest_canonical_sha256": "f87dc3e0af2ec8c841191c70195808ac5e686656d15f00c479f6d030abebf356",
+      "components": {
+        "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+        "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+        "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+        "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+      },
+      "terminal_evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-primary-canary-amendment",
+        "expected_file_count": 9,
+        "files": {
+          "checkpoint/coordinator.sqlite": "dc2b426ceff514683ccec719fb064158b7bc58b3f5f01d1fc620571d6fb13956",
+          "checkpoint/messages.sqlite": "3091ebbe147af151ed9ad37aff3a5d14979bc187a0d69a685a72e8de3b6e14bb",
+          "checkpoint/messages.sqlite-shm": "fd4c9fda9cd3f9ae7c962b0ddf37232294d55580e1aa165aa06129b8549389eb",
+          "checkpoint/messages.sqlite-wal": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "ledgers/baseline.jsonl": "01137d096b55c447655946373afe517135f01306aaf54797aad700dfb69aece2",
+          "ledgers/parent.jsonl": "683c68dc1f2626915c9a7a722db11701dbef667a8fac3d187acf22c269644891",
+          "markers/amendment-controlled-pair-attempt.json": "0d7526bcd7c9af3d3d3349964d2df4cdf15c1503f53fd705c2fcbda16fe00cc0",
+          "markers/amendment-reachability-attempt.json": "51212cbfc00b887f2540343bef156d0e3b1bd680f760a65debcf2eddeee5fa23",
+          "reports/reachability.json": "ff664651aacea073cb8541594c1d443cd92654fe2c9d9767227788dd10adeb48"
+        },
+        "sqlite_sidecars_retained": true
+      }
+    },
+    "protocol_artifacts": {
+      "backend/tests/test_forge_checkpoint_censored_pilot_recovery.py": "0857c83fc14df4e49a4c73db0de5de41970e8bbf941d37307add82a0c6acba7d",
+      "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md": "401d58798235ce7905da15a8089f8bbfb8a2a1fbad6a12e40a768e1eb99e2b88",
+      "scripts/forge_checkpoint_censored_pilot_recovery_protocol.py": "be431981451b072c039bf9357b89cc7b4ea5031eb1b24073bde189dcb45446d4",
+      "scripts/forge_checkpoint_censored_pilot_recovery_runner.py": "336d9217c83ee60ebb479615200a0eddbcfb82233140bfaca6711baa0d79d786"
+    },
+    "recovery": {
+      "parent_manifest_canonical_sha256": "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391",
+      "parent_components": {
+        "benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json": "640c463331ab2eaded74417a1311fc841c6561fc98153dbed88a9754619a67ee",
+        "scripts/forge_checkpoint_censored_pilot_protocol.py": "b48b43568d0a1f4c1c548e56aeb7e31a94ef6bb40c515fdcedf0edda5e650758",
+        "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768"
+      },
+      "imported_pair": {
+        "pair_id": "pair-01",
+        "status": "complete",
+        "recorded_tokens": 23811,
+        "source_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+        "expected_file_count": 8,
+        "files": {
+          "markers/pilot-attempt.json": "90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575",
+          "pairs/pair-01/checkpoint/coordinator.sqlite": "304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c",
+          "pairs/pair-01/checkpoint/messages.sqlite": "7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9",
+          "pairs/pair-01/ledgers/baseline.jsonl": "717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea",
+          "pairs/pair-01/ledgers/parent.jsonl": "858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d",
+          "pairs/pair-01/ledgers/treatment.jsonl": "c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840",
+          "pairs/pair-01/markers/pair-attempt.json": "8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d",
+          "pairs/pair-01/reports/controlled-pair.json": "afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4"
+        },
+        "session_terminals": {
+          ".compile-sessions/baseline-primary-canary-a8d91e3243a3-thread/baseline-primary-canary-a8d91e3243a3-session/session.json": "39cc1947501b01b63afa25479d35e9e4531193a33b4923701f326d9dbf1f6847",
+          ".compile-sessions/parent-0f56a49c49ea/parent-7f16996f020f/session.json": "281308e574ce629a01026c3611397c7ceca47fc8a780cd71a140b5285d82337d",
+          ".compile-sessions/treatment-primary-canary-a8d91e3243a3-thread/treatment-primary-canary-a8d91e3243a3-session/session.json": "b0b94326e284456f5c0c8cc7272efc95a465d8c43680e6c49759f11e0fdc1bbf"
+        },
+        "rerun_forbidden": true
+      },
+      "failure_classification": "post_pair_coordinator_wal_visibility_race",
+      "replacement": false,
+      "backfill": false
+    }
+  }
+}

--- a/scripts/forge_checkpoint_censored_pilot_recovery_protocol.py
+++ b/scripts/forge_checkpoint_censored_pilot_recovery_protocol.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Issue #161 coordinator WAL 审计 recovery amendment 协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+V1_MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-censored-pilot-v1.json"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-censored-pilot-recovery-v1.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-censored-pilot-recovery-v1.schema.json"
+V1_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1")
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1")
+
+SCHEMA_VERSION = "forge-checkpoint-censored-pilot-recovery-1.0.0"
+DOCUMENT_TYPE = "forge_checkpoint_censored_pilot_recovery"
+V1_CANONICAL_SHA256 = "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391"
+IMPORTED_RECORDED_TOKENS = 23_811
+ADDITIONAL_RECORDED_TOKEN_LIMIT = 1_200_000
+TOTAL_RECORDED_TOKEN_LIMIT = 1_440_000
+
+V1_COMPONENTS = {
+    "benchmarks/manifests/cpp-verifier-checkpoint-censored-pilot-v1.json": ("640c463331ab2eaded74417a1311fc841c6561fc98153dbed88a9754619a67ee"),
+    "scripts/forge_checkpoint_censored_pilot_protocol.py": ("b48b43568d0a1f4c1c548e56aeb7e31a94ef6bb40c515fdcedf0edda5e650758"),
+    "scripts/forge_checkpoint_censored_pilot_runner.py": ("819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768"),
+}
+
+V1_EVIDENCE = {
+    "markers/pilot-attempt.json": ("90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575"),
+    "pairs/pair-01/checkpoint/coordinator.sqlite": ("304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c"),
+    "pairs/pair-01/checkpoint/messages.sqlite": ("7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9"),
+    "pairs/pair-01/ledgers/baseline.jsonl": ("717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea"),
+    "pairs/pair-01/ledgers/parent.jsonl": ("858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d"),
+    "pairs/pair-01/ledgers/treatment.jsonl": ("c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840"),
+    "pairs/pair-01/markers/pair-attempt.json": ("8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d"),
+    "pairs/pair-01/reports/controlled-pair.json": ("afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4"),
+}
+
+V1_SESSION_TERMINALS = {
+    ".compile-sessions/baseline-primary-canary-a8d91e3243a3-thread/baseline-primary-canary-a8d91e3243a3-session/session.json": ("39cc1947501b01b63afa25479d35e9e4531193a33b4923701f326d9dbf1f6847"),
+    ".compile-sessions/parent-0f56a49c49ea/parent-7f16996f020f/session.json": ("281308e574ce629a01026c3611397c7ceca47fc8a780cd71a140b5285d82337d"),
+    ".compile-sessions/treatment-primary-canary-a8d91e3243a3-thread/treatment-primary-canary-a8d91e3243a3-session/session.json": ("b0b94326e284456f5c0c8cc7272efc95a465d8c43680e6c49759f11e0fdc1bbf"),
+}
+
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_checkpoint_censored_pilot_recovery_protocol.py",
+    "scripts/forge_checkpoint_censored_pilot_recovery_runner.py",
+    "backend/tests/test_forge_checkpoint_censored_pilot_recovery.py",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-censored-pilot-recovery-v1.md",
+}
+
+
+class ProtocolError(RuntimeError):
+    """Recovery amendment identity 或冻结 evidence 发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _hash_protocol_artifacts(repo_root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(PROTOCOL_ARTIFACT_PATHS):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"recovery 协议制品缺失: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent = _load_json(repo_root / V1_MANIFEST_PATH.relative_to(REPO_ROOT))
+    if canonical_sha256(parent) != V1_CANONICAL_SHA256:
+        raise ProtocolError("v1 manifest canonical identity 发生漂移")
+    manifest = copy.deepcopy(parent)
+    manifest["$schema"] = "../schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json"
+    manifest["schema_version"] = SCHEMA_VERSION
+    manifest["document_type"] = DOCUMENT_TYPE
+    manifest["authorization"] = {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/161",
+        "authorized_by": "experiment_owner",
+        "route": "B-recovery",
+        "pilot_collection_authorized": True,
+        "authorized_additional_pairs": 5,
+        "maximum_additional_recorded_tokens": ADDITIONAL_RECORDED_TOKEN_LIMIT,
+        "maximum_total_recorded_tokens": TOTAL_RECORDED_TOKEN_LIMIT,
+    }
+    manifest["budget"].update(
+        imported_recorded_tokens=IMPORTED_RECORDED_TOKENS,
+        additional_recorded_token_limit=ADDITIONAL_RECORDED_TOKEN_LIMIT,
+        stage_maximum_recorded_tokens=TOTAL_RECORDED_TOKEN_LIMIT,
+    )
+    manifest["execution"].update(
+        evidence_directory=str(DEFAULT_OUTPUT_DIR),
+        authorization_baseline_commit="95dafbe7ca2f69c2beb2b5a4c9779b8619c70736",
+        recovery_import="pair-01",
+        recovery_execution_pairs=[
+            "pair-02",
+            "pair-03",
+            "pair-04",
+            "pair-05",
+            "pair-06",
+        ],
+        coordinator_audit="copy-main-wal-shm-then-read-copy",
+    )
+    manifest["recovery"] = {
+        "parent_manifest_canonical_sha256": V1_CANONICAL_SHA256,
+        "parent_components": dict(sorted(V1_COMPONENTS.items())),
+        "imported_pair": {
+            "pair_id": "pair-01",
+            "status": "complete",
+            "recorded_tokens": IMPORTED_RECORDED_TOKENS,
+            "source_directory": str(V1_OUTPUT_DIR),
+            "expected_file_count": len(V1_EVIDENCE),
+            "files": dict(sorted(V1_EVIDENCE.items())),
+            "session_terminals": dict(sorted(V1_SESSION_TERMINALS.items())),
+            "rerun_forbidden": True,
+        },
+        "failure_classification": "post_pair_coordinator_wal_visibility_race",
+        "replacement": False,
+        "backfill": False,
+    }
+    manifest["protocol_artifacts"] = _hash_protocol_artifacts(repo_root)
+    return manifest
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("recovery manifest 与冻结协议不一致")
+    if value["execution"]["recovery_execution_pairs"] != [f"pair-{number:02d}" for number in range(2, 7)]:
+        raise ProtocolError("recovery 只能执行 pair-02 至 pair-06")
+    return value
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    for relative_path, expected in manifest["recovery"]["parent_components"].items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise ProtocolError(f"v1 冻结组件发生漂移: {relative_path}")
+    for relative_path, expected in manifest["protocol_artifacts"].items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise ProtocolError(f"recovery 协议制品发生漂移: {relative_path}")
+
+
+def verify_v1_evidence(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = V1_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    imported = manifest["recovery"]["imported_pair"]
+    expected = imported["files"]
+    actual = {path.relative_to(output_dir).as_posix() for path in output_dir.rglob("*") if path.is_file()}
+    if actual != set(expected):
+        raise ProtocolError("v1 pilot evidence 文件集合发生漂移")
+    for relative_path, digest in expected.items():
+        if file_sha256(output_dir / relative_path) != digest:
+            raise ProtocolError(f"v1 pilot evidence hash 发生漂移: {relative_path}")
+    for relative_path, digest in imported["session_terminals"].items():
+        if file_sha256(repo_root / relative_path) != digest:
+            raise ProtocolError(f"v1 Session 终态发生漂移: {relative_path}")
+    return {
+        "status": "valid",
+        "file_count": len(actual),
+        "imported_pair": imported["pair_id"],
+        "recorded_tokens": imported["recorded_tokens"],
+    }
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": ("https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-censored-pilot-recovery-v1.schema.json"),
+        "title": "Forge checkpoint censored pilot recovery amendment",
+        "const": manifest or generate_manifest(),
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "validate-v1-evidence"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--v1-output-dir", type=Path, default=V1_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            _write_json(args.schema, schema_document(manifest))
+            status = "generated"
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+            if args.command == "validate-v1-evidence":
+                verify_v1_evidence(manifest, output_dir=args.v1_output_dir)
+            status = "valid"
+    except (OSError, ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "manifest_sha256": canonical_sha256(manifest),
+                "imported_pairs": 1,
+                "authorized_additional_pairs": 5,
+                "maximum_additional_recorded_tokens": (ADDITIONAL_RECORDED_TOKEN_LIMIT),
+                "provider_calls": 0,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_checkpoint_censored_pilot_recovery_runner.py
+++ b/scripts/forge_checkpoint_censored_pilot_recovery_runner.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""执行 Issue #161 checkpoint 六配对 pilot recovery amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_checkpoint_censored_pilot_protocol as v1_protocol  # noqa: E402
+import forge_checkpoint_censored_pilot_recovery_protocol as protocol  # noqa: E402
+import forge_checkpoint_censored_pilot_runner as v1_runner  # noqa: E402
+
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = protocol.DEFAULT_OUTPUT_DIR
+BATCH_MARKER = "markers/recovery-attempt.json"
+PILOT_REPORT = "reports/pilot.json"
+IMPORTED_OUTCOME = "imports/pair-01.json"
+
+
+class RecoveryError(RuntimeError):
+    """Recovery identity、导入 evidence 或停止规则失败。"""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RecoveryError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise RecoveryError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _file_snapshot(database: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in (database, Path(f"{database}-wal"), Path(f"{database}-shm")):
+        if path.is_file():
+            result[path.name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def coordinator_terminal_from_copy(pair_dir: Path) -> dict[str, Any]:
+    database = (pair_dir / "checkpoint" / "coordinator.sqlite").resolve()
+    if not database.is_file():
+        raise RecoveryError("pair 缺少 checkpoint coordinator evidence")
+    before = _file_snapshot(database)
+    with tempfile.TemporaryDirectory(prefix="forge-coordinator-audit-") as temp:
+        target = Path(temp) / database.name
+        for source in (
+            database,
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+        ):
+            if source.is_file():
+                shutil.copy2(source, Path(temp) / source.name)
+        copied_shm = Path(f"{target}-shm")
+        copied_shm.unlink(missing_ok=True)
+        try:
+            with sqlite3.connect(target) as connection:
+                rows = connection.execute("SELECT capture_id, phase, payload_json FROM checkpoint_capture").fetchall()
+        except sqlite3.Error as exc:
+            raise RecoveryError("无法从 coordinator 临时副本恢复 WAL") from exc
+    after = _file_snapshot(database)
+    if before != after:
+        raise RecoveryError("copy-based 审计期间 coordinator 源文件发生变化")
+    if len(rows) != 1:
+        raise RecoveryError("pair coordinator capture 数量不是 1")
+    capture_id, phase, payload_raw = rows[0]
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError as exc:
+        raise RecoveryError("pair coordinator payload 不是有效 JSON") from exc
+    if phase != "cleaned" or payload.get("cleanup", {}).get("succeeded") is not True:
+        raise RecoveryError("pair cleanup 未闭合")
+    return {
+        "capture_id": capture_id,
+        "phase": phase,
+        "cleanup_succeeded": True,
+        "audit": "copied-main-wal-shm",
+        "source_files": sorted(before),
+    }
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo_root}", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RecoveryError("无法验证 recovery release Git identity")
+    return result.stdout.strip()
+
+
+def require_release_identity(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    branch = _git(repo_root, "branch", "--show-current")
+    revision = _git(repo_root, "rev-parse", "HEAD")
+    origin_main = _git(repo_root, "rev-parse", "origin/main")
+    dirty = _git(repo_root, "status", "--porcelain", "--untracked-files=normal")
+    if branch != "main" or revision != origin_main or dirty:
+        raise RecoveryError("真实 recovery 需要干净的 main == origin/main")
+    baseline = manifest["execution"]["authorization_baseline_commit"]
+    if _git(repo_root, "merge-base", baseline, revision) != baseline:
+        raise RecoveryError("当前 release 不是 recovery baseline 的后代")
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+@contextmanager
+def _adapt_v1_runner(manifest: dict[str, Any]) -> Iterator[None]:
+    original_verify = v1_runner.protocol.verify_frozen_components
+    original_coordinator = v1_runner._coordinator_terminal
+    v1_runner.protocol.verify_frozen_components = lambda _value, repo_root=REPO_ROOT: protocol.verify_frozen_components(manifest, repo_root)
+    v1_runner._coordinator_terminal = coordinator_terminal_from_copy
+    try:
+        yield
+    finally:
+        v1_runner.protocol.verify_frozen_components = original_verify
+        v1_runner._coordinator_terminal = original_coordinator
+
+
+def _import_pair_one(manifest: dict[str, Any]) -> dict[str, Any]:
+    v1_manifest = _load_json(protocol.V1_MANIFEST_PATH)
+    if v1_protocol.canonical_sha256(v1_manifest) != protocol.V1_CANONICAL_SHA256:
+        raise RecoveryError("导入的 v1 manifest identity 发生漂移")
+    pair = v1_manifest["schedule"][0]
+    pair_dir = protocol.V1_OUTPUT_DIR / "pairs" / pair["pair_id"]
+    pair_manifest = v1_runner._pair_manifest(v1_manifest, pair)
+    pair_manifest["execution"]["evidence_directory"] = str(pair_dir)
+    report = _load_json(pair_dir / "reports" / "controlled-pair.json")
+    with _adapt_v1_runner(manifest):
+        outcome = v1_runner._passed_outcome(v1_manifest, pair, pair_manifest, pair_dir, report)
+    if outcome["recorded_tokens"] != protocol.IMPORTED_RECORDED_TOKENS:
+        raise RecoveryError("导入 pair-01 的 recorded tokens 发生漂移")
+    outcome["manifest_sha256"] = protocol.canonical_sha256(manifest)
+    outcome["source"] = {
+        "kind": "frozen-v1-complete-pair",
+        "manifest_sha256": protocol.V1_CANONICAL_SHA256,
+        "evidence_directory": str(protocol.V1_OUTPUT_DIR),
+        "rerun": False,
+    }
+    return outcome
+
+
+def _claim_marker(path: Path, digest: str, revision: str) -> dict[str, Any]:
+    if path.exists():
+        marker = _load_json(path)
+        if marker.get("manifest_sha256") != digest or marker.get("release_revision") != revision or marker.get("status") not in {"started", "passed"}:
+            raise RecoveryError("recovery marker identity 或终态无效")
+        return marker
+    value = {
+        "schema_version": "forge-checkpoint-censored-pilot-recovery-attempt-1.0.0",
+        "document_type": "forge_checkpoint_censored_pilot_recovery_attempt",
+        "manifest_sha256": digest,
+        "release_revision": revision,
+        "status": "started",
+        "error_class": None,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    v1_runner._write_once(path, value)
+    return value
+
+
+def run_recovery(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    pair_executor: v1_runner.PairExecutor | None = None,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    if output_dir.resolve(strict=False) != Path(manifest["execution"]["evidence_directory"]).resolve(strict=False):
+        raise RecoveryError("recovery evidence 必须写入独立冻结目录")
+    release = require_release_identity(manifest, repo_root)
+    v1_runner.require_network_medium(manifest)
+    v1_runner.primary.require_compose_dood()
+    protocol.verify_v1_evidence(manifest, repo_root=repo_root)
+    v1_manifest = _load_json(protocol.V1_MANIFEST_PATH)
+    v1_protocol.verify_parent_evidence(v1_manifest)
+    v1_runner.require_zero_managed_containers()
+    digest = protocol.canonical_sha256(manifest)
+    marker_path = output_dir / BATCH_MARKER
+    marker = _claim_marker(marker_path, digest, release["revision"])
+    report_path = output_dir / PILOT_REPORT
+    if marker["status"] == "passed":
+        report = _load_json(report_path)
+        if report.get("manifest_sha256") != digest:
+            raise RecoveryError("已完成 recovery report identity 发生漂移")
+        return report
+
+    outcomes: list[dict[str, Any]] = []
+    try:
+        imported_path = output_dir / IMPORTED_OUTCOME
+        if imported_path.exists():
+            imported = _load_json(imported_path)
+        else:
+            imported = _import_pair_one(manifest)
+            v1_runner._write_once(imported_path, imported)
+        if imported.get("manifest_sha256") != digest or imported.get("pair_id") != "pair-01" or imported.get("status") != "complete":
+            raise RecoveryError("导入 pair-01 outcome 无效")
+        outcomes.append(imported)
+
+        with asyncio.Runner() as async_runner, _adapt_v1_runner(manifest):
+            for pair in manifest["schedule"][1:]:
+                pair_dir = output_dir / "pairs" / pair["pair_id"]
+                outcome_path = pair_dir / v1_runner.PAIR_OUTCOME
+                if outcome_path.exists():
+                    outcome = _load_json(outcome_path)
+                    if outcome.get("manifest_sha256") != digest or outcome.get("pair_id") != pair["pair_id"] or outcome.get("status") not in {"complete", "endpoint_censored"}:
+                        raise RecoveryError("已有 recovery pair outcome 无效")
+                else:
+                    if pair_dir.exists() and any(pair_dir.iterdir()):
+                        raise RecoveryError(f"{pair['pair_id']} 已开始但没有终态，禁止补跑")
+                    v1_runner.require_zero_managed_containers()
+                    if pair_executor is None:
+                        outcome = v1_runner.execute_real_pair(manifest, pair, pair_dir, async_runner)
+                    else:
+                        outcome = pair_executor(manifest, pair, pair_dir)
+                    if outcome.get("status") not in {
+                        "complete",
+                        "endpoint_censored",
+                    }:
+                        raise RecoveryError("非 endpoint 失败关闭 recovery")
+                    v1_runner._write_once(outcome_path, outcome)
+                outcomes.append(outcome)
+                additional = sum(item["recorded_tokens"] for item in outcomes[1:])
+                total = sum(item["recorded_tokens"] for item in outcomes)
+                if additional > protocol.ADDITIONAL_RECORDED_TOKEN_LIMIT or total > protocol.TOTAL_RECORDED_TOKEN_LIMIT:
+                    raise RecoveryError("recovery 超过 recorded-token 机械上限")
+                v1_runner.require_zero_managed_containers()
+        if len(outcomes) != 6:
+            raise RecoveryError("recovery 未形成原预注册 6 pair 终态")
+        report = v1_runner.summarize(manifest, release, outcomes)
+        report["recovery"] = {
+            "imported_pair_ids": ["pair-01"],
+            "executed_pair_ids": [f"pair-{number:02d}" for number in range(2, 7)],
+            "replacement": False,
+            "backfill": False,
+            "coordinator_audit": "copy-main-wal-shm-then-read-copy",
+        }
+        v1_runner._write_once(report_path, report)
+        marker.update(
+            status="passed",
+            error_class=None,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        v1_runner._atomic_write(marker_path, marker)
+        return report
+    except BaseException as exc:
+        marker.update(
+            status="failed",
+            error_class=type(exc).__name__,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        v1_runner._atomic_write(marker_path, marker)
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "run", "report"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    try:
+        manifest = protocol.validate_manifest(_load_json(args.manifest))
+        if args.command == "validate":
+            protocol.verify_frozen_components(manifest)
+            result = {
+                "status": "valid",
+                "manifest_sha256": protocol.canonical_sha256(manifest),
+                "provider_calls": 0,
+            }
+        elif args.command == "report":
+            result = _load_json(args.output_dir / PILOT_REPORT)
+            if result.get("manifest_sha256") != protocol.canonical_sha256(manifest):
+                raise RecoveryError("recovery report identity 发生漂移")
+        else:
+            result = run_recovery(manifest, output_dir=args.output_dir)
+    except (OSError, RecoveryError, protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 根因

路线 B v1 的 pair-01 实际已完整通过：双臂均完成 4 次模型请求、submit、candidate verification 与 clean replay，pair report/marker 为 passed，三个 Session 已终结且 0 orphan。外层 batch 在 inner cleanup 后立即用 immutable=1 打开 WAL coordinator，未读取尚在 WAL 的最新 cleaned phase，因此产生 post-pair false negative。

## 修复

- 新增独立 recovery manifest/runner，不修改或覆盖 v1 evidence；
- 固定 v1 的 8 个批次文件与 3 个 Session JSON SHA-256；
- 将唯一 pair-01 作为 complete pair 导入，只计一次且禁止重跑；
- 只授权执行原 schedule 的 pair-02 至 pair-06；
- 新增执行上限 1,200,000 recorded tokens，总上限仍为 1,440,000；
- coordinator 审计复制 source main/WAL/SHM 到临时目录，只在副本重建 SHM、恢复 WAL 与读取；
- 审计前后核对源文件集合与 SHA-256，源 evidence 不产生 sidecar 或内容变化；
- endpoint timeout 删失、300 秒 timeout、0 retry、非 streaming、无 fallback/replacement/backfill 和双 estimand 均不改变。

## 验证

- WAL-only cleaned 回归：通过，源 main/WAL/SHM 哈希前后相同；
- recovery 聚焦与相邻 checkpoint：39 passed；
- Ruff check/format：通过；
- 实际 v1 8 文件与 3 Session 终态哈希：通过；
- 实际 pair-01 copy-based 导入：complete / 23,811 tokens / cleaned；
- recovery manifest SHA-256：4e26976373bd02937a55703081794bcb45c4e9d07f6eec27931a368a32174d89；
- 全部验证 0 provider，未创建 recovery marker/evidence/容器。

## 执行边界

合并后才在干净 main == origin/main 上执行剩余五个 pair。v1 失败 batch marker 与已有 pair-01 evidence 保持不变，不做 replacement、backfill、补跑或第 7 个 pair。

Closes #161