### PR TITLE
研究：冻结多 checkpoint behavioral pilot v3 协议

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-29 — 冻结多 checkpoint behavioral pilot v3 未授权协议
+  - 文件: `scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py`, `scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py`, `backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3.py`, `benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json`, `benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json`, `benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.md`
+  - 动机: Issue #170 把 #168 已通过零 provider 门禁的 CMake `cppitertools`、Make `janet`、Autotools `libcheck` 冻结为新的跨构建系统描述性 pilot；不修改 behavioral v2、生产 Compiler/Oracle 或历史 evidence。
+  - 结果: 固定 `3 cases x 2 pairs = 6 pairs / 12 arms`，每个 case 各一个 baseline-first 与 treatment-first；单臂/单对/阶段 recorded-token 上限为 120,000 / 240,000 / 1,440,000，逐 case 报四格、请求、tokens、失败迁移并以 case 等权 macro-average 汇总。canonical manifest SHA-256 为 `7efa555cb95ace497833c5fb9e9106778d5f856214f9d07a3511bd04298cae5b`。
+  - 验证: 定向 pytest `6 passed`；Ruff check/format、协议生成一致性、runner plan、冻结组件和敏感信息扫描通过。
+  - 边界: runner 为 `protocol_plan_only` 并机械拒绝 collection；0 provider、0 formal physical attempt、0 model token、未读取 AK、未创建实验 evidence。下一步是中文提交、WSL helper 推送、中文 PR 与 CI；真实采集必须另建授权 identity。
+
 - 2026-08-29 — 完成跨构建系统多 checkpoint 零 provider 门禁
   - 文件: `scripts/forge_multi_checkpoint_zero_provider_gate.py`, `backend/tests/test_forge_multi_checkpoint_zero_provider_gate.py`, `backend/tests/test_forge_multi_checkpoint_zero_provider_docker.py`, `benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json`, `benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json`, `benchmarks/preregistrations/cpp-verifier-multi-checkpoint-zero-provider-gate.md`
   - 动机: behavioral pilot v2 的 6 对全部来自同一 CMake checkpoint；Issue #168 在不修改冻结 runner/evidence 的前提下，补 Make `janet` 与 Autotools `libcheck` 的真实 checkpoint 可恢复性证据。

--- a/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3.py
+++ b/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3.py
@@ -1,0 +1,130 @@
+"""Issue #170 多 checkpoint behavioral pilot v3 的零请求协议门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_multi_checkpoint_behavioral_pilot_v3_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_multi_checkpoint_behavioral_pilot_v3_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_generated_manifest_schema_and_frozen_components_are_current() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(manifest, REPO_ROOT)
+
+
+def test_schedule_has_three_cases_two_balanced_pairs_and_twelve_arms() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    schedule = manifest["schedule"]
+    assert len(schedule) == 6
+    assert sum(len(pair["arm_order"]) for pair in schedule) == 12
+    for case_id in protocol.CASE_IDS:
+        case_pairs = [pair for pair in schedule if pair["case_id"] == case_id]
+        assert [pair["arm_order"] for pair in case_pairs] == [
+            ["baseline", "treatment"],
+            ["treatment", "baseline"],
+        ]
+    assert manifest["schedule_sha256"] == protocol.canonical_sha256(schedule)
+
+
+def test_runner_maps_every_pair_to_the_frozen_case() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    plan = runner.build_pilot_plan(manifest, REPO_ROOT)
+    assert plan["pair_count"] == 6
+    assert plan["arm_count"] == 12
+    assert plan["maximum_recorded_tokens"] == 1_440_000
+    by_case = {pair["case"]["case_id"]: pair["case"] for pair in plan["pairs"]}
+    assert {case_id: case["build_system"] for case_id, case in by_case.items()} == {
+        "cppitertools": "cmake",
+        "janet": "make",
+        "libcheck": "autotools",
+    }
+    assert by_case["janet"]["artifact"]["staged_relative_path"] == "libjanet.a"
+    assert by_case["libcheck"]["commands"][0]["role"] == "dependency_setup"
+    assert all(pair["runner_mode"] == "protocol_plan_only" for pair in plan["pairs"])
+    assert all(pair["provider_calls_authorized"] is False for pair in plan["pairs"])
+
+
+def test_authorization_budget_and_analysis_contract_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["authorization"] == {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/170",
+        "protocol_freeze_authorized": True,
+        "provider_calls_authorized": False,
+        "formal_attempts_authorized": False,
+        "model_tokens_authorized": 0,
+        "pilot_collection_authorized": False,
+    }
+    assert manifest["budget"]["recorded_tokens_per_arm"] == 120_000
+    assert manifest["budget"]["recorded_tokens_per_pair"] == 240_000
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 1_440_000
+    assert manifest["analysis"]["per_case_outputs"] == [
+        "paired_four_cell",
+        "requests",
+        "recorded_tokens",
+        "failure_transitions",
+    ]
+    assert manifest["analysis"]["cross_case_summary"] == "equal_weight_macro_average"
+    assert set(manifest["analysis"]["case_weights"].values()) == {"1/3"}
+    assert manifest["analysis"]["p_value_computed"] is False
+    assert manifest["analysis"]["providers_pooled"] is False
+    assert manifest["analysis"]["model_ranking_performed"] is False
+
+
+def test_schema_and_semantics_reject_authorization_or_schedule_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    authorized = copy.deepcopy(manifest)
+    authorized["authorization"]["provider_calls_authorized"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(authorized)
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(authorized, REPO_ROOT)
+
+    reordered = copy.deepcopy(manifest)
+    reordered["schedule"][0]["arm_order"].reverse()
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(reordered, REPO_ROOT)
+
+
+def test_runner_has_no_real_collection_path() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    with pytest.raises(runner.RunnerPlanError, match="does not authorize"):
+        runner.execute_collection(manifest)
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    for forbidden in ("os.environ", "create_chat_model", "execute_real_pair", "DEEPSEEK_API_KEY"):
+        assert forbidden not in source

--- a/benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json
+++ b/benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "../schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+  "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.0.0",
+  "document_type": "forge_multi_checkpoint_behavioral_pilot",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/170",
+    "protocol_freeze_authorized": true,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "model_tokens_authorized": 0,
+    "pilot_collection_authorized": false
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "mechanism": "failure_checkpoint",
+    "controlled_fault": "artifact_staging_missing",
+    "build_systems": [
+      "cmake",
+      "make",
+      "autotools"
+    ],
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "case_source": {
+    "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json",
+    "schema_version": "forge-multi-checkpoint-zero-provider-gate-1.0.0",
+    "canonical_sha256": "6d953ae758056dca00b9013979e0f03d1c5877b386fc803feaea1131fd17339c",
+    "file_sha256": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+    "case_ids": [
+      "cppitertools",
+      "janet",
+      "libcheck"
+    ]
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "v3-cppitertools-pair-01",
+      "order": 1,
+      "case_id": "cppitertools",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-cppitertools-pair-02",
+      "order": 2,
+      "case_id": "cppitertools",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v3-janet-pair-01",
+      "order": 3,
+      "case_id": "janet",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-janet-pair-02",
+      "order": 4,
+      "case_id": "janet",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v3-libcheck-pair-01",
+      "order": 5,
+      "case_id": "libcheck",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-libcheck-pair-02",
+      "order": 6,
+      "case_id": "libcheck",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    }
+  ],
+  "schedule_sha256": "91b57bc91ad16e7154c2e9b8a36ce93e65d0b2c0b29930ea4ed2cb2289f369d8",
+  "budget": {
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 1440000,
+    "expected_recorded_tokens_planning_only": 231944,
+    "reachability_requests": 0,
+    "enforcement": "after_each_arm_and_pair_before_next_pair"
+  },
+  "terminal_taxonomy": {
+    "infrastructure": [
+      "valid",
+      "endpoint_censored",
+      "invalid"
+    ],
+    "model_behavior": [
+      "completed",
+      "graph_step_limit",
+      "work_wall_clock_limit",
+      "no_submit",
+      "verification_failed",
+      "not_observed"
+    ],
+    "verification_outcome": [
+      "passed",
+      "failed",
+      "not_attempted"
+    ]
+  },
+  "stopping": {
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "model_behavior_failure_is_outcome": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "descriptive_only": true,
+    "unit_of_analysis": "failure_checkpoint_case",
+    "per_case_outputs": [
+      "paired_four_cell",
+      "requests",
+      "recorded_tokens",
+      "failure_transitions"
+    ],
+    "cross_case_summary": "equal_weight_macro_average",
+    "case_weights": {
+      "cppitertools": "1/3",
+      "janet": "1/3",
+      "libcheck": "1/3"
+    },
+    "pairs_pooled_as_independent_contexts": false,
+    "providers_pooled": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "execution": {
+    "mode": "protocol_plan_only",
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3",
+    "pair_directory_pattern": "pairs/v3-CASE-pair-NN",
+    "release_branch": "main",
+    "authorization_baseline_commit": "24a79228e3b6e5b49d7101666d16a3479c6b9e52",
+    "release_revision_policy": "descendant-compatible",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_zero_managed_containers_between_pairs": true
+  },
+  "frozen_components": {
+    "benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json": "fb803eac7189dbc697a6fdf9bddac1f9ae4a0ec262cf548f62360cd6ad762f2e",
+    "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+    "benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json": "3cf28d9c18815230e5a6e5cafddda634201987ec048b576b9a218b2f42d14af0",
+    "benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json": "57fd748f4bb33d385bdd6adb51f15c1e3ec0f38a1b640fc134b59d60056dbd1c",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py": "3e0032dbc065feb6a780799b2b59bc211e79fd796df8fb5f2a34800f9fa942e0",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95",
+    "scripts/forge_multi_checkpoint_zero_provider_gate.py": "be0265b852527065a826ba34e0fb282388a5ce5eccbb11a1e175598fd1a25883"
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.md
+++ b/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.md
@@ -1,0 +1,45 @@
+# 多 checkpoint behavioral pilot v3 未授权预注册
+
+本协议承接 Issue #168 的三构建系统零 provider 门禁和 Issue #170 的协议冻结授权。当前版本只冻结实验身份与 runner 适配边界，不授权读取 AK、调用 provider、创建 formal physical attempt 或写入真实 evidence。
+
+## 研究问题与实验单位
+
+研究问题保持为：在同一个 `artifact_staging_missing` actionable failure checkpoint 上，向 compiler continuation 提供白名单结构化 verifier repair packet，是否比 baseline 原始反馈提高 candidate verification 与 clean replay 的配对 conversion。
+
+实验单位是 failure checkpoint case，不是单个随机重复。三个 case 固定为：
+
+- `cppitertools@531b3d7`：CMake，可执行文件；
+- `janet@c0b32d4`：Make，静态库；
+- `libcheck@11970a7`：Autotools，静态库。
+
+三者的仓库、提交、命令、依赖、产物和 controlled fault 身份只从 `cpp-verifier-multi-checkpoint-zero-provider-gate.json` 读取，并同时校验 canonical 与文件 SHA-256。不得把历史自然失败 fixture 伪装为可续跑 checkpoint。
+
+## Schedule、provider 与预算
+
+- 每个 case 固定 2 pair：一个 `baseline -> treatment`，一个 `treatment -> baseline`；共 6 pair / 12 arm。
+- provider identity 延续 behavioral v2：DeepSeek `deepseek-v4-flash`、`https://api.deepseek.com`、300 秒 timeout、0 retry、非 streaming、禁止 fallback。
+- 每臂最多 8 requests、8 model turns、24 graph steps、600 秒工作时间加 120 秒 cleanup reserve、120,000 recorded tokens。
+- 每对机械上限 240,000 recorded tokens，阶段总机械上限 1,440,000。约 231,944 tokens 仅是资源规划估计，不是停止阈值。
+
+当前 manifest 的 provider 字段只是未来授权身份，不构成真实请求许可。runner 只有 `validate`、`plan` 与 `show-pair`，任何 collection 入口必须 fail closed。
+
+## 终态与停止规则
+
+沿用 behavioral v2 的三层终态：`infrastructure`、`model_behavior` 与 `verification_outcome`。合法 endpoint timeout 记为删失，已分类模型行为失败保留为 outcome；identity、evidence、预算、cleanup 或无法分类的基础设施失败立即停止 batch。
+
+禁止 retry、replacement、backfill、schedule extension 和第 7 个 pair。不得修改或回填 behavioral v2 与零 provider gate 的冻结 evidence。
+
+## 分析契约
+
+每个 case 独立报告：
+
+1. baseline/treatment 配对四格；
+2. 请求数与 recorded tokens；
+3. failure transition；
+4. 两个 pair 的顺序与三层终态。
+
+跨 case 只使用三个 case 等权的 macro-average，每个 case 权重固定为 `1/3`。不能把 6 个 pair 平铺为 6 个独立 failure contexts；不计算 p 值、不池化 provider、不做模型排名，也不与历史 v2 pair 池化。
+
+## 下一授权门禁
+
+只有本协议、Schema、runner plan、定向 pytest、Ruff 和 CI 全绿并合并到 `main` 后，才能建立新的中文采集 Issue 与授权 manifest。真实采集仍需先核对 Ubuntu 原生 `docker.service`、干净 `main == origin/main`、网络介质、provider identity、预算与 0 managed orphan。

--- a/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json
+++ b/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+  "title": "Forge multi-checkpoint behavioral pilot v3 protocol",
+  "const": {
+    "$schema": "../schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+    "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.0.0",
+    "document_type": "forge_multi_checkpoint_behavioral_pilot",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/170",
+      "protocol_freeze_authorized": true,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "model_tokens_authorized": 0,
+      "pilot_collection_authorized": false
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "mechanism": "failure_checkpoint",
+      "controlled_fault": "artifact_staging_missing",
+      "build_systems": [
+        "cmake",
+        "make",
+        "autotools"
+      ],
+      "natural_collection_authorized": false,
+      "secondary_provider_authorized": false
+    },
+    "case_source": {
+      "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json",
+      "schema_version": "forge-multi-checkpoint-zero-provider-gate-1.0.0",
+      "canonical_sha256": "6d953ae758056dca00b9013979e0f03d1c5877b386fc803feaea1131fd17339c",
+      "file_sha256": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+      "case_ids": [
+        "cppitertools",
+        "janet",
+        "libcheck"
+      ]
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "v3-cppitertools-pair-01",
+        "order": 1,
+        "case_id": "cppitertools",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-cppitertools-pair-02",
+        "order": 2,
+        "case_id": "cppitertools",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v3-janet-pair-01",
+        "order": 3,
+        "case_id": "janet",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-janet-pair-02",
+        "order": 4,
+        "case_id": "janet",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v3-libcheck-pair-01",
+        "order": 5,
+        "case_id": "libcheck",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-libcheck-pair-02",
+        "order": 6,
+        "case_id": "libcheck",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "schedule_sha256": "91b57bc91ad16e7154c2e9b8a36ce93e65d0b2c0b29930ea4ed2cb2289f369d8",
+    "budget": {
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 1440000,
+      "expected_recorded_tokens_planning_only": 231944,
+      "reachability_requests": 0,
+      "enforcement": "after_each_arm_and_pair_before_next_pair"
+    },
+    "terminal_taxonomy": {
+      "infrastructure": [
+        "valid",
+        "endpoint_censored",
+        "invalid"
+      ],
+      "model_behavior": [
+        "completed",
+        "graph_step_limit",
+        "work_wall_clock_limit",
+        "no_submit",
+        "verification_failed",
+        "not_observed"
+      ],
+      "verification_outcome": [
+        "passed",
+        "failed",
+        "not_attempted"
+      ]
+    },
+    "stopping": {
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "model_behavior_failure_is_outcome": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "descriptive_only": true,
+      "unit_of_analysis": "failure_checkpoint_case",
+      "per_case_outputs": [
+        "paired_four_cell",
+        "requests",
+        "recorded_tokens",
+        "failure_transitions"
+      ],
+      "cross_case_summary": "equal_weight_macro_average",
+      "case_weights": {
+        "cppitertools": "1/3",
+        "janet": "1/3",
+        "libcheck": "1/3"
+      },
+      "pairs_pooled_as_independent_contexts": false,
+      "providers_pooled": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "execution": {
+      "mode": "protocol_plan_only",
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3",
+      "pair_directory_pattern": "pairs/v3-CASE-pair-NN",
+      "release_branch": "main",
+      "authorization_baseline_commit": "24a79228e3b6e5b49d7101666d16a3479c6b9e52",
+      "release_revision_policy": "descendant-compatible",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_zero_managed_containers_between_pairs": true
+    },
+    "frozen_components": {
+      "benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json": "fb803eac7189dbc697a6fdf9bddac1f9ae4a0ec262cf548f62360cd6ad762f2e",
+      "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+      "benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json": "3cf28d9c18815230e5a6e5cafddda634201987ec048b576b9a218b2f42d14af0",
+      "benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json": "57fd748f4bb33d385bdd6adb51f15c1e3ec0f38a1b640fc134b59d60056dbd1c",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py": "3e0032dbc065feb6a780799b2b59bc211e79fd796df8fb5f2a34800f9fa942e0",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95",
+      "scripts/forge_multi_checkpoint_zero_provider_gate.py": "be0265b852527065a826ba34e0fb282388a5ce5eccbb11a1e175598fd1a25883"
+    }
+  }
+}

--- a/scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py
+++ b/scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Issue #170 多 checkpoint behavioral pilot v3 的未授权冻结协议。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json"
+CASE_MANIFEST_PATH = "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json"
+
+SCHEMA_VERSION = "forge-multi-checkpoint-behavioral-pilot-3.0.0"
+DOCUMENT_TYPE = "forge_multi_checkpoint_behavioral_pilot"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/170"
+AUTHORIZATION_BASELINE = "24a79228e3b6e5b49d7101666d16a3479c6b9e52"
+CASE_IDS = ("cppitertools", "janet", "libcheck")
+RECORDED_TOKENS_PER_ARM = 120_000
+PAIR_COUNT = len(CASE_IDS) * 2
+RECORDED_TOKEN_LIMIT = PAIR_COUNT * 2 * RECORDED_TOKENS_PER_ARM
+
+FROZEN_COMPONENT_PATHS = {
+    "benchmarks/manifests/cpp-verifier-checkpoint-behavioral-pilot-v2.json",
+    "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json",
+    "benchmarks/schemas/forge-checkpoint-behavioral-pilot-v2.schema.json",
+    "benchmarks/schemas/forge-multi-checkpoint-zero-provider-gate.schema.json",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_protocol.py",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py",
+    "scripts/forge_multi_checkpoint_zero_provider_gate.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """v3 协议、case identity 或授权边界无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_case_gate(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_multi_checkpoint_zero_provider_gate.py"
+    name = "forge_multi_checkpoint_zero_provider_gate_v3_dependency"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load zero-provider case gate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _case_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    gate = _load_case_gate(repo_root)
+    manifest = gate.load_manifest(repo_root / CASE_MANIFEST_PATH)
+    gate.verify_historical_components(manifest, repo_root)
+    if tuple(case.case_id for case in gate.cases(manifest)) != CASE_IDS:
+        raise ProtocolError("zero-provider case set drifted")
+    return manifest, gate
+
+
+def _schedule() -> list[dict[str, Any]]:
+    schedule: list[dict[str, Any]] = []
+    order = 1
+    for case_id in CASE_IDS:
+        for case_pair_index, arm_order in enumerate((("baseline", "treatment"), ("treatment", "baseline")), start=1):
+            schedule.append(
+                {
+                    "pair_id": f"v3-{case_id}-pair-{case_pair_index:02d}",
+                    "order": order,
+                    "case_id": case_id,
+                    "case_pair_index": case_pair_index,
+                    "arm_order": list(arm_order),
+                }
+            )
+            order += 1
+    return schedule
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    case_manifest, _gate = _case_manifest(repo_root)
+    schedule = _schedule()
+    return {
+        "$schema": "../schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "protocol_freeze_authorized": True,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "model_tokens_authorized": 0,
+            "pilot_collection_authorized": False,
+        },
+        "scope": {
+            "languages": ["C", "C++"],
+            "mechanism": "failure_checkpoint",
+            "controlled_fault": "artifact_staging_missing",
+            "build_systems": ["cmake", "make", "autotools"],
+            "natural_collection_authorized": False,
+            "secondary_provider_authorized": False,
+        },
+        "case_source": {
+            "manifest_path": CASE_MANIFEST_PATH,
+            "schema_version": case_manifest["schema_version"],
+            "canonical_sha256": canonical_sha256(case_manifest),
+            "file_sha256": file_sha256(repo_root / CASE_MANIFEST_PATH),
+            "case_ids": list(CASE_IDS),
+        },
+        "provider": {
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "continuation": {
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "budget": {
+            "recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+            "recorded_tokens_per_pair": RECORDED_TOKENS_PER_ARM * 2,
+            "stage_maximum_recorded_tokens": RECORDED_TOKEN_LIMIT,
+            "expected_recorded_tokens_planning_only": 231_944,
+            "reachability_requests": 0,
+            "enforcement": "after_each_arm_and_pair_before_next_pair",
+        },
+        "terminal_taxonomy": {
+            "infrastructure": ["valid", "endpoint_censored", "invalid"],
+            "model_behavior": [
+                "completed",
+                "graph_step_limit",
+                "work_wall_clock_limit",
+                "no_submit",
+                "verification_failed",
+                "not_observed",
+            ],
+            "verification_outcome": ["passed", "failed", "not_attempted"],
+        },
+        "stopping": {
+            "classified_arm_outcome_continues_other_arm": True,
+            "endpoint_timeout_censors_arm_and_continues": True,
+            "model_behavior_failure_is_outcome": True,
+            "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": True,
+            "retry_forbidden": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "analysis": {
+            "descriptive_only": True,
+            "unit_of_analysis": "failure_checkpoint_case",
+            "per_case_outputs": ["paired_four_cell", "requests", "recorded_tokens", "failure_transitions"],
+            "cross_case_summary": "equal_weight_macro_average",
+            "case_weights": {case_id: "1/3" for case_id in CASE_IDS},
+            "pairs_pooled_as_independent_contexts": False,
+            "providers_pooled": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+        },
+        "execution": {
+            "mode": "protocol_plan_only",
+            "control_plane": "compose-dood-on-ubuntu-native-docker",
+            "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3",
+            "pair_directory_pattern": "pairs/v3-CASE-pair-NN",
+            "release_branch": "main",
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE,
+            "release_revision_policy": "descendant-compatible",
+            "require_clean_worktree": True,
+            "require_origin_main_identity": True,
+            "require_zero_managed_containers_between_pairs": True,
+        },
+        "frozen_components": _hash_paths(repo_root, FROZEN_COMPONENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    expected = generate_manifest(repo_root)
+    if value != expected:
+        raise ProtocolError("multi-checkpoint behavioral v3 manifest drifted")
+    return value
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    if manifest["frozen_components"] != _hash_paths(repo_root, FROZEN_COMPONENT_PATHS):
+        raise ProtocolError("frozen component identity drifted")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read multi-checkpoint behavioral v3 manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def case_definitions(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    validate_manifest(manifest, repo_root)
+    case_manifest, gate = _case_manifest(repo_root)
+    return {case.case_id: case for case in gate.cases(case_manifest)}
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+        "title": "Forge multi-checkpoint behavioral pilot v3 protocol",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "show-schedule"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        verify_frozen_components(manifest)
+    result: Any = (
+        manifest["schedule"]
+        if args.command == "show-schedule"
+        else {
+            "manifest_sha256": canonical_sha256(manifest),
+            "pairs": len(manifest["schedule"]),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py
+++ b/scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""把 v3 冻结 schedule 映射为逐 case 运行计划；本版本禁止真实采集。"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+PROTOCOL_PATH = SCRIPT_ROOT / "forge_multi_checkpoint_behavioral_pilot_v3_protocol.py"
+
+
+class RunnerPlanError(RuntimeError):
+    """未授权 runner 收到无效 pair 或真实执行请求。"""
+
+
+def _load_protocol():
+    name = "forge_multi_checkpoint_behavioral_pilot_v3_protocol_runner_dependency"
+    spec = importlib.util.spec_from_file_location(name, PROTOCOL_PATH)
+    if spec is None or spec.loader is None:
+        raise RunnerPlanError("cannot load v3 protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+
+
+def _case_payload(case: Any) -> dict[str, Any]:
+    return {
+        "case_id": case.case_id,
+        "repository_url": case.repository_url,
+        "commit_sha": case.commit_sha,
+        "language": case.language,
+        "build_system": case.build_system,
+        "source_subdir": case.source_subdir,
+        "build_targets": list(case.build_targets),
+        "required_system_packages": list(case.required_system_packages),
+        "cmake_arguments": list(case.cmake_arguments),
+        "configure_arguments": list(case.configure_arguments),
+        "artifact": {
+            "build_output_relative_path": case.build_output_relative_path,
+            "staged_relative_path": case.staged_relative_path,
+            "artifact_type": case.artifact_type,
+        },
+        "commands": [{"role": role, "command": command} for role, command in case.commands],
+    }
+
+
+def build_pair_plan(manifest: dict[str, Any], pair_id: str, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    matches = [pair for pair in manifest["schedule"] if pair["pair_id"] == pair_id]
+    if len(matches) != 1:
+        raise RunnerPlanError(f"unknown pair: {pair_id}")
+    pair = matches[0]
+    case = protocol.case_definitions(manifest, repo_root)[pair["case_id"]]
+    return {
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "case_pair_index": pair["case_pair_index"],
+        "arm_order": pair["arm_order"],
+        "case": _case_payload(case),
+        "provider": manifest["provider"],
+        "continuation": manifest["continuation"],
+        "budget": {
+            "recorded_tokens_per_arm": manifest["budget"]["recorded_tokens_per_arm"],
+            "recorded_tokens_per_pair": manifest["budget"]["recorded_tokens_per_pair"],
+        },
+        "controlled_fault": manifest["scope"]["controlled_fault"],
+        "runner_mode": manifest["execution"]["mode"],
+        "provider_calls_authorized": manifest["authorization"]["provider_calls_authorized"],
+    }
+
+
+def build_pilot_plan(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    pairs = [build_pair_plan(manifest, pair["pair_id"], repo_root) for pair in manifest["schedule"]]
+    return {
+        "schema_version": manifest["schema_version"],
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "authorization": manifest["authorization"],
+        "case_source": manifest["case_source"],
+        "analysis": manifest["analysis"],
+        "pair_count": len(pairs),
+        "arm_count": sum(len(pair["arm_order"]) for pair in pairs),
+        "maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+        "pairs": pairs,
+    }
+
+
+def execute_collection(*_args: Any, **_kwargs: Any) -> None:
+    raise RunnerPlanError("v3 protocol freeze does not authorize provider collection")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "plan", "show-pair"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--pair-id")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "show-pair":
+        if not args.pair_id:
+            raise RunnerPlanError("show-pair requires --pair-id")
+        result: Any = build_pair_plan(manifest, args.pair_id)
+    else:
+        result = build_pilot_plan(manifest)
+        if args.command == "validate":
+            result = {
+                "manifest_sha256": result["manifest_sha256"],
+                "pairs": result["pair_count"],
+                "arms": result["arm_count"],
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+            }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 behavioral pilot v3 未授权 manifest、Schema 与预注册，冻结 CMake/Make/Autotools 三个 case。
- 固定 `3 cases x 2 pairs = 6 pairs / 12 arms`，每个 case 内各一个 baseline-first 与 treatment-first。
- 新增只生成逐 case 运行计划的最小 runner adapter；当前版本机械拒绝真实 collection。
- 冻结逐 case 四格、请求、recorded tokens、失败迁移和 case 等权 macro-average 分析契约。
- 增加零请求协议测试，校验 case source、冻结组件、预算、顺序与授权边界。

## 验证

- `6 passed`：`backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3.py`
- Ruff check：通过
- Ruff format check：通过
- protocol/runner validate：6 pairs、12 arms、0 provider calls、0 formal attempts、0 model tokens
- canonical manifest SHA-256：`7efa555cb95ace497833c5fb9e9106778d5f856214f9d07a3511bd04298cae5b`

## 边界

不读取 AK、不调用 provider、不创建真实 evidence；不修改冻结的 primary canary、behavioral v2 runner、历史 evidence 或生产 Compiler/Oracle。真实采集必须另建授权 identity。

Closes #170