### PR TITLE
研究：增加跨构建系统多 checkpoint 零 provider 门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-29 — 完成跨构建系统多 checkpoint 零 provider 门禁
+  - 文件: `scripts/forge_multi_checkpoint_zero_provider_gate.py`, `backend/tests/test_forge_multi_checkpoint_zero_provider_gate.py`, `backend/tests/test_forge_multi_checkpoint_zero_provider_docker.py`, `benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json`, `benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json`, `benchmarks/preregistrations/cpp-verifier-multi-checkpoint-zero-provider-gate.md`
+  - 动机: behavioral pilot v2 的 6 对全部来自同一 CMake checkpoint；Issue #168 在不修改冻结 runner/evidence 的前提下，补 Make `janet` 与 Autotools `libcheck` 的真实 checkpoint 可恢复性证据。
+  - 结果: 静态协议 `7 passed`；Make 新 case 完整通过；Autotools 新 case `1 passed in 249.93s`；既有 CMake Windows-bind anchor `1 passed in 125.98s`。三个构建系统均闭合 parent build、受控缺产物故障、checkpoint、双臂恢复、candidate verifier、clean replay 与 cleanup，最终 0 container/image orphan。
+  - 边界: canonical manifest SHA-256 为 `6d953ae758056dca00b9013979e0f03d1c5877b386fc803feaea1131fd17339c`；0 provider、0 formal physical attempt、0 model token，不证明跨 fault-family 泛化或 repair treatment 效应。下一步是完成中文提交/推送/PR/CI，再另行冻结 3 cases x 2 pairs 的描述性 pilot。
+
 - 2026-08-29 — 完成 checkpoint 行为终态 v2 六配对实验
   - 文件: `benchmarks/reports/cpp-verifier-checkpoint-behavioral-pilot-v2.md`, `.compile-sessions/benchmark-evidence-checkpoint-behavioral-pilot-v2/`
   - 动机: 按 Issue #163 选择 A 和 Issue #165 冻结协议，把模型预算内失败保留为 outcome，并避免已观察旧 pair 进入新估计。
@@ -404,6 +410,9 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- `ExperimentPolicy.required_system_packages` 非空时，成功命令必须以生产契约角色 `dependency_setup` 记录；自定义 manifest 写成 `dependency` 会让 submit 正确归类为 `dependency_setup_not_observed`，掩盖预期的 verifier failure。环境查询也不能代替缺失依赖安装：`libcheck` 必须实际安装 `texinfo`，否则 parent build 在 `makeinfo` 处退出 127。
+- 2026-08-29 门禁期间 Ubuntu `docker.service` 曾收到一次 systemd 正常停止信号并自动恢复，来源未能从 Docker journal 归因；每个重型 Docker gate 前仍应重新执行 `scripts/require-ubuntu-native-docker.sh`，但不得自行重启 daemon 或切换 Docker Desktop。
 
 - Windows bind/DrvFS 目录大小写不敏感；上游若跟踪 `BUILD`，CMake `-B build` 会解析到同一普通文件。checkpoint canary 使用 `.forge-cmake-build`，并必须在真实 Compose `/workspace/.compile-sessions` 挂载上做 parity gate，不能再用 WSL ext4 `tmp_path` 代替。
 - Issue #149 runner 和测试的 SHA-256 已冻结在授权 manifest。跨阶段修复必须新增版本化 adapter/test，不能原地修改冻结文件或更新旧 manifest hash；后续 provider 运行还需要独立 amendment identity 与新授权。

--- a/backend/tests/test_forge_multi_checkpoint_zero_provider_docker.py
+++ b/backend/tests/test_forge_multi_checkpoint_zero_provider_docker.py
@@ -1,0 +1,310 @@
+"""Issue #168 Make/Autotools 多 checkpoint 的 opt-in Compose/DooD 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices, submit_build_result_impl
+from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_workspace_dir
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json"
+COMPILE_IMAGE = "autocompiler:gcc13"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_MULTI_CHECKPOINT_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_MULTI_CHECKPOINT_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_module(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+multi_gate = _load_module("forge_multi_checkpoint_zero_provider_docker", "forge_multi_checkpoint_zero_provider_gate.py")
+fault_module = _load_module("forge_controlled_fault_v1_multi_checkpoint_docker", "forge_controlled_fault_v1_gate.py")
+lifecycle = _load_module("forge_real_lifecycle_multi_checkpoint_docker", "forge_real_lifecycle_checkpoint_gate.py")
+primary = _load_module("forge_checkpoint_primary_multi_checkpoint_docker", "forge_checkpoint_primary_canary.py")
+
+
+def _load_manifest() -> dict[str, Any]:
+    value = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return multi_gate.validate_manifest(value)
+
+
+def _record_command(*, manager: CompileSessionManager, runtime: CompileDockerRuntime, session: Any, command: str, role: str) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(session, command, workdir="/workspace/repo", timeout_seconds=300)
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir="/workspace/repo",
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=300,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def _policy(case: Any, *, image_id: str, manifest_sha256: str) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-multi-checkpoint-zero-provider-gate",
+        manifest_sha256=manifest_sha256,
+        case_id=case.case_id,
+        condition="controlled-fault-v1",
+        repetition=1,
+        expected_repo_url=case.repository_url,
+        expected_commit_sha=case.commit_sha,
+        expected_build_system=case.build_system,
+        compile_image=COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        model_max_retries=0,
+        compiler_max_turns=8,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=case.required_system_packages,
+        cmake_arguments=case.cmake_arguments,
+        configure_arguments=case.configure_arguments,
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir=case.source_subdir,
+        build_targets=case.build_targets,
+        artifact_instructions=((case.staged_relative_path, case.build_output_relative_path, case.artifact_type),),
+    )
+
+
+def _remove_session_dir(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+    try:
+        path.parent.rmdir()
+    except OSError:
+        pass
+
+
+@pytest.mark.parametrize("case_id", ["janet", "libcheck"])
+def test_new_case_checkpoint_restore_verifier_replay_and_cleanup(case_id: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    primary.require_compose_dood()
+    manifest = _load_manifest()
+    multi_gate.verify_historical_components(manifest, REPO_ROOT)
+    case = multi_gate.case_by_id(manifest, case_id)
+    assert case.role == "new_gate"
+
+    capture_id = f"issue168-{case_id}-{uuid.uuid4().hex[:8]}"
+    paths = Paths()
+    output_dir = paths.compile_sessions_dir / capture_id
+    snapshot = output_dir / "snapshot"
+    manager = CompileSessionManager(paths=paths, default_image=COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    docker = lifecycle.environment_checkpoint.DockerCLI()
+    created_session_dirs: list[Path] = []
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_session_dirs.append(Path(session.metadata_path).parent)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=case.repository_url,
+        image=COMPILE_IMAGE,
+    )
+    ledger = ExperimentLedger.create(
+        output_dir / "parent.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-168-multi-checkpoint-zero-provider", "case_id": case.case_id},
+    )
+    active = False
+    gate = None
+    arm_sessions: list[Any] = []
+    continuation_images: set[str] = set()
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        assert parent.image_id is not None
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {case.repository_url} && git fetch --depth 1 origin {case.commit_sha} && git checkout --detach FETCH_HEAD",
+            workdir="/workspace/repo",
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        parent.commit_sha = case.commit_sha
+        parent.build_system = case.build_system
+        parent.build_system_capabilities = [case.build_system]
+        parent.selected_build_system = case.build_system
+        parent.status = "inspected"
+        manager.save_session(parent)
+
+        supporting = None
+        for role, command in case.commands:
+            record = _record_command(manager=manager, runtime=runtime, session=parent, command=command, role=role)
+            if role == "build":
+                supporting = record
+        assert supporting is not None
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=ledger.experiment_id,
+            physical_attempt_id=ledger.physical_attempt_id,
+            ledger=ledger,
+            policy=_policy(case, image_id=parent.image_id, manifest_sha256=multi_gate.canonical_sha256(manifest)),
+        )
+        active = True
+        fault = fault_module.ControlledFaultV1(
+            fault_module.ControlledFaultSpec(
+                case_id=case.case_id,
+                build_output_relative_path=case.build_output_relative_path,
+                staged_relative_path=case.staged_relative_path,
+                artifact_type=case.artifact_type,
+            )
+        )
+        fault_manifest = fault.inject(session=parent, ledger=ledger, fault_id=new_evidence_id("fault"))
+        assert fault_manifest["state"]["staged_artifact_present"] is False
+
+        submit_results: list[str] = []
+
+        def submit() -> str:
+            result = submit_build_result_impl(session=parent, supporting_command_id=supporting.command_id)
+            submit_results.append(result)
+            return result
+
+        def evidence() -> dict[str, Any]:
+            result = fault_module.validate_actionable_failure(ledger=ledger, session=parent)
+            result["session_sha256"] = lifecycle.sha256_file(Path(parent.metadata_path))
+            result["fault_state_sha256"] = fault_manifest["fault_state_sha256"]
+            return result
+
+        coordinator = lifecycle.CaptureCoordinator(output_dir / "coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(output_dir / "messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = lifecycle.LifecycleMessageRuntime(
+                saver,
+                submit,
+                repair_packet={"schema_version": "forge-verifier-repair-packet-1.0.0", "primary_classification": "candidate_verification_failed"},
+            )
+            environment = lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=primary.host_snapshot_root(snapshot),
+            )
+            gate = lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=primary._budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="issue-168-multi-checkpoint-gate",
+            )
+            capture = gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="freeze the controlled artifact staging failure before continuation",
+                arm_plan=primary._arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(parent.session_id, parent.thread_id, paths),
+                    "artifacts": get_host_artifacts_dir(parent.session_id, parent.thread_id, paths),
+                    "logs": get_host_logs_dir(parent.session_id, parent.thread_id, paths),
+                    "repro": get_host_repro_dir(parent.session_id, parent.thread_id, paths),
+                },
+                evidence=evidence,
+            )
+            continuation_images.add(capture["environment"]["continuation_image_id"])
+            assert len(submit_results) == 1
+            assert json.loads(submit_results[0])["candidate_status"] == "failed"
+            assert parent.replay_attempts == []
+            deactivate_experiment(parent.thread_id)
+            active = False
+            ledger.append("experiment.completed", {"status": "passed"})
+
+            baseline = gate.provision_arm(capture_id, "baseline", parent_session=parent)
+            treatment = gate.provision_arm(capture_id, "treatment", parent_session=parent)
+            arm_sessions.extend([baseline.session, treatment.session])
+            assert gate.canonical_arm_environment("baseline") == gate.canonical_arm_environment("treatment")
+            assert list(Path(baseline.session.leadagent_artifacts_dir).iterdir()) == []
+            assert list(Path(treatment.session.leadagent_artifacts_dir).iterdir()) == []
+
+            fault.restore_arm(session=baseline.session, runtime=runtime)
+            assert list(Path(treatment.session.leadagent_artifacts_dir).iterdir()) == []
+            fault.restore_arm(session=treatment.session, runtime=runtime)
+            baseline_result = fault_module.validate_arm_submit_result(submit_build_result_impl(session=baseline.session, supporting_command_id=supporting.command_id))
+            treatment_result = fault_module.validate_arm_submit_result(submit_build_result_impl(session=treatment.session, supporting_command_id=supporting.command_id))
+            assert baseline_result["artifacts"][0]["sha256"] == treatment_result["artifacts"][0]["sha256"]
+            assert len(baseline.session.replay_attempts) == 1
+            assert len(treatment.session.replay_attempts) == 1
+
+            cleaned = gate.cleanup(capture_id, parent_session=parent)
+            assert cleaned.phase == "cleaned"
+            assert gate.external_counts() == {"provider_calls": 0, "formal_physical_attempts": 0, "model_tokens": 0}
+    finally:
+        if active:
+            deactivate_experiment(parent.thread_id)
+        for session in arm_sessions:
+            runtime.stop_and_remove_container(session)
+        runtime.stop_and_remove_container(parent)
+        for container_id in docker.run(["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"], check=False, timeout_seconds=30).stdout.split():
+            docker.run(["rm", "-f", container_id], check=False, timeout_seconds=30)
+        continuation_images.update(docker.run(["image", "ls", "-q", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"], check=False, timeout_seconds=30).stdout.split())
+        for image_id in continuation_images:
+            docker.run(["image", "rm", "-f", image_id], check=False, timeout_seconds=60)
+        for session_dir in reversed(created_session_dirs):
+            _remove_session_dir(session_dir)
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+    assert docker.run(["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"], check=False, timeout_seconds=30).stdout.split() == []
+    assert docker.run(["image", "ls", "-q", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"], check=False, timeout_seconds=30).stdout.split() == []
+    assert not snapshot.exists()

--- a/backend/tests/test_forge_multi_checkpoint_zero_provider_gate.py
+++ b/backend/tests/test_forge_multi_checkpoint_zero_provider_gate.py
@@ -1,0 +1,112 @@
+"""Issue #168 多 checkpoint 零 provider gate 的静态与语义门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_multi_checkpoint_zero_provider_gate.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("forge_multi_checkpoint_zero_provider_gate_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_schema_manifest_and_semantic_identity_are_valid() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert gate.validate_manifest(manifest) is manifest
+    assert [case.case_id for case in gate.cases(manifest)] == ["cppitertools", "janet", "libcheck"]
+    assert [case.build_system for case in gate.cases(manifest)] == ["cmake", "make", "autotools"]
+
+
+def test_authorization_and_fault_are_strictly_zero_provider() -> None:
+    manifest = gate.load_manifest(MANIFEST_PATH)
+    assert manifest["authorization"] == {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/168",
+        "provider_calls_authorized": False,
+        "formal_attempts_authorized": False,
+        "model_tokens_authorized": 0,
+        "pilot_collection_authorized": False,
+    }
+    assert manifest["fault"]["required_artifacts_per_case"] == 1
+    assert manifest["fault"]["replay_attempts_required"] == 0
+
+
+def test_case_commands_and_artifacts_are_frozen() -> None:
+    manifest = gate.load_manifest(MANIFEST_PATH)
+    janet = gate.case_by_id(manifest, "janet")
+    libcheck = gate.case_by_id(manifest, "libcheck")
+    assert janet.supporting_build_command == "make -j2"
+    assert janet.commands[0] == ("dependency_setup", "dpkg-query -W build-essential")
+    assert janet.build_output_relative_path == "build/libjanet.a"
+    assert janet.staged_relative_path == "libjanet.a"
+    assert libcheck.supporting_build_command == "make -j2"
+    assert libcheck.commands[0][0] == "dependency_setup"
+    assert ("configure", "autoreconf -fi && ./configure --disable-subunit") in libcheck.commands
+    assert libcheck.required_system_packages[-1] == "texinfo"
+
+
+def test_schema_rejects_multi_artifact_and_semantics_reject_command_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    multi_artifact = copy.deepcopy(manifest)
+    multi_artifact["cases"][1]["artifact"] = [multi_artifact["cases"][1]["artifact"]]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(multi_artifact)
+
+    command_drift = copy.deepcopy(manifest)
+    command_drift["cases"][1]["commands"][0]["command"] = "make -j8; curl https://example.invalid"
+    with pytest.raises(gate.MultiCheckpointGateError, match="definition drifted"):
+        gate.validate_manifest(command_drift)
+
+    missing_dependency_setup = copy.deepcopy(manifest)
+    missing_dependency_setup["cases"][1]["commands"] = missing_dependency_setup["cases"][1]["commands"][1:]
+    with pytest.raises(gate.MultiCheckpointGateError, match="dependency_setup"):
+        gate.CheckpointCase.from_dict(missing_dependency_setup["cases"][1])
+
+
+def test_rejects_unsafe_artifact_path_and_unknown_case() -> None:
+    manifest = _load(MANIFEST_PATH)
+    unsafe = copy.deepcopy(manifest)
+    unsafe["cases"][1]["artifact"]["build_output_relative_path"] = "../libjanet.a"
+    with pytest.raises(gate.MultiCheckpointGateError, match="safe relative path"):
+        gate.validate_manifest(unsafe)
+    with pytest.raises(gate.MultiCheckpointGateError, match="unknown case"):
+        gate.case_by_id(gate.load_manifest(MANIFEST_PATH), "hiredis")
+
+
+def test_historical_components_remain_byte_identical() -> None:
+    manifest = gate.load_manifest(MANIFEST_PATH)
+    gate.verify_historical_components(manifest, REPO_ROOT)
+
+
+def test_gate_source_has_no_provider_or_secret_access() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    for forbidden in ("create_chat_model", "DEEPSEEK_API_KEY", "OpenAI_AK", "formal_collection_runner"):
+        assert forbidden not in source

--- a/benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json
+++ b/benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "../schemas/forge-multi-checkpoint-zero-provider-gate.schema.json",
+  "schema_version": "forge-multi-checkpoint-zero-provider-gate-1.0.0",
+  "document_type": "forge_multi_checkpoint_zero_provider_gate",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/168",
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "model_tokens_authorized": 0,
+    "pilot_collection_authorized": false
+  },
+  "fault": {
+    "family": "artifact_staging_missing",
+    "expected_classification": "candidate_verification_failed",
+    "replay_attempts_required": 0,
+    "required_artifacts_per_case": 1
+  },
+  "cases": [
+    {
+      "case_id": "cppitertools",
+      "role": "anchor",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "language": "C++",
+      "build_system": "cmake",
+      "source_subdir": "examples",
+      "build_targets": ["accumulate_examples"],
+      "required_system_packages": ["build-essential", "cmake"],
+      "cmake_arguments": ["-DCMAKE_BUILD_TYPE=Release"],
+      "configure_arguments": [],
+      "artifact": {
+        "build_output_relative_path": ".forge-cmake-build/accumulate_examples",
+        "staged_relative_path": "accumulate_examples",
+        "artifact_type": "executable"
+      },
+      "commands": [
+        {"role": "dependency_setup", "command": "dpkg-query -W build-essential cmake"},
+        {"role": "configure", "command": "cmake -S examples -B .forge-cmake-build -DCMAKE_BUILD_TYPE=Release"},
+        {"role": "build", "command": "cmake --build .forge-cmake-build --target accumulate_examples -j2"},
+        {"role": "artifact_stage", "command": "cp .forge-cmake-build/accumulate_examples /artifacts/accumulate_examples"}
+      ]
+    },
+    {
+      "case_id": "janet",
+      "role": "new_gate",
+      "repository_url": "https://github.com/janet-lang/janet",
+      "commit_sha": "c0b32d4e3798d0ceaf4131e642e59602a31ce151",
+      "language": "C",
+      "build_system": "make",
+      "source_subdir": ".",
+      "build_targets": ["all"],
+      "required_system_packages": ["build-essential"],
+      "cmake_arguments": [],
+      "configure_arguments": [],
+      "artifact": {
+        "build_output_relative_path": "build/libjanet.a",
+        "staged_relative_path": "libjanet.a",
+        "artifact_type": "static_library"
+      },
+      "commands": [
+        {"role": "dependency_setup", "command": "dpkg-query -W build-essential"},
+        {"role": "build", "command": "make -j2"},
+        {"role": "artifact_stage", "command": "cp build/libjanet.a /artifacts/libjanet.a"}
+      ]
+    },
+    {
+      "case_id": "libcheck",
+      "role": "new_gate",
+      "repository_url": "https://github.com/libcheck/check",
+      "commit_sha": "11970a7e112dfe243a2e68773f014687df2900e8",
+      "language": "C",
+      "build_system": "autotools",
+      "source_subdir": ".",
+      "build_targets": ["all"],
+      "required_system_packages": ["autoconf", "automake", "build-essential", "libtool", "pkg-config", "texinfo"],
+      "cmake_arguments": [],
+      "configure_arguments": ["--disable-subunit"],
+      "artifact": {
+        "build_output_relative_path": "src/.libs/libcheck.a",
+        "staged_relative_path": "libcheck.a",
+        "artifact_type": "static_library"
+      },
+      "commands": [
+        {"role": "dependency_setup", "command": "apt-get update && apt-get install -y --no-install-recommends texinfo"},
+        {"role": "configure", "command": "autoreconf -fi && ./configure --disable-subunit"},
+        {"role": "build", "command": "make -j2"},
+        {"role": "artifact_stage", "command": "cp src/.libs/libcheck.a /artifacts/libcheck.a"}
+      ]
+    }
+  ],
+  "historical_components": {
+    "benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json": "fb803eac7189dbc697a6fdf9bddac1f9ae4a0ec262cf548f62360cd6ad762f2e",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95",
+    "scripts/forge_checkpoint_primary_canary.py": "031bac753459a060e134df765a27eaa1c8fca0ac784f239d46e243f89c8b3282",
+    "scripts/forge_controlled_fault_v1_gate.py": "3dd4b2495cb21594f9348aaf8416dc17c57f6aa850f14b739049b030bc4d9f2d"
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-zero-provider-gate.md
@@ -1,0 +1,35 @@
+# 跨构建系统多 checkpoint 零 provider 门禁
+
+## 研究目的
+
+behavioral pilot v2 的 6 个配对全部来自同一个 `cppitertools` CMake checkpoint。本门禁只验证 `artifact_staging_missing` controlled fault 能否在 CMake、Make、Autotools 三种构建系统和三个独立项目上形成相同的可恢复 checkpoint，不产生 repair effect 结论。
+
+## 冻结 case
+
+| Case | 角色 | 构建系统 | 唯一 required artifact |
+| --- | --- | --- | --- |
+| `cppitertools@531b3d7` | 已验证 anchor | CMake | `.forge-cmake-build/accumulate_examples -> accumulate_examples` |
+| `janet@c0b32d4` | 新 gate | Make | `build/libjanet.a -> libjanet.a` |
+| `libcheck@11970a7` | 新 gate | Autotools | `src/.libs/libcheck.a -> libcheck.a` |
+
+`hiredis` 因要求两个产物而排除；历史 `openthread`/`mupdf` fixture 不含真实可恢复环境，也不进入本门禁。
+
+## 执行契约
+
+1. 严格校验 repo、exact commit、build system、依赖、命令顺序、单产物路径和历史 protocol artifact hash。
+2. 对每个新 case 执行真实 parent build，将唯一产物暂存到 `/artifacts`，再由 controlled fault v1 只删除 staged artifact。
+3. 真实 candidate verifier 必须产生唯一 pre-replay `candidate_verification_failed`，且 `replay_attempts == 0`。
+4. 从同一个 committed message/environment/budget checkpoint 派生 baseline/treatment；两臂初始环境同源且写入隔离。
+5. 两臂只执行确定性 artifact restore，随后 candidate verification 与 clean replay 都必须通过。
+6. cleanup 后 0 paused/orphan container、continuation image、helper 和 snapshot。
+
+## 环境与授权
+
+- Docker 只使用 WSL Ubuntu 原生 `docker.service` 与 Forge Compose/DooD 共享 daemon，不使用 Docker Desktop。
+- Provider calls、formal physical attempts 和 model tokens 均为 0；不读取任何 AK。
+- 不修改 production Compiler、Oracle、clean replay、自然任务 ITT、primary canary、behavioral v2 runner 或冻结 evidence。
+- 本 gate 通过不授权 3 cases x 2 pairs、第二 provider 或 natural-failure collection。
+
+## 停止规则
+
+任一 case 的 exact commit、构建、fault classification、checkpoint identity、candidate/clean replay 或 cleanup 失败即停止并保留诊断；不得切换 Docker daemon、调用 provider 或把失败回填到 behavioral v2。

--- a/benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json
+++ b/benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forge-autocompiler.local/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json",
+  "title": "Forge multi-checkpoint zero-provider gate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "document_type",
+    "authorization",
+    "fault",
+    "cases",
+    "historical_components"
+  ],
+  "properties": {
+    "$schema": {"type": "string", "const": "../schemas/forge-multi-checkpoint-zero-provider-gate.schema.json"},
+    "schema_version": {"type": "string", "const": "forge-multi-checkpoint-zero-provider-gate-1.0.0"},
+    "document_type": {"type": "string", "const": "forge_multi_checkpoint_zero_provider_gate"},
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issue_url",
+        "provider_calls_authorized",
+        "formal_attempts_authorized",
+        "model_tokens_authorized",
+        "pilot_collection_authorized"
+      ],
+      "properties": {
+        "issue_url": {"type": "string", "const": "https://github.com/WWFXL/Forge-AutoCompiler/issues/168"},
+        "provider_calls_authorized": {"type": "boolean", "const": false},
+        "formal_attempts_authorized": {"type": "boolean", "const": false},
+        "model_tokens_authorized": {"type": "integer", "const": 0},
+        "pilot_collection_authorized": {"type": "boolean", "const": false}
+      }
+    },
+    "fault": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "expected_classification", "replay_attempts_required", "required_artifacts_per_case"],
+      "properties": {
+        "family": {"type": "string", "const": "artifact_staging_missing"},
+        "expected_classification": {"type": "string", "const": "candidate_verification_failed"},
+        "replay_attempts_required": {"type": "integer", "const": 0},
+        "required_artifacts_per_case": {"type": "integer", "const": 1}
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {"$ref": "#/$defs/case"}
+    },
+    "historical_components": {
+      "type": "object",
+      "minProperties": 4,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{64}$"
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["build_output_relative_path", "staged_relative_path", "artifact_type"],
+      "properties": {
+        "build_output_relative_path": {"type": "string", "pattern": "^[A-Za-z0-9._/+\\-]+$"},
+        "staged_relative_path": {"type": "string", "pattern": "^[A-Za-z0-9._+\\-]+$"},
+        "artifact_type": {"type": "string", "enum": ["executable", "static_library"]}
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "command"],
+      "properties": {
+        "role": {"type": "string", "enum": ["dependency_setup", "configure", "build", "artifact_stage"]},
+        "command": {"type": "string", "minLength": 1, "maxLength": 300, "pattern": "^[^\\r\\n]+$"}
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "role",
+        "repository_url",
+        "commit_sha",
+        "language",
+        "build_system",
+        "source_subdir",
+        "build_targets",
+        "required_system_packages",
+        "cmake_arguments",
+        "configure_arguments",
+        "artifact",
+        "commands"
+      ],
+      "properties": {
+        "case_id": {"type": "string", "pattern": "^[a-z0-9-]+$"},
+        "role": {"type": "string", "enum": ["anchor", "new_gate"]},
+        "repository_url": {"type": "string", "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+        "commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "language": {"type": "string", "enum": ["C", "C++"]},
+        "build_system": {"type": "string", "enum": ["cmake", "make", "autotools"]},
+        "source_subdir": {"type": "string", "pattern": "^(\\.|[A-Za-z0-9._/+-]+)$"},
+        "build_targets": {"type": "array", "minItems": 1, "items": {"type": "string", "pattern": "^[A-Za-z0-9._+\\-]+$"}},
+        "required_system_packages": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z0-9.+-]+$"}},
+        "cmake_arguments": {"type": "array", "items": {"type": "string"}},
+        "configure_arguments": {"type": "array", "items": {"type": "string"}},
+        "artifact": {"$ref": "#/$defs/artifact"},
+        "commands": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/command"}}
+      }
+    }
+  }
+}

--- a/scripts/forge_multi_checkpoint_zero_provider_gate.py
+++ b/scripts/forge_multi_checkpoint_zero_provider_gate.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Issue #168 多 checkpoint 零 provider 门禁的冻结 case 配置。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCHEMA_VERSION = "forge-multi-checkpoint-zero-provider-gate-1.0.0"
+DOCUMENT_TYPE = "forge_multi_checkpoint_zero_provider_gate"
+FAULT_FAMILY = "artifact_staging_missing"
+EXPECTED_CLASSIFICATION = "candidate_verification_failed"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json"
+EXPECTED_CASE_SHA256 = {
+    "cppitertools": "745da134b689a7b6de004ec117513603380b5a2cc6117ac93b43b5e121ce2ca2",
+    "janet": "97f79827f13f9c8af9906dce37281c39ac7ed1b46af0e7167f90f5e4e98f41bd",
+    "libcheck": "2ea0580af644bacbb13394eb5c91f55943b4b8b9b9b7241f1c0bed2964b723cf",
+}
+
+
+class MultiCheckpointGateError(RuntimeError):
+    """多 checkpoint gate 配置或历史 identity 无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative_path(value: str, label: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise MultiCheckpointGateError(f"{label} must be a safe relative path")
+    return path.as_posix()
+
+
+@dataclass(frozen=True)
+class CheckpointCase:
+    case_id: str
+    role: str
+    repository_url: str
+    commit_sha: str
+    language: str
+    build_system: str
+    source_subdir: str
+    build_targets: tuple[str, ...]
+    required_system_packages: tuple[str, ...]
+    cmake_arguments: tuple[str, ...]
+    configure_arguments: tuple[str, ...]
+    build_output_relative_path: str
+    staged_relative_path: str
+    artifact_type: str
+    commands: tuple[tuple[str, str], ...]
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> CheckpointCase:
+        artifact = value["artifact"]
+        return cls(
+            case_id=value["case_id"],
+            role=value["role"],
+            repository_url=value["repository_url"],
+            commit_sha=value["commit_sha"],
+            language=value["language"],
+            build_system=value["build_system"],
+            source_subdir=value["source_subdir"],
+            build_targets=tuple(value["build_targets"]),
+            required_system_packages=tuple(value["required_system_packages"]),
+            cmake_arguments=tuple(value["cmake_arguments"]),
+            configure_arguments=tuple(value["configure_arguments"]),
+            build_output_relative_path=artifact["build_output_relative_path"],
+            staged_relative_path=artifact["staged_relative_path"],
+            artifact_type=artifact["artifact_type"],
+            commands=tuple((item["role"], item["command"]) for item in value["commands"]),
+        ).validate()
+
+    def validate(self) -> CheckpointCase:
+        if self.role not in {"anchor", "new_gate"} or self.build_system not in {"cmake", "make", "autotools"}:
+            raise MultiCheckpointGateError("case role or build system is invalid")
+        if self.artifact_type not in {"executable", "static_library"}:
+            raise MultiCheckpointGateError("case artifact type is invalid")
+        _safe_relative_path(self.build_output_relative_path, "build_output_relative_path")
+        _safe_relative_path(self.staged_relative_path, "staged_relative_path")
+        if "/" in self.staged_relative_path:
+            raise MultiCheckpointGateError("controlled fault v1 requires one top-level staged artifact")
+        roles = [role for role, _command in self.commands]
+        if roles.count("build") != 1 or roles.count("artifact_stage") != 1 or roles[-1] != "artifact_stage":
+            raise MultiCheckpointGateError("case commands require one build and a final artifact_stage")
+        if self.required_system_packages and roles.count("dependency_setup") != 1:
+            raise MultiCheckpointGateError("cases with required packages require one dependency_setup command")
+        if any("\n" in command or "\r" in command for _role, command in self.commands):
+            raise MultiCheckpointGateError("case commands must be single-line frozen commands")
+        return self
+
+    @property
+    def supporting_build_command(self) -> str:
+        return next(command for role, command in self.commands if role == "build")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MultiCheckpointGateError("cannot read multi-checkpoint gate manifest") from exc
+    return validate_manifest(value)
+
+
+def validate_manifest(value: Any) -> dict[str, Any]:
+    required = {"$schema", "schema_version", "document_type", "authorization", "fault", "cases", "historical_components"}
+    if not isinstance(value, dict) or set(value) != required:
+        raise MultiCheckpointGateError("manifest field set is invalid")
+    if value["schema_version"] != SCHEMA_VERSION or value["document_type"] != DOCUMENT_TYPE:
+        raise MultiCheckpointGateError("manifest identity is invalid")
+    if value["authorization"] != {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/168",
+        "provider_calls_authorized": False,
+        "formal_attempts_authorized": False,
+        "model_tokens_authorized": 0,
+        "pilot_collection_authorized": False,
+    }:
+        raise MultiCheckpointGateError("zero-provider authorization boundary drifted")
+    if value["fault"] != {
+        "family": FAULT_FAMILY,
+        "expected_classification": EXPECTED_CLASSIFICATION,
+        "replay_attempts_required": 0,
+        "required_artifacts_per_case": 1,
+    }:
+        raise MultiCheckpointGateError("controlled fault identity drifted")
+    cases = [CheckpointCase.from_dict(item) for item in value["cases"]]
+    if [case.case_id for case in cases] != ["cppitertools", "janet", "libcheck"] or [case.role for case in cases] != ["anchor", "new_gate", "new_gate"]:
+        raise MultiCheckpointGateError("frozen case schedule drifted")
+    if [case.build_system for case in cases] != ["cmake", "make", "autotools"]:
+        raise MultiCheckpointGateError("frozen build-system coverage drifted")
+    for item in value["cases"]:
+        if canonical_sha256(item) != EXPECTED_CASE_SHA256.get(item["case_id"]):
+            raise MultiCheckpointGateError(f"frozen case definition drifted: {item['case_id']}")
+    if len({case.staged_relative_path for case in cases}) != len(cases):
+        raise MultiCheckpointGateError("case staged artifact identities must be unique")
+    return value
+
+
+def cases(manifest: dict[str, Any]) -> tuple[CheckpointCase, ...]:
+    validate_manifest(manifest)
+    return tuple(CheckpointCase.from_dict(item) for item in manifest["cases"])
+
+
+def case_by_id(manifest: dict[str, Any], case_id: str) -> CheckpointCase:
+    selected = [case for case in cases(manifest) if case.case_id == case_id]
+    if len(selected) != 1:
+        raise MultiCheckpointGateError(f"unknown case: {case_id}")
+    return selected[0]
+
+
+def verify_historical_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest)
+    for relative_path, expected in manifest["historical_components"].items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise MultiCheckpointGateError(f"historical component drifted: {relative_path}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "show-case"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--case-id", choices=("cppitertools", "janet", "libcheck"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    verify_historical_components(manifest)
+    if args.command == "validate":
+        result: Any = {"manifest_sha256": canonical_sha256(manifest), "cases": [case.case_id for case in cases(manifest)], "provider_calls": 0, "formal_attempts": 0, "model_tokens": 0}
+    else:
+        if args.case_id is None:
+            raise MultiCheckpointGateError("show-case requires --case-id")
+        result = case_by_id(manifest, args.case_id).__dict__
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更摘要

- 新增 CMake、Make、Autotools 三类 checkpoint 的版本化零 provider manifest、Schema 与静态语义门禁。
- 为 Janet 和 Libcheck 增加 Compose/DooD 真实 Docker gate，覆盖固定提交构建、受控缺产物故障、checkpoint、同源双臂恢复、candidate verifier、clean replay 和 cleanup。
- 保持历史 primary canary、behavioral v2 runner 与冻结 evidence 逐字不变，并记录 dependency_setup 与 Texinfo 环境问题。

## 验证

- 静态协议测试：7 passed；Docker opt-in 默认：2 skipped。
- Janet（Make）真实 checkpoint gate：通过。
- Libcheck（Autotools）真实 checkpoint gate：1 passed in 249.93s。
- cppitertools（CMake）Windows-bind anchor：1 passed in 125.98s。
- Ruff check/format、git diff --check、历史组件哈希和敏感信息检查通过。
- cleanup 后 Compile Session container、checkpoint container 与 checkpoint image 均为 0 orphan。

## 研究边界

本 PR 仅证明 artifact_staging_missing 在三个构建系统上的确定性 checkpoint 可恢复性。全程 0 provider call、0 formal physical attempt、0 model token；不证明跨 fault-family 泛化或 verifier repair treatment 效应，也不授权后续 6-pair provider 采集。

Closes #168
