### PR TITLE
研究：预注册 checkpoint 行为终态 v2 实验

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,15 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-29 — 决策 checkpoint 机制实验 v2 estimand
-  - 已完成: 路线 B v1 通过中文 Issue #159 / PR #160 合并为 `95dafbe7`；WAL recovery 通过 Issue #161 / PR #162 合并为 `main@0bbd50e7`。两轮 CI 的 backend tests、backend lint、frontend lint 全绿。
-  - pair-01: baseline/treatment 均通过 candidate verification 与 clean replay，分别为 4 requests/11,996 tokens 和 4 requests/11,815 tokens。
-  - pair-02: treatment 为 4/4 requests、13,895 tokens、verification/replay passed；baseline 为 8/8 requests、29,415 tokens、2 次非法 `command_role`、0 submit/replay，最终触发 24-step `GraphRecursionError`。无 endpoint timeout。
-  - 完整性: 两个 batch 均按各自预注册规则失败关闭；pair-03 至 pair-06 未启动。累计 67,121 recorded tokens；coordinator 均经副本 WAL 审计确认 `cleaned`，所有 Session 已终结，0 orphan。
-  - 发现: 当前 runner 把 `GraphRecursionError`、max turns、无 submit 等模型行为 outcome 当作采集异常，导致成功者条件化；pair-02 的 treatment 成功/baseline 失败正是潜在机制差异。
-  - 决策门禁: 中文 Issue #163 已创建。推荐停止当前 pilot，将 pair-01/02 作为 exploratory feasibility evidence，重新预注册 v2；当前不授权 provider、pair-03 至 pair-06、replacement、backfill 或修改冻结 evidence。
-  - v2 候选: 每个 pair 尽量执行双臂；终态拆为 infrastructure、model behavior、verification outcome；endpoint timeout 进入 attrition/censoring，模型预算内失败进入 outcome；只有 identity/evidence、cleanup/orphan、预算越界等基础设施错误关闭批次。
+- 2026-08-29 — 实现 checkpoint 行为终态 v2 六配对实验
+  - 决策: 实验负责人确认 Issue #163 选择 A；旧 v1/recovery 保持失败关闭，pair-01/02 只作 exploratory feasibility evidence，旧 pair-03 至 pair-06 永不续跑。中文 Issue #165 已创建并回读。
+  - 协议: 全新 6 pair/12 arms、3:3 交叉 arm order、DeepSeek `deepseek-v4-flash`、300 秒/0 retry、每臂 120,000 tokens、总上限 1,440,000；禁止 replacement/backfill/旧 pair 池化。
+  - estimand: arm 终态拆为 infrastructure、model behavior、verification outcome；`GraphRecursionError`、work wall-clock、无 submit、verification failed 留在模型行为 outcome，endpoint timeout 进入 attrition。第一臂形成上述可分类终态后仍执行第二臂。
+  - hard stop: release/manifest/evidence identity、ledger 哈希链、预算、cleanup/orphan 或无法分类的基础设施错误关闭 batch；repair conversion 是 primary mechanism outcome，效率指标只做条件描述。
+  - 验证: 新增与 v1/recovery 相邻回归 `17 passed`，Ruff check/format、确定性 manifest/Schema、旧 evidence 17 文件哈希通过；真实 Compose/DooD fake-model gate `1 passed in 129.12s`，双臂 candidate verification + clean replay 通过，最终 0 container/image/temp。
+  - identity: 当前 manifest canonical SHA-256 为 `1df45a6e0b72f67a914098fc7336eee3bcc8f7b517b132407b88244da10882a3`；实际仍为 0 provider calls、0 model tokens，未读取或输出 AK。
+  - 下一步: 完成扩大回归、敏感信息检查与中文提交；使用 WSL helper 推送并创建中文 PR，CI 合并后在干净主干执行非模型门禁，再启动已授权 v2 真实六配对。
+  - 文件: `scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py`, `scripts/forge_checkpoint_behavioral_pilot_v2_runner.py`, `backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py`, `backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py`, `benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json`, `benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。

--- a/backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py
+++ b/backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPT_ROOT / "forge_checkpoint_behavioral_pilot_v2_protocol.py"
+RUNNER_PATH = SCRIPT_ROOT / "forge_checkpoint_behavioral_pilot_v2_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-behavioral-pilot-v2.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-behavioral-pilot-v2.schema.json"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load("forge_checkpoint_behavioral_pilot_v2_protocol_test", PROTOCOL_PATH)
+runner = _load("forge_checkpoint_behavioral_pilot_v2_runner_test", RUNNER_PATH)
+
+
+class GraphRecursionError(RuntimeError):
+    pass
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _ledger(tmp_path: Path, arm: str):
+    return runner.primary.ExperimentLedger.create(
+        tmp_path / f"{arm}.jsonl",
+        experiment_id="experiment_1234567890abcdef1234567890abcdef",
+        physical_attempt_id="mechanism_attempt_1234567890abcdef1234567890abcdef",
+        context={"arm": arm},
+    )
+
+
+def _request(ledger, *, tokens: int = 10) -> None:
+    suffix = len([event for event in ledger.read() if event["event"] == "model.request_started"]) + 1
+    call_id = f"model_call_{suffix:02d}_1234567890abcdef1234567890"
+    request_id = f"model_request_{suffix:02d}_1234567890abcdef123456"
+    ledger.append(
+        "model.request_started",
+        {
+            "attempt": 1,
+            "configured_model": "deepseek-v4-flash",
+            "max_attempts": 1,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "observed_endpoint": "https://api.deepseek.com",
+            "provider_max_retries": 0,
+            "request_timeout_seconds": 300,
+            "role": "compiler",
+        },
+    )
+    ledger.append(
+        "model.request_completed",
+        {
+            "actual_model": "deepseek-v4-flash",
+            "attempt": 1,
+            "latency_seconds": 1.0,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "status_code": 200,
+            "token_usage": {"input_tokens": tokens - 1, "output_tokens": 1, "total_tokens": tokens},
+        },
+    )
+
+
+def _timeout_request(ledger) -> None:
+    call_id = "model_call_timeout_1234567890abcdef123456"
+    request_id = "model_request_timeout_1234567890abcdef1234"
+    ledger.append(
+        "model.request_started",
+        {
+            "attempt": 1,
+            "configured_model": "deepseek-v4-flash",
+            "max_attempts": 1,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "observed_endpoint": "https://api.deepseek.com",
+            "provider_max_retries": 0,
+            "request_timeout_seconds": 300,
+            "role": "compiler",
+        },
+    )
+    ledger.append(
+        "model.request_failed",
+        {
+            "attempt": 1,
+            "classification": "timeout",
+            "latency_seconds": 300.1,
+            "max_attempts": 1,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "retriable": True,
+            "retry_exhausted": True,
+            "status_code": None,
+        },
+    )
+    ledger.append(
+        "failure.recorded",
+        {
+            "classification": "timeout",
+            "domain": "model_endpoint",
+            "failure_id": "failure_timeout_1234567890abcdef1234567890",
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "primary": True,
+            "secondary_classifications": ["retry_exhausted"],
+        },
+    )
+
+
+def _metrics(tokens: int = 10) -> dict:
+    return {
+        "model_requests": 1,
+        "submit_attempts": 0,
+        "clean_replay_attempts": 0,
+        "recorded_tokens": tokens,
+        "ledger_wall_clock_seconds": 1.0,
+    }
+
+
+def _arm(arm: str, *, infrastructure: str = "valid", behavior: str = "completed", verification: str = "passed", tokens: int = 10) -> dict:
+    return {
+        "arm": arm,
+        "status": "observed",
+        "infrastructure": {"status": infrastructure},
+        "model_behavior": {"status": behavior, "terminal_error_class": None},
+        "verification_outcome": {"status": verification, "submit_attempts": int(verification != "not_attempted"), "clean_replay_attempts": int(verification == "passed")},
+        "recorded_tokens": tokens,
+        "metrics": _metrics(tokens),
+    }
+
+
+def _outcome(manifest: dict, pair: dict, *, endpoint: bool = False, baseline_passed: bool = True) -> dict:
+    arms = {
+        "baseline": _arm("baseline", behavior="completed" if baseline_passed else "graph_step_limit", verification="passed" if baseline_passed else "not_attempted"),
+        "treatment": _arm("treatment"),
+    }
+    if endpoint:
+        arms["baseline"] = _arm("baseline", infrastructure="endpoint_censored", behavior="not_observed", verification="not_attempted", tokens=0)
+    eligible = not endpoint
+    success = {arm: value["verification_outcome"]["status"] == "passed" for arm, value in arms.items()}
+    return {
+        "schema_version": "forge-checkpoint-behavioral-pair-outcome-2.0.0",
+        "document_type": "forge_checkpoint_behavioral_pair_outcome",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_manifest_sha256": "a" * 64,
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "observed" if eligible else "observed_with_endpoint_censoring",
+        "arms": arms,
+        "recorded_tokens": sum(value["recorded_tokens"] for value in arms.values()),
+        "primary_mechanism_eligible": eligible,
+        "repair_success": success,
+        "paired_repair_conversion_delta": int(success["treatment"]) - int(success["baseline"]) if eligible else None,
+    }
+
+
+def test_manifest_freezes_fresh_v2_identity_and_excludes_old_pairs() -> None:
+    manifest = _manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    assert protocol.generate_manifest() == manifest
+    assert protocol.validate_manifest(manifest) == manifest
+    protocol.verify_frozen_components(manifest)
+    assert schema == protocol.schema_document(manifest)
+    assert manifest["authorization"]["selected_option"] == "A"
+    assert manifest["historical_exclusion"]["pooled_into_v2"] is False
+    assert manifest["historical_exclusion"]["recorded_tokens"] == 67_121
+    assert [item["pair_id"] for item in manifest["schedule"]] == [f"v2-pair-{number:02d}" for number in range(1, 7)]
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 1_440_000
+
+
+def test_graph_recursion_is_model_behavior_outcome_not_infrastructure_failure(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path, "baseline")
+    for _ in range(8):
+        _request(ledger, tokens=10)
+
+    result = runner.classify_arm_terminal(_manifest(), arm="baseline", ledger=ledger, error=GraphRecursionError("limit"))
+
+    assert result["infrastructure"]["status"] == "valid"
+    assert result["model_behavior"]["status"] == "graph_step_limit"
+    assert result["verification_outcome"]["status"] == "not_attempted"
+    assert result["recorded_tokens"] == 80
+    assert ledger.read()[-1]["event"] == "experiment.completed"
+
+
+def test_endpoint_timeout_is_censored_arm_and_not_model_behavior(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path, "treatment")
+    _timeout_request(ledger)
+
+    result = runner.classify_arm_terminal(_manifest(), arm="treatment", ledger=ledger, error=TimeoutError("endpoint"))
+
+    assert result["infrastructure"]["status"] == "endpoint_censored"
+    assert result["model_behavior"]["status"] == "not_observed"
+    assert result["verification_outcome"]["status"] == "not_attempted"
+
+
+def test_parent_adapter_continues_second_arm_after_classified_behavior_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _manifest()
+    pair_manifest = runner._pair_manifest(manifest, manifest["schedule"][0])
+    baseline = _ledger(tmp_path, "baseline")
+    treatment = _ledger(tmp_path, "treatment")
+    _request(baseline)
+    _request(treatment)
+    original = runner.primary.run_arm_continuation
+
+    async def fake_continuation(*_args, **kwargs):
+        if kwargs["arm"] == "baseline":
+            raise GraphRecursionError("limit")
+        kwargs["ledger"].append("experiment.completed", {"status": "passed"})
+        return {
+            "arm": "treatment",
+            "status": "passed",
+            "physical_attempt_id": kwargs["ledger"].physical_attempt_id,
+            "model_requests": 1,
+            "recorded_tokens": 10,
+            "actual_model": "deepseek-v4-flash",
+            "session_status": "verified",
+            "replay_attempts": 1,
+            "ledger_head_sha256": kwargs["ledger"].read()[-1]["event_sha256"],
+        }
+
+    monkeypatch.setattr(runner.primary, "run_arm_continuation", fake_continuation)
+    with asyncio.Runner() as async_runner:
+        with runner._adapt_parent_runner(manifest, pair_manifest, async_runner):
+            first = async_runner.run(runner.primary.run_arm_continuation(arm="baseline", ledger=baseline))
+            second = async_runner.run(runner.primary.run_arm_continuation(arm="treatment", ledger=treatment))
+
+    assert first["model_behavior"]["status"] == "graph_step_limit"
+    assert second["verification_outcome"]["status"] == "passed"
+    assert runner.primary.run_arm_continuation is fake_continuation
+    monkeypatch.setattr(runner.primary, "run_arm_continuation", original)
+
+
+def test_unclassified_request_failure_fails_closed(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path, "baseline")
+    call_id = "model_call_connection_1234567890abcdef1234"
+    request_id = "model_request_connection_1234567890abcdef12"
+    ledger.append(
+        "model.request_started",
+        {
+            "attempt": 1,
+            "configured_model": "deepseek-v4-flash",
+            "max_attempts": 1,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "observed_endpoint": "https://api.deepseek.com",
+            "provider_max_retries": 0,
+            "request_timeout_seconds": 300,
+            "role": "compiler",
+        },
+    )
+    ledger.append(
+        "model.request_failed",
+        {
+            "attempt": 1,
+            "classification": "connection_error",
+            "latency_seconds": 1.0,
+            "max_attempts": 1,
+            "model_call_id": call_id,
+            "model_request_id": request_id,
+            "retriable": False,
+            "retry_exhausted": True,
+            "status_code": None,
+        },
+    )
+
+    with pytest.raises(runner.BehavioralPilotError, match="未分类"):
+        runner.classify_arm_terminal(_manifest(), arm="baseline", ledger=ledger, error=RuntimeError("unknown"))
+
+
+def _patch_preflight(monkeypatch: pytest.MonkeyPatch, manifest: dict, output_dir: Path) -> dict:
+    candidate = copy.deepcopy(manifest)
+    candidate["execution"]["evidence_directory"] = str(output_dir)
+    monkeypatch.setattr(runner.protocol, "validate_manifest", lambda value, *_args: value)
+    monkeypatch.setattr(runner.protocol, "verify_historical_evidence", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(runner, "require_release_identity", lambda *_args: {"branch": "main", "revision": "b" * 40, "origin_main": "b" * 40})
+    monkeypatch.setattr(runner, "require_network_medium", lambda *_args: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+    return candidate
+
+
+def test_batch_keeps_model_behavior_failures_in_estimand_and_continues_endpoint_pair(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _patch_preflight(monkeypatch, _manifest(), tmp_path)
+    calls: list[str] = []
+
+    def execute(value: dict, pair: dict, _pair_dir: Path) -> dict:
+        calls.append(pair["pair_id"])
+        if pair["order"] == 2:
+            return _outcome(value, pair, baseline_passed=False)
+        if pair["order"] == 3:
+            return _outcome(value, pair, endpoint=True)
+        return _outcome(value, pair)
+
+    report = runner.run_pilot(manifest, output_dir=tmp_path, pair_executor=execute)
+
+    assert calls == [f"v2-pair-{number:02d}" for number in range(1, 7)]
+    assert report["itt_attrition"]["observed_pairs"] == 6
+    assert report["itt_attrition"]["attempted_arms"] == {"baseline": 6, "treatment": 6}
+    assert report["itt_attrition"]["endpoint_censored_pairs"] == 1
+    assert report["primary_mechanism"]["eligible_pairs"] == 5
+    assert report["primary_mechanism"]["repair_success"] == {"baseline": 4, "treatment": 5}
+    assert report["primary_mechanism"]["model_behavior_counts"]["baseline"] == {"completed": 4, "graph_step_limit": 1, "not_observed": 1}
+
+    resumed = runner.run_pilot(manifest, output_dir=tmp_path, pair_executor=lambda *_args: pytest.fail("v2 终态不得重跑"))
+    assert resumed == report
+
+
+def test_manifest_rejects_old_pair_reuse_or_schedule_extension() -> None:
+    manifest = _manifest()
+    manifest["schedule"][0]["pair_id"] = "pair-01"
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)
+
+    manifest = _manifest()
+    manifest["schedule"].append(copy.deepcopy(manifest["schedule"][-1]))
+    with pytest.raises(protocol.ProtocolError, match="冻结协议"):
+        protocol.validate_manifest(manifest)

--- a/backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py
+++ b/backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py
@@ -1,0 +1,161 @@
+"""Issue #165 v2 适配器的 opt-in Compose/DooD 零 provider gate。"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_checkpoint_behavioral_pilot_v2_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-behavioral-pilot-v2.json"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_CHECKPOINT_BEHAVIORAL_V2_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_CHECKPOINT_BEHAVIORAL_V2_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_checkpoint_behavioral_pilot_v2_docker_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_module()
+
+
+class RestoreAndSubmitModel(BaseChatModel):
+    model_name: str = "deepseek-v4-flash"
+    base_url: str = "https://api.deepseek.com"
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "checkpoint-behavior-v2-docker-fake"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("successful automatic submit 后不应再次调用 fake model")
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "run_container_bash",
+                                "args": {
+                                    "command": "cp .forge-cmake-build/accumulate_examples /artifacts/accumulate_examples",
+                                    "timeout_seconds": 60,
+                                    "workdir": "/workspace/repo",
+                                    "command_role": "artifact_stage",
+                                },
+                                "id": "restore-controlled-artifact",
+                                "type": "tool_call",
+                            }
+                        ],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                    )
+                )
+            ]
+        )
+
+
+def test_v2_adapter_runs_real_checkpoint_verifier_replay_and_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner.primary.require_compose_dood()
+    paths = Paths()
+    output_dir = paths.compile_sessions_dir / f"issue-165-v2-docker-{uuid.uuid4().hex[:12]}"
+    created_session_dirs: list[Path] = []
+    manager = CompileSessionManager(paths=paths, default_image=runner.primary.COMPILE_IMAGE)
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_session_dirs.append(Path(session.metadata_path).parent)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {"branch": "main", "revision": "e" * 40, "origin_main": "e" * 40},
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    manifest = runner.protocol.validate_manifest(json_load(MANIFEST_PATH))
+    pair = manifest["schedule"][0]
+
+    try:
+        with asyncio.Runner() as async_runner:
+            result = runner.execute_real_pair(
+                manifest,
+                pair,
+                output_dir,
+                async_runner,
+                model_factory=lambda _provider, _thread_id: RestoreAndSubmitModel(),
+            )
+        assert result["status"] == "observed"
+        assert result["primary_mechanism_eligible"] is True
+        assert result["repair_success"] == {"baseline": True, "treatment": True}
+        assert all(item["infrastructure"]["status"] == "valid" for item in result["arms"].values())
+        assert all(item["verification_outcome"]["status"] == "passed" for item in result["arms"].values())
+    finally:
+        for session_dir in reversed(created_session_dirs):
+            shutil.rmtree(session_dir, ignore_errors=True)
+            try:
+                session_dir.parent.rmdir()
+            except OSError:
+                pass
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def json_load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value

--- a/benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json
+++ b/benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "../schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+  "schema_version": "forge-checkpoint-behavioral-pilot-2.0.0",
+  "document_type": "forge_checkpoint_behavioral_pilot",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/165",
+    "decision_issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/163",
+    "selected_option": "A",
+    "authorized_by": "experiment_owner",
+    "pilot_collection_authorized": true,
+    "authorized_pairs": 6,
+    "maximum_recorded_tokens": 1440000
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "mechanism": "failure_checkpoint",
+    "controlled_fault": "artifact_staging_missing",
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "v2-pair-01",
+      "order": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v2-pair-02",
+      "order": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v2-pair-03",
+      "order": 3,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v2-pair-04",
+      "order": 4,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v2-pair-05",
+      "order": 5,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v2-pair-06",
+      "order": 6,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    }
+  ],
+  "schedule_sha256": "1e173e573ff61256048e39906ef094bf962d3b976f862d867f83f78b09e48430",
+  "budget": {
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 1440000,
+    "reachability_requests": 0,
+    "enforcement": "after_each_arm_and_pair_before_next_pair"
+  },
+  "terminal_taxonomy": {
+    "infrastructure": [
+      "valid",
+      "endpoint_censored",
+      "invalid"
+    ],
+    "model_behavior": [
+      "completed",
+      "graph_step_limit",
+      "work_wall_clock_limit",
+      "no_submit",
+      "verification_failed",
+      "not_observed"
+    ],
+    "verification_outcome": [
+      "passed",
+      "failed",
+      "not_attempted"
+    ]
+  },
+  "stopping": {
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "model_behavior_failure_is_outcome": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "itt_attrition_includes_all_scheduled_pairs": true,
+    "primary_mechanism_requires_both_arms_attempted_and_infrastructure_valid": true,
+    "repair_conversion_outcome": "candidate_verification_and_clean_replay_passed",
+    "efficiency_metrics_are_conditionally_descriptive": true,
+    "descriptive_only": true,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "execution": {
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "network_access_medium": "wifi",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-behavioral-pilot-v2",
+    "pair_directory_pattern": "pairs/v2-pair-NN",
+    "batch_marker": "markers/v2-pilot-attempt.json",
+    "pair_marker": "markers/pair-attempt.json",
+    "release_branch": "main",
+    "authorization_baseline_commit": "3bc211219e1d458ebdad2d02274c58c209e99113",
+    "release_revision_policy": "descendant-compatible",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_zero_managed_containers_between_pairs": true
+  },
+  "historical_exclusion": {
+    "v1_manifest_sha256": "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391",
+    "recovery_manifest_sha256": "4e26976373bd02937a55703081794bcb45c4e9d07f6eec27931a368a32174d89",
+    "recorded_tokens": 67121,
+    "pair_ids": [
+      "v1:pair-01",
+      "recovery:pair-02"
+    ],
+    "role": "exploratory_feasibility_only",
+    "pooled_into_v2": false,
+    "v1_evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+      "files": {
+        "markers/pilot-attempt.json": "90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575",
+        "pairs/pair-01/checkpoint/coordinator.sqlite": "304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c",
+        "pairs/pair-01/checkpoint/messages.sqlite": "7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9",
+        "pairs/pair-01/ledgers/baseline.jsonl": "717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea",
+        "pairs/pair-01/ledgers/parent.jsonl": "858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d",
+        "pairs/pair-01/ledgers/treatment.jsonl": "c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840",
+        "pairs/pair-01/markers/pair-attempt.json": "8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d",
+        "pairs/pair-01/reports/controlled-pair.json": "afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4"
+      }
+    },
+    "recovery_evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1",
+      "files": {
+        "imports/pair-01.json": "4efffb5c899b716e5b1a066c8cc71a67befa4c4a1fa6696bc3d07df39202fef7",
+        "markers/recovery-attempt.json": "f673ced8588a585aaa83f0bd4e180da63c96d873f7a48493f6dd9453f6c0a1a1",
+        "pairs/pair-02/checkpoint/coordinator.sqlite": "01a72d5a13e33ee23a76b5943063e3cbd6f8b0fc4b2f0cbcc1dee688cf5eb380",
+        "pairs/pair-02/checkpoint/messages.sqlite": "ac0f8c958c9839ed357508e26be4935d3e17188386e5db3d24aee6a23890297c",
+        "pairs/pair-02/ledgers/baseline.jsonl": "9f4c713adb772576ac413bf65ea780fdaa31195d2066dea8755d27093935ddd5",
+        "pairs/pair-02/ledgers/parent.jsonl": "dd5085ad7595e2eae19209a91b31b92845d304233fafb5f9a89507bd10183dd5",
+        "pairs/pair-02/ledgers/treatment.jsonl": "27e7f71ebc13984e75238a9d072ed2db24c3e1cc6246d856b833104363087084",
+        "pairs/pair-02/markers/pair-attempt.json": "ca74fa29c5a3a7e310ccc49a4bfe72b9c7a4d37033f74acca53ed5cca704144b"
+      }
+    }
+  },
+  "parent_components": {
+    "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+    "scripts/forge_checkpoint_censored_pilot_recovery_runner.py": "336d9217c83ee60ebb479615200a0eddbcfb82233140bfaca6711baa0d79d786",
+    "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768",
+    "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+    "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+    "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+  },
+  "protocol_artifacts": {
+    "backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py": "6854bd882dc25bcc61eabf53c4a396135aa396d330880eb7cdb541c143a77381",
+    "backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py": "f423f139f0ba06458517dd2f8b364814ad98c686513c41889a9991f5d12bd859",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md": "0f617538f98402f017b0debd2350b8202be8c73d2659df102da0264c20cb429b",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py": "3e0032dbc065feb6a780799b2b59bc211e79fd796df8fb5f2a34800f9fa942e0",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md
+++ b/benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md
@@ -1,0 +1,48 @@
+# Checkpoint 行为终态 v2 六配对实验预注册
+
+本协议承接 Issue #163 的选择 A 决策和 Issue #165 的长程任务授权。路线 B v1 的 pair-01 与 recovery pair-02 只作为 exploratory feasibility evidence；旧 pair-03 至 pair-06 永不执行，也不与 v2 池化。
+
+## 研究问题与 estimand
+
+研究变量保持不变：在同一个 actionable verifier failure checkpoint 上，treatment 向 compiler continuation 提供结构化 repair packet，baseline 不提供。Primary mechanism estimand 比较 candidate verification + clean replay 的 repair conversion。
+
+Replay success 是 outcome，不再兼任采集纳入 gate。只有两臂均被尝试且 infrastructure 为 `valid` 的 pair 进入 primary mechanism 分母；其中 `GraphRecursionError`、work wall-clock 耗尽、无 submit 和 verification failed 都以失败 outcome 保留。
+
+## 身份、provider 与预算
+
+- 语言固定为 C/C++，controlled fault 固定为 `artifact_staging_missing`。
+- provider 固定为 DeepSeek `deepseek-v4-flash` 与 `https://api.deepseek.com`；300 秒 timeout、0 retry、非 streaming、禁止 fallback。
+- 新建 6 pair / 12 arms；pair 1/3/5 为 `baseline -> treatment`，pair 2/4/6 为 `treatment -> baseline`。
+- 每臂最多 8 requests、8 model turns、24 graph steps、600 秒 work + 120 秒 cleanup、120,000 recorded tokens；总机械上限 1,440,000 recorded tokens。
+- 禁止 replacement、backfill、补跑、第 7 个 pair 和任何旧 pair 复用。
+
+## 三层 arm 终态
+
+每个已尝试 arm 同时记录：
+
+1. `infrastructure`: `valid` / `endpoint_censored` / `invalid`；
+2. `model_behavior`: `completed` / `graph_step_limit` / `work_wall_clock_limit` / `no_submit` / `verification_failed` / `not_observed`；
+3. `verification_outcome`: `passed` / `failed` / `not_attempted`。
+
+唯一合法 endpoint timeout 需要请求/失败分类、0 retry、ledger 哈希链、预算和 cleanup 全部闭合，记为 `endpoint_censored`。它进入 ITT/attrition，但不进入 primary mechanism 分母。第一臂出现 endpoint censoring 或可分类模型行为失败时，第二臂仍继续。
+
+Release/manifest/evidence identity 漂移、ledger 损坏、预算越界、cleanup/orphan 或无法分类的异常属于 hard infrastructure failure，立即关闭 batch。
+
+## Evidence 与停止规则
+
+- v2 只写入 `/workspace/.compile-sessions/benchmark-evidence-checkpoint-behavioral-pilot-v2`。
+- 每个 `v2-pair-NN` 使用独立 checkpoint、ledger、marker、outcome 与 Compile Session。
+- 已形成合法 pair outcome 的 pair 在同一 started batch 恢复时只读跳过；存在部分内容但没有终态时禁止自动补跑。
+- v1/recovery 的文件集合和 SHA-256 在 v2 manifest 中冻结，运行前只读核验；旧目录不得删除、覆盖或写 sidecar。
+- 每个 pair 后核验累计 recorded tokens 与 0 Compile Session/replay orphan。
+
+## 分析边界
+
+- ITT/attrition 固定分母为 6 个新 pair，报告 attempted arms、endpoint censoring 和 hard infrastructure stop。
+- Primary mechanism 报告 infrastructure-valid 双臂 pair 的 baseline/treatment repair success、配对 conversion delta 和模型行为失败分类。
+- 请求数、tokens、submit/replay 次数与 wall-clock 只按终态做条件描述。
+- 仅做描述性机制评估，不计算 p 值、不做模型排名、不跨 provider 外推。
+
+## 发布与执行
+
+实现合并前只允许 0-provider 单测、Ruff、确定性 manifest/Schema、历史 evidence 核验和真实 Compose/DooD fake-model 门禁。真实采集必须位于干净 `main == origin/main`，使用 WSL Ubuntu 原生 Docker Engine，网络介质记录为 `wifi`。AK 只做环境变量非空核验，不写入日志、Git、evidence 或文档。

--- a/benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json
+++ b/benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+  "title": "Forge checkpoint behavioral outcome pilot v2",
+  "const": {
+    "$schema": "../schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+    "schema_version": "forge-checkpoint-behavioral-pilot-2.0.0",
+    "document_type": "forge_checkpoint_behavioral_pilot",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/165",
+      "decision_issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/163",
+      "selected_option": "A",
+      "authorized_by": "experiment_owner",
+      "pilot_collection_authorized": true,
+      "authorized_pairs": 6,
+      "maximum_recorded_tokens": 1440000
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "mechanism": "failure_checkpoint",
+      "controlled_fault": "artifact_staging_missing",
+      "natural_collection_authorized": false,
+      "secondary_provider_authorized": false
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "v2-pair-01",
+        "order": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v2-pair-02",
+        "order": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v2-pair-03",
+        "order": 3,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v2-pair-04",
+        "order": 4,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v2-pair-05",
+        "order": 5,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v2-pair-06",
+        "order": 6,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "schedule_sha256": "1e173e573ff61256048e39906ef094bf962d3b976f862d867f83f78b09e48430",
+    "budget": {
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 1440000,
+      "reachability_requests": 0,
+      "enforcement": "after_each_arm_and_pair_before_next_pair"
+    },
+    "terminal_taxonomy": {
+      "infrastructure": [
+        "valid",
+        "endpoint_censored",
+        "invalid"
+      ],
+      "model_behavior": [
+        "completed",
+        "graph_step_limit",
+        "work_wall_clock_limit",
+        "no_submit",
+        "verification_failed",
+        "not_observed"
+      ],
+      "verification_outcome": [
+        "passed",
+        "failed",
+        "not_attempted"
+      ]
+    },
+    "stopping": {
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "model_behavior_failure_is_outcome": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "itt_attrition_includes_all_scheduled_pairs": true,
+      "primary_mechanism_requires_both_arms_attempted_and_infrastructure_valid": true,
+      "repair_conversion_outcome": "candidate_verification_and_clean_replay_passed",
+      "efficiency_metrics_are_conditionally_descriptive": true,
+      "descriptive_only": true,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "execution": {
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "network_access_medium": "wifi",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-behavioral-pilot-v2",
+      "pair_directory_pattern": "pairs/v2-pair-NN",
+      "batch_marker": "markers/v2-pilot-attempt.json",
+      "pair_marker": "markers/pair-attempt.json",
+      "release_branch": "main",
+      "authorization_baseline_commit": "3bc211219e1d458ebdad2d02274c58c209e99113",
+      "release_revision_policy": "descendant-compatible",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_zero_managed_containers_between_pairs": true
+    },
+    "historical_exclusion": {
+      "v1_manifest_sha256": "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391",
+      "recovery_manifest_sha256": "4e26976373bd02937a55703081794bcb45c4e9d07f6eec27931a368a32174d89",
+      "recorded_tokens": 67121,
+      "pair_ids": [
+        "v1:pair-01",
+        "recovery:pair-02"
+      ],
+      "role": "exploratory_feasibility_only",
+      "pooled_into_v2": false,
+      "v1_evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1",
+        "files": {
+          "markers/pilot-attempt.json": "90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575",
+          "pairs/pair-01/checkpoint/coordinator.sqlite": "304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c",
+          "pairs/pair-01/checkpoint/messages.sqlite": "7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9",
+          "pairs/pair-01/ledgers/baseline.jsonl": "717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea",
+          "pairs/pair-01/ledgers/parent.jsonl": "858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d",
+          "pairs/pair-01/ledgers/treatment.jsonl": "c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840",
+          "pairs/pair-01/markers/pair-attempt.json": "8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d",
+          "pairs/pair-01/reports/controlled-pair.json": "afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4"
+        }
+      },
+      "recovery_evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1",
+        "files": {
+          "imports/pair-01.json": "4efffb5c899b716e5b1a066c8cc71a67befa4c4a1fa6696bc3d07df39202fef7",
+          "markers/recovery-attempt.json": "f673ced8588a585aaa83f0bd4e180da63c96d873f7a48493f6dd9453f6c0a1a1",
+          "pairs/pair-02/checkpoint/coordinator.sqlite": "01a72d5a13e33ee23a76b5943063e3cbd6f8b0fc4b2f0cbcc1dee688cf5eb380",
+          "pairs/pair-02/checkpoint/messages.sqlite": "ac0f8c958c9839ed357508e26be4935d3e17188386e5db3d24aee6a23890297c",
+          "pairs/pair-02/ledgers/baseline.jsonl": "9f4c713adb772576ac413bf65ea780fdaa31195d2066dea8755d27093935ddd5",
+          "pairs/pair-02/ledgers/parent.jsonl": "dd5085ad7595e2eae19209a91b31b92845d304233fafb5f9a89507bd10183dd5",
+          "pairs/pair-02/ledgers/treatment.jsonl": "27e7f71ebc13984e75238a9d072ed2db24c3e1cc6246d856b833104363087084",
+          "pairs/pair-02/markers/pair-attempt.json": "ca74fa29c5a3a7e310ccc49a4bfe72b9c7a4d37033f74acca53ed5cca704144b"
+        }
+      }
+    },
+    "parent_components": {
+      "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json": "fb483a55542adf4be1d213a2130d87b11e783df9d6e5270ed7aa1573d88c7776",
+      "scripts/forge_checkpoint_censored_pilot_recovery_runner.py": "336d9217c83ee60ebb479615200a0eddbcfb82233140bfaca6711baa0d79d786",
+      "scripts/forge_checkpoint_censored_pilot_runner.py": "819a8d25d65d1e6019c1d994515ee5534533513e3dcc299ca75a043480c3d768",
+      "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+      "scripts/forge_checkpoint_primary_canary_amendment_authorized.py": "89cce741bf56c234b9e31560a5662cd701cc6fab4f948858ca187ed64141f5ba",
+      "scripts/forge_checkpoint_windows_build_layout.py": "df757d63ad493393957b1fb167dd5b01d5e9c1ae1d76796cca26d616b77355e5"
+    },
+    "protocol_artifacts": {
+      "backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py": "6854bd882dc25bcc61eabf53c4a396135aa396d330880eb7cdb541c143a77381",
+      "backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py": "f423f139f0ba06458517dd2f8b364814ad98c686513c41889a9991f5d12bd859",
+      "benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md": "0f617538f98402f017b0debd2350b8202be8c73d2659df102da0264c20cb429b",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py": "3e0032dbc065feb6a780799b2b59bc211e79fd796df8fb5f2a34800f9fa942e0",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+    }
+  }
+}

--- a/scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py
+++ b/scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Issue #165 checkpoint 行为终态 v2 六配对实验协议。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-behavioral-pilot-v2.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks" / "schemas" / "forge-checkpoint-behavioral-pilot-v2.schema.json"
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-behavioral-pilot-v2")
+V1_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-v1")
+RECOVERY_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-checkpoint-censored-pilot-recovery-v1")
+
+SCHEMA_VERSION = "forge-checkpoint-behavioral-pilot-2.0.0"
+DOCUMENT_TYPE = "forge_checkpoint_behavioral_pilot"
+AUTHORIZATION_BASELINE = "3bc211219e1d458ebdad2d02274c58c209e99113"
+PAIR_COUNT = 6
+RECORDED_TOKENS_PER_ARM = 120_000
+RECORDED_TOKEN_LIMIT = PAIR_COUNT * 2 * RECORDED_TOKENS_PER_ARM
+
+PARENT_COMPONENT_PATHS = {
+    "benchmarks/manifests/cpp-verifier-checkpoint-primary-canary-amendment-authorized.json",
+    "scripts/forge_checkpoint_primary_canary.py",
+    "scripts/forge_checkpoint_primary_canary_amendment_authorized.py",
+    "scripts/forge_checkpoint_windows_build_layout.py",
+    "scripts/forge_checkpoint_censored_pilot_runner.py",
+    "scripts/forge_checkpoint_censored_pilot_recovery_runner.py",
+}
+
+PROTOCOL_ARTIFACT_PATHS = {
+    "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py",
+    "backend/tests/test_forge_checkpoint_behavioral_pilot_v2.py",
+    "backend/tests/test_forge_checkpoint_behavioral_pilot_v2_docker.py",
+    "benchmarks/preregistrations/cpp-verifier-checkpoint-behavioral-pilot-v2.md",
+}
+
+V1_EVIDENCE = {
+    "markers/pilot-attempt.json": "90637cef19d2859c3067c6b1b982d8b91c180a94b20d999a5349948c68023575",
+    "pairs/pair-01/checkpoint/coordinator.sqlite": "304288805942f5b210c82e06d421a6264edc344b7ff15066ddb6a91456c89a7c",
+    "pairs/pair-01/checkpoint/messages.sqlite": "7a16adf27013d6e6f76a4c11c43f179ea63436f8dfec253359a4644feca633e9",
+    "pairs/pair-01/ledgers/baseline.jsonl": "717755fa47d5f585282a76b4767454b8fe446c39f453375dc8f6bb6d38375aea",
+    "pairs/pair-01/ledgers/parent.jsonl": "858097dfa4ce93815e304f14974a799e35d15d5286293470e22c8686bebf738d",
+    "pairs/pair-01/ledgers/treatment.jsonl": "c504c61b3a492d00740d3abbf3cb19a457a6599a5212602b4d1f1f0c612ab840",
+    "pairs/pair-01/markers/pair-attempt.json": "8178d32c61f4ed4425aa5dfa0ad155ba86fcf9626ef1b31bfe0eee1492f5de5d",
+    "pairs/pair-01/reports/controlled-pair.json": "afad25b4c41ae3098b7feb4711d8f4f746f856a9e9773052c13b05a6054471f4",
+}
+
+RECOVERY_EVIDENCE = {
+    "imports/pair-01.json": "4efffb5c899b716e5b1a066c8cc71a67befa4c4a1fa6696bc3d07df39202fef7",
+    "markers/recovery-attempt.json": "f673ced8588a585aaa83f0bd4e180da63c96d873f7a48493f6dd9453f6c0a1a1",
+    "pairs/pair-02/checkpoint/coordinator.sqlite": "01a72d5a13e33ee23a76b5943063e3cbd6f8b0fc4b2f0cbcc1dee688cf5eb380",
+    "pairs/pair-02/checkpoint/messages.sqlite": "ac0f8c958c9839ed357508e26be4935d3e17188386e5db3d24aee6a23890297c",
+    "pairs/pair-02/ledgers/baseline.jsonl": "9f4c713adb772576ac413bf65ea780fdaa31195d2066dea8755d27093935ddd5",
+    "pairs/pair-02/ledgers/parent.jsonl": "dd5085ad7595e2eae19209a91b31b92845d304233fafb5f9a89507bd10183dd5",
+    "pairs/pair-02/ledgers/treatment.jsonl": "27e7f71ebc13984e75238a9d072ed2db24c3e1cc6246d856b833104363087084",
+    "pairs/pair-02/markers/pair-attempt.json": "ca74fa29c5a3a7e310ccc49a4bfe72b9c7a4d37033f74acca53ed5cca704144b",
+}
+
+
+class ProtocolError(RuntimeError):
+    """协议、组件或历史 evidence 发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"协议制品缺失: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def _schedule() -> list[dict[str, Any]]:
+    return [
+        {
+            "pair_id": f"v2-pair-{number:02d}",
+            "order": number,
+            "arm_order": ["baseline", "treatment"] if number % 2 == 1 else ["treatment", "baseline"],
+        }
+        for number in range(1, PAIR_COUNT + 1)
+    ]
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    schedule = _schedule()
+    return {
+        "$schema": "../schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/165",
+            "decision_issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/163",
+            "selected_option": "A",
+            "authorized_by": "experiment_owner",
+            "pilot_collection_authorized": True,
+            "authorized_pairs": PAIR_COUNT,
+            "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+        },
+        "scope": {
+            "languages": ["C", "C++"],
+            "mechanism": "failure_checkpoint",
+            "controlled_fault": "artifact_staging_missing",
+            "natural_collection_authorized": False,
+            "secondary_provider_authorized": False,
+        },
+        "provider": {
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "continuation": {
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "budget": {
+            "recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+            "recorded_tokens_per_pair": RECORDED_TOKENS_PER_ARM * 2,
+            "stage_maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+            "reachability_requests": 0,
+            "enforcement": "after_each_arm_and_pair_before_next_pair",
+        },
+        "terminal_taxonomy": {
+            "infrastructure": ["valid", "endpoint_censored", "invalid"],
+            "model_behavior": [
+                "completed",
+                "graph_step_limit",
+                "work_wall_clock_limit",
+                "no_submit",
+                "verification_failed",
+                "not_observed",
+            ],
+            "verification_outcome": ["passed", "failed", "not_attempted"],
+        },
+        "stopping": {
+            "classified_arm_outcome_continues_other_arm": True,
+            "endpoint_timeout_censors_arm_and_continues": True,
+            "model_behavior_failure_is_outcome": True,
+            "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": True,
+            "retry_forbidden": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "analysis": {
+            "itt_attrition_includes_all_scheduled_pairs": True,
+            "primary_mechanism_requires_both_arms_attempted_and_infrastructure_valid": True,
+            "repair_conversion_outcome": "candidate_verification_and_clean_replay_passed",
+            "efficiency_metrics_are_conditionally_descriptive": True,
+            "descriptive_only": True,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+        },
+        "execution": {
+            "control_plane": "compose-dood-on-ubuntu-native-docker",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "network_access_medium": "wifi",
+            "evidence_directory": str(DEFAULT_OUTPUT_DIR),
+            "pair_directory_pattern": "pairs/v2-pair-NN",
+            "batch_marker": "markers/v2-pilot-attempt.json",
+            "pair_marker": "markers/pair-attempt.json",
+            "release_branch": "main",
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE,
+            "release_revision_policy": "descendant-compatible",
+            "require_clean_worktree": True,
+            "require_origin_main_identity": True,
+            "require_zero_managed_containers_between_pairs": True,
+        },
+        "historical_exclusion": {
+            "v1_manifest_sha256": "d5edd9683def7c8842ad1eb0471cce877b47b52b2939f1b45d9c2a51f2362391",
+            "recovery_manifest_sha256": "4e26976373bd02937a55703081794bcb45c4e9d07f6eec27931a368a32174d89",
+            "recorded_tokens": 67_121,
+            "pair_ids": ["v1:pair-01", "recovery:pair-02"],
+            "role": "exploratory_feasibility_only",
+            "pooled_into_v2": False,
+            "v1_evidence": {
+                "directory": str(V1_OUTPUT_DIR),
+                "files": dict(sorted(V1_EVIDENCE.items())),
+            },
+            "recovery_evidence": {
+                "directory": str(RECOVERY_OUTPUT_DIR),
+                "files": dict(sorted(RECOVERY_EVIDENCE.items())),
+            },
+        },
+        "parent_components": _hash_paths(repo_root, PARENT_COMPONENT_PATHS),
+        "protocol_artifacts": _hash_paths(repo_root, PROTOCOL_ARTIFACT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("v2 manifest 与冻结协议不一致")
+    first_arms = [item["arm_order"][0] for item in value["schedule"]]
+    if first_arms != ["baseline", "treatment"] * 3:
+        raise ProtocolError("v2 arm order 未交叉平衡")
+    return value
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    for group in ("parent_components", "protocol_artifacts"):
+        for relative_path, expected in manifest[group].items():
+            path = repo_root / relative_path
+            if not path.is_file() or file_sha256(path) != expected:
+                raise ProtocolError(f"v2 冻结组件发生漂移: {relative_path}")
+
+
+def _verify_evidence_set(output_dir: Path, expected: dict[str, str], label: str) -> None:
+    actual = {path.relative_to(output_dir).as_posix() for path in output_dir.rglob("*") if path.is_file()}
+    if actual != set(expected):
+        raise ProtocolError(f"{label} 历史 evidence 文件集合发生漂移")
+    for relative_path, digest in expected.items():
+        if file_sha256(output_dir / relative_path) != digest:
+            raise ProtocolError(f"{label} 历史 evidence 哈希发生漂移: {relative_path}")
+
+
+def verify_historical_evidence(
+    manifest: dict[str, Any],
+    v1_output_dir: Path = V1_OUTPUT_DIR,
+    recovery_output_dir: Path = RECOVERY_OUTPUT_DIR,
+) -> dict[str, Any]:
+    validate_manifest(manifest)
+    exclusion = manifest["historical_exclusion"]
+    _verify_evidence_set(v1_output_dir, exclusion["v1_evidence"]["files"], "v1")
+    _verify_evidence_set(recovery_output_dir, exclusion["recovery_evidence"]["files"], "recovery")
+    return {
+        "status": "valid",
+        "excluded_pairs": 2,
+        "recorded_tokens": exclusion["recorded_tokens"],
+    }
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+        "title": "Forge checkpoint behavioral outcome pilot v2",
+        "const": manifest or generate_manifest(),
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "validate-evidence"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = generate_manifest()
+            _write_json(args.manifest, manifest)
+            _write_json(args.schema, schema_document(manifest))
+            status = "generated"
+        else:
+            manifest = validate_manifest(_load_json(args.manifest))
+            verify_frozen_components(manifest)
+            if args.command == "validate-evidence":
+                verify_historical_evidence(manifest)
+            status = "valid"
+    except (OSError, ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "manifest_sha256": canonical_sha256(manifest),
+                "authorized_pairs": PAIR_COUNT,
+                "maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+                "provider_calls": 0,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_checkpoint_behavioral_pilot_v2_runner.py
+++ b/scripts/forge_checkpoint_behavioral_pilot_v2_runner.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""执行 Issue #165 checkpoint 行为终态 v2 六配对实验。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_checkpoint_behavioral_pilot_v2_protocol as protocol  # noqa: E402
+import forge_checkpoint_censored_pilot_recovery_runner as recovery_runner  # noqa: E402
+import forge_checkpoint_censored_pilot_runner as v1_runner  # noqa: E402
+
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = protocol.DEFAULT_OUTPUT_DIR
+BATCH_MARKER = "markers/v2-pilot-attempt.json"
+PAIR_MARKER = "pair-attempt.json"
+PAIR_OUTCOME = "reports/pair-outcome.json"
+PILOT_REPORT = "reports/pilot.json"
+
+primary = v1_runner.primary
+parent_adapter = v1_runner.parent_adapter
+
+
+class BehavioralPilotError(RuntimeError):
+    """v2 identity、evidence、预算、cleanup 或终态分类失败。"""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BehavioralPilotError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise BehavioralPilotError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _write_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+    except FileExistsError as exc:
+        raise BehavioralPilotError(f"不可覆盖已存在的 evidence: {path}") from exc
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo_root}", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise BehavioralPilotError("无法验证 v2 release Git identity")
+    return result.stdout.strip()
+
+
+def require_release_identity(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    branch = _git(repo_root, "branch", "--show-current")
+    revision = _git(repo_root, "rev-parse", "HEAD")
+    origin_main = _git(repo_root, "rev-parse", "origin/main")
+    dirty = _git(repo_root, "status", "--porcelain", "--untracked-files=normal")
+    execution = manifest["execution"]
+    if branch != execution["release_branch"] or revision != origin_main or dirty:
+        raise BehavioralPilotError("真实 v2 必须位于干净且与 origin/main 一致的 main")
+    baseline = execution["authorization_baseline_commit"]
+    if _git(repo_root, "merge-base", baseline, revision) != baseline:
+        raise BehavioralPilotError("当前 release 不是 v2 授权 baseline 的后代")
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+def require_network_medium(manifest: dict[str, Any]) -> str:
+    execution = manifest["execution"]
+    if os.environ.get(execution["network_access_medium_env"]) != execution["network_access_medium"]:
+        raise BehavioralPilotError("必须通过 FORGE_NETWORK_ACCESS_MEDIUM=wifi 确认当前网络介质")
+    return execution["network_access_medium"]
+
+
+def require_zero_managed_containers() -> None:
+    try:
+        v1_runner.require_zero_managed_containers()
+    except v1_runner.PilotError as exc:
+        raise BehavioralPilotError(str(exc)) from exc
+
+
+def _pair_manifest(manifest: dict[str, Any], pair: dict[str, Any]) -> dict[str, Any]:
+    parent_path = REPO_ROOT / "benchmarks" / "manifests" / "cpp-verifier-checkpoint-primary-canary-amendment-authorized.json"
+    value = _load_json(parent_path)
+    value["schema_version"] = "forge-checkpoint-behavioral-pair-runtime-2.0.0"
+    value["document_type"] = "forge_checkpoint_behavioral_pair_runtime"
+    value["scope"]["pilot_collection_authorized"] = True
+    value["continuation"].update(copy.deepcopy(manifest["continuation"]))
+    value["continuation"]["arm_order"] = copy.deepcopy(pair["arm_order"])
+    value["budget"] = {
+        "reachability_requests": 0,
+        "reachability_expected_tokens": 0,
+        "reachability_maximum_tokens": 0,
+        "mechanism_canary_expected_tokens": 120_000,
+        "mechanism_canary_maximum_tokens": 240_000,
+        "stage_expected_tokens": 120_000,
+        "stage_maximum_tokens": 240_000,
+    }
+    pair_dir = DEFAULT_OUTPUT_DIR / "pairs" / pair["pair_id"]
+    value["execution"]["evidence_directory"] = str(pair_dir)
+    value["execution"]["controlled_pair_marker"] = PAIR_MARKER
+    value["execution"]["authorization_baseline_commit"] = manifest["execution"]["authorization_baseline_commit"]
+    value["authorization"] = {
+        "issue_url": manifest["authorization"]["issue_url"],
+        "authorized_reachability_attempts": 0,
+        "authorized_controlled_pairs": 1,
+        "stage_maximum_tokens": 240_000,
+        "pilot_collection_authorized": True,
+    }
+    value["pilot"] = {
+        "parent_manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "classified_arm_outcome_continues_other_arm": True,
+        "historical_pairs_pooled": False,
+    }
+    return value
+
+
+class _AsyncioProxy:
+    def __init__(self, runner: asyncio.Runner):
+        self._runner = runner
+
+    def run(self, coroutine: Any) -> Any:
+        return self._runner.run(coroutine)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(asyncio, name)
+
+
+def _request_evidence(manifest: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    started = [event for event in events if event["event"] == "model.request_started"]
+    completed = [event for event in events if event["event"] == "model.request_completed"]
+    failed = [event for event in events if event["event"] in {"model.request_failed", "model.request_cancelled"}]
+    provider = manifest["provider"]
+    if len(started) > manifest["continuation"]["maximum_requests_per_arm"]:
+        raise BehavioralPilotError("arm 超过模型请求上限")
+    if any(
+        event["payload"].get("configured_model") != provider["model"]
+        or event["payload"].get("observed_endpoint") != provider["endpoint"]
+        or event["payload"].get("request_timeout_seconds") != provider["request_timeout_seconds"]
+        or event["payload"].get("provider_max_retries") != 0
+        for event in started
+    ):
+        raise BehavioralPilotError("arm 请求 policy identity 发生漂移")
+    if any(event["payload"].get("actual_model") != provider["model"] for event in completed):
+        raise BehavioralPilotError("arm actual model identity 发生漂移")
+    tokens = v1_runner._recorded_tokens(events)
+    if tokens > manifest["continuation"]["maximum_recorded_tokens_per_arm"]:
+        raise BehavioralPilotError("arm 超过 recorded-token 上限")
+    if len(started) != len(completed) + len(failed):
+        raise BehavioralPilotError("arm 模型请求 started/terminal 不闭合")
+    return {
+        "started": started,
+        "completed": completed,
+        "failed": failed,
+        "recorded_tokens": tokens,
+    }
+
+
+def _endpoint_censored_arm(events: list[dict[str, Any]], request: dict[str, Any]) -> bool:
+    failed = request["failed"]
+    if len(failed) != 1 or failed[0]["event"] != "model.request_failed":
+        return False
+    payload = failed[0]["payload"]
+    classifications = [event for event in events if event["event"] == "failure.recorded" and event["payload"].get("primary") is True]
+    matching = [event for event in classifications if event["payload"].get("domain") == "model_endpoint" and event["payload"].get("classification") == "timeout" and "retry_exhausted" in event["payload"].get("secondary_classifications", [])]
+    return payload.get("classification") == "timeout" and payload.get("retry_exhausted") is True and payload.get("status_code") is None and len(classifications) == 1 and len(matching) == 1
+
+
+def _verification_outcome(events: list[dict[str, Any]]) -> dict[str, Any]:
+    submit_started = sum(event["event"] == "submit.started" for event in events)
+    replay_started = sum(event["event"] == "replay.started" for event in events)
+    submit_passed = any(event["event"] == "submit.completed" and event["payload"].get("status") == "passed" for event in events)
+    replay_passed = any(event["event"] == "replay.completed" and event["payload"].get("status") == "passed" for event in events)
+    if submit_passed and replay_passed:
+        status = "passed"
+    elif submit_started:
+        status = "failed"
+    else:
+        status = "not_attempted"
+    return {
+        "status": status,
+        "submit_attempts": submit_started,
+        "clean_replay_attempts": replay_started,
+    }
+
+
+def classify_arm_terminal(
+    manifest: dict[str, Any],
+    *,
+    arm: str,
+    ledger: Any,
+    error: Exception,
+) -> dict[str, Any]:
+    events = ledger.read()
+    if not events:
+        raise BehavioralPilotError(f"{arm} arm 缺少 ledger evidence") from error
+    request = _request_evidence(manifest, events)
+    verification = _verification_outcome(events)
+    metrics = v1_runner._arm_metrics(events)
+    metrics["recorded_tokens"] = request["recorded_tokens"]
+    if _endpoint_censored_arm(events, request):
+        infrastructure = "endpoint_censored"
+        behavior = "not_observed"
+    else:
+        if request["failed"]:
+            if type(error).__name__ in {"TimeoutError", "CancelledError"} and all(event["event"] == "model.request_cancelled" for event in request["failed"]):
+                infrastructure = "valid"
+                behavior = "work_wall_clock_limit"
+            else:
+                raise BehavioralPilotError(f"{arm} arm 存在未分类的模型请求失败") from error
+        else:
+            infrastructure = "valid"
+            error_name = type(error).__name__
+            if error_name == "GraphRecursionError":
+                behavior = "graph_step_limit"
+            elif error_name == "TimeoutError":
+                behavior = "work_wall_clock_limit"
+            elif verification["status"] == "failed":
+                behavior = "verification_failed"
+            elif verification["status"] == "not_attempted":
+                behavior = "no_submit"
+            else:
+                raise BehavioralPilotError(f"{arm} arm 异常无法归入冻结行为 taxonomy") from error
+    ledger.append(
+        "experiment.completed",
+        {
+            "status": "endpoint_censored" if infrastructure == "endpoint_censored" else "model_behavior_outcome",
+            "model_behavior": behavior,
+            "verification_outcome": verification["status"],
+        },
+    )
+    terminal_events = ledger.read()
+    result = {
+        "arm": arm,
+        "status": "observed",
+        "infrastructure": {"status": infrastructure},
+        "model_behavior": {
+            "status": behavior,
+            "terminal_error_class": type(error).__name__,
+        },
+        "verification_outcome": verification,
+        "physical_attempt_id": ledger.physical_attempt_id,
+        "model_requests": metrics["model_requests"],
+        "recorded_tokens": metrics["recorded_tokens"],
+        "actual_model": manifest["provider"]["model"] if request["completed"] else None,
+        "metrics": metrics,
+        "ledger_head_sha256": terminal_events[-1]["event_sha256"],
+    }
+    return result
+
+
+def _passed_arm(result: dict[str, Any], ledger: Any) -> dict[str, Any]:
+    events = ledger.read()
+    metrics = v1_runner._arm_metrics(events)
+    return {
+        **result,
+        "status": "observed",
+        "infrastructure": {"status": "valid"},
+        "model_behavior": {"status": "completed", "terminal_error_class": None},
+        "verification_outcome": {
+            "status": "passed",
+            "submit_attempts": metrics["submit_attempts"],
+            "clean_replay_attempts": metrics["clean_replay_attempts"],
+        },
+        "metrics": metrics,
+    }
+
+
+@contextmanager
+def _adapt_parent_runner(
+    manifest: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    async_runner: asyncio.Runner,
+) -> Iterator[None]:
+    original = {
+        "validate_manifest": primary.validate_manifest,
+        "verify_frozen_artifacts": primary.verify_frozen_artifacts,
+        "require_release_identity": primary.require_release_identity,
+        "require_passed_reachability": primary.require_passed_reachability,
+        "PAIR_MARKER": primary.PAIR_MARKER,
+        "asyncio": primary.asyncio,
+        "run_arm_continuation": primary.run_arm_continuation,
+    }
+
+    def validate(value: Any) -> dict[str, Any]:
+        if value != pair_manifest:
+            raise BehavioralPilotError("v2 pair runtime manifest 发生漂移")
+        return value
+
+    def verify(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+        validate(value)
+        protocol.verify_frozen_components(manifest, repo_root)
+
+    async def capture_arm(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        ledger = kwargs["ledger"]
+        arm = kwargs["arm"]
+        try:
+            result = await original["run_arm_continuation"](*args, **kwargs)
+        except Exception as exc:
+            return classify_arm_terminal(manifest, arm=arm, ledger=ledger, error=exc)
+        return _passed_arm(result, ledger)
+
+    primary.validate_manifest = validate
+    primary.verify_frozen_artifacts = verify
+    primary.require_release_identity = lambda value, repo_root=REPO_ROOT: require_release_identity(manifest, repo_root)
+    primary.require_passed_reachability = lambda *_args, **_kwargs: {
+        "recorded_tokens": 0,
+        "inherited_reachability": False,
+    }
+    primary.PAIR_MARKER = PAIR_MARKER
+    primary.asyncio = _AsyncioProxy(async_runner)
+    primary.run_arm_continuation = capture_arm
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            setattr(primary, name, value)
+
+
+def _pair_outcome(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    pair_dir: Path,
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    if report.get("complete_pair") is not True or report.get("cleanup_succeeded") is not True or report.get("arm_order") != pair["arm_order"]:
+        raise BehavioralPilotError("v2 pair 未形成双臂尝试与 cleanup 终态")
+    arms = report.get("arms")
+    if not isinstance(arms, list) or {item.get("arm") for item in arms} != {
+        "baseline",
+        "treatment",
+    }:
+        raise BehavioralPilotError("v2 pair 缺少唯一双臂结果")
+    arm_map = {item["arm"]: item for item in arms}
+    taxonomy = manifest["terminal_taxonomy"]
+    for arm, item in arm_map.items():
+        if (
+            item.get("infrastructure", {}).get("status") not in taxonomy["infrastructure"]
+            or item.get("model_behavior", {}).get("status") not in taxonomy["model_behavior"]
+            or item.get("verification_outcome", {}).get("status") not in taxonomy["verification_outcome"]
+        ):
+            raise BehavioralPilotError(f"{arm} arm 三层终态不在冻结 taxonomy")
+        if item.get("recorded_tokens") != item.get("metrics", {}).get("recorded_tokens") or item["recorded_tokens"] > manifest["continuation"]["maximum_recorded_tokens_per_arm"]:
+            raise BehavioralPilotError(f"{arm} arm token evidence 无效")
+    coordinator = recovery_runner.coordinator_terminal_from_copy(pair_dir)
+    require_zero_managed_containers()
+    eligible = all(item["infrastructure"]["status"] == "valid" for item in arm_map.values())
+    repair_success = {arm: item["verification_outcome"]["status"] == "passed" for arm, item in arm_map.items()}
+    return {
+        "schema_version": "forge-checkpoint-behavioral-pair-outcome-2.0.0",
+        "document_type": "forge_checkpoint_behavioral_pair_outcome",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_manifest_sha256": protocol.canonical_sha256(pair_manifest),
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "arm_order": pair["arm_order"],
+        "status": "observed" if eligible else "observed_with_endpoint_censoring",
+        "arms": arm_map,
+        "recorded_tokens": sum(item["recorded_tokens"] for item in arm_map.values()),
+        "primary_mechanism_eligible": eligible,
+        "repair_success": repair_success,
+        "paired_repair_conversion_delta": int(repair_success["treatment"]) - int(repair_success["baseline"]) if eligible else None,
+        "itt_attrition_contribution": 1,
+        "coordinator": coordinator,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def execute_real_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: asyncio.Runner,
+    model_factory: Callable[[dict[str, Any], str], Any] | None = None,
+) -> dict[str, Any]:
+    pair_manifest = _pair_manifest(manifest, pair)
+    pair_manifest["execution"]["evidence_directory"] = str(pair_dir)
+    with _adapt_parent_runner(manifest, pair_manifest, async_runner):
+        with parent_adapter.build_layout.use_windows_safe_build_layout(primary):
+            report = primary.run_controlled_pair(
+                pair_manifest,
+                output_dir=pair_dir,
+                repo_root=REPO_ROOT,
+                model_factory=model_factory,
+            )
+    return _pair_outcome(manifest, pair, pair_manifest, pair_dir, report)
+
+
+def _claim_batch_marker(path: Path, digest: str, revision: str) -> dict[str, Any]:
+    if path.exists():
+        marker = _load_json(path)
+        if marker.get("manifest_sha256") != digest or marker.get("release_revision") != revision:
+            raise BehavioralPilotError("已有 v2 batch marker identity 发生漂移")
+        if marker.get("status") not in {"started", "passed"}:
+            raise BehavioralPilotError("已有 v2 batch marker 已失败关闭")
+        return marker
+    marker = {
+        "schema_version": "forge-checkpoint-behavioral-pilot-attempt-2.0.0",
+        "document_type": "forge_checkpoint_behavioral_pilot_attempt",
+        "manifest_sha256": digest,
+        "release_revision": revision,
+        "status": "started",
+        "error_class": None,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    _write_once(path, marker)
+    return marker
+
+
+def summarize(manifest: dict[str, Any], release: dict[str, str], outcomes: list[dict[str, Any]]) -> dict[str, Any]:
+    eligible = [item for item in outcomes if item["primary_mechanism_eligible"]]
+    censored = [item for item in outcomes if not item["primary_mechanism_eligible"]]
+    behavior_counts = {arm: dict(sorted(Counter(item["arms"][arm]["model_behavior"]["status"] for item in outcomes).items())) for arm in ("baseline", "treatment")}
+    repair_success = {arm: sum(item["repair_success"][arm] for item in eligible) for arm in ("baseline", "treatment")}
+    metric_names = (
+        "model_requests",
+        "submit_attempts",
+        "clean_replay_attempts",
+        "recorded_tokens",
+        "ledger_wall_clock_seconds",
+    )
+    efficiency = {arm: {name: [item["arms"][arm]["metrics"][name] for item in outcomes if item["arms"][arm]["infrastructure"]["status"] == "valid"] for name in metric_names} for arm in ("baseline", "treatment")}
+    return {
+        "schema_version": "forge-checkpoint-behavioral-pilot-report-2.0.0",
+        "document_type": "forge_checkpoint_behavioral_pilot_report",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": manifest["execution"]["network_access_medium"],
+        "status": "completed_with_endpoint_censoring" if censored else "completed",
+        "itt_attrition": {
+            "scheduled_pairs": protocol.PAIR_COUNT,
+            "observed_pairs": len(outcomes),
+            "attempted_arms": {arm: sum(arm in item["arms"] for item in outcomes) for arm in ("baseline", "treatment")},
+            "endpoint_censored_pairs": len(censored),
+            "endpoint_censored_pair_ids": [item["pair_id"] for item in censored],
+        },
+        "primary_mechanism": {
+            "eligible_pairs": len(eligible),
+            "pair_ids": [item["pair_id"] for item in eligible],
+            "repair_success": repair_success,
+            "paired_conversion_deltas": [item["paired_repair_conversion_delta"] for item in eligible],
+            "model_behavior_counts": behavior_counts,
+            "descriptive_only": True,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+        },
+        "conditional_efficiency": efficiency,
+        "recorded_tokens": sum(item["recorded_tokens"] for item in outcomes),
+        "maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+        "historical_pairs_pooled": False,
+        "pairs": outcomes,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+PairExecutor = Callable[[dict[str, Any], dict[str, Any], Path], dict[str, Any]]
+
+
+def run_pilot(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    pair_executor: PairExecutor | None = None,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    if output_dir.resolve(strict=False) != Path(manifest["execution"]["evidence_directory"]).resolve(strict=False):
+        raise BehavioralPilotError("v2 evidence 必须写入冻结授权目录")
+    release = require_release_identity(manifest, repo_root)
+    require_network_medium(manifest)
+    primary.require_compose_dood()
+    protocol.verify_historical_evidence(manifest)
+    require_zero_managed_containers()
+    digest = protocol.canonical_sha256(manifest)
+    marker_path = output_dir / BATCH_MARKER
+    marker = _claim_batch_marker(marker_path, digest, release["revision"])
+    report_path = output_dir / PILOT_REPORT
+    if marker["status"] == "passed":
+        report = _load_json(report_path)
+        if report.get("manifest_sha256") != digest:
+            raise BehavioralPilotError("已完成 v2 report identity 发生漂移")
+        return report
+    outcomes: list[dict[str, Any]] = []
+    try:
+        with asyncio.Runner() as async_runner:
+            for pair in manifest["schedule"]:
+                pair_dir = output_dir / "pairs" / pair["pair_id"]
+                outcome_path = pair_dir / PAIR_OUTCOME
+                if outcome_path.exists():
+                    outcome = _load_json(outcome_path)
+                    if outcome.get("manifest_sha256") != digest or outcome.get("pair_id") != pair["pair_id"] or outcome.get("status") not in {"observed", "observed_with_endpoint_censoring"}:
+                        raise BehavioralPilotError("已有 v2 pair outcome identity 或终态无效")
+                else:
+                    if pair_dir.exists() and any(pair_dir.iterdir()):
+                        raise BehavioralPilotError(f"{pair['pair_id']} 已开始但没有终态，禁止自动补跑")
+                    require_zero_managed_containers()
+                    outcome = execute_real_pair(manifest, pair, pair_dir, async_runner) if pair_executor is None else pair_executor(manifest, pair, pair_dir)
+                    if outcome.get("status") not in {
+                        "observed",
+                        "observed_with_endpoint_censoring",
+                    }:
+                        raise BehavioralPilotError("pair 未形成冻结 v2 outcome")
+                    _write_once(outcome_path, outcome)
+                outcomes.append(outcome)
+                if sum(item["recorded_tokens"] for item in outcomes) > manifest["budget"]["stage_maximum_recorded_tokens"]:
+                    raise BehavioralPilotError("v2 超过 recorded-token 机械上限")
+                require_zero_managed_containers()
+        if len(outcomes) != protocol.PAIR_COUNT:
+            raise BehavioralPilotError("v2 未形成 6 个预注册 pair 终态")
+        report = summarize(manifest, release, outcomes)
+        _write_once(report_path, report)
+        marker.update(status="passed", error_class=None, updated_at=datetime.now(UTC).isoformat())
+        _atomic_write(marker_path, marker)
+        return report
+    except BaseException as exc:
+        marker.update(
+            status="failed",
+            error_class=type(exc).__name__,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write(marker_path, marker)
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "run", "report"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    try:
+        manifest = protocol.validate_manifest(_load_json(args.manifest))
+        if args.command == "validate":
+            protocol.verify_frozen_components(manifest)
+            result = {
+                "status": "valid",
+                "manifest_sha256": protocol.canonical_sha256(manifest),
+                "provider_calls": 0,
+            }
+        elif args.command == "report":
+            result = _load_json(args.output_dir / PILOT_REPORT)
+            if result.get("manifest_sha256") != protocol.canonical_sha256(manifest):
+                raise BehavioralPilotError("v2 report identity 发生漂移")
+        else:
+            result = run_pilot(manifest, output_dir=args.output_dir)
+    except (OSError, BehavioralPilotError, protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更内容

- 新增独立 v2 manifest、Schema、预注册、runner 与报告器
- 将 arm 终态拆为 infrastructure、model behavior、verification outcome
- 把 GraphRecursionError、work wall-clock、无 submit 与 verification failed 保留为 outcome
- endpoint timeout 只进入 attrition；可分类第一臂失败后继续第二臂
- 冻结并排除旧 v1/recovery pair，不复用旧 schedule 或 evidence
- 只在 identity/evidence、预算、cleanup/orphan 或无法分类基础设施错误时关闭 batch

## 验证

- 聚焦与 v1/recovery 相邻回归：17 passed
- Ruff check/format：通过
- 历史 evidence 文件集合与 SHA-256：通过
- manifest/Schema 确定性生成：通过
- Compose/DooD fake-model gate：1 passed in 129.12s
- gate 后 Compile Session/replay/checkpoint container、checkpoint image 与临时目录均为 0
- 敏感信息扫描：通过
- 实现阶段 0 provider calls、0 model tokens

## 研究边界

旧 pair-01/02 只作为 exploratory feasibility evidence，不进入 v2 正式估计。PR 合并不等于实验已经完成；合并后仍须先通过干净主干的非模型门禁，再按 Issue #165 冻结授权执行新 6-pair schedule。

Refs #165
