### PR TITLE
研究：冻结 opaque provenance 最小 canary 协议

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 冻结 opaque build provenance 最小 provider canary 候选协议
+  - 文件: `scripts/forge_opaque_provenance_minimal_canary_protocol.py`, `benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json`, `benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md`, `backend/tests/test_forge_opaque_provenance_minimal_canary.py`
+  - 范围: Issue #180 固定单个 `cppitertools` checkpoint、一个 `baseline -> treatment` pair，以及 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、禁止 fallback 的未来运行身份；每臂 8 requests / 8 turns / 24 graph steps / 120,000 recorded tokens，阶段机械上限 245,000。
+  - 边界: 当前只支持 `generate`、`validate`、`show-plan`，所有 reachability/provider/formal/canary 授权均为 false；无 model 创建、credential 读取或 execute path。单 pair 只验证机制接线，不估计 treatment effect、不计算 p 值、不排名模型。
+  - 验证: manifest canonical SHA-256 为 `ad5a1ac989c4072ec097a3b0949d5e4393475d6df0896e108dbc313690dd3ee7`；本阶段聚焦与前三层相邻静态回归 `53 passed`，Ruff check/format、Python 语法、协议 CLI 和 `git diff --check` 通过。固定 0 provider、0 formal attempt、0 model token，未读取 AK、未启动 Docker。
+  - 下一步: 合并后从干净主干执行 0-provider preflight，核对 `main == origin/main`、Ubuntu-native Docker、网络介质、候选 evidence 空目录与 0 managed orphan；真实 reachability 和 canary 仍需独立授权。
+
 - 2026-08-30 — 闭合 opaque build provenance 真实 Docker 生命周期门禁
   - 文件: `scripts/forge_opaque_build_provenance_real_docker_gate.py`, `backend/tests/test_forge_opaque_build_provenance_real_docker_gate.py`, `backend/tests/test_forge_opaque_build_provenance_real_docker_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md`
   - 动机: Issue #178 为 #174 P2 reference criterion 与 #176 合成 lifecycle adapter 补充真实 production candidate verifier、独立 clean replay 和 cleanup 证据；不修改 production Compiler/Oracle、`operations.py` 或历史 evidence。

--- a/backend/tests/test_forge_opaque_provenance_minimal_canary.py
+++ b/backend/tests/test_forge_opaque_provenance_minimal_canary.py
@@ -1,0 +1,122 @@
+"""Issue #180 opaque provenance 最小 canary 的零 provider 协议测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_minimal_canary_protocol.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json"
+
+
+def _load_module():
+    name = "forge_opaque_provenance_minimal_canary_protocol_test"
+    spec = importlib.util.spec_from_file_location(name, PROTOCOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module()
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_generated_manifest_schema_and_components_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert set(manifest["frozen_components"]) == protocol.FROZEN_COMPONENT_PATHS
+
+
+def test_single_cppitertools_pair_and_unique_exposure_are_fixed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["case"]["case_id"] == "cppitertools-opaque-provenance-real-docker"
+    assert manifest["case"]["commit_sha"] == "531b3d753d2bbfe3b0ababe61c2e95e965c54a66"
+    assert manifest["schedule"] == [
+        {
+            "pair_id": protocol.PAIR_ID,
+            "order": 1,
+            "case_id": "cppitertools-opaque-provenance-real-docker",
+            "arm_order": ["baseline", "treatment"],
+            "treatment_exposure_only": "repair_packet",
+        }
+    ]
+    assert manifest["schedule_sha256"] == protocol.canonical_sha256(manifest["schedule"])
+
+
+def test_provider_budget_and_analysis_boundaries_are_fixed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["provider"] == {
+        "status": "future_identity_only",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": False,
+    }
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 245_000
+    assert manifest["continuation"]["maximum_requests_per_arm"] == 8
+    assert manifest["analysis"]["treatment_effect_estimated"] is False
+    assert manifest["analysis"]["p_value_computed"] is False
+    assert manifest["analysis"]["model_ranking_performed"] is False
+
+
+def test_all_execution_authorization_and_paths_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    authorization = manifest["authorization"]
+    assert authorization["reachability_request_authorized"] is False
+    assert authorization["provider_calls_authorized"] is False
+    assert authorization["formal_attempts_authorized"] is False
+    assert authorization["canary_collection_authorized"] is False
+    assert authorization["model_tokens_authorized"] == 0
+    assert manifest["execution"]["provider_model_creation_supported"] is False
+    assert manifest["execution"]["credential_read_supported"] is False
+    assert manifest["execution"]["execute_path_supported"] is False
+
+
+def test_schema_and_semantics_reject_authorization_or_schedule_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    authorized = copy.deepcopy(manifest)
+    authorized["authorization"]["provider_calls_authorized"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(authorized)
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(authorized, REPO_ROOT)
+
+    reordered = copy.deepcopy(manifest)
+    reordered["schedule"][0]["arm_order"].reverse()
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(reordered, REPO_ROOT)
+
+
+def test_protocol_source_has_no_provider_or_credential_execution_path() -> None:
+    source = PROTOCOL_PATH.read_text(encoding="utf-8")
+    for forbidden in ("os.environ", "create_chat_model", "ChatOpenAI", "execute_collection", "api_key="):
+        assert forbidden not in source
+    plan = protocol.show_plan(protocol.load_manifest(MANIFEST_PATH, REPO_ROOT))
+    assert plan["provider_calls"] == 0
+    assert plan["formal_attempts"] == 0
+    assert plan["model_tokens"] == 0
+    assert plan["execution_authorized"] is False

--- a/benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-minimal-canary.schema.json",
+  "schema_version": "forge-opaque-provenance-minimal-canary-1.0.0",
+  "document_type": "forge_opaque_provenance_minimal_canary_protocol",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/180",
+    "protocol_freeze_authorized": true,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "canary_collection_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "scope": {
+    "languages": [
+      "C++"
+    ],
+    "mechanism": "provenance_compliance_repair",
+    "fault_family": "opaque_build_provenance",
+    "production_classification": "build_system_unproven",
+    "reference_criterion": "P2",
+    "behavioral_pilot_expansion_authorized": false
+  },
+  "case": {
+    "case_id": "cppitertools-opaque-provenance-real-docker",
+    "repository_url": "https://github.com/ryanhaining/cppitertools",
+    "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+    "compile_image": "autocompiler:gcc13",
+    "build_system": "cmake",
+    "build_directory": "/workspace/repo/build",
+    "target": "accumulate_examples",
+    "staged_artifact": "accumulate_examples",
+    "checkpoint_source": "issue-178-real-docker-lifecycle",
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "reference_chain": [
+    {
+      "issue": 174,
+      "purpose": "P2_reference_contract",
+      "main_commit": "869686b3"
+    },
+    {
+      "issue": 176,
+      "purpose": "synthetic_lifecycle_contract",
+      "main_commit": "5b5d867d"
+    },
+    {
+      "issue": 178,
+      "purpose": "real_docker_lifecycle",
+      "main_commit": "aa1768dd"
+    }
+  ],
+  "provider": {
+    "status": "future_identity_only",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-cppitertools-pair-01",
+      "order": 1,
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "treatment_exposure_only": "repair_packet"
+    }
+  ],
+  "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "purpose": "mechanism_wiring_canary_only",
+    "unit_of_analysis": "single_failure_checkpoint_pair",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "execution": {
+    "mode": "protocol_plan_only",
+    "control_plane": "compose-dood-on-ubuntu-native-docker",
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_origin_main_identity": true,
+    "require_network_medium_record": true,
+    "require_empty_evidence_directory": true,
+    "require_zero_managed_orphans": true,
+    "provider_model_creation_supported": false,
+    "credential_read_supported": false,
+    "execute_path_supported": false
+  },
+  "frozen_components": {
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md": "a2636bf2f2c2364d287444d30bfba6ab4a764f4b2653be05845609acc5a1e014",
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md": "971e67fdf51ad19b58222928b9330edfb37a4eca0eb7c453bb7bd8df4175f2d3",
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-zero-provider-gate.md": "37f433010577f53ecaf43ff29c349c93489b1b94131b7a9840af746bd91a1a6b",
+    "scripts/forge_opaque_build_provenance_gate.py": "0f21ece5f3419a477925515f5312a009b0d447c1fa982f9e7fb626bf0f30e07a",
+    "scripts/forge_opaque_build_provenance_lifecycle_gate.py": "a7197fb03dbb48fa99ec70cd1007153bd8a625c311b4068bc69dfbac608e8ff3",
+    "scripts/forge_opaque_build_provenance_real_docker_gate.py": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md
@@ -1,0 +1,35 @@
+# Opaque build provenance 最小 provider canary 候选协议
+
+本协议承接 Issue #174 的 P2 reference contract、Issue #176 的合成 lifecycle contract 和 Issue #178 的真实 Ubuntu-native Docker lifecycle。Issue #180 只授权冻结候选协议及其零 provider 校验，不授权读取 AK、创建模型客户端、发送 reachability 请求、执行 canary 或产生正式实验 evidence。
+
+## 研究问题与解释边界
+
+候选 canary 研究结构化 verifier repair packet 能否在同一个 opaque build provenance failure checkpoint 上支持 baseline/treatment 双臂的真实 continuation 接线。本阶段只验证机制与证据路径，不估计 treatment effect，不计算 p 值、不排名模型，也不与历史 pair 池化。
+
+实验单位固定为一个 `cppitertools@531b3d753d2bbfe3b0ababe61c2e95e965c54a66` checkpoint pair。父状态的 artifact 正确，但 trusted command chain 只有 opaque wrapper，production classification 为 `build_system_unproven`，P2 reference outcome 为 `opaque_build_provenance / opaque_wrapper`。
+
+## 双臂、provider 与预算
+
+- 顺序固定为 `baseline -> treatment`，两臂从同一个 committed message/environment/budget checkpoint 派生。
+- Treatment 唯一额外 exposure 是 Issue #178 已验证的白名单 repair packet；不得泄露完整命令、argv、shell、prompt、solution 或 secret。
+- 未来运行身份固定为 DeepSeek `deepseek-v4-flash`、`https://api.deepseek.com`、300 秒 timeout、0 retry、非 streaming、禁止 fallback。
+- 每臂最多 8 requests、8 model turns、24 graph steps、600 秒工作时间和 120 秒 cleanup reserve。
+- 每臂最多 120,000 recorded tokens；一次 reachability 上限 5,000，pair 上限 240,000，阶段机械上限 245,000。
+
+当前 provider 字段只是未来运行身份，不构成请求授权。reachability、provider call、formal attempt、canary collection 与 model token 授权全部保持关闭。
+
+## 停止规则
+
+未来若获独立授权，reachability 失败应在 pair 前停止。Identity、evidence、预算、cleanup 或未分类基础设施失败立即停止；合法 endpoint timeout 记为 arm 删失并继续另一臂，已分类模型行为失败保留为 outcome。禁止 retry、replacement、backfill、schedule extension 和第二个 pair。
+
+## 零 provider preflight
+
+协议合并后，从干净主干只读核对：
+
+1. `main == origin/main` 且工作树干净；
+2. Docker provider 为 WSL Ubuntu 原生 `docker.service` 和 `/var/run/docker.sock`；
+3. 记录网络介质，但不记录 SSID、IP 或账户信息；
+4. 候选 evidence 目录为空；
+5. Forge managed container orphan 为 0。
+
+该 preflight 不读取 `DEEPSEEK_API_KEY`，不调用 provider，不产生 attempt/evidence。真实 reachability 与单 pair canary 必须由后续中文 Issue 明确授权。

--- a/benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json",
+  "title": "Forge opaque provenance minimal canary protocol",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-minimal-canary.schema.json",
+    "schema_version": "forge-opaque-provenance-minimal-canary-1.0.0",
+    "document_type": "forge_opaque_provenance_minimal_canary_protocol",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/180",
+      "protocol_freeze_authorized": true,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "canary_collection_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "scope": {
+      "languages": [
+        "C++"
+      ],
+      "mechanism": "provenance_compliance_repair",
+      "fault_family": "opaque_build_provenance",
+      "production_classification": "build_system_unproven",
+      "reference_criterion": "P2",
+      "behavioral_pilot_expansion_authorized": false
+    },
+    "case": {
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "compile_image": "autocompiler:gcc13",
+      "build_system": "cmake",
+      "build_directory": "/workspace/repo/build",
+      "target": "accumulate_examples",
+      "staged_artifact": "accumulate_examples",
+      "checkpoint_source": "issue-178-real-docker-lifecycle",
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "reference_chain": [
+      {
+        "issue": 174,
+        "purpose": "P2_reference_contract",
+        "main_commit": "869686b3"
+      },
+      {
+        "issue": 176,
+        "purpose": "synthetic_lifecycle_contract",
+        "main_commit": "5b5d867d"
+      },
+      {
+        "issue": 178,
+        "purpose": "real_docker_lifecycle",
+        "main_commit": "aa1768dd"
+      }
+    ],
+    "provider": {
+      "status": "future_identity_only",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-cppitertools-pair-01",
+        "order": 1,
+        "case_id": "cppitertools-opaque-provenance-real-docker",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "treatment_exposure_only": "repair_packet"
+      }
+    ],
+    "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "purpose": "mechanism_wiring_canary_only",
+      "unit_of_analysis": "single_failure_checkpoint_pair",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "execution": {
+      "mode": "protocol_plan_only",
+      "control_plane": "compose-dood-on-ubuntu-native-docker",
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_origin_main_identity": true,
+      "require_network_medium_record": true,
+      "require_empty_evidence_directory": true,
+      "require_zero_managed_orphans": true,
+      "provider_model_creation_supported": false,
+      "credential_read_supported": false,
+      "execute_path_supported": false
+    },
+    "frozen_components": {
+      "benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md": "a2636bf2f2c2364d287444d30bfba6ab4a764f4b2653be05845609acc5a1e014",
+      "benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md": "971e67fdf51ad19b58222928b9330edfb37a4eca0eb7c453bb7bd8df4175f2d3",
+      "benchmarks/preregistrations/cpp-opaque-build-provenance-zero-provider-gate.md": "37f433010577f53ecaf43ff29c349c93489b1b94131b7a9840af746bd91a1a6b",
+      "scripts/forge_opaque_build_provenance_gate.py": "0f21ece5f3419a477925515f5312a009b0d447c1fa982f9e7fb626bf0f30e07a",
+      "scripts/forge_opaque_build_provenance_lifecycle_gate.py": "a7197fb03dbb48fa99ec70cd1007153bd8a625c311b4068bc69dfbac608e8ff3",
+      "scripts/forge_opaque_build_provenance_real_docker_gate.py": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_minimal_canary_protocol.py
+++ b/scripts/forge_opaque_provenance_minimal_canary_protocol.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Issue #180 opaque build provenance 最小 provider canary 候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json"
+
+SCHEMA_VERSION = "forge-opaque-provenance-minimal-canary-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_minimal_canary_protocol"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/180"
+PAIR_ID = "opaque-provenance-cppitertools-pair-01"
+RECORDED_TOKENS_PER_ARM = 120_000
+PAIR_RECORDED_TOKEN_LIMIT = RECORDED_TOKENS_PER_ARM * 2
+REACHABILITY_RECORDED_TOKEN_LIMIT = 5_000
+STAGE_RECORDED_TOKEN_LIMIT = PAIR_RECORDED_TOKEN_LIMIT + REACHABILITY_RECORDED_TOKEN_LIMIT
+
+FROZEN_COMPONENT_PATHS = {
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-lifecycle-zero-provider-gate.md",
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-real-docker-zero-provider-gate.md",
+    "benchmarks/preregistrations/cpp-opaque-build-provenance-zero-provider-gate.md",
+    "scripts/forge_opaque_build_provenance_gate.py",
+    "scripts/forge_opaque_build_provenance_lifecycle_gate.py",
+    "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """候选协议、预算或冻结组件发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    schedule = [
+        {
+            "pair_id": PAIR_ID,
+            "order": 1,
+            "case_id": "cppitertools-opaque-provenance-real-docker",
+            "arm_order": ["baseline", "treatment"],
+            "treatment_exposure_only": "repair_packet",
+        }
+    ]
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-minimal-canary.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "protocol_freeze_authorized": True,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "canary_collection_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "scope": {
+            "languages": ["C++"],
+            "mechanism": "provenance_compliance_repair",
+            "fault_family": "opaque_build_provenance",
+            "production_classification": "build_system_unproven",
+            "reference_criterion": "P2",
+            "behavioral_pilot_expansion_authorized": False,
+        },
+        "case": {
+            "case_id": "cppitertools-opaque-provenance-real-docker",
+            "repository_url": "https://github.com/ryanhaining/cppitertools",
+            "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+            "compile_image": "autocompiler:gcc13",
+            "build_system": "cmake",
+            "build_directory": "/workspace/repo/build",
+            "target": "accumulate_examples",
+            "staged_artifact": "accumulate_examples",
+            "checkpoint_source": "issue-178-real-docker-lifecycle",
+            "parent_proof_status": "opaque_wrapper",
+            "parent_expected_failure": "build_system_unproven",
+        },
+        "reference_chain": [
+            {"issue": 174, "purpose": "P2_reference_contract", "main_commit": "869686b3"},
+            {"issue": 176, "purpose": "synthetic_lifecycle_contract", "main_commit": "5b5d867d"},
+            {"issue": 178, "purpose": "real_docker_lifecycle", "main_commit": "aa1768dd"},
+        ],
+        "provider": {
+            "status": "future_identity_only",
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "continuation": {
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "budget": {
+            "maximum_reachability_requests": 1,
+            "reachability_maximum_recorded_tokens": REACHABILITY_RECORDED_TOKEN_LIMIT,
+            "recorded_tokens_per_arm": RECORDED_TOKENS_PER_ARM,
+            "recorded_tokens_per_pair": PAIR_RECORDED_TOKEN_LIMIT,
+            "stage_maximum_recorded_tokens": STAGE_RECORDED_TOKEN_LIMIT,
+            "enforcement": "after_reachability_and_each_arm_before_continuation",
+        },
+        "stopping": {
+            "reachability_failure_stops_before_pair": True,
+            "identity_evidence_budget_cleanup_or_unclassified_failure_stops": True,
+            "classified_arm_outcome_continues_other_arm": True,
+            "endpoint_timeout_censors_arm_and_continues": True,
+            "retry_forbidden": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "analysis": {
+            "purpose": "mechanism_wiring_canary_only",
+            "unit_of_analysis": "single_failure_checkpoint_pair",
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+        },
+        "execution": {
+            "mode": "protocol_plan_only",
+            "control_plane": "compose-dood-on-ubuntu-native-docker",
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_origin_main_identity": True,
+            "require_network_medium_record": True,
+            "require_empty_evidence_directory": True,
+            "require_zero_managed_orphans": True,
+            "provider_model_creation_supported": False,
+            "credential_read_supported": False,
+            "execute_path_supported": False,
+        },
+        "frozen_components": _hash_paths(repo_root, FROZEN_COMPONENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("opaque provenance minimal canary manifest drifted")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read opaque provenance minimal canary manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json",
+        "title": "Forge opaque provenance minimal canary protocol",
+        "const": frozen,
+    }
+
+
+def show_plan(manifest: dict[str, Any]) -> dict[str, Any]:
+    validate_manifest(manifest)
+    return {
+        "case_id": manifest["case"]["case_id"],
+        "pair_id": manifest["schedule"][0]["pair_id"],
+        "arm_order": manifest["schedule"][0]["arm_order"],
+        "provider": manifest["provider"]["id"],
+        "stage_maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "execution_authorized": False,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "show-plan"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    result = (
+        show_plan(manifest)
+        if args.command == "show-plan"
+        else {
+            "manifest_sha256": canonical_sha256(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增版本化的 opaque build provenance 最小 provider canary 候选协议。
- 固定单个 cppitertools checkpoint、一个 baseline -> treatment pair、DeepSeek 未来运行身份、预算和停止规则。
- 通过 manifest 与完整 const Schema 哈希锁定 Issue #174/#176/#178 的关键组件。
- CLI 仅提供 generate、validate 和 show-plan；所有 provider、formal attempt 与 collection 授权保持关闭。
- 补充预注册、聚焦测试与项目状态记录。

## 研究边界

该单 pair 只用于验证机制接线，不估计 treatment effect，不计算 p 值，不排名模型。本 PR 未读取 AK、未调用 provider、未启动 Docker，也未产生 formal attempt/evidence。

## 验证

- 53 passed：本协议聚焦测试与前三层相邻静态回归
- Ruff check/format 通过
- Python 语法、协议 validate/show-plan、git diff --check 通过
- CLI 固定输出 0 provider call、0 formal attempt、0 model token

Closes #180