### PR TITLE
研究：闭合 opaque build provenance 真实 Docker 生命周期门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 闭合 opaque build provenance 真实 Docker 生命周期门禁
+  - 文件: `scripts/forge_opaque_build_provenance_real_docker_gate.py`, `backend/tests/test_forge_opaque_build_provenance_real_docker_gate.py`, `backend/tests/test_forge_opaque_build_provenance_real_docker_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md`
+  - 动机: Issue #178 为 #174 P2 reference criterion 与 #176 合成 lifecycle adapter 补充真实 production candidate verifier、独立 clean replay 和 cleanup 证据；不修改 production Compiler/Oracle、`operations.py` 或历史 evidence。
+  - 结果: 自包含 opaque `sh -c` parent 在真实 CMake/Ninja 项目中只触发 `build_system_unproven`，P2 为 `unproven/opaque_wrapper`；同源 baseline 保持 unproven、0 replay，treatment 仅接收白名单 packet并 append direct `cmake --build` 后转为 P2 `proven/direct_cmake`，production candidate 与 clean replay 均 passed，最终 container/image 0 orphan。
+  - 验证: Ubuntu-native provider gate 确认为 `/var/run/docker.sock`；真实 opt-in gate `1 passed in 74.34s`，相邻静态回归 `47 passed`，Ruff check/format、Python 语法和 `git diff --check` 通过。固定 0 provider call、0 formal physical attempt、0 model token，未读取 AK。
+
 - 2026-08-29 — 接入 opaque build provenance 零 provider 生命周期契约
   - 文件: `scripts/forge_opaque_build_provenance_lifecycle_gate.py`, `backend/tests/test_forge_opaque_build_provenance_lifecycle_gate.py`, `benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md`
   - 动机: Issue #176 把 #174 的 P2 reference criterion 接到同源 failure checkpoint 双臂边界，先验证 treatment exposure、post-checkpoint conversion 与终态观察顺序，不直接进入 provider 或 Docker 实验。
@@ -436,6 +442,10 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- 真实 lifecycle capture 的 evidence Schema 强制要求 `submit_attempt_id`；只记录 classification/failure ID 会在 environment freeze 前 fail closed。新 gate 应直接从同一 `failure.recorded` payload 复制该 ID，并先做 Schema 级静态断言。
+- Budget checkpoint 中“请求容量”与“实际请求数”是两个概念：原型要求 `limits.provider_requests >= 1`，零 provider gate 应保持正容量但让 consumed/external counts 为 0，不能把容量 0 误写成零调用证明。
+- `sh -c` wrapper 的 role parser 能递归看到 configure/build，但 `_command_contains_arguments` 只看到整段 inner command token；若 policy 冻结非空 CMake 参数，会额外产生 `cmake_arguments_not_observed`。研究 opaque provenance 时应把非 estimand 参数约束显式冻结为空，并从 authoritative `session.verification.checks` 核对 failure 列表，而不能只看 primary classification。
 
 - 冻结 manifest 中的容器路径不能用宿主 `Path` 再 `str()` 序列化；Windows 会生成反斜杠而 WSL/Linux 重算为正斜杠，导致跨环境 identity 漂移。协议使用固定 POSIX 字符串，`Path` 只用于运行时访问。
 - PowerShell 调 WSL 的 `docker info --format` 时，含 `|` 的 Go template 可能失去参数引号并被 Bash 当作管道。daemon 摘要统一使用无特殊字符的 `docker info --format json`，再在 PowerShell 侧解析；不要继续调试多层模板引号。

--- a/backend/tests/test_forge_opaque_build_provenance_real_docker_gate.py
+++ b/backend/tests/test_forge_opaque_build_provenance_real_docker_gate.py
@@ -1,0 +1,141 @@
+"""Issue #178 真实 Docker gate adapter 的零 provider 静态门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "forge_opaque_build_provenance_real_docker_gate.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "forge_opaque_build_provenance_real_docker_gate_test",
+            SCRIPT_PATH,
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+gate = _load_module()
+
+
+def _frozen():
+    return gate.build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-static-test",
+        build_tree_sha256="3" * 64,
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+
+
+def test_parent_wrapper_is_replayable_but_does_not_prove_cmake_identity() -> None:
+    result = gate.validate_parent_command_contract()
+    assert result == {
+        "roles": ["artifact_stage", "build", "configure"],
+        "top_level_executable": "sh",
+        "cmake_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+    assert "cmake -S examples" in gate.PARENT_COMMAND
+    assert "cmake --build build" in gate.PARENT_COMMAND
+    assert "/artifacts/accumulate_examples" in gate.PARENT_COMMAND
+
+
+def test_repair_packet_is_whitelisted_and_does_not_leak_a_command() -> None:
+    packet = gate.validate_repair_packet(gate.build_repair_packet())
+    assert packet["proof_status"] == "opaque_wrapper"
+    assert packet["build_directory"] == "/workspace/repo/build"
+    serialized = json.dumps(packet, sort_keys=True).lower()
+    for forbidden in ("cmake --build", "sh -c", "argv", "api_key"):
+        assert forbidden not in serialized
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(command="cmake --build build"),
+        lambda value: value.update(build_directory="/workspace/repo/other"),
+        lambda value: value.update(proof_status="proven"),
+    ],
+)
+def test_repair_packet_drift_fails_closed(mutation) -> None:
+    packet = gate.build_repair_packet()
+    mutation(packet)
+    with pytest.raises(gate.RealDockerGateError, match="identity or whitelist drifted"):
+        gate.validate_repair_packet(packet)
+
+
+def test_parent_p2_is_unproven_and_treatment_is_append_only_proven() -> None:
+    frozen = _frozen()
+    parent, parent_history = gate.evaluate_parent(
+        frozen,
+        parent_command_id="parent-wrapper",
+    )
+    treatment, treatment_history = gate.evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-build",
+        treatment_stage_command_id="treatment-stage",
+    )
+    assert parent.status == "unproven"
+    assert parent.classification == gate.provenance.FAULT_FAMILY
+    assert parent.reason == "opaque_wrapper"
+    assert treatment.status == "proven"
+    assert treatment.proof_mode == "direct_cmake"
+    assert treatment_history[: len(parent_history)] == parent_history
+    assert gate.provenance.command_history_sha256(treatment_history) != gate.provenance.command_history_sha256(parent_history)
+
+
+def test_identity_drift_fails_closed() -> None:
+    frozen = _frozen()
+    with pytest.raises(gate.provenance.ProvenanceContractError, match="frozen artifact identity is invalid"):
+        gate.evaluate_parent(
+            replace(frozen, artifact_size=0),
+            parent_command_id="parent-wrapper",
+        )
+
+
+def test_cli_reports_zero_external_counts_and_no_docker_execution() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "validate"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = json.loads(completed.stdout)
+    assert result["parent"]["status"] == "unproven"
+    assert result["treatment"]["status"] == "proven"
+    assert result["parent_history_prefix_preserved"] is True
+    assert result["docker_executed"] is False
+    assert (result["provider_calls"], result["formal_attempts"], result["model_tokens"]) == (0, 0, 0)
+
+
+def test_source_does_not_access_provider_credentials_or_formal_runner() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "create_chat_model",
+        "openai_ak",
+        "deepseek_api_key",
+        "os.getenv",
+        "import docker",
+        "docker.from_env",
+        "execute_collection",
+    ):
+        assert forbidden not in source

--- a/backend/tests/test_forge_opaque_build_provenance_real_docker_gate_docker.py
+++ b/backend/tests/test_forge_opaque_build_provenance_real_docker_gate_docker.py
@@ -1,0 +1,579 @@
+"""Issue #178 opaque build provenance 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import (
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices, submit_build_result_impl
+from deerflow.compile.paths import (
+    get_host_artifacts_dir,
+    get_host_logs_dir,
+    get_host_repro_dir,
+    get_host_workspace_dir,
+)
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_module(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+adapter = _load_module(
+    "forge_opaque_build_provenance_real_docker_adapter",
+    "forge_opaque_build_provenance_real_docker_gate.py",
+)
+lifecycle = _load_module(
+    "forge_opaque_build_provenance_real_docker_lifecycle",
+    "forge_real_lifecycle_checkpoint_gate.py",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_ubuntu_native_docker():
+    if not DOCKER_ENABLED:
+        yield
+        return
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Ubuntu native Docker is unavailable: {daemon.stderr.strip()}")
+    image = subprocess.run(
+        ["docker", "image", "inspect", adapter.COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {adapter.COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _record_command(
+    *,
+    manager: CompileSessionManager,
+    runtime: CompileDockerRuntime,
+    session: Any,
+    command: str,
+    role: str,
+) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(
+        session,
+        command,
+        workdir=adapter.WORKDIR,
+        timeout_seconds=300,
+    )
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir=adapter.WORKDIR,
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=300,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination=("timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed")),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def _policy(*, image_id: str) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-real-docker-gate",
+        manifest_sha256="8" * 64,
+        case_id=adapter.CASE_ID,
+        condition="opaque-build-provenance-zero-provider",
+        repetition=1,
+        expected_repo_url=adapter.REPOSITORY_URL,
+        expected_commit_sha=adapter.COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=adapter.COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        model_max_retries=0,
+        compiler_max_turns=8,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir="examples",
+        build_targets=(adapter.TARGET,),
+        artifact_instructions=((adapter.STAGED_ARTIFACT, adapter.BUILD_OUTPUT, "executable"),),
+    )
+
+
+def _budget_manifest(capture_id: str, _message_sha256: str) -> dict[str, Any]:
+    return lifecycle.budget_checkpoint.build_manifest(
+        checkpoint_id=capture_id,
+        limits={
+            "provider_requests": 1,
+            "compiler_invocations": 2,
+            "compiler_model_turns": 0,
+            "graph_recursion_steps": 8,
+            "attempt_wall_clock_seconds": 900,
+            "attempt_cleanup_reserve_seconds": 120,
+            "compiler_wall_clock_seconds": 720,
+            "compiler_post_build_reserve_seconds": 120,
+            "post_build_commands": 2,
+        },
+        consumed_before_capture={
+            "provider_requests": 0,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 0,
+            "graph_recursion_steps": 3,
+            "attempt_wall_clock_seconds": 10,
+            "compiler_wall_clock_seconds": 5,
+            "post_build_commands": 0,
+            "tokens": 0,
+        },
+        post_build_started=True,
+    )
+
+
+def _arm_plan(capture_id: str) -> dict[str, dict[str, str]]:
+    return {
+        arm: {
+            "thread_id": f"{arm}-{capture_id}-thread",
+            "session_id": f"{arm}-{capture_id}-session",
+            "environment_id": f"{arm}-{capture_id}-environment",
+        }
+        for arm in ("baseline", "treatment")
+    }
+
+
+def _failure_event(ledger: ExperimentLedger) -> dict[str, Any]:
+    failures = [event for event in ledger.read() if event["event"] == "failure.recorded"]
+    assert len(failures) == 1
+    return failures[0]
+
+
+def _constraint_failures(session: Any) -> list[str]:
+    assert session.verification is not None
+    benchmark = [check for check in session.verification.checks if check.name == "benchmark_constraints"]
+    return [] if not benchmark else list(benchmark[0].actual)
+
+
+def _feedback(message_runtime: Any, config: dict[str, Any]) -> dict[str, Any]:
+    messages = message_runtime.graph.get_state(config).values["messages"]
+    return json.loads(messages[-1].content)
+
+
+def test_real_parent_checkpoint_treatment_replay_and_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter.validate_gate_contract()
+    capture_id = f"issue178-{uuid.uuid4().hex[:10]}"
+    workspace = tmp_path / "workspace"
+    paths = Paths(
+        base_dir=tmp_path / ".deer-flow",
+        workspace_root=workspace,
+        host_workspace_root=str(workspace),
+    )
+    manager = CompileSessionManager(paths=paths, default_image=adapter.COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    docker = lifecycle.environment_checkpoint.DockerCLI()
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=adapter.REPOSITORY_URL,
+        image=adapter.COMPILE_IMAGE,
+    )
+    parent_ledger = ExperimentLedger.create(
+        tmp_path / "parent-ledger.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-178-opaque-provenance-real-docker-gate"},
+    )
+    active_threads: set[str] = set()
+    arm_sessions: list[Any] = []
+    continuation_images: set[str] = set()
+    known_container_ids: set[str] = set()
+    known_replay_container_ids: set[str] = set()
+    gate = None
+    cleaned = False
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        assert parent.image_id is not None and parent.container_id is not None
+        known_container_ids.add(parent.container_id)
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {adapter.REPOSITORY_URL} && git fetch --depth 1 origin {adapter.COMMIT_SHA} && git checkout --detach FETCH_HEAD",
+            workdir=adapter.WORKDIR,
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        parent.commit_sha = adapter.COMMIT_SHA
+        parent.build_system = "cmake"
+        parent.build_system_capabilities = ["cmake"]
+        parent.selected_build_system = "cmake"
+        parent.status = "inspected"
+        manager.save_session(parent)
+
+        supporting = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=parent,
+            command=adapter.PARENT_COMMAND,
+            role="build",
+        )
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        workspace_artifact = Path(parent.leadagent_repo_dir) / adapter.BUILD_OUTPUT
+        build_tree = Path(parent.leadagent_repo_dir) / "build" / "build.ninja"
+        assert workspace_artifact.is_file() and build_tree.is_file()
+        parent_frozen = adapter.build_frozen_identity(
+            image_id=parent.image_id,
+            physical_attempt_id=f"{capture_id}-parent",
+            build_tree_sha256=lifecycle.sha256_file(build_tree),
+            artifact_size=workspace_artifact.stat().st_size,
+            artifact_sha256=lifecycle.sha256_file(workspace_artifact),
+        )
+        parent_p2, _ = adapter.evaluate_parent(
+            parent_frozen,
+            parent_command_id=supporting.command_id,
+        )
+        assert parent_p2.reason == "opaque_wrapper"
+
+        activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_policy(image_id=parent.image_id),
+        )
+        active_threads.add(parent.thread_id)
+        submit_results: list[str] = []
+
+        def submit_parent() -> str:
+            result = submit_build_result_impl(
+                session=parent,
+                supporting_command_id=supporting.command_id,
+            )
+            submit_results.append(result)
+            return result
+
+        def capture_evidence() -> dict[str, Any]:
+            failure = _failure_event(parent_ledger)
+            return {
+                "classification": failure["payload"]["classification"],
+                "failure_id": failure["payload"]["failure_id"],
+                "submit_attempt_id": failure["payload"]["submit_attempt_id"],
+                "session_sha256": lifecycle.sha256_file(Path(parent.metadata_path)),
+                "parent_p2": asdict(parent_p2),
+                "parent_command_history_sha256": adapter.provenance.command_history_sha256(
+                    adapter.evaluate_parent(
+                        parent_frozen,
+                        parent_command_id=supporting.command_id,
+                    )[1]
+                ),
+            }
+
+        snapshot = tmp_path / "snapshot"
+        coordinator = lifecycle.CaptureCoordinator(tmp_path / "coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(tmp_path / "messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = lifecycle.LifecycleMessageRuntime(
+                saver,
+                submit_parent,
+                repair_packet=adapter.build_repair_packet(),
+            )
+            environment = lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=str(snapshot),
+            )
+            gate = lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=_budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="issue-178-real-docker-gate",
+            )
+            capture = gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="freeze the opaque build provenance failure before continuation",
+                arm_plan=_arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "artifacts": get_host_artifacts_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "logs": get_host_logs_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "repro": get_host_repro_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                },
+                evidence=capture_evidence,
+            )
+            continuation_images.add(capture["environment"]["continuation_image_id"])
+            parent_payload = json.loads(submit_results[0])
+            parent_failure = _failure_event(parent_ledger)["payload"]
+            assert parent_payload["status"] == "failed"
+            assert parent_payload["candidate_status"] == "failed"
+            assert parent_payload["replay_status"] == "not_run"
+            assert parent.replay_attempts == []
+            assert parent_failure["classification"] == "build_system_unproven"
+            assert parent_failure["secondary_classifications"] == []
+            assert _constraint_failures(parent) == ["build_system_unproven"]
+            deactivate_experiment(parent.thread_id)
+            active_threads.remove(parent.thread_id)
+
+            baseline = gate.provision_arm(capture_id, "baseline", parent_session=parent)
+            treatment = gate.provision_arm(capture_id, "treatment", parent_session=parent)
+            arm_sessions.extend([baseline.session, treatment.session])
+            known_container_ids.update(session.container_id for session in arm_sessions if session.container_id is not None)
+            assert gate.canonical_arm_environment("baseline") == gate.canonical_arm_environment("treatment")
+            assert _feedback(message_runtime, baseline.message_config).get("repair_packet") is None
+            treatment_feedback = _feedback(message_runtime, treatment.message_config)
+            assert adapter.validate_repair_packet(treatment_feedback["repair_packet"]) == adapter.build_repair_packet()
+            assert {key: value for key, value in treatment_feedback.items() if key != "repair_packet"} == _feedback(message_runtime, baseline.message_config)
+
+            assert baseline.session.image_id == treatment.session.image_id
+            branch_artifact = Path(treatment.session.leadagent_repo_dir) / adapter.BUILD_OUTPUT
+            branch_tree = Path(treatment.session.leadagent_repo_dir) / "build" / "build.ninja"
+            branch_frozen = adapter.build_frozen_identity(
+                image_id=treatment.session.image_id,
+                physical_attempt_id=f"{capture_id}-branches",
+                build_tree_sha256=lifecycle.sha256_file(branch_tree),
+                artifact_size=branch_artifact.stat().st_size,
+                artifact_sha256=lifecycle.sha256_file(branch_artifact),
+            )
+            baseline_p2, baseline_history = adapter.evaluate_parent(
+                branch_frozen,
+                parent_command_id=supporting.command_id,
+            )
+            assert baseline_p2.status == "unproven"
+
+            arm_ledgers: dict[str, ExperimentLedger] = {}
+            for arm in (baseline, treatment):
+                ledger = ExperimentLedger.create(
+                    tmp_path / f"{arm.arm}-ledger.jsonl",
+                    experiment_id=new_evidence_id("experiment"),
+                    physical_attempt_id=new_evidence_id("physical_attempt"),
+                    context={"scope": "issue-178-arm", "arm": arm.arm},
+                )
+                arm_ledgers[arm.arm] = ledger
+                activate_experiment(
+                    thread_id=arm.session.thread_id,
+                    experiment_id=ledger.experiment_id,
+                    physical_attempt_id=ledger.physical_attempt_id,
+                    ledger=ledger,
+                    policy=_policy(image_id=arm.session.image_id),
+                )
+                active_threads.add(arm.session.thread_id)
+
+            baseline_payload = json.loads(
+                submit_build_result_impl(
+                    session=baseline.session,
+                    supporting_command_id=supporting.command_id,
+                )
+            )
+            assert baseline_payload["status"] == "failed"
+            assert baseline_payload["replay_status"] == "not_run"
+            assert baseline.session.replay_attempts == []
+            assert _failure_event(arm_ledgers["baseline"])["payload"]["classification"] == "build_system_unproven"
+            assert _constraint_failures(baseline.session) == ["build_system_unproven"]
+
+            treatment_build = _record_command(
+                manager=manager,
+                runtime=runtime,
+                session=treatment.session,
+                command=adapter.TREATMENT_BUILD_COMMAND,
+                role="build",
+            )
+            treatment_stage = _record_command(
+                manager=manager,
+                runtime=runtime,
+                session=treatment.session,
+                command=adapter.TREATMENT_STAGE_COMMAND,
+                role="artifact_stage",
+            )
+            assert branch_artifact.stat().st_size == branch_frozen.artifact_size
+            assert lifecycle.sha256_file(branch_artifact) == branch_frozen.artifact_sha256
+            treatment_p2, treatment_history = adapter.evaluate_treatment(
+                branch_frozen,
+                parent_command_id=supporting.command_id,
+                treatment_build_command_id=treatment_build.command_id,
+                treatment_stage_command_id=treatment_stage.command_id,
+            )
+            assert treatment_p2.status == "proven"
+            assert treatment_history[: len(baseline_history)] == baseline_history
+
+            treatment_payload = json.loads(
+                submit_build_result_impl(
+                    session=treatment.session,
+                    supporting_command_id=treatment_build.command_id,
+                )
+            )
+            assert treatment_payload["status"] == "passed", treatment_payload
+            assert treatment_payload["candidate_status"] == "passed"
+            assert treatment_payload["replay_status"] == "passed"
+            assert len(treatment.session.replay_attempts) == 1
+            replay = treatment.session.replay_attempts[0]
+            assert replay.status == "passed" and replay.cleanup_succeeded is True
+            if replay.container_id is not None:
+                known_replay_container_ids.add(replay.container_id)
+
+            for thread_id in tuple(active_threads):
+                deactivate_experiment(thread_id)
+                active_threads.remove(thread_id)
+            record = gate.cleanup(capture_id, parent_session=parent)
+            cleaned = True
+            assert record.phase == "cleaned"
+            assert record.payload["cleanup"]["succeeded"] is True
+            assert gate.external_counts() == {
+                "provider_calls": 0,
+                "formal_physical_attempts": 0,
+                "model_tokens": 0,
+            }
+    finally:
+        for thread_id in tuple(active_threads):
+            deactivate_experiment(thread_id)
+        if gate is not None and not cleaned:
+            try:
+                gate.cleanup(capture_id, parent_session=parent)
+            except Exception:
+                pass
+        for session in arm_sessions:
+            runtime.stop_and_remove_container(session)
+        runtime.stop_and_remove_container(parent)
+        for container_id in docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split():
+            docker.run(["rm", "-f", container_id], check=False, timeout_seconds=30)
+        continuation_images.update(
+            docker.run(
+                [
+                    "image",
+                    "ls",
+                    "-q",
+                    "--filter",
+                    f"label={lifecycle.CAPTURE_LABEL}={capture_id}",
+                ],
+                check=False,
+                timeout_seconds=30,
+            ).stdout.split()
+        )
+        for image_id in continuation_images:
+            docker.run(["image", "rm", "-f", image_id], check=False, timeout_seconds=60)
+
+    for container_id in known_container_ids | known_replay_container_ids:
+        assert (
+            docker.run(
+                ["container", "inspect", container_id],
+                check=False,
+                timeout_seconds=20,
+            ).returncode
+            != 0
+        )
+    assert (
+        docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )
+    assert (
+        docker.run(
+            [
+                "image",
+                "ls",
+                "-q",
+                "--filter",
+                f"label={lifecycle.CAPTURE_LABEL}={capture_id}",
+            ],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )

--- a/benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md
@@ -1,0 +1,70 @@
+# C/C++ opaque build provenance 真实 Docker 零 provider 门禁预注册
+
+## 身份
+
+- Tracking Issue：#178
+- Schema：`forge-opaque-build-provenance-real-docker-gate-1.0.0`
+- Case：`cppitertools@531b3d753d2bbfe3b0ababe61c2e95e965c54a66`
+- 构建系统：CMake + Ninja
+- Compile image：`autocompiler:gcc13`，运行时固定实际 image ID
+- Fault family：`opaque_build_provenance`
+- Production classification：`build_system_unproven`
+- P2 parent reason：`opaque_wrapper`
+
+## 研究目的
+
+Issue #174 已证明 P2 reference criterion 能区分可信 direct CMake、可信 generator link 与 opaque/unbound invocation；Issue #176 已证明 failure checkpoint 双臂和 observation binding 的合成生命周期契约。本门禁只补真实执行证据：在同一个可恢复 CMake checkpoint 上闭合 production candidate verifier、独立 clean replay 和 cleanup。
+
+本门禁不测模型效果，不产生正式实验样本，也不把 provenance compliance repair 表述为普通编译失败修复。
+
+## Controlled fault
+
+Parent Compile Session 在 trusted runtime 中执行一条顶层为 `sh -c` 的自包含命令。Wrapper 内真实完成：
+
+1. 清理并用 CMake + Ninja configure 冻结 build directory；
+2. 构建真实 `accumulate_examples` target；
+3. 将 executable staging 到 `/artifacts/accumulate_examples`。
+
+Production role parser 能从 wrapper 叶子文本识别 `configure/build/artifact_stage`，但 build-system identity parser 只接受顶层可信 executable，因而不能用该 opaque wrapper 证明 CMake。父命令自身包含完整 configure/build/stage，所以 clean replay 从空 workspace 检出冻结 commit 后可以成功执行，不依赖未记录的 preparation 状态。
+
+本 gate 的 experiment policy 将 `cmake_arguments` 冻结为空：参数观察不是本阶段 estimand，且不能让 shell wrapper 的 token 可见性额外产生 `cmake_arguments_not_observed`。实际 parent command 仍固定使用 `-DCMAKE_BUILD_TYPE=Release`。
+
+Parent submit 必须只有 `build_system_unproven`，artifact checks 可以通过，但 candidate bundle 与 clean replay 不得启动，`replay_attempts == 0`。P2 reference evaluator必须独立得到 `unproven / opaque_wrapper`。
+
+## 双臂与唯一差异
+
+Baseline 与 treatment 从同一个 committed message/environment/budget checkpoint 派生。两臂必须具有相同 continuation image、workspace、artifact 和 parent command records。
+
+- Baseline：只接收原始中性 submit failure；不追加 invocation，再次 submit 仍为 `build_system_unproven`，0 replay。
+- Treatment：唯一 checkpoint exposure 是白名单 repair packet。Packet 只包含 classification、build system、build directory、target、`proof_status=opaque_wrapper` 与抽象 repair goal；禁止完整命令、argv、shell、prompt、solution 和 secret。
+- Treatment continuation：append-only 执行可信 direct `cmake --build`，再重新 staging 同一 artifact；不得删除、重排或改写 parent command records。
+
+## Gate outcomes
+
+Treatment 必须同时满足：
+
+1. P2 reference evaluator 为 `proven / direct_cmake`；
+2. production candidate verification 为 `passed`；
+3. clean replay 在原 continuation image ID、空 workspace/artifacts 和独立 replay container 中为 `passed`；
+4. replay cleanup、Compile Session cleanup 与 checkpoint cleanup 为 `passed`；
+5. parent、baseline、treatment、replay、checkpoint container 与 checkpoint image 均为 0 orphan。
+
+## 授权和运行边界
+
+- 固定 `provider_calls=0`、`formal_physical_attempts=0`、`model_tokens=0`；
+- 不读取任何 AK，不创建模型 client，不运行 provider canary；
+- 只允许 WSL Ubuntu 原生 `docker.service`；禁止 Windows Docker CLI、Docker Desktop context 和 Docker Desktop fallback；
+- Docker 测试默认 skip，只有显式设置 `FORGE_RUN_OPAQUE_PROVENANCE_DOCKER=1` 才运行；
+- 不修改 production Compiler、Oracle、`operations.py`、历史 runner、manifest 或 evidence；
+- 本门禁通过不自动授权 behavioral pilot。
+
+## 停止规则
+
+出现下列任一情况即停止：
+
+1. Parent 同时产生第二个 protocol failure；
+2. Parent wrapper 无法从 clean workspace 独立 replay；
+3. Baseline 意外启动 replay 或转为 proven；
+4. Treatment 必须改写 parent records，或 P2/candidate/replay 任一层不能通过；
+5. Cleanup 不能闭合或发现 orphan；
+6. 完成 gate 需要修改 production Compiler、Oracle 或历史 evidence。

--- a/scripts/forge_opaque_build_provenance_real_docker_gate.py
+++ b/scripts/forge_opaque_build_provenance_real_docker_gate.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Issue #178 opaque build provenance 真实 Docker 生命周期门禁适配器。"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shlex
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from deerflow.compile import operations
+
+SCHEMA_VERSION = "forge-opaque-build-provenance-real-docker-gate-1.0.0"
+CASE_ID = "cppitertools-opaque-provenance-real-docker"
+REPOSITORY_URL = "https://github.com/ryanhaining/cppitertools"
+COMMIT_SHA = "531b3d753d2bbfe3b0ababe61c2e95e965c54a66"
+COMPILE_IMAGE = "autocompiler:gcc13"
+WORKDIR = "/workspace/repo"
+BUILD_DIRECTORY = "/workspace/repo/build"
+BUILD_OUTPUT = "build/accumulate_examples"
+STAGED_ARTIFACT = "accumulate_examples"
+TARGET = "accumulate_examples"
+PROOF_STATUS = "opaque_wrapper"
+REPAIR_GOAL = "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+
+_PARENT_INNER_COMMAND = "rm -rf build && cmake -S examples -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --target accumulate_examples -j2 && cp build/accumulate_examples /artifacts/accumulate_examples"
+PARENT_COMMAND = f"sh -c {shlex.quote(_PARENT_INNER_COMMAND)}"
+TREATMENT_BUILD_COMMAND = "cmake --build /workspace/repo/build --target accumulate_examples -j2"
+TREATMENT_STAGE_COMMAND = "cp /workspace/repo/build/accumulate_examples /artifacts/accumulate_examples"
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+class RealDockerGateError(RuntimeError):
+    """真实 gate 的预注册 identity 或确定性契约无效。"""
+
+
+def _load_provenance_module():
+    module_path = SCRIPTS_DIR / "forge_opaque_build_provenance_gate.py"
+    module_name = "forge_opaque_build_provenance_real_docker_reference"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RealDockerGateError("cannot load the P2 reference evaluator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+provenance = _load_provenance_module()
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def build_repair_packet() -> dict[str, str]:
+    return {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": provenance.EXPECTED_CLASSIFICATION,
+        "mechanism_classification": provenance.FAULT_FAMILY,
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": BUILD_DIRECTORY,
+        "target": TARGET,
+        "proof_status": PROOF_STATUS,
+        "repair_goal": REPAIR_GOAL,
+    }
+
+
+def validate_repair_packet(value: dict[str, Any]) -> dict[str, str]:
+    expected = build_repair_packet()
+    if value != expected:
+        raise RealDockerGateError("repair packet identity or whitelist drifted")
+    serialized = canonical_bytes(value).decode("utf-8").lower()
+    for forbidden in (
+        "cmake --build",
+        "bash -lc",
+        "sh -c",
+        "argv",
+        "command_line",
+        "shell",
+        "secret",
+        "api_key",
+    ):
+        if forbidden in serialized:
+            raise RealDockerGateError("repair packet leaked a forbidden solution field")
+    return expected
+
+
+def validate_parent_command_contract() -> dict[str, Any]:
+    roles = operations.infer_command_roles(PARENT_COMMAND)
+    expected_roles = {"configure", "build", "artifact_stage"}
+    if roles != expected_roles:
+        raise RealDockerGateError(f"parent wrapper roles drifted: {sorted(roles)}")
+    if operations._command_invokes(PARENT_COMMAND, "cmake"):
+        raise RealDockerGateError("parent wrapper unexpectedly proves CMake identity")
+    if not operations._command_invokes(PARENT_COMMAND, "sh"):
+        raise RealDockerGateError("parent wrapper top-level identity drifted")
+    if operations.infer_command_role(PARENT_COMMAND) != "build":
+        raise RealDockerGateError("parent wrapper no longer resolves to a build command")
+    return {
+        "roles": sorted(roles),
+        "top_level_executable": "sh",
+        "cmake_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+
+
+def build_frozen_identity(
+    *,
+    image_id: str,
+    physical_attempt_id: str,
+    build_tree_sha256: str,
+    artifact_size: int,
+    artifact_sha256: str,
+):
+    return provenance.FrozenIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        case_id=CASE_ID,
+        repository_url=REPOSITORY_URL,
+        commit_sha=COMMIT_SHA,
+        image_id=image_id,
+        physical_attempt_id=physical_attempt_id,
+        workdir=WORKDIR,
+        build_directory=BUILD_DIRECTORY,
+        generator="Ninja",
+        build_tree_sha256=build_tree_sha256,
+        target=TARGET,
+        artifact_relative_path=BUILD_OUTPUT,
+        artifact_type="executable",
+        artifact_size=artifact_size,
+        artifact_sha256=artifact_sha256,
+    ).validate()
+
+
+def _parent_invocation(frozen: Any, command_id: str):
+    return provenance.record_invocation(
+        command_id=command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", _PARENT_INNER_COMMAND),
+        workdir=frozen.workdir,
+        previous_hash=provenance.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def evaluate_parent(frozen: Any, *, parent_command_id: str):
+    parent = _parent_invocation(frozen, parent_command_id)
+    artifact = provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=parent.command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=2,
+    )
+    decision = provenance.evaluate_p2(frozen, (parent,), artifact)
+    if decision.status != "unproven" or decision.classification != provenance.FAULT_FAMILY or decision.reason != PROOF_STATUS:
+        raise RealDockerGateError("parent did not produce the frozen opaque-wrapper P2 failure")
+    return decision, (parent,)
+
+
+def evaluate_treatment(
+    frozen: Any,
+    *,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    parent = _parent_invocation(frozen, parent_command_id)
+    build = provenance.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cmake",
+        argv=("--build", frozen.build_directory, "--target", frozen.target, "-j2"),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = provenance.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(frozen.artifact_relative_path, f"/artifacts/{STAGED_ARTIFACT}"),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    artifact = provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=build.command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=4,
+    )
+    invocations = (parent, build, stage)
+    decision = provenance.evaluate_p2(frozen, invocations, artifact)
+    if decision.status != "proven" or decision.proof_mode != "direct_cmake":
+        raise RealDockerGateError("treatment did not convert the frozen P2 outcome")
+    if invocations[:1] != (parent,):
+        raise RealDockerGateError("treatment rewrote parent command history")
+    return decision, invocations
+
+
+def validate_gate_contract() -> dict[str, Any]:
+    command_contract = validate_parent_command_contract()
+    packet = validate_repair_packet(build_repair_packet())
+    frozen = build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-real-docker-contract",
+        build_tree_sha256="3" * 64,
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+    parent, parent_history = evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-cmake-build",
+        treatment_stage_command_id="treatment-artifact-stage",
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_id": CASE_ID,
+        "command_contract": command_contract,
+        "repair_packet": packet,
+        "parent": asdict(parent),
+        "treatment": asdict(treatment),
+        "parent_history_sha256": provenance.command_history_sha256(parent_history),
+        "treatment_history_sha256": provenance.command_history_sha256(treatment_history),
+        "parent_history_prefix_preserved": treatment_history[: len(parent_history)] == parent_history,
+        "docker_executed": False,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    _parser().parse_args(argv)
+    print(json.dumps(validate_gate_contract(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

- 新增 experiment-only 的 opaque build provenance 真实 Docker gate adapter，冻结自包含 opaque wrapper、白名单 repair packet 和 append-only P2 conversion
- 新增静态契约测试与 opt-in Ubuntu-native Docker 测试，闭合 parent fault、同源双臂、baseline、treatment candidate、clean replay 和 cleanup
- 新增独立预注册与项目状态记录，不修改 production Compiler、Oracle、`operations.py` 或历史 evidence

## 真实门禁结果

- Ubuntu-native provider：`/var/run/docker.sock`
- parent：唯一 constraint failure 为 `build_system_unproven`，P2 `unproven/opaque_wrapper`，0 replay
- baseline：仍为 `build_system_unproven`，0 replay
- treatment：append direct `cmake --build` 后 P2 `proven/direct_cmake`，candidate 与 clean replay 均 passed
- cleanup：parent、双臂、replay、checkpoint container/image 0 orphan
- 外部使用：0 provider call、0 formal physical attempt、0 model token，未读取 AK

## 验证

- `47 passed`：P2、合成 lifecycle 与本阶段静态相邻回归
- `1 passed in 74.34s`：真实 Ubuntu-native Docker gate
- Ruff check/format、Python 语法、`git diff --check` 通过

Closes #178