### PR TITLE
研究：授权多 checkpoint behavioral pilot v3 采集

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-29 — 实现多 checkpoint behavioral pilot v3 授权采集 runner
+  - 文件: `scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol.py`, `scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py`, `backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized.py`, `backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized_docker.py`, `benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json`, `benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json`, `benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.md`
+  - 动机: Issue #172 在实验负责人确认 `wifi` 与 Ubuntu `docker.service` active 后，授权一次 DeepSeek canary 和 #170 冻结的 6 pair / 12 arm，maximum 1,440,000 recorded tokens。
+  - 实现: 新 identity 冻结一次性 canary、空 evidence/clean main/Compose-DooD/0 orphan preflight 和 fail-closed batch；通用 case runtime 复用 #168 parent/checkpoint 生命周期与 behavioral v2 三层终态、candidate verifier、clean replay 和单事件循环语义；报告逐 case 四格、请求、tokens、failure transitions 与 case 等权 macro-average。
+  - 验证: canonical manifest SHA-256 为 `933891035aa6cf4ddaa842bdb60ff97343099484a1cb1b448b511d1d16081a8e`；未授权/授权相邻回归 `14 passed`，Ruff check/format 通过；Janet/Make fake-model 真实 Docker gate `1 passed in 171.56s`，结束后 0 managed container / 0 checkpoint image。
+  - 边界: 当前仍为 0 provider、0 formal physical attempt、0 model token，未读取 AK；下一步完成中文提交、WSL 推送、PR/CI/合并后，才在干净主干执行零请求 preflight 与唯一 canary。
+
 - 2026-08-29 — 冻结多 checkpoint behavioral pilot v3 未授权协议
   - 文件: `scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py`, `scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py`, `backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3.py`, `benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json`, `benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json`, `benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.md`
   - 动机: Issue #170 把 #168 已通过零 provider 门禁的 CMake `cppitertools`、Make `janet`、Autotools `libcheck` 冻结为新的跨构建系统描述性 pilot；不修改 behavioral v2、生产 Compiler/Oracle 或历史 evidence。
@@ -417,6 +424,9 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- 冻结 manifest 中的容器路径不能用宿主 `Path` 再 `str()` 序列化；Windows 会生成反斜杠而 WSL/Linux 重算为正斜杠，导致跨环境 identity 漂移。协议使用固定 POSIX 字符串，`Path` 只用于运行时访问。
+- PowerShell 调 WSL 的 `docker info --format` 时，含 `|` 的 Go template 可能失去参数引号并被 Bash 当作管道。daemon 摘要统一使用无特殊字符的 `docker info --format json`，再在 PowerShell 侧解析；不要继续调试多层模板引号。
 
 - `ExperimentPolicy.required_system_packages` 非空时，成功命令必须以生产契约角色 `dependency_setup` 记录；自定义 manifest 写成 `dependency` 会让 submit 正确归类为 `dependency_setup_not_observed`，掩盖预期的 verifier failure。环境查询也不能代替缺失依赖安装：`libcheck` 必须实际安装 `texinfo`，否则 parent build 在 `makeinfo` 处退出 127。
 - 2026-08-29 门禁期间 Ubuntu `docker.service` 曾收到一次 systemd 正常停止信号并自动恢复，来源未能从 Docker journal 归因；每个重型 Docker gate 前仍应重新执行 `scripts/require-ubuntu-native-docker.sh`，但不得自行重启 daemon 或切换 Docker Desktop。

--- a/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized.py
+++ b/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized.py
@@ -1,0 +1,240 @@
+"""Issue #172 多 checkpoint behavioral pilot v3 授权协议与 runner 门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+from langchain_core.messages import AIMessage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS / "forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol.py"
+RUNNER_PATH = SCRIPTS / "forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _arm(arm: str, *, passed: bool, tokens: int = 100) -> dict[str, Any]:
+    return {
+        "arm": arm,
+        "status": "observed",
+        "infrastructure": {"status": "valid"},
+        "model_behavior": {"status": "completed", "terminal_error_class": None},
+        "verification_outcome": {
+            "status": "passed" if passed else "failed",
+            "submit_attempts": 1,
+            "clean_replay_attempts": 1 if passed else 0,
+        },
+        "physical_attempt_id": f"attempt-{arm}",
+        "model_requests": 1,
+        "recorded_tokens": tokens,
+        "actual_model": "deepseek-v4-flash",
+        "metrics": {
+            "model_requests": 1,
+            "submit_attempts": 1,
+            "clean_replay_attempts": 1 if passed else 0,
+            "recorded_tokens": tokens,
+            "ledger_wall_clock_seconds": 1.0,
+        },
+        "ledger_head_sha256": "a" * 64,
+    }
+
+
+def _outcome(pair: dict[str, Any]) -> dict[str, Any]:
+    treatment_passed = pair["case_pair_index"] == 2 or pair["case_id"] != "janet"
+    baseline_passed = pair["case_id"] == "cppitertools"
+    arms = {
+        "baseline": _arm("baseline", passed=baseline_passed),
+        "treatment": _arm("treatment", passed=treatment_passed),
+    }
+    return {
+        "schema_version": "forge-multi-checkpoint-behavioral-pair-outcome-3.1.0",
+        "document_type": "forge_multi_checkpoint_behavioral_pair_outcome",
+        "manifest_sha256": "b" * 64,
+        "pair_manifest_sha256": "c" * 64,
+        "pair_id": pair["pair_id"],
+        "order": pair["order"],
+        "case_id": pair["case_id"],
+        "build_system": {"cppitertools": "cmake", "janet": "make", "libcheck": "autotools"}[pair["case_id"]],
+        "case_pair_index": pair["case_pair_index"],
+        "arm_order": pair["arm_order"],
+        "status": "observed",
+        "arms": arms,
+        "recorded_tokens": 200,
+        "primary_mechanism_eligible": True,
+        "repair_success": {"baseline": baseline_passed, "treatment": treatment_passed},
+        "paired_repair_conversion_delta": int(treatment_passed) - int(baseline_passed),
+        "itt_attrition_contribution": 1,
+        "coordinator": {"phase": "cleaned"},
+        "completed_at": "2026-08-29T00:00:00+00:00",
+    }
+
+
+class CanaryModel:
+    def invoke(self, _prompt: str) -> AIMessage:
+        return AIMessage(
+            content="CANARY_OK",
+            response_metadata={"model_name": "deepseek-v4-flash"},
+            usage_metadata={"input_tokens": 8, "output_tokens": 2, "total_tokens": 10},
+        )
+
+
+def test_generated_manifest_schema_and_parent_protocol_are_current() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(manifest, REPO_ROOT)
+    assert manifest["parent_protocol"]["canonical_sha256"] == "7efa555cb95ace497833c5fb9e9106778d5f856214f9d07a3511bd04298cae5b"
+
+
+def test_authorization_canary_schedule_and_budget_are_exact() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["authorization"] == {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/172",
+        "authorized_by": "experiment_owner",
+        "provider_calls_authorized": True,
+        "formal_attempts_authorized": True,
+        "model_tokens_authorized": 1_440_000,
+        "pilot_collection_authorized": True,
+        "authorized_provider_canaries": 1,
+        "authorized_pairs": 6,
+    }
+    assert manifest["canary"]["maximum_requests"] == 1
+    assert manifest["canary"]["retry_forbidden"] is True
+    assert len(manifest["schedule"]) == 6
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 1_440_000
+    assert manifest["execution"]["network_access_medium"] == "wifi"
+
+
+def test_schema_and_protocol_reject_authorization_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    drifted = copy.deepcopy(manifest)
+    drifted["authorization"]["authorized_provider_canaries"] = 2
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(drifted)
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_pair_runtime_maps_all_case_policy_fields() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    cases = protocol.case_definitions(manifest, REPO_ROOT)
+    for pair in manifest["schedule"]:
+        case = cases[pair["case_id"]]
+        pair_manifest = runner._pair_manifest(manifest, pair, case, Path("/tmp") / pair["pair_id"])
+        policy = runner._case_policy(manifest, case, arm="baseline", image_id="sha256:" + "a" * 64)
+        assert pair_manifest["pilot"]["case_id"] == case.case_id
+        assert pair_manifest["pilot"]["build_system"] == case.build_system
+        assert policy.case_id == case.case_id
+        assert policy.expected_repo_url == case.repository_url
+        assert policy.expected_build_system == case.build_system
+        assert policy.required_system_packages == case.required_system_packages
+        assert policy.artifact_instructions == ((case.staged_relative_path, case.build_output_relative_path, case.artifact_type),)
+
+
+def test_preflight_is_zero_request_and_checks_frozen_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_args: None)
+    monkeypatch.setattr(runner, "_require_output_dir", lambda *_args: None)
+    monkeypatch.setattr(runner, "require_release_identity", lambda *_args: {"branch": "main", "revision": "a" * 40, "origin_main": "a" * 40})
+    monkeypatch.setattr(runner, "require_network_medium", lambda *_args: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+    monkeypatch.setattr(runner, "_provider_config_preflight", lambda *_args: None)
+    result = runner.collect_preflight(manifest, output_dir=tmp_path)
+    assert result["ready"] is True
+    assert (result["provider_calls"], result["formal_attempts"], result["model_tokens"]) == (0, 0, 0)
+
+
+def test_canary_is_single_use_and_records_no_response_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    release = {"ready": True, "release_revision": "a" * 40, "network_access_medium": "wifi"}
+    monkeypatch.setattr(runner, "collect_preflight", lambda *_args, **_kwargs: release)
+    report = runner.collect_provider_canary(manifest, output_dir=tmp_path, model_factory=lambda _provider: CanaryModel())
+    assert report["passed"] is True
+    assert report["request_count"] == 1
+    assert report["recorded_tokens"] == 10
+    assert "CANARY_OK" not in json.dumps(report)
+    marker = _load(tmp_path / manifest["execution"]["canary_marker"])
+    assert marker["status"] == "passed"
+    with pytest.raises(runner.AuthorizedPilotError, match="不可覆盖"):
+        runner.collect_provider_canary(manifest, output_dir=tmp_path, model_factory=lambda _provider: CanaryModel())
+
+
+def test_batch_reports_per_case_macro_and_counts_canary_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    revision = "a" * 40
+    digest = protocol.canonical_sha256(manifest)
+    canary = {
+        "manifest_sha256": digest,
+        "release_revision": revision,
+        "recorded_tokens": 10,
+        "passed": True,
+    }
+    runner._write_once(
+        tmp_path / manifest["execution"]["canary_marker"],
+        {"manifest_sha256": digest, "release_revision": revision, "status": "passed"},
+    )
+    runner._write_once(tmp_path / "reports/provider-canary.json", canary)
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_args: None)
+    monkeypatch.setattr(runner, "_require_output_dir", lambda *_args: None)
+    monkeypatch.setattr(runner, "require_release_identity", lambda *_args: {"branch": "main", "revision": revision, "origin_main": revision})
+    monkeypatch.setattr(runner, "require_network_medium", lambda *_args: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+
+    report = runner.run_pilot(
+        manifest,
+        output_dir=tmp_path,
+        pair_executor=lambda _manifest, pair, _pair_dir: _outcome(pair),
+    )
+    assert report["observed_pairs"] == 6
+    assert set(report["per_case"]) == {"cppitertools", "janet", "libcheck"}
+    assert all(item["scheduled_pairs"] == 2 for item in report["per_case"].values())
+    assert report["equal_weight_macro_average"]["case_weights"] == {
+        "cppitertools": "1/3",
+        "janet": "1/3",
+        "libcheck": "1/3",
+    }
+    assert report["recorded_tokens"] == 1_210
+    assert report["p_value_computed"] is False
+    assert report["providers_pooled"] is False
+    assert _load(tmp_path / manifest["execution"]["batch_marker"])["status"] == "passed"
+
+
+def test_new_files_do_not_contain_secret_values() -> None:
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert "sk-" not in source
+    assert "OpenAI_AK" not in source

--- a/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized_docker.py
+++ b/backend/tests/test_forge_multi_checkpoint_behavioral_pilot_v3_authorized_docker.py
@@ -1,0 +1,163 @@
+"""Issue #172 authorized runner 的 opt-in Make fake-model Docker 门禁。"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_MULTI_CHECKPOINT_BEHAVIORAL_V3_AUTHORIZED_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_MULTI_CHECKPOINT_BEHAVIORAL_V3_AUTHORIZED_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_module():
+    scripts = REPO_ROOT / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    spec = importlib.util.spec_from_file_location("forge_multi_checkpoint_behavioral_v3_authorized_docker_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_module()
+
+
+class RestoreJanetArtifactModel(BaseChatModel):
+    model_name: str = "deepseek-v4-flash"
+    base_url: str = "https://api.deepseek.com"
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "multi-checkpoint-behavioral-v3-authorized-docker-fake"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("successful automatic submit 后不应再次调用 fake model")
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "run_container_bash",
+                                "args": {
+                                    "command": "cp build/libjanet.a /artifacts/libjanet.a",
+                                    "timeout_seconds": 60,
+                                    "workdir": "/workspace/repo",
+                                    "command_role": "artifact_stage",
+                                },
+                                "id": "restore-janet-artifact",
+                                "type": "tool_call",
+                            }
+                        ],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                    )
+                )
+            ]
+        )
+
+
+def test_authorized_runner_maps_janet_through_real_verifier_replay_and_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner.primary.require_compose_dood()
+    paths = Paths()
+    output_dir = paths.compile_sessions_dir / f"issue-172-janet-{uuid.uuid4().hex[:12]}"
+    created_session_dirs: list[Path] = []
+    manager = CompileSessionManager(paths=paths, default_image=runner.COMPILE_IMAGE)
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_session_dirs.append(Path(session.metadata_path).parent)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {"branch": "main", "revision": "e" * 40, "origin_main": "e" * 40},
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    manifest = runner.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    pair = next(item for item in manifest["schedule"] if item["case_id"] == "janet")
+
+    try:
+        with asyncio.Runner() as async_runner:
+            result = runner.execute_real_pair(
+                manifest,
+                pair,
+                output_dir,
+                async_runner,
+                model_factory=lambda _provider, _thread_id: RestoreJanetArtifactModel(),
+            )
+        assert result["status"] == "observed"
+        assert result["case_id"] == "janet"
+        assert result["build_system"] == "make"
+        assert result["primary_mechanism_eligible"] is True
+        assert result["repair_success"] == {"baseline": True, "treatment": True}
+        assert all(item["verification_outcome"]["status"] == "passed" for item in result["arms"].values())
+    finally:
+        for session_dir in reversed(created_session_dirs):
+            shutil.rmtree(session_dir, ignore_errors=True)
+            try:
+                session_dir.parent.rmdir()
+            except OSError:
+                pass
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_manifest_file_is_json() -> None:
+    assert isinstance(json.loads(MANIFEST_PATH.read_text(encoding="utf-8")), dict)

--- a/benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json
+++ b/benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "../schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json",
+  "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.1.0-authorized",
+  "document_type": "forge_multi_checkpoint_behavioral_pilot_authorized",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/172",
+    "authorized_by": "experiment_owner",
+    "provider_calls_authorized": true,
+    "formal_attempts_authorized": true,
+    "model_tokens_authorized": 1440000,
+    "pilot_collection_authorized": true,
+    "authorized_provider_canaries": 1,
+    "authorized_pairs": 6
+  },
+  "scope": {
+    "languages": [
+      "C",
+      "C++"
+    ],
+    "mechanism": "failure_checkpoint",
+    "controlled_fault": "artifact_staging_missing",
+    "build_systems": [
+      "cmake",
+      "make",
+      "autotools"
+    ],
+    "natural_collection_authorized": false,
+    "secondary_provider_authorized": false
+  },
+  "case_source": {
+    "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json",
+    "schema_version": "forge-multi-checkpoint-zero-provider-gate-1.0.0",
+    "canonical_sha256": "6d953ae758056dca00b9013979e0f03d1c5877b386fc803feaea1131fd17339c",
+    "file_sha256": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+    "case_ids": [
+      "cppitertools",
+      "janet",
+      "libcheck"
+    ]
+  },
+  "provider": {
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "v3-cppitertools-pair-01",
+      "order": 1,
+      "case_id": "cppitertools",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-cppitertools-pair-02",
+      "order": 2,
+      "case_id": "cppitertools",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v3-janet-pair-01",
+      "order": 3,
+      "case_id": "janet",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-janet-pair-02",
+      "order": 4,
+      "case_id": "janet",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    },
+    {
+      "pair_id": "v3-libcheck-pair-01",
+      "order": 5,
+      "case_id": "libcheck",
+      "case_pair_index": 1,
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ]
+    },
+    {
+      "pair_id": "v3-libcheck-pair-02",
+      "order": 6,
+      "case_id": "libcheck",
+      "case_pair_index": 2,
+      "arm_order": [
+        "treatment",
+        "baseline"
+      ]
+    }
+  ],
+  "schedule_sha256": "91b57bc91ad16e7154c2e9b8a36ce93e65d0b2c0b29930ea4ed2cb2289f369d8",
+  "budget": {
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 1440000,
+    "expected_recorded_tokens_planning_only": 231944,
+    "reachability_requests": 0,
+    "enforcement": "after_each_arm_and_pair_before_next_pair"
+  },
+  "terminal_taxonomy": {
+    "infrastructure": [
+      "valid",
+      "endpoint_censored",
+      "invalid"
+    ],
+    "model_behavior": [
+      "completed",
+      "graph_step_limit",
+      "work_wall_clock_limit",
+      "no_submit",
+      "verification_failed",
+      "not_observed"
+    ],
+    "verification_outcome": [
+      "passed",
+      "failed",
+      "not_attempted"
+    ]
+  },
+  "stopping": {
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "model_behavior_failure_is_outcome": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "descriptive_only": true,
+    "unit_of_analysis": "failure_checkpoint_case",
+    "per_case_outputs": [
+      "paired_four_cell",
+      "requests",
+      "recorded_tokens",
+      "failure_transitions"
+    ],
+    "cross_case_summary": "equal_weight_macro_average",
+    "case_weights": {
+      "cppitertools": "1/3",
+      "janet": "1/3",
+      "libcheck": "1/3"
+    },
+    "pairs_pooled_as_independent_contexts": false,
+    "providers_pooled": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "execution": {
+    "mode": "authorized_collection",
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3-authorized",
+    "pair_directory_pattern": "pairs/v3-CASE-pair-NN",
+    "release_branch": "main",
+    "authorization_baseline_commit": "4cd3b900bf23facd71c1e1905ff8de040ac598b6",
+    "release_revision_policy": "descendant-compatible",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_zero_managed_containers_between_pairs": true,
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "network_access_medium": "wifi",
+    "canary_marker": "markers/provider-canary-attempt.json",
+    "batch_marker": "markers/pilot-attempt.json",
+    "pair_marker": "markers/pair-attempt.json"
+  },
+  "canary": {
+    "prompt": "Reply with exactly CANARY_OK and nothing else.",
+    "expected_response": "CANARY_OK",
+    "maximum_requests": 1,
+    "maximum_recorded_tokens": 5000,
+    "success_required_before_first_pair": true,
+    "retry_forbidden": true
+  },
+  "parent_protocol": {
+    "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json",
+    "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.0.0",
+    "canonical_sha256": "7efa555cb95ace497833c5fb9e9106778d5f856214f9d07a3511bd04298cae5b",
+    "file_sha256": "bbee3bcb8f0f8fc2f908a968b7b7b0080acffe7386d06c2b69bbeedef5ec3161",
+    "components": {
+      "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json": "bbee3bcb8f0f8fc2f908a968b7b7b0080acffe7386d06c2b69bbeedef5ec3161",
+      "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json": "e9fa109589ca444069a57dcf438aff4c96b94a37573a7497821c7c959386df7a",
+      "scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py": "e0ee1ab642980aaade1e9e2d270b248ff4a91ed0b019dd410e80601f8627e669",
+      "scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py": "246ce10c12cf8e3441370b94f0876e649f531b9499b07f4de68cee6b2f2f0b07"
+    }
+  }
+}

--- a/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.md
+++ b/benchmarks/preregistrations/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.md
@@ -1,0 +1,27 @@
+# 多 checkpoint behavioral pilot v3 授权采集预注册
+
+本协议承接 Issue #170 / PR #171 的未授权冻结设计。实验负责人在 Issue #172 前确认当前网络介质为 `wifi`、Ubuntu 原生 `docker.service` 已启动，并授权 DeepSeek `deepseek-v4-flash` 的一次 canary 与后续 6 个冻结 pair，总 recorded-token 机械上限保持 1,440,000。
+
+## 不变的研究设计
+
+- Case 固定为 CMake `cppitertools`、Make `janet`、Autotools `libcheck`，继续引用 #168 的零 provider case identity。
+- 每个 case 固定两个 pair：一个 baseline-first，一个 treatment-first；共 6 pair / 12 arm。
+- Provider 固定为 `https://api.deepseek.com` / `deepseek-v4-flash`，300 秒 timeout、0 retry、禁止 fallback。
+- 每臂 120,000、每对 240,000、阶段总计 1,440,000 recorded tokens。
+- 三层终态、endpoint censoring、模型行为 outcome、candidate verifier、clean replay 和 cleanup 语义保持 behavioral v2 不变。
+
+## 授权顺序
+
+1. 在合并后的干净 `main == origin/main`、Compose/DooD 与 Ubuntu 原生 daemon 上运行零请求 preflight。
+2. 唯一 provider canary 只允许 1 个请求，必须精确返回 `CANARY_OK`，actual model、endpoint、300 秒 timeout、0 retry 和 token usage 全部闭合。
+3. Canary marker 无论成功或失败都消耗机会；失败后不得重试或创建 replacement identity。
+4. Canary 通过后按 manifest 顺序执行 6 pair。每个 pair 后检查累计预算、三层终态、ledger 哈希链和 0 managed orphan。
+5. Identity、evidence、预算、cleanup 或未分类基础设施失败立即关闭 batch；合法 endpoint timeout 与已分类模型行为失败按预注册 outcome 保留并继续另一臂。
+
+## Evidence 与分析
+
+Evidence 只写入 `/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3-authorized`。禁止覆盖已有 marker、ledger、pair outcome、report 或 sidecar。
+
+结果逐 case 报 paired four-cell、请求、recorded tokens、failure transitions 和执行顺序；跨 case 使用三个 case 各 `1/3` 权重的 macro-average。禁止 p 值、provider 池化、模型排名、历史 pair 池化、replacement、backfill 和 schedule extension。
+
+AK 只允许通过 `DEEPSEEK_API_KEY` 非空门禁进入模型 SDK；不得输出、哈希、写入 Git、日志、marker、report 或 evidence。

--- a/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json
+++ b/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json",
+  "title": "Forge authorized multi-checkpoint behavioral pilot v3",
+  "const": {
+    "$schema": "../schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json",
+    "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.1.0-authorized",
+    "document_type": "forge_multi_checkpoint_behavioral_pilot_authorized",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/172",
+      "authorized_by": "experiment_owner",
+      "provider_calls_authorized": true,
+      "formal_attempts_authorized": true,
+      "model_tokens_authorized": 1440000,
+      "pilot_collection_authorized": true,
+      "authorized_provider_canaries": 1,
+      "authorized_pairs": 6
+    },
+    "scope": {
+      "languages": [
+        "C",
+        "C++"
+      ],
+      "mechanism": "failure_checkpoint",
+      "controlled_fault": "artifact_staging_missing",
+      "build_systems": [
+        "cmake",
+        "make",
+        "autotools"
+      ],
+      "natural_collection_authorized": false,
+      "secondary_provider_authorized": false
+    },
+    "case_source": {
+      "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-zero-provider-gate.json",
+      "schema_version": "forge-multi-checkpoint-zero-provider-gate-1.0.0",
+      "canonical_sha256": "6d953ae758056dca00b9013979e0f03d1c5877b386fc803feaea1131fd17339c",
+      "file_sha256": "081250beafa7d0d5a55a0541eecce2ed3196e132ecdc3f3d5ef99595335e1ab1",
+      "case_ids": [
+        "cppitertools",
+        "janet",
+        "libcheck"
+      ]
+    },
+    "provider": {
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "v3-cppitertools-pair-01",
+        "order": 1,
+        "case_id": "cppitertools",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-cppitertools-pair-02",
+        "order": 2,
+        "case_id": "cppitertools",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v3-janet-pair-01",
+        "order": 3,
+        "case_id": "janet",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-janet-pair-02",
+        "order": 4,
+        "case_id": "janet",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "v3-libcheck-pair-01",
+        "order": 5,
+        "case_id": "libcheck",
+        "case_pair_index": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "v3-libcheck-pair-02",
+        "order": 6,
+        "case_id": "libcheck",
+        "case_pair_index": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "schedule_sha256": "91b57bc91ad16e7154c2e9b8a36ce93e65d0b2c0b29930ea4ed2cb2289f369d8",
+    "budget": {
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 1440000,
+      "expected_recorded_tokens_planning_only": 231944,
+      "reachability_requests": 0,
+      "enforcement": "after_each_arm_and_pair_before_next_pair"
+    },
+    "terminal_taxonomy": {
+      "infrastructure": [
+        "valid",
+        "endpoint_censored",
+        "invalid"
+      ],
+      "model_behavior": [
+        "completed",
+        "graph_step_limit",
+        "work_wall_clock_limit",
+        "no_submit",
+        "verification_failed",
+        "not_observed"
+      ],
+      "verification_outcome": [
+        "passed",
+        "failed",
+        "not_attempted"
+      ]
+    },
+    "stopping": {
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "model_behavior_failure_is_outcome": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops_batch": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "descriptive_only": true,
+      "unit_of_analysis": "failure_checkpoint_case",
+      "per_case_outputs": [
+        "paired_four_cell",
+        "requests",
+        "recorded_tokens",
+        "failure_transitions"
+      ],
+      "cross_case_summary": "equal_weight_macro_average",
+      "case_weights": {
+        "cppitertools": "1/3",
+        "janet": "1/3",
+        "libcheck": "1/3"
+      },
+      "pairs_pooled_as_independent_contexts": false,
+      "providers_pooled": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "execution": {
+      "mode": "authorized_collection",
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "evidence_directory": "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3-authorized",
+      "pair_directory_pattern": "pairs/v3-CASE-pair-NN",
+      "release_branch": "main",
+      "authorization_baseline_commit": "4cd3b900bf23facd71c1e1905ff8de040ac598b6",
+      "release_revision_policy": "descendant-compatible",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_zero_managed_containers_between_pairs": true,
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "network_access_medium": "wifi",
+      "canary_marker": "markers/provider-canary-attempt.json",
+      "batch_marker": "markers/pilot-attempt.json",
+      "pair_marker": "markers/pair-attempt.json"
+    },
+    "canary": {
+      "prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "expected_response": "CANARY_OK",
+      "maximum_requests": 1,
+      "maximum_recorded_tokens": 5000,
+      "success_required_before_first_pair": true,
+      "retry_forbidden": true
+    },
+    "parent_protocol": {
+      "manifest_path": "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json",
+      "schema_version": "forge-multi-checkpoint-behavioral-pilot-3.0.0",
+      "canonical_sha256": "7efa555cb95ace497833c5fb9e9106778d5f856214f9d07a3511bd04298cae5b",
+      "file_sha256": "bbee3bcb8f0f8fc2f908a968b7b7b0080acffe7386d06c2b69bbeedef5ec3161",
+      "components": {
+        "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json": "bbee3bcb8f0f8fc2f908a968b7b7b0080acffe7386d06c2b69bbeedef5ec3161",
+        "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json": "e9fa109589ca444069a57dcf438aff4c96b94a37573a7497821c7c959386df7a",
+        "scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py": "e0ee1ab642980aaade1e9e2d270b248ff4a91ed0b019dd410e80601f8627e669",
+        "scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py": "246ce10c12cf8e3441370b94f0876e649f531b9499b07f4de68cee6b2f2f0b07"
+      }
+    }
+  }
+}

--- a/scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol.py
+++ b/scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Issue #172 多 checkpoint behavioral pilot v3 授权采集协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3.json"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-verifier-multi-checkpoint-behavioral-pilot-v3-authorized.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-multi-checkpoint-behavioral-pilot-v3-authorized"
+DEFAULT_OUTPUT_DIR = Path(EVIDENCE_DIRECTORY)
+
+SCHEMA_VERSION = "forge-multi-checkpoint-behavioral-pilot-3.1.0-authorized"
+DOCUMENT_TYPE = "forge_multi_checkpoint_behavioral_pilot_authorized"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/172"
+AUTHORIZATION_BASELINE = "4cd3b900bf23facd71c1e1905ff8de040ac598b6"
+PARENT_COMPONENT_PATHS = {
+    PARENT_MANIFEST_PATH,
+    "benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3.schema.json",
+    "scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py",
+    "scripts/forge_multi_checkpoint_behavioral_pilot_v3_runner.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """授权协议、父协议或预算 identity 无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_multi_checkpoint_behavioral_pilot_v3_protocol.py"
+    name = "forge_multi_checkpoint_behavioral_pilot_v3_authorized_parent"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load frozen v3 parent protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot read JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"JSON root must be an object: {path}")
+    return value
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"parent component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    manifest = parent.validate_manifest(_load_json(repo_root / PARENT_MANIFEST_PATH), repo_root)
+    parent.verify_frozen_components(manifest, repo_root)
+    return manifest, parent
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent_value, parent = parent_manifest(repo_root)
+    value = copy.deepcopy(parent_value)
+    value["$schema"] = "../schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json"
+    value["schema_version"] = SCHEMA_VERSION
+    value["document_type"] = DOCUMENT_TYPE
+    value["authorization"] = {
+        "issue_url": ISSUE_URL,
+        "authorized_by": "experiment_owner",
+        "provider_calls_authorized": True,
+        "formal_attempts_authorized": True,
+        "model_tokens_authorized": 1_440_000,
+        "pilot_collection_authorized": True,
+        "authorized_provider_canaries": 1,
+        "authorized_pairs": 6,
+    }
+    value["canary"] = {
+        "prompt": "Reply with exactly CANARY_OK and nothing else.",
+        "expected_response": "CANARY_OK",
+        "maximum_requests": 1,
+        "maximum_recorded_tokens": 5_000,
+        "success_required_before_first_pair": True,
+        "retry_forbidden": True,
+    }
+    value["execution"].update(
+        {
+            "mode": "authorized_collection",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "network_access_medium": "wifi",
+            "evidence_directory": EVIDENCE_DIRECTORY,
+            "canary_marker": "markers/provider-canary-attempt.json",
+            "batch_marker": "markers/pilot-attempt.json",
+            "pair_marker": "markers/pair-attempt.json",
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE,
+        }
+    )
+    value["parent_protocol"] = {
+        "manifest_path": PARENT_MANIFEST_PATH,
+        "schema_version": parent_value["schema_version"],
+        "canonical_sha256": parent.canonical_sha256(parent_value),
+        "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+        "components": _hash_paths(repo_root, PARENT_COMPONENT_PATHS),
+    }
+    value.pop("frozen_components")
+    return value
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("authorized multi-checkpoint behavioral v3 manifest drifted")
+    if value["budget"]["stage_maximum_recorded_tokens"] != value["authorization"]["model_tokens_authorized"]:
+        raise ProtocolError("authorized token ceiling does not match the frozen stage budget")
+    return value
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    parent_value, parent = parent_manifest(repo_root)
+    if manifest["parent_protocol"] != {
+        "manifest_path": PARENT_MANIFEST_PATH,
+        "schema_version": parent_value["schema_version"],
+        "canonical_sha256": parent.canonical_sha256(parent_value),
+        "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+        "components": _hash_paths(repo_root, PARENT_COMPONENT_PATHS),
+    }:
+        raise ProtocolError("frozen parent protocol drifted")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return validate_manifest(_load_json(path), repo_root)
+
+
+def case_definitions(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    validate_manifest(manifest, repo_root)
+    _parent_value, parent = parent_manifest(repo_root)
+    return parent.case_definitions(_parent_value, repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-multi-checkpoint-behavioral-pilot-v3-authorized.schema.json",
+        "title": "Forge authorized multi-checkpoint behavioral pilot v3",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        verify_frozen_components(manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "provider_canaries": manifest["authorization"]["authorized_provider_canaries"],
+                "pairs": manifest["authorization"]["authorized_pairs"],
+                "maximum_recorded_tokens": manifest["authorization"]["model_tokens_authorized"],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py
+++ b/scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""执行 Issue #172 授权的多 checkpoint behavioral pilot v3。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from collections import Counter
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_checkpoint_behavioral_pilot_v2_runner as v2_runner  # noqa: E402
+import forge_multi_checkpoint_behavioral_pilot_v3_authorized_protocol as protocol  # noqa: E402
+
+primary = v2_runner.primary
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = protocol.DEFAULT_OUTPUT_DIR
+COMPILE_IMAGE = primary.COMPILE_IMAGE
+ARMS = ("baseline", "treatment")
+PAIR_OUTCOME = "reports/pair-outcome.json"
+PILOT_REPORT = "reports/pilot.json"
+
+
+class AuthorizedPilotError(RuntimeError):
+    """授权 identity、canary、预算、evidence 或 cleanup 无效。"""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuthorizedPilotError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise AuthorizedPilotError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _write_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+    except FileExistsError as exc:
+        raise AuthorizedPilotError(f"不可覆盖已存在的 evidence: {path}") from exc
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo_root}", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise AuthorizedPilotError(f"git {' '.join(arguments)} 失败")
+    return result.stdout.strip()
+
+
+def require_release_identity(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    branch = _git(repo_root, "branch", "--show-current")
+    revision = _git(repo_root, "rev-parse", "HEAD")
+    origin_main = _git(repo_root, "rev-parse", "origin/main")
+    if branch != manifest["execution"]["release_branch"] or revision != origin_main:
+        raise AuthorizedPilotError("真实采集要求干净 main == origin/main")
+    if _git(repo_root, "status", "--porcelain"):
+        raise AuthorizedPilotError("真实采集要求干净工作树")
+    baseline = manifest["execution"]["authorization_baseline_commit"]
+    try:
+        _git(repo_root, "merge-base", "--is-ancestor", baseline, revision)
+    except AuthorizedPilotError as exc:
+        raise AuthorizedPilotError("release revision 不是授权基线的后代") from exc
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+def require_network_medium(manifest: dict[str, Any]) -> str:
+    execution = manifest["execution"]
+    if os.environ.get(execution["network_access_medium_env"]) != execution["network_access_medium"]:
+        raise AuthorizedPilotError("必须通过 FORGE_NETWORK_ACCESS_MEDIUM=wifi 确认当前网络介质")
+    return execution["network_access_medium"]
+
+
+def require_zero_managed_containers() -> None:
+    try:
+        v2_runner.require_zero_managed_containers()
+    except v2_runner.BehavioralPilotError as exc:
+        raise AuthorizedPilotError(str(exc)) from exc
+
+
+def _require_output_dir(manifest: dict[str, Any], output_dir: Path) -> None:
+    expected = Path(manifest["execution"]["evidence_directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise AuthorizedPilotError("evidence 必须写入冻结授权目录")
+
+
+def _provider_config_preflight(manifest: dict[str, Any]) -> None:
+    from deerflow.config import get_app_config
+
+    provider = manifest["provider"]
+    configured = get_app_config().get_model_config(provider["id"])
+    if configured is None or configured.model != provider["model"]:
+        raise AuthorizedPilotError("config.yaml 缺少冻结 provider model")
+    settings = configured.model_dump(exclude_none=True)
+    endpoint = settings.get("base_url", settings.get("openai_api_base"))
+    if endpoint is None or str(endpoint).rstrip("/") != provider["endpoint"].rstrip("/"):
+        raise AuthorizedPilotError("config.yaml provider endpoint 漂移")
+    if not os.environ.get(provider["credential_env"]):
+        raise AuthorizedPilotError("provider credential env 未注入")
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool = True,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _require_output_dir(manifest, output_dir)
+    release = require_release_identity(manifest, repo_root)
+    medium = require_network_medium(manifest)
+    primary.require_compose_dood()
+    require_zero_managed_containers()
+    _provider_config_preflight(manifest)
+    if require_empty and output_dir.exists() and any(output_dir.iterdir()):
+        raise AuthorizedPilotError("首次 preflight 要求授权 evidence 目录为空")
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": medium,
+        "provider": manifest["provider"]["id"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "zero_managed_containers": True,
+    }
+
+
+def _claim_marker(path: Path, *, kind: str, manifest_sha256: str, revision: str) -> None:
+    _write_once(
+        path,
+        {
+            "schema_version": "forge-multi-checkpoint-authorized-attempt-1.0.0",
+            "document_type": kind,
+            "manifest_sha256": manifest_sha256,
+            "release_revision": revision,
+            "status": "started",
+            "error_class": None,
+            "updated_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _finish_marker(path: Path, *, status: str, error_class: str | None = None) -> None:
+    marker = _load_json(path)
+    marker.update(status=status, error_class=error_class, updated_at=datetime.now(UTC).isoformat())
+    _atomic_write(path, marker)
+
+
+def collect_provider_canary(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    preflight = collect_preflight(manifest, output_dir=output_dir, repo_root=repo_root, require_empty=True)
+    digest = protocol.canonical_sha256(manifest)
+    marker = output_dir / manifest["execution"]["canary_marker"]
+    _claim_marker(
+        marker,
+        kind="forge_multi_checkpoint_provider_canary_attempt",
+        manifest_sha256=digest,
+        revision=preflight["release_revision"],
+    )
+    started = time.perf_counter()
+    try:
+        provider = manifest["provider"]
+        model = (model_factory or primary._create_provider_model)(provider)
+        response = model.invoke(manifest["canary"]["prompt"])
+        text = primary._response_text(response).strip()
+        actual_model, usage = primary.model_response_metadata(response)
+        recorded_tokens = usage.get("total_tokens")
+        passed = text == manifest["canary"]["expected_response"] and actual_model == provider["model"] and type(recorded_tokens) is int and 0 <= recorded_tokens <= manifest["canary"]["maximum_recorded_tokens"]
+        report = {
+            "schema_version": "forge-multi-checkpoint-provider-canary-1.0.0",
+            "document_type": "forge_multi_checkpoint_provider_canary",
+            "manifest_sha256": digest,
+            "release_revision": preflight["release_revision"],
+            "provider": provider["id"],
+            "endpoint": provider["endpoint"],
+            "credential_env": provider["credential_env"],
+            "network_access_medium": preflight["network_access_medium"],
+            "request_count": 1,
+            "request_timeout_seconds": provider["request_timeout_seconds"],
+            "max_retries": provider["max_retries"],
+            "duration_ms": round((time.perf_counter() - started) * 1000),
+            "response_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "actual_model": actual_model,
+            "recorded_tokens": recorded_tokens,
+            "passed": passed,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        _write_once(output_dir / "reports/provider-canary.json", report)
+        if not passed:
+            raise AuthorizedPilotError("provider canary 响应、模型 identity 或 token evidence 无效")
+    except BaseException as exc:
+        _finish_marker(marker, status="failed", error_class=type(exc).__name__)
+        raise
+    _finish_marker(marker, status="passed")
+    return report
+
+
+def _passed_canary(manifest: dict[str, Any], output_dir: Path, revision: str) -> dict[str, Any]:
+    marker = _load_json(output_dir / manifest["execution"]["canary_marker"])
+    report = _load_json(output_dir / "reports/provider-canary.json")
+    digest = protocol.canonical_sha256(manifest)
+    if (
+        marker.get("status") != "passed"
+        or marker.get("manifest_sha256") != digest
+        or marker.get("release_revision") != revision
+        or report.get("passed") is not True
+        or report.get("manifest_sha256") != digest
+        or report.get("release_revision") != revision
+    ):
+        raise AuthorizedPilotError("唯一 provider canary 未形成通过终态")
+    return report
+
+
+def _pair_manifest(manifest: dict[str, Any], pair: dict[str, Any], case: Any, pair_dir: Path) -> dict[str, Any]:
+    value = v2_runner._pair_manifest(manifest, pair)
+    value["execution"]["evidence_directory"] = str(pair_dir)
+    value["pilot"].update(
+        {
+            "case_id": case.case_id,
+            "build_system": case.build_system,
+            "case_pair_index": pair["case_pair_index"],
+            "parent_manifest_sha256": protocol.canonical_sha256(manifest),
+        }
+    )
+    return value
+
+
+def _case_policy(manifest: dict[str, Any], case: Any, *, arm: str, image_id: str) -> Any:
+    continuation = manifest["continuation"]
+    provider = manifest["provider"]
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-multi-checkpoint-behavioral-pilot-v3",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=case.case_id,
+        condition=arm,
+        repetition=1,
+        expected_repo_url=case.repository_url,
+        expected_commit_sha=case.commit_sha,
+        expected_build_system=case.build_system,
+        compile_image=COMPILE_IMAGE,
+        image_id=image_id,
+        model_name=provider["model"],
+        endpoint=provider["endpoint"],
+        credential_env=provider["credential_env"],
+        request_timeout_seconds=provider["request_timeout_seconds"],
+        model_max_retries=0,
+        compiler_max_turns=continuation["maximum_model_turns_per_arm"],
+        subagent_timeout_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=case.required_system_packages,
+        cmake_arguments=case.cmake_arguments,
+        configure_arguments=case.configure_arguments,
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=continuation["maximum_model_turns_per_arm"],
+        compiler_graph_recursion_limit=continuation["maximum_graph_steps_per_arm"],
+        compiler_wall_clock_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        compiler_post_build_reserve_seconds=continuation["cleanup_reserve_seconds_per_arm"],
+        source_subdir=case.source_subdir,
+        build_targets=case.build_targets,
+        artifact_instructions=((case.staged_relative_path, case.build_output_relative_path, case.artifact_type),),
+    )
+
+
+class _AsyncioProxy:
+    def __init__(self, runner: asyncio.Runner):
+        self._runner = runner
+
+    def run(self, coroutine: Any) -> Any:
+        return self._runner.run(coroutine)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(asyncio, name)
+
+
+@contextmanager
+def _adapt_primary_runner(
+    manifest: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    case: Any,
+    async_runner: asyncio.Runner,
+):
+    original = {
+        "validate_manifest": primary.validate_manifest,
+        "verify_frozen_artifacts": primary.verify_frozen_artifacts,
+        "require_release_identity": primary.require_release_identity,
+        "require_passed_reachability": primary.require_passed_reachability,
+        "PAIR_MARKER": primary.PAIR_MARKER,
+        "asyncio": primary.asyncio,
+        "run_arm_continuation": primary.run_arm_continuation,
+        "_policy": primary._policy,
+    }
+
+    def validate(value: Any) -> dict[str, Any]:
+        if value != pair_manifest:
+            raise AuthorizedPilotError("authorized pair runtime manifest 漂移")
+        return value
+
+    def verify(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+        validate(value)
+        protocol.verify_frozen_components(manifest, repo_root)
+
+    async def capture_arm(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        ledger = kwargs["ledger"]
+        arm = kwargs["arm"]
+        try:
+            result = await original["run_arm_continuation"](*args, **kwargs)
+        except Exception as exc:
+            return v2_runner.classify_arm_terminal(manifest, arm=arm, ledger=ledger, error=exc)
+        return v2_runner._passed_arm(result, ledger)
+
+    primary.validate_manifest = validate
+    primary.verify_frozen_artifacts = verify
+    primary.require_release_identity = lambda value, repo_root=REPO_ROOT: require_release_identity(manifest, repo_root)
+    primary.require_passed_reachability = lambda *_args, **_kwargs: {"recorded_tokens": 0, "inherited_reachability": True}
+    primary.PAIR_MARKER = manifest["execution"]["pair_marker"].split("/")[-1]
+    primary.asyncio = _AsyncioProxy(async_runner)
+    primary.run_arm_continuation = capture_arm
+    primary._policy = lambda _value, *, arm, image_id: _case_policy(manifest, case, arm=arm, image_id=image_id)
+    try:
+        yield
+    finally:
+        for name, value in original.items():
+            setattr(primary, name, value)
+
+
+def _parent_policy(manifest: dict[str, Any], case: Any, *, image_id: str) -> Any:
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-multi-checkpoint-behavioral-pilot-v3",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=case.case_id,
+        condition="controlled-parent",
+        repetition=1,
+        expected_repo_url=case.repository_url,
+        expected_commit_sha=case.commit_sha,
+        expected_build_system=case.build_system,
+        compile_image=COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        model_max_retries=0,
+        compiler_max_turns=1,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=case.required_system_packages,
+        cmake_arguments=case.cmake_arguments,
+        configure_arguments=case.configure_arguments,
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir=case.source_subdir,
+        build_targets=case.build_targets,
+        artifact_instructions=((case.staged_relative_path, case.build_output_relative_path, case.artifact_type),),
+    )
+
+
+def _run_case_controlled_pair(
+    manifest: dict[str, Any],
+    case: Any,
+    *,
+    output_dir: Path,
+    repo_root: Path,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+
+    from deerflow.compile import operations
+    from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_workspace_dir
+    from deerflow.compile.schemas import utc_now_iso
+
+    primary.validate_manifest(manifest)
+    primary.require_authorized_output_dir(manifest, output_dir)
+    release = primary.require_release_identity(manifest, repo_root)
+    medium = primary._network_medium(manifest)
+    primary.require_compose_dood()
+    reachability = primary.require_passed_reachability(manifest, output_dir, release["revision"])
+    marker = output_dir / "markers" / primary.PAIR_MARKER
+    manifest_digest = protocol.canonical_sha256(manifest)
+    primary._claim_marker(
+        marker,
+        kind="forge_multi_checkpoint_controlled_pair_attempt",
+        manifest_sha256=manifest_digest,
+        revision=release["revision"],
+    )
+
+    capture_id = f"v3-{case.case_id}-{uuid.uuid4().hex[:12]}"
+    services = operations.get_compile_services()
+    manager = services.manager
+    runtime = services.runtime
+    docker = primary.lifecycle.environment_checkpoint.DockerCLI()
+    snapshot = output_dir / "checkpoint" / capture_id
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=case.repository_url,
+        image=COMPILE_IMAGE,
+    )
+    parent_ledger = primary.ExperimentLedger.create(
+        output_dir / "ledgers/parent.jsonl",
+        experiment_id=primary.new_evidence_id("experiment"),
+        physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+        context={"scope": "multi-checkpoint-controlled-parent", "manifest_sha256": manifest_digest, "case_id": case.case_id},
+    )
+    gate = None
+    parent_active = False
+    repair_packet: dict[str, Any] | None = None
+    arm_results: list[dict[str, Any]] = []
+    cleanup_succeeded = False
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {case.repository_url} && git fetch --depth 1 origin {case.commit_sha} && git checkout --detach FETCH_HEAD",
+            workdir="/workspace/repo",
+            timeout_seconds=180,
+        )
+        if clone.exit_code != 0:
+            raise AuthorizedPilotError(f"{case.case_id} parent 无法检出冻结 commit")
+        parent.commit_sha = case.commit_sha
+        parent.build_system = case.build_system
+        parent.build_system_capabilities = [case.build_system]
+        parent.selected_build_system = case.build_system
+        parent.status = "inspected"
+        manager.save_session(parent)
+        supporting = None
+        for role, command in case.commands:
+            record = primary._record_command(manager=manager, runtime=runtime, session=parent, command=command, role=role)
+            if role == "build":
+                supporting = record
+        if supporting is None:
+            raise AuthorizedPilotError(f"{case.case_id} 缺少 supporting build command")
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        primary.activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_parent_policy(manifest, case, image_id=parent.image_id),
+        )
+        parent_active = True
+        fault = primary.controlled_fault.ControlledFaultV1(
+            primary.controlled_fault.ControlledFaultSpec(
+                case_id=case.case_id,
+                build_output_relative_path=case.build_output_relative_path,
+                staged_relative_path=case.staged_relative_path,
+                artifact_type=case.artifact_type,
+            )
+        )
+        fault_manifest = fault.inject(session=parent, ledger=parent_ledger, fault_id=primary.new_evidence_id("fault"))
+        submit_result: str | None = None
+
+        def submit() -> str:
+            nonlocal submit_result, repair_packet
+            if submit_result is not None:
+                raise AuthorizedPilotError("neutral submit 不得重复执行")
+            submit_result = operations.submit_build_result_impl(session=parent, supporting_command_id=supporting.command_id)
+            repair_packet = primary.repair_runtime.build_repair_packet(
+                json.loads(submit_result),
+                parent_ledger.read(),
+                expected_artifacts=((case.staged_relative_path, case.artifact_type),),
+            )
+            if repair_packet is None:
+                raise AuthorizedPilotError("controlled failure 未生成 schema-valid repair packet")
+            return submit_result
+
+        def evidence() -> dict[str, Any]:
+            result = primary.controlled_fault.validate_actionable_failure(ledger=parent_ledger, session=parent)
+            result["session_sha256"] = primary.lifecycle.sha256_file(Path(parent.metadata_path))
+            result["fault_state_sha256"] = fault_manifest["fault_state_sha256"]
+            return result
+
+        coordinator = primary.lifecycle.CaptureCoordinator(output_dir / "checkpoint/coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(output_dir / "checkpoint/messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = primary.lifecycle.LifecycleMessageRuntime(saver, submit)
+            environment = primary.lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=primary.host_snapshot_root(snapshot),
+            )
+            gate = primary.lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=primary._budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="multi-checkpoint-behavioral-pilot-v3",
+            )
+            gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="Repair this controlled artifact staging failure and submit the build.",
+                arm_plan=primary._arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "artifacts": get_host_artifacts_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "logs": get_host_logs_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "repro": get_host_repro_dir(parent.session_id, parent.thread_id, manager.paths),
+                },
+                evidence=evidence,
+            )
+            if repair_packet is None:
+                raise AuthorizedPilotError("repair packet 在 checkpoint capture 后缺失")
+            message_runtime.repair_packet = repair_packet
+            primary.deactivate_experiment(parent.thread_id)
+            parent_active = False
+            parent_ledger.append("experiment.completed", {"status": "passed"})
+            provisioned = {arm: gate.provision_arm(capture_id, arm, parent_session=parent) for arm in ARMS}
+            if gate.canonical_arm_environment("baseline") != gate.canonical_arm_environment("treatment"):
+                raise AuthorizedPilotError("baseline/treatment 初始环境不同源")
+            for arm in manifest["continuation"]["arm_order"]:
+                current = provisioned[arm]
+                message_state = primary._message_state(gate, current)
+                ledger = primary.ExperimentLedger.create(
+                    output_dir / "ledgers" / f"{arm}.jsonl",
+                    experiment_id=primary.new_evidence_id("experiment"),
+                    physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+                    context={
+                        "scope": "multi-checkpoint-controlled-arm",
+                        "manifest_sha256": manifest_digest,
+                        "case_id": case.case_id,
+                        "thread_id": current.session.thread_id,
+                        "arm": arm,
+                        "capture_id": capture_id,
+                    },
+                )
+                result = primary.asyncio.run(
+                    primary.run_arm_continuation(
+                        manifest,
+                        arm=arm,
+                        lifecycle_arm=current,
+                        message_state=message_state,
+                        ledger=ledger,
+                        model_factory=model_factory,
+                    )
+                )
+                arm_results.append(result)
+            cleaned = gate.cleanup(capture_id, parent_session=parent)
+            cleanup_succeeded = cleaned.phase == "cleaned"
+            if not cleanup_succeeded:
+                raise AuthorizedPilotError("controlled pair cleanup 未闭合")
+        report = {
+            "schema_version": "forge-multi-checkpoint-controlled-pair-1.0.0",
+            "document_type": "forge_multi_checkpoint_controlled_pair",
+            "manifest_sha256": manifest_digest,
+            "release_revision": release["revision"],
+            "capture_id": capture_id,
+            "case_id": case.case_id,
+            "build_system": case.build_system,
+            "provider": manifest["provider"]["id"],
+            "network_access_medium": medium,
+            "reachability_recorded_tokens": reachability["recorded_tokens"],
+            "arm_order": manifest["continuation"]["arm_order"],
+            "arms": arm_results,
+            "complete_pair": len(arm_results) == 2,
+            "cleanup_succeeded": cleanup_succeeded,
+            "passed": len(arm_results) == 2 and cleanup_succeeded,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        _atomic_write(output_dir / "reports/controlled-pair.json", report)
+    except BaseException as exc:
+        if parent_active:
+            primary.deactivate_experiment(parent.thread_id)
+        if gate is not None and not cleanup_succeeded:
+            try:
+                record = gate.coordinator.get(capture_id)
+                if record.phase not in {"committed", "aborted", "cleanup_pending", "cleaned"}:
+                    record = gate.reconcile(capture_id)
+                if record.phase == "cleaned":
+                    cleanup_succeeded = True
+                else:
+                    cleanup_succeeded = gate.cleanup(capture_id, parent_session=parent).phase == "cleaned"
+            except Exception:
+                cleanup_succeeded = False
+        else:
+            runtime.stop_and_remove_container(parent)
+        primary._finish_marker(marker, status="failed", error_class=type(exc).__name__)
+        raise
+    primary._finish_marker(marker, status="passed")
+    return report
+
+
+def execute_real_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: asyncio.Runner,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    case = protocol.case_definitions(manifest, REPO_ROOT)[pair["case_id"]]
+    pair_manifest = _pair_manifest(manifest, pair, case, pair_dir)
+    with _adapt_primary_runner(manifest, pair_manifest, case, async_runner):
+        report = _run_case_controlled_pair(
+            pair_manifest,
+            case,
+            output_dir=pair_dir,
+            repo_root=REPO_ROOT,
+            model_factory=model_factory,
+        )
+    outcome = v2_runner._pair_outcome(manifest, pair, pair_manifest, pair_dir, report)
+    outcome.update(
+        schema_version="forge-multi-checkpoint-behavioral-pair-outcome-3.1.0",
+        document_type="forge_multi_checkpoint_behavioral_pair_outcome",
+        case_id=case.case_id,
+        build_system=case.build_system,
+        case_pair_index=pair["case_pair_index"],
+    )
+    return outcome
+
+
+def _case_summary(case_id: str, outcomes: list[dict[str, Any]]) -> dict[str, Any]:
+    eligible = [item for item in outcomes if item["primary_mechanism_eligible"]]
+    four_cell = Counter()
+    for item in eligible:
+        baseline = item["repair_success"]["baseline"]
+        treatment = item["repair_success"]["treatment"]
+        label = "both" if baseline and treatment else "baseline_only" if baseline else "treatment_only" if treatment else "neither"
+        four_cell[label] += 1
+    requests = {arm: sum(item["arms"][arm]["metrics"]["model_requests"] for item in outcomes) for arm in ARMS}
+    tokens = {arm: sum(item["arms"][arm]["recorded_tokens"] for item in outcomes) for arm in ARMS}
+    transitions = Counter(f"{item['arms']['baseline']['model_behavior']['status']}->{item['arms']['treatment']['model_behavior']['status']}" for item in outcomes)
+    scheduled = len(outcomes)
+    baseline_success = sum(item["repair_success"]["baseline"] for item in outcomes)
+    treatment_success = sum(item["repair_success"]["treatment"] for item in outcomes)
+    return {
+        "case_id": case_id,
+        "scheduled_pairs": scheduled,
+        "eligible_pairs": len(eligible),
+        "paired_four_cell": {name: four_cell[name] for name in ("both", "baseline_only", "treatment_only", "neither")},
+        "requests": requests,
+        "recorded_tokens": tokens,
+        "failure_transitions": dict(sorted(transitions.items())),
+        "itt_repair_success_rate": {
+            "baseline": baseline_success / scheduled,
+            "treatment": treatment_success / scheduled,
+        },
+        "itt_paired_delta": (treatment_success - baseline_success) / scheduled,
+        "pair_ids": [item["pair_id"] for item in outcomes],
+    }
+
+
+def summarize(
+    manifest: dict[str, Any],
+    release: dict[str, str],
+    canary: dict[str, Any],
+    outcomes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    by_case = {case_id: _case_summary(case_id, [item for item in outcomes if item["case_id"] == case_id]) for case_id in manifest["case_source"]["case_ids"]}
+    if any(item["scheduled_pairs"] != 2 for item in by_case.values()):
+        raise AuthorizedPilotError("逐 case 报告缺少两个冻结 pair")
+    macro = {arm: sum(item["itt_repair_success_rate"][arm] for item in by_case.values()) / len(by_case) for arm in ARMS}
+    return {
+        "schema_version": "forge-multi-checkpoint-behavioral-pilot-report-3.1.0",
+        "document_type": "forge_multi_checkpoint_behavioral_pilot_report",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": manifest["execution"]["network_access_medium"],
+        "status": "completed",
+        "canary": canary,
+        "scheduled_pairs": len(manifest["schedule"]),
+        "observed_pairs": len(outcomes),
+        "per_case": by_case,
+        "equal_weight_macro_average": {
+            "case_weights": manifest["analysis"]["case_weights"],
+            "baseline_itt_repair_success_rate": macro["baseline"],
+            "treatment_itt_repair_success_rate": macro["treatment"],
+            "itt_paired_delta": macro["treatment"] - macro["baseline"],
+        },
+        "recorded_tokens": canary["recorded_tokens"] + sum(item["recorded_tokens"] for item in outcomes),
+        "maximum_recorded_tokens": manifest["authorization"]["model_tokens_authorized"],
+        "descriptive_only": True,
+        "p_value_computed": False,
+        "providers_pooled": False,
+        "model_ranking_performed": False,
+        "historical_pairs_pooled": False,
+        "pairs": outcomes,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def run_pilot(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    pair_executor: Any | None = None,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _require_output_dir(manifest, output_dir)
+    release = require_release_identity(manifest, repo_root)
+    require_network_medium(manifest)
+    primary.require_compose_dood()
+    require_zero_managed_containers()
+    canary = _passed_canary(manifest, output_dir, release["revision"])
+    digest = protocol.canonical_sha256(manifest)
+    marker = output_dir / manifest["execution"]["batch_marker"]
+    _claim_marker(marker, kind="forge_multi_checkpoint_pilot_attempt", manifest_sha256=digest, revision=release["revision"])
+    outcomes: list[dict[str, Any]] = []
+    try:
+        with asyncio.Runner() as async_runner:
+            for pair in manifest["schedule"]:
+                pair_dir = output_dir / "pairs" / pair["pair_id"]
+                outcome_path = pair_dir / PAIR_OUTCOME
+                if pair_dir.exists():
+                    raise AuthorizedPilotError(f"pair evidence 已存在，禁止自动补跑: {pair['pair_id']}")
+                used = canary["recorded_tokens"] + sum(item["recorded_tokens"] for item in outcomes)
+                if used + manifest["budget"]["recorded_tokens_per_pair"] > manifest["authorization"]["model_tokens_authorized"]:
+                    raise AuthorizedPilotError("剩余总预算不足以启动下一个完整 pair")
+                if pair_executor is None:
+                    outcome = execute_real_pair(manifest, pair, pair_dir, async_runner)
+                else:
+                    outcome = pair_executor(manifest, pair, pair_dir)
+                _write_once(outcome_path, outcome)
+                outcomes.append(outcome)
+                require_zero_managed_containers()
+        report = summarize(manifest, release, canary, outcomes)
+        if report["recorded_tokens"] > manifest["authorization"]["model_tokens_authorized"]:
+            raise AuthorizedPilotError("pilot 超过授权总 recorded-token 上限")
+        _write_once(output_dir / PILOT_REPORT, report)
+    except BaseException as exc:
+        _finish_marker(marker, status="failed", error_class=type(exc).__name__)
+        raise
+    _finish_marker(marker, status="passed")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "preflight", "canary", "batch"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        result: Any = {
+            "status": "valid",
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    elif args.command == "preflight":
+        result = collect_preflight(manifest, output_dir=args.output_dir)
+    elif args.command == "canary":
+        result = collect_provider_canary(manifest, output_dir=args.output_dir)
+    else:
+        result = run_pilot(manifest, output_dir=args.output_dir)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 派生多 checkpoint behavioral pilot v3 authorized manifest、Schema 与预注册，冻结一次 DeepSeek canary、6 pair / 12 arm 和 1,440,000 recorded-token 总上限。
- 新增零请求 preflight，核对干净主干、`wifi`、Compose/DooD、provider 配置、AK 非空和 0 managed orphan。
- 新增通用 case controlled-pair runtime，复用 #168 的 parent/checkpoint 生命周期和 behavioral v2 的三层终态、单事件循环、candidate verifier、clean replay 与 cleanup。
- Canary marker 和 batch/pair evidence 均为一次性、不可覆盖；失败禁止 retry、replacement、backfill 或 schedule extension。
- 报告逐 case 输出四格、请求、tokens、failure transitions，并使用 case 等权 macro-average；禁止 p 值、provider 池化和模型排名。

## 验证

- 未授权/授权相邻协议回归：`14 passed`
- Janet/Make fake-model Compose/DooD Docker gate：`1 passed in 171.56s`
- Docker gate 后：0 managed container、0 checkpoint image
- Ruff check / format：通过
- protocol validate / py_compile / 敏感信息扫描：通过
- canonical manifest SHA-256：`933891035aa6cf4ddaa842bdb60ff97343099484a1cb1b448b511d1d16081a8e`

## 授权与执行边界

本 PR 的测试阶段保持 0 provider call、0 formal physical attempt、0 model token，未读取 AK。真实 preflight/canary/batch 只允许在本 PR 合并后的干净 `main == origin/main` 上运行；唯一 canary 失败即停止。

Closes #172