### PR TITLE
研究：接入 opaque build provenance 零 provider 生命周期门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-29 — 接入 opaque build provenance 零 provider 生命周期契约
+  - 文件: `scripts/forge_opaque_build_provenance_lifecycle_gate.py`, `backend/tests/test_forge_opaque_build_provenance_lifecycle_gate.py`, `benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md`
+  - 动机: Issue #176 把 #174 的 P2 reference criterion 接到同源 failure checkpoint 双臂边界，先验证 treatment exposure、post-checkpoint conversion 与终态观察顺序，不直接进入 provider 或 Docker 实验。
+  - 结果: baseline/treatment 共用 checkpoint `892cecacebba9410d1fa64dcf24d338efcf7e87b12005db85353946b943b8a40` 和 parent history `ed9c0bad711097c6d28d3b534b78604da92e1b6fcdec6dbfd3383508d7ec016f`；baseline 保持 unproven，treatment 只在 parent ledger 尾部追加 trusted direct-CMake invocation 后转为 P2 proven。Candidate/replay/cleanup observer 按顺序 fail closed，并绑定同一 observation subject SHA-256。
+  - 验证: 本阶段聚焦测试 `17 passed`，连同 #174 P2 gate 的相邻回归为 `38 passed`；Ruff check/format、Python 语法与 CLI validate 通过。固定 0 provider、0 formal attempt、0 model token、`docker_executed=false`；observer 为 deterministic contract callback，不构成真实 candidate/clean replay 证据。
+
 - 2026-08-29 — 建立 opaque build provenance P2 零 provider 契约门禁
   - 文件: `scripts/forge_opaque_build_provenance_gate.py`, `backend/tests/test_forge_opaque_build_provenance_gate.py`, `benchmarks/preregistrations/cpp-opaque-build-provenance-zero-provider-gate.md`
   - 动机: Issue #174 按路线 P 把 `build_system_unproven` 收敛为独立 provenance compliance stratum，避免把合法 native build 的 parser 假阴性表述为普通编译失败。

--- a/backend/tests/test_forge_opaque_build_provenance_lifecycle_gate.py
+++ b/backend/tests/test_forge_opaque_build_provenance_lifecycle_gate.py
@@ -1,0 +1,178 @@
+"""Issue #176 opaque build provenance 生命周期适配的零 provider 门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import asdict, replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "forge_opaque_build_provenance_lifecycle_gate.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location("forge_opaque_build_provenance_lifecycle_gate_test", SCRIPT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+gate = _load_module()
+
+
+def test_parent_checkpoint_is_single_unproven_pre_replay_identity() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    assert checkpoint.validate() is checkpoint
+    assert checkpoint.decision.status == "unproven"
+    assert checkpoint.decision.classification == gate.provenance.FAULT_FAMILY
+    assert checkpoint.decision.reason == gate.PROOF_STATUS
+    assert checkpoint.replay_attempts == 0
+    assert checkpoint.parent_history_sha256 == gate.provenance.command_history_sha256(checkpoint.invocations)
+
+
+def test_arms_share_one_checkpoint_and_only_treatment_receives_packet() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    arms = gate.derive_arms(checkpoint)
+    gate.validate_arm_pair(checkpoint, arms)
+    baseline = arms[gate.BASELINE_ARM]
+    treatment = arms[gate.TREATMENT_ARM]
+    assert baseline.parent_checkpoint_sha256 == treatment.parent_checkpoint_sha256 == checkpoint.checkpoint_sha256
+    assert baseline.common_state_sha256 == treatment.common_state_sha256
+    assert "repair_packet" not in baseline.feedback
+    assert {key: value for key, value in treatment.feedback.items() if key != "repair_packet"} == baseline.feedback
+
+
+def test_repair_packet_is_whitelisted_and_does_not_leak_a_complete_command() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    packet = asdict(gate.build_repair_packet(checkpoint.frozen))
+    assert gate.validate_repair_packet(packet, checkpoint.frozen).proof_status == gate.PROOF_STATUS
+    serialized = json.dumps(packet, sort_keys=True).lower()
+    for forbidden in ("cmake --build", "ninja -c", "bash -lc", "argv", "command_line", "shell"):
+        assert forbidden not in serialized
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value.update(command="cmake --build /workspace/repo/build"), "field set drifted"),
+        (lambda value: value.update(build_directory="/workspace/repo/other"), "identity or whitelist drifted"),
+        (lambda value: value.update(target="other"), "identity or whitelist drifted"),
+        (lambda value: value.update(proof_status="proven"), "identity or whitelist drifted"),
+    ],
+)
+def test_repair_packet_drift_fails_closed(mutation, message: str) -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    packet = asdict(gate.build_repair_packet(checkpoint.frozen))
+    mutation(packet)
+    with pytest.raises(gate.LifecycleGateError, match=message):
+        gate.validate_repair_packet(packet, checkpoint.frozen)
+
+
+def test_baseline_remains_unproven_without_candidate_or_replay() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    arm = gate.derive_arms(checkpoint)[gate.BASELINE_ARM]
+    observers = gate.ContractObservers()
+    outcome = gate.run_arm(checkpoint, arm, observers)
+    assert outcome.p2_decision.status == "unproven"
+    assert outcome.p2_decision.reason == gate.PROOF_STATUS
+    assert outcome.appended_command_ids == ()
+    assert outcome.candidate_status == "not_run"
+    assert outcome.clean_replay_status == "not_run"
+    assert outcome.cleanup_status == "passed"
+    assert observers.calls == ["cleanup"]
+
+
+def test_treatment_appends_trusted_invocation_and_closes_observed_lifecycle() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    arm = gate.derive_arms(checkpoint)[gate.TREATMENT_ARM]
+    observers = gate.ContractObservers()
+    outcome = gate.run_arm(checkpoint, arm, observers)
+    assert outcome.p2_decision.status == "proven"
+    assert outcome.p2_decision.proof_mode == "direct_cmake"
+    assert outcome.parent_history_sha256 == checkpoint.parent_history_sha256
+    assert outcome.appended_command_ids == ("continuation-trusted-cmake-build",)
+    assert outcome.continuation_history_sha256 != checkpoint.parent_history_sha256
+    assert (outcome.candidate_status, outcome.clean_replay_status, outcome.cleanup_status) == ("passed", "passed", "passed")
+    assert observers.calls == ["candidate", "clean_replay", "cleanup"]
+    assert len(outcome.observation_subject_sha256) == 64
+
+
+def test_baseline_rejects_treatment_packet_leakage() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    baseline = gate.derive_arms(checkpoint)[gate.BASELINE_ARM]
+    feedback = copy.deepcopy(baseline.feedback)
+    feedback["repair_packet"] = asdict(gate.build_repair_packet(checkpoint.frozen))
+    with pytest.raises(gate.LifecycleGateError, match="baseline arm was exposed"):
+        replace(baseline, feedback=feedback).validate(checkpoint)
+
+
+@pytest.mark.parametrize(
+    ("fail_at", "expected_calls", "message"),
+    [
+        ("candidate", ["candidate", "cleanup"], "candidate observer failed closed"),
+        ("clean_replay", ["candidate", "clean_replay", "cleanup"], "clean replay observer failed closed"),
+        ("cleanup", ["candidate", "clean_replay", "cleanup"], "cleanup observer failed closed"),
+    ],
+)
+def test_observer_failure_blocks_later_stages_and_cleanup_still_runs(fail_at: str, expected_calls: list[str], message: str) -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    treatment = gate.derive_arms(checkpoint)[gate.TREATMENT_ARM]
+    observers = gate.ContractObservers(fail_at=fail_at)
+    with pytest.raises(gate.LifecycleGateError, match=message):
+        gate.run_arm(checkpoint, treatment, observers)
+    assert observers.calls == expected_calls
+
+
+def test_observer_result_from_another_subject_fails_closed() -> None:
+    class UnboundCandidateObservers(gate.ContractObservers):
+        def candidate(self, subject_sha256: str):
+            result = super().candidate(subject_sha256)
+            return replace(result, subject_sha256="7" * 64)
+
+    checkpoint = gate.build_failure_checkpoint()
+    treatment = gate.derive_arms(checkpoint)[gate.TREATMENT_ARM]
+    observers = UnboundCandidateObservers()
+    with pytest.raises(gate.LifecycleGateError, match="candidate observer subject identity drifted"):
+        gate.run_arm(checkpoint, treatment, observers)
+    assert observers.calls == ["candidate", "cleanup"]
+
+
+def test_parent_ledger_and_artifact_drift_fail_closed() -> None:
+    checkpoint = gate.build_failure_checkpoint()
+    bad_invocation = replace(checkpoint.invocations[-1], ledger_hash="9" * 64)
+    with pytest.raises(gate.LifecycleGateError, match="checkpoint P2 evidence is invalid"):
+        replace(checkpoint, invocations=(checkpoint.invocations[0], bad_invocation)).validate()
+    with pytest.raises(gate.LifecycleGateError, match="checkpoint P2 evidence is invalid"):
+        replace(checkpoint, artifact=replace(checkpoint.artifact, sha256="8" * 64)).validate()
+
+
+def test_cli_reports_contract_observation_boundary_and_zero_counts() -> None:
+    completed = subprocess.run([sys.executable, str(SCRIPT_PATH), "validate"], check=True, capture_output=True, text=True)
+    result = json.loads(completed.stdout)
+    assert result["arm_common_state_equal"] is True
+    assert result["treatment_exposure_only"] == "repair_packet"
+    assert result["baseline"]["p2_decision"]["status"] == "unproven"
+    assert result["treatment"]["p2_decision"]["status"] == "proven"
+    assert result["treatment"]["observer_order"] == ["candidate", "clean_replay", "cleanup"]
+    assert result["observation_mode"] == "deterministic_contract_callback"
+    assert result["docker_executed"] is False
+    assert (result["provider_calls"], result["formal_attempts"], result["model_tokens"]) == (0, 0, 0)
+
+
+def test_source_does_not_access_provider_docker_or_production_lifecycle() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    for forbidden in ("create_chat_model", "deepseek_api_key", "openai_ak", "import docker", "docker.from_env", "compile.operations", "forge_real_lifecycle_checkpoint_gate"):
+        assert forbidden not in source.lower()

--- a/benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md
@@ -1,0 +1,56 @@
+# Opaque build provenance 生命周期零 provider 门禁预注册
+
+本协议承接 Issue #174 的 P2 reference criterion 与 Issue #176。目标是验证 `opaque_build_provenance` 能否安全进入 failure checkpoint 的双臂 continuation 契约，而不是估计模型效果或宣称真实编译成功。
+
+## 实验单位与 capture point
+
+实验单位固定为一个 synthetic CMake failure checkpoint。capture point 是失败 submit 已形成中性反馈、candidate replay 尚未启动、下一次 continuation 尚未发生的时刻。Parent 固定 repository URL、exact commit、image ID、physical attempt、workdir、build directory、target、artifact type/size/SHA-256、两条 trusted invocation 与 ledger hash chain。
+
+Parent artifact 存在且绑定成功的 native Ninja producer command，但 trusted generator link 缺失。P2 reference outcome 固定为：
+
+- `status=unproven`；
+- `mechanism_classification=opaque_build_provenance`；
+- production 对应分类 `build_system_unproven`；
+- `proof_status=missing_trusted_generator_link`；
+- `replay_attempts=0`。
+
+## 双臂唯一差异
+
+Baseline 与 treatment 必须引用同一个 parent checkpoint SHA-256 和 common-state SHA-256，session identity 相互隔离。Baseline 接收原始中性 feedback；treatment 只在同一 feedback 增加一个白名单 `repair_packet`。
+
+Packet 只允许：Schema version、production/mechanism classification、expected/selected CMake identity、冻结 build directory、target、proof status 和抽象 repair goal。禁止 `command`、`argv`、shell、prompt、solution、secret 或完整命令字符串。Packet 不告诉 continuation 使用 `cmake --build`、Ninja 或任何可直接复制的 shell 答案。
+
+## 合成 continuation 与 ledger
+
+本门禁不调用模型。Baseline 确定性不追加 trusted invocation，再次 P2 判定仍为 unproven。Treatment 使用实验夹具模拟一个遵循 repair goal 的 continuation，在 parent ledger 尾部 append 一条新的 trusted direct-CMake build invocation，并把 artifact producer binding 更新到该新 invocation；parent history 必须保持逐对象前缀相等，parent history SHA-256 不变。
+
+Treatment 的预期 P2 outcome 为 `proven/direct_cmake`。这个合成转换只证明 adapter 能表达 post-checkpoint provenance conversion，不能证明模型会采取相同行为。
+
+## 终态 observer
+
+Candidate verification、clean replay 与 cleanup 使用依赖注入的 deterministic contract callback。它们只记录调用顺序和 fail-closed 行为，不执行 production verifier、Docker、Compile Session 或真实 clean replay：
+
+1. baseline 不调用 candidate/replay，只调用 cleanup；
+2. treatment 只有 P2 proven 后才能调用 candidate；
+3. candidate passed 后才能调用 clean replay；
+4. 任一阶段失败都阻断后续阶段，但 cleanup 仍必须运行；
+5. 正向 treatment 顺序固定为 `candidate -> clean_replay -> cleanup`。
+
+三个 observer result 还必须绑定同一个 observation subject SHA-256；该 subject 包含 parent checkpoint、arm/session、P2 decision 与 continuation history。来自其他 arm、checkpoint 或 history 的 `passed` 结果必须 fail closed。
+
+CLI 必须明确输出 `observation_mode=deterministic_contract_callback` 与 `docker_executed=false`，不得把 callback 的 `passed` 写成真实构建证据。
+
+## 零消耗与禁止范围
+
+- `provider_calls=0`；
+- `formal_attempts=0`；
+- `model_tokens=0`；
+- 不读取 AK，不启动 Docker；
+- 不修改 production Compiler、Oracle、`operations.py`；
+- 不修改历史 checkpoint/repair runner、manifest 或 evidence。
+
+## 停止规则与下一门禁
+
+若双臂不能保持同源、packet 必须泄露完整命令、treatment 需要改写 parent ledger、baseline 被误转为 proven，或 observer 可以越过失败阶段，则停止路线 P。
+
+本门禁通过后仍不能创建 provider canary。下一步应单独设计真实 Docker lifecycle gate，使用 fake continuation 或预注册命令在隔离 Compile Session 中闭合真实 candidate verifier、clean replay 与 cleanup；只有该运行时门禁通过并冻结 evidence identity 后，才能申请最小 provider canary。

--- a/scripts/forge_opaque_build_provenance_lifecycle_gate.py
+++ b/scripts/forge_opaque_build_provenance_lifecycle_gate.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Issue #176 opaque build provenance 的零 provider 生命周期门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+import forge_opaque_build_provenance_gate as provenance
+
+SCHEMA_VERSION = "forge-opaque-build-provenance-lifecycle-gate-1.0.0"
+PACKET_SCHEMA_VERSION = "forge-opaque-build-provenance-repair-packet-1.0.0"
+BASELINE_ARM = "baseline"
+TREATMENT_ARM = "treatment"
+ARMS = (BASELINE_ARM, TREATMENT_ARM)
+REPAIR_GOAL = "Execute and record a trusted build bound to the frozen build tree, then resubmit."
+PROOF_STATUS = "missing_trusted_generator_link"
+SESSION_PATTERN = re.compile(r"^[a-z][a-z0-9-]{0,95}$")
+FORBIDDEN_PACKET_FIELDS = frozenset({"argv", "command", "command_line", "prompt", "shell", "solution"})
+
+
+class LifecycleGateError(RuntimeError):
+    """生命周期 checkpoint、packet 或 observer 契约无效。"""
+
+
+def canonical_sha256(value: Any) -> str:
+    return provenance.canonical_sha256(value)
+
+
+@dataclass(frozen=True)
+class FailureCheckpoint:
+    """失败 submit 后、continuation 前冻结的单一 P2 checkpoint。"""
+
+    schema_version: str
+    checkpoint_id: str
+    frozen: provenance.FrozenIdentity
+    invocations: tuple[provenance.InvocationEvidence, ...]
+    artifact: provenance.ArtifactIdentity
+    decision: provenance.ProvenanceDecision
+    parent_history_sha256: str
+    neutral_feedback: dict[str, Any]
+    neutral_feedback_sha256: str
+    replay_attempts: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "checkpoint_id": self.checkpoint_id,
+            "frozen": asdict(self.frozen),
+            "invocations": [asdict(item) for item in self.invocations],
+            "artifact": asdict(self.artifact),
+            "decision": asdict(self.decision),
+            "parent_history_sha256": self.parent_history_sha256,
+            "neutral_feedback": copy.deepcopy(self.neutral_feedback),
+            "neutral_feedback_sha256": self.neutral_feedback_sha256,
+            "replay_attempts": self.replay_attempts,
+        }
+
+    @property
+    def checkpoint_sha256(self) -> str:
+        return canonical_sha256(self.payload())
+
+    def validate(self) -> FailureCheckpoint:
+        if self.schema_version != SCHEMA_VERSION or not SESSION_PATTERN.fullmatch(self.checkpoint_id):
+            raise LifecycleGateError("checkpoint identity is invalid")
+        try:
+            decision = provenance.evaluate_p2(self.frozen, self.invocations, self.artifact)
+            history_sha256 = provenance.command_history_sha256(self.invocations)
+        except provenance.ProvenanceContractError as exc:
+            raise LifecycleGateError("checkpoint P2 evidence is invalid") from exc
+        if decision != self.decision or (decision.status, decision.classification, decision.reason) != (
+            "unproven",
+            provenance.FAULT_FAMILY,
+            PROOF_STATUS,
+        ):
+            raise LifecycleGateError("checkpoint is not the frozen opaque provenance failure")
+        if history_sha256 != self.parent_history_sha256:
+            raise LifecycleGateError("checkpoint parent history identity drifted")
+        if self.neutral_feedback_sha256 != canonical_sha256(self.neutral_feedback):
+            raise LifecycleGateError("checkpoint neutral feedback identity drifted")
+        expected_feedback = {
+            "status": "failed",
+            "submit_attempt_id": "submit-opaque-provenance-1",
+            "primary_classification": provenance.EXPECTED_CLASSIFICATION,
+            "mechanism_classification": provenance.FAULT_FAMILY,
+            "proof_status": PROOF_STATUS,
+            "p2_status": "unproven",
+            "replay_attempts": 0,
+        }
+        if self.neutral_feedback != expected_feedback or self.replay_attempts != 0:
+            raise LifecycleGateError("checkpoint submit or replay identity drifted")
+        return self
+
+
+@dataclass(frozen=True)
+class RepairPacket:
+    """Treatment 唯一允许附加的白名单 provenance repair 信息。"""
+
+    schema_version: str
+    primary_classification: str
+    mechanism_classification: str
+    expected_build_system: str
+    selected_build_system: str
+    build_directory: str
+    target: str
+    proof_status: str
+    repair_goal: str
+
+    def validate(self, frozen: provenance.FrozenIdentity) -> RepairPacket:
+        expected = {
+            "schema_version": PACKET_SCHEMA_VERSION,
+            "primary_classification": provenance.EXPECTED_CLASSIFICATION,
+            "mechanism_classification": provenance.FAULT_FAMILY,
+            "expected_build_system": "cmake",
+            "selected_build_system": "cmake",
+            "build_directory": frozen.build_directory,
+            "target": frozen.target,
+            "proof_status": PROOF_STATUS,
+            "repair_goal": REPAIR_GOAL,
+        }
+        if asdict(self) != expected:
+            raise LifecycleGateError("repair packet identity or whitelist drifted")
+        lowered = self.repair_goal.lower()
+        if "cmake --build" in lowered or "ninja -c" in lowered or "bash -lc" in lowered:
+            raise LifecycleGateError("repair packet leaked a complete command")
+        return self
+
+
+@dataclass(frozen=True)
+class ArmCheckpoint:
+    schema_version: str
+    arm: str
+    session_id: str
+    parent_checkpoint_sha256: str
+    common_state_sha256: str
+    feedback: dict[str, Any]
+
+    def validate(self, checkpoint: FailureCheckpoint) -> ArmCheckpoint:
+        checkpoint.validate()
+        if self.schema_version != SCHEMA_VERSION or self.arm not in ARMS or not SESSION_PATTERN.fullmatch(self.session_id):
+            raise LifecycleGateError("arm checkpoint identity is invalid")
+        if self.parent_checkpoint_sha256 != checkpoint.checkpoint_sha256 or self.common_state_sha256 != checkpoint.checkpoint_sha256:
+            raise LifecycleGateError("arm checkpoint is not derived from the frozen parent")
+        neutral = checkpoint.neutral_feedback
+        if self.arm == BASELINE_ARM:
+            if self.feedback != neutral or "repair_packet" in self.feedback:
+                raise LifecycleGateError("baseline arm was exposed to a repair packet")
+        else:
+            without_packet = {key: value for key, value in self.feedback.items() if key != "repair_packet"}
+            if without_packet != neutral or set(self.feedback) != set(neutral) | {"repair_packet"}:
+                raise LifecycleGateError("treatment feedback differs outside the repair packet")
+            validate_repair_packet(self.feedback["repair_packet"], checkpoint.frozen)
+        return self
+
+
+@dataclass(frozen=True)
+class ObserverResult:
+    stage: str
+    status: str
+    observation_id: str
+    subject_sha256: str
+    mode: str = "deterministic_contract_callback"
+
+    def validate(self, expected_stage: str, expected_subject_sha256: str) -> ObserverResult:
+        if self.stage != expected_stage or self.status not in {"passed", "failed"} or not SESSION_PATTERN.fullmatch(self.observation_id):
+            raise LifecycleGateError(f"{expected_stage} observer returned an invalid result")
+        if self.subject_sha256 != expected_subject_sha256:
+            raise LifecycleGateError(f"{expected_stage} observer subject identity drifted")
+        if self.mode != "deterministic_contract_callback":
+            raise LifecycleGateError(f"{expected_stage} observer mode drifted")
+        return self
+
+
+@dataclass(frozen=True)
+class ArmOutcome:
+    schema_version: str
+    arm: str
+    p2_decision: provenance.ProvenanceDecision
+    parent_history_sha256: str
+    continuation_history_sha256: str
+    appended_command_ids: tuple[str, ...]
+    candidate_status: str
+    clean_replay_status: str
+    cleanup_status: str
+    observer_order: tuple[str, ...]
+    observation_subject_sha256: str
+
+
+class ContractObservers:
+    """记录 lifecycle 顺序的确定性 observer；不执行 Docker 或真实 verifier。"""
+
+    def __init__(self, *, fail_at: str | None = None) -> None:
+        if fail_at not in {None, "candidate", "clean_replay", "cleanup"}:
+            raise LifecycleGateError("unknown observer failure stage")
+        self.fail_at = fail_at
+        self.calls: list[str] = []
+
+    def _observe(self, stage: str, subject_sha256: str) -> ObserverResult:
+        self.calls.append(stage)
+        return ObserverResult(stage, "failed" if self.fail_at == stage else "passed", f"{stage.replace('_', '-')}-observation", subject_sha256)
+
+    def candidate(self, subject_sha256: str) -> ObserverResult:
+        return self._observe("candidate", subject_sha256)
+
+    def clean_replay(self, subject_sha256: str) -> ObserverResult:
+        return self._observe("clean_replay", subject_sha256)
+
+    def cleanup(self, subject_sha256: str) -> ObserverResult:
+        return self._observe("cleanup", subject_sha256)
+
+
+def validate_repair_packet(value: Any, frozen: provenance.FrozenIdentity) -> RepairPacket:
+    if not isinstance(value, dict) or set(value) != set(RepairPacket.__dataclass_fields__):
+        raise LifecycleGateError("repair packet field set drifted")
+    if any(key in FORBIDDEN_PACKET_FIELDS for key in value):
+        raise LifecycleGateError("repair packet contains a forbidden solution field")
+    try:
+        packet = RepairPacket(**value)
+    except TypeError as exc:
+        raise LifecycleGateError("repair packet cannot be parsed") from exc
+    return packet.validate(frozen)
+
+
+def build_failure_checkpoint() -> FailureCheckpoint:
+    artifact_bytes = b"synthetic-cmake-artifact-v1"
+    frozen = provenance.FrozenIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        case_id="cmake-opaque-provenance-lifecycle-case",
+        repository_url="https://github.com/example/opaque-provenance-fixture.git",
+        commit_sha="1" * 40,
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-lifecycle-parent",
+        workdir="/workspace/repo",
+        build_directory="/workspace/repo/build",
+        generator="Ninja",
+        build_tree_sha256="3" * 64,
+        target="fixture",
+        artifact_relative_path="build/fixture",
+        artifact_type="executable",
+        artifact_size=len(artifact_bytes),
+        artifact_sha256=hashlib.sha256(artifact_bytes).hexdigest(),
+    )
+    configure = provenance.record_invocation(
+        command_id="parent-configure",
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cmake",
+        argv=("-S", frozen.workdir, "-B", frozen.build_directory, "-G", frozen.generator),
+        workdir=frozen.workdir,
+        previous_hash=provenance.ZERO_HASH,
+    )
+    native_build = provenance.record_invocation(
+        command_id="parent-native-build",
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="ninja",
+        argv=("-C", frozen.build_directory, frozen.target),
+        workdir=frozen.workdir,
+        previous_hash=configure.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+    )
+    invocations = (configure, native_build)
+    artifact = provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=native_build.command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=3,
+    )
+    decision = provenance.evaluate_p2(frozen, invocations, artifact)
+    neutral_feedback = {
+        "status": "failed",
+        "submit_attempt_id": "submit-opaque-provenance-1",
+        "primary_classification": provenance.EXPECTED_CLASSIFICATION,
+        "mechanism_classification": provenance.FAULT_FAMILY,
+        "proof_status": PROOF_STATUS,
+        "p2_status": "unproven",
+        "replay_attempts": 0,
+    }
+    return FailureCheckpoint(
+        schema_version=SCHEMA_VERSION,
+        checkpoint_id="opaque-provenance-checkpoint-1",
+        frozen=frozen,
+        invocations=invocations,
+        artifact=artifact,
+        decision=decision,
+        parent_history_sha256=provenance.command_history_sha256(invocations),
+        neutral_feedback=neutral_feedback,
+        neutral_feedback_sha256=canonical_sha256(neutral_feedback),
+        replay_attempts=0,
+    ).validate()
+
+
+def build_repair_packet(frozen: provenance.FrozenIdentity) -> RepairPacket:
+    return RepairPacket(
+        schema_version=PACKET_SCHEMA_VERSION,
+        primary_classification=provenance.EXPECTED_CLASSIFICATION,
+        mechanism_classification=provenance.FAULT_FAMILY,
+        expected_build_system="cmake",
+        selected_build_system="cmake",
+        build_directory=frozen.build_directory,
+        target=frozen.target,
+        proof_status=PROOF_STATUS,
+        repair_goal=REPAIR_GOAL,
+    ).validate(frozen)
+
+
+def derive_arms(checkpoint: FailureCheckpoint) -> dict[str, ArmCheckpoint]:
+    checkpoint.validate()
+    packet = asdict(build_repair_packet(checkpoint.frozen))
+    baseline = ArmCheckpoint(
+        SCHEMA_VERSION,
+        BASELINE_ARM,
+        "baseline-opaque-provenance-session",
+        checkpoint.checkpoint_sha256,
+        checkpoint.checkpoint_sha256,
+        copy.deepcopy(checkpoint.neutral_feedback),
+    )
+    treatment_feedback = copy.deepcopy(checkpoint.neutral_feedback)
+    treatment_feedback["repair_packet"] = packet
+    treatment = ArmCheckpoint(
+        SCHEMA_VERSION,
+        TREATMENT_ARM,
+        "treatment-opaque-provenance-session",
+        checkpoint.checkpoint_sha256,
+        checkpoint.checkpoint_sha256,
+        treatment_feedback,
+    )
+    arms = {BASELINE_ARM: baseline.validate(checkpoint), TREATMENT_ARM: treatment.validate(checkpoint)}
+    validate_arm_pair(checkpoint, arms)
+    return arms
+
+
+def validate_arm_pair(checkpoint: FailureCheckpoint, arms: dict[str, ArmCheckpoint]) -> None:
+    if set(arms) != set(ARMS):
+        raise LifecycleGateError("lifecycle gate requires exactly two frozen arms")
+    baseline = arms[BASELINE_ARM].validate(checkpoint)
+    treatment = arms[TREATMENT_ARM].validate(checkpoint)
+    if baseline.session_id == treatment.session_id:
+        raise LifecycleGateError("arm session identities must be isolated")
+    if baseline.common_state_sha256 != treatment.common_state_sha256:
+        raise LifecycleGateError("arm common checkpoint state drifted")
+    if {key: value for key, value in treatment.feedback.items() if key != "repair_packet"} != baseline.feedback:
+        raise LifecycleGateError("treatment differs from baseline outside repair_packet")
+
+
+def _append_treatment_invocation(checkpoint: FailureCheckpoint) -> tuple[tuple[provenance.InvocationEvidence, ...], provenance.ArtifactIdentity]:
+    parent = checkpoint.invocations
+    continuation = provenance.record_invocation(
+        command_id="continuation-trusted-cmake-build",
+        physical_attempt_id=checkpoint.frozen.physical_attempt_id,
+        sequence=len(parent) + 1,
+        repository_url=checkpoint.frozen.repository_url,
+        commit_sha=checkpoint.frozen.commit_sha,
+        image_id=checkpoint.frozen.image_id,
+        executable="cmake",
+        argv=("--build", checkpoint.frozen.build_directory, "--target", checkpoint.frozen.target),
+        workdir=checkpoint.frozen.workdir,
+        previous_hash=parent[-1].ledger_hash,
+        output_paths=(checkpoint.frozen.artifact_relative_path,),
+    )
+    artifact = replace(
+        checkpoint.artifact,
+        producer_command_id=continuation.command_id,
+        observed_after_sequence=continuation.sequence + 1,
+    )
+    return (*parent, continuation), artifact
+
+
+def run_arm(checkpoint: FailureCheckpoint, arm: ArmCheckpoint, observers: ContractObservers) -> ArmOutcome:
+    checkpoint.validate()
+    arm.validate(checkpoint)
+    parent_sha256 = provenance.command_history_sha256(checkpoint.invocations)
+    if arm.arm == BASELINE_ARM:
+        invocations = checkpoint.invocations
+        artifact = checkpoint.artifact
+    else:
+        validate_repair_packet(arm.feedback["repair_packet"], checkpoint.frozen)
+        invocations, artifact = _append_treatment_invocation(checkpoint)
+    if invocations[: len(checkpoint.invocations)] != checkpoint.invocations:
+        raise LifecycleGateError("continuation rewrote the parent command history")
+
+    try:
+        decision = provenance.evaluate_p2(checkpoint.frozen, invocations, artifact)
+    except provenance.ProvenanceContractError as exc:
+        raise LifecycleGateError("continuation P2 evaluation failed closed") from exc
+
+    candidate_status = "not_run"
+    replay_status = "not_run"
+    cleanup_status = "not_run"
+    continuation_history_sha256 = provenance.command_history_sha256(invocations)
+    observation_subject_sha256 = canonical_sha256(
+        {
+            "checkpoint_sha256": checkpoint.checkpoint_sha256,
+            "arm": arm.arm,
+            "session_id": arm.session_id,
+            "p2_decision": asdict(decision),
+            "continuation_history_sha256": continuation_history_sha256,
+        }
+    )
+    try:
+        if arm.arm == BASELINE_ARM:
+            if decision.status != "unproven" or decision.reason != PROOF_STATUS:
+                raise LifecycleGateError("baseline unexpectedly converted provenance")
+        else:
+            if decision.status != "proven":
+                raise LifecycleGateError("treatment did not convert provenance to P2")
+            candidate = observers.candidate(observation_subject_sha256).validate("candidate", observation_subject_sha256)
+            candidate_status = candidate.status
+            if candidate.status != "passed":
+                raise LifecycleGateError("candidate observer failed closed")
+            replay = observers.clean_replay(observation_subject_sha256).validate("clean_replay", observation_subject_sha256)
+            replay_status = replay.status
+            if replay.status != "passed":
+                raise LifecycleGateError("clean replay observer failed closed")
+    finally:
+        cleanup = observers.cleanup(observation_subject_sha256).validate("cleanup", observation_subject_sha256)
+        cleanup_status = cleanup.status
+        if cleanup.status != "passed":
+            raise LifecycleGateError("cleanup observer failed closed")
+
+    appended_ids = tuple(item.command_id for item in invocations[len(checkpoint.invocations) :])
+    return ArmOutcome(
+        schema_version=SCHEMA_VERSION,
+        arm=arm.arm,
+        p2_decision=decision,
+        parent_history_sha256=parent_sha256,
+        continuation_history_sha256=continuation_history_sha256,
+        appended_command_ids=appended_ids,
+        candidate_status=candidate_status,
+        clean_replay_status=replay_status,
+        cleanup_status=cleanup_status,
+        observer_order=tuple(observers.calls),
+        observation_subject_sha256=observation_subject_sha256,
+    )
+
+
+def validate_gate() -> dict[str, Any]:
+    checkpoint = build_failure_checkpoint()
+    arms = derive_arms(checkpoint)
+    baseline = run_arm(checkpoint, arms[BASELINE_ARM], ContractObservers())
+    treatment = run_arm(checkpoint, arms[TREATMENT_ARM], ContractObservers())
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "checkpoint_sha256": checkpoint.checkpoint_sha256,
+        "parent_history_sha256": checkpoint.parent_history_sha256,
+        "arm_common_state_equal": arms[BASELINE_ARM].common_state_sha256 == arms[TREATMENT_ARM].common_state_sha256,
+        "treatment_exposure_only": "repair_packet",
+        "baseline": asdict(baseline),
+        "treatment": asdict(treatment),
+        "observation_mode": "deterministic_contract_callback",
+        "docker_executed": False,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    _parser().parse_args(argv)
+    print(json.dumps(validate_gate(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 experiment-only opaque build provenance lifecycle adapter，把 #174 的 P2 evaluator 接到同源 failure checkpoint 双臂边界。
- 冻结 baseline/treatment 唯一差异为白名单 `repair_packet`，拒绝完整命令、额外字段、identity 漂移和 baseline 泄露。
- baseline 保持 `opaque_build_provenance / unproven`；treatment 只在 parent ledger 尾部追加 trusted direct-CMake invocation 后转为 P2 proven。
- candidate、clean replay、cleanup 使用绑定同一 subject SHA-256 的 deterministic callback 验证顺序和 fail-closed 行为。
- 新增预注册，明确 callback 结果不是真实 Docker candidate/replay 证据。

## 验证

- 本阶段聚焦测试：`17 passed`
- 连同 #174 P2 gate 相邻回归：`38 passed`
- Ruff check 与 format check 通过
- Python 语法、CLI validate、`git diff --check` 通过

## 边界

- `provider_calls=0`
- `formal_attempts=0`
- `model_tokens=0`
- `docker_executed=false`
- 未读取 AK，未修改 production Compiler/Oracle、`operations.py`、历史 runner/manifest/evidence

Closes #176