### PR TITLE
研究：建立 opaque provenance 最小 canary 授权候选门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 建立 opaque provenance 最小 canary 授权候选与零 provider 接线门禁
+  - 文件: `scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py`, `scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py`, `benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json`, `benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md`, `backend/tests/test_forge_opaque_provenance_minimal_canary_authorized.py`
+  - 范围: Issue #182 从 #180 parent identity 派生独立授权候选，冻结 evidence 目录、preflight/marker/ledger/report 路径、单次 reachability/pair 顺序和 runtime adapter 文件哈希；只允许 validate、plan 与只读 preflight。
+  - 边界: reachability/provider/formal/canary/token 授权均关闭，`execute_reachability` / `execute_canary` 机械拒绝；无 credential 读取、model 创建或 evidence 写入，不修改 production Compiler/Oracle、`operations.py` 或历史 evidence。
+  - 验证: manifest canonical SHA-256 为 `00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771`，evidence identity SHA-256 为 `f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538`；聚焦与路线 P 相邻静态回归 `69 passed`，Ruff check/format、Python 语法、Schema、CLI 和 `git diff --check` 通过。
+  - 下一步: 合并后从干净主干运行真实 0-provider preflight；通过后只形成一次真实 reachability + 单 pair canary 的授权决策包，不自动调用 provider或扩大 pilot。
+
 - 2026-08-30 — 冻结 opaque build provenance 最小 provider canary 候选协议
   - 文件: `scripts/forge_opaque_provenance_minimal_canary_protocol.py`, `benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json`, `benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md`, `backend/tests/test_forge_opaque_provenance_minimal_canary.py`
   - 范围: Issue #180 固定单个 `cppitertools` checkpoint、一个 `baseline -> treatment` pair，以及 DeepSeek `deepseek-v4-flash`、300 秒 timeout、0 retry、禁止 fallback 的未来运行身份；每臂 8 requests / 8 turns / 24 graph steps / 120,000 recorded tokens，阶段机械上限 245,000。

--- a/backend/tests/test_forge_opaque_provenance_minimal_canary_authorized.py
+++ b/backend/tests/test_forge_opaque_provenance_minimal_canary_authorized.py
@@ -1,0 +1,193 @@
+"""Issue #182 授权候选与零 provider runtime adapter 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_opaque_provenance_minimal_canary_authorized_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_opaque_provenance_minimal_canary_authorized_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _valid_snapshot(manifest: dict) -> dict:
+    return {
+        "schema_version": "forge-opaque-provenance-minimal-canary-preflight-1.0.0",
+        "branch": "main",
+        "head_commit": "a" * 40,
+        "origin_main_commit": "a" * 40,
+        "worktree_clean": True,
+        "authorization_baseline_ancestor": True,
+        "docker_provider": "ubuntu-native",
+        "docker_context": "default",
+        "docker_endpoint": "/var/run/docker.sock",
+        "network_medium": "wifi",
+        "evidence_directory": manifest["evidence"]["directory"],
+        "evidence_entries": 0,
+        "managed_orphans": [],
+    }
+
+
+def test_generated_manifest_schema_parent_and_runtime_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["parent"]["canonical_sha256"] == protocol.PARENT_MANIFEST_SHA256
+    assert manifest["runtime_adapter"]["file_sha256"] == protocol.file_sha256(RUNNER_PATH)
+
+
+def test_evidence_and_single_opportunity_identity_are_immutable() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    evidence = manifest["evidence"]
+    identity = {key: value for key, value in evidence.items() if key != "identity_sha256"}
+    assert evidence["identity_sha256"] == protocol.canonical_sha256(identity)
+    assert evidence["directory"].endswith("authorized-v1")
+    assert evidence["zero_provider_preflight_writes_evidence"] is False
+    assert manifest["opportunities"]["maximum_reachability_requests"] == 1
+    assert manifest["opportunities"]["maximum_canary_pairs"] == 1
+    assert manifest["opportunities"]["required_order"] == ["reachability", manifest["schedule"][0]["pair_id"]]
+
+
+def test_all_real_execution_authorizations_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    authorization = manifest["authorization"]
+    assert authorization["runtime_adapter_candidate_authorized"] is True
+    assert authorization["zero_provider_preflight_authorized"] is True
+    assert authorization["reachability_request_authorized"] is False
+    assert authorization["provider_calls_authorized"] is False
+    assert authorization["formal_attempts_authorized"] is False
+    assert authorization["canary_collection_authorized"] is False
+    assert authorization["model_tokens_authorized"] == 0
+    assert manifest["runtime_adapter"]["credential_read_supported"] is False
+    assert manifest["runtime_adapter"]["provider_model_creation_supported"] is False
+
+
+def test_valid_preflight_snapshot_and_plan_are_zero_provider() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert runner.validate_preflight_snapshot(manifest, _valid_snapshot(manifest))["network_medium"] == "wifi"
+    plan = runner.build_plan(manifest)
+    assert plan["provider_calls"] == 0
+    assert plan["formal_attempts"] == 0
+    assert plan["model_tokens"] == 0
+    assert plan["evidence_writes"] == 0
+    assert plan["execution_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("branch", "research/issue-182"),
+        ("origin_main_commit", "b" * 40),
+        ("worktree_clean", False),
+        ("authorization_baseline_ancestor", False),
+        ("docker_provider", "desktop-linux"),
+        ("docker_endpoint", "npipe:////./pipe/docker_engine"),
+        ("network_medium", "unknown"),
+        ("evidence_entries", 1),
+        ("managed_orphans", ["deerflow-compile-stale"]),
+    ],
+)
+def test_preflight_drift_fails_closed(field: str, value: object) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    snapshot = _valid_snapshot(manifest)
+    snapshot[field] = value
+    with pytest.raises(runner.RuntimeGateError):
+        runner.validate_preflight_snapshot(manifest, snapshot)
+
+
+def test_collector_uses_read_only_git_docker_and_evidence_checks() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    evidence_dir = REPO_ROOT / ".compile-sessions" / Path(manifest["evidence"]["directory"]).name
+    commands: list[tuple[str, ...]] = []
+
+    def fake_command(command, _cwd: Path) -> str:
+        key = tuple(command)
+        commands.append(key)
+        if key == ("git", "branch", "--show-current"):
+            return "main"
+        if key in (("git", "rev-parse", "HEAD"), ("git", "rev-parse", "origin/main")):
+            return "c" * 40
+        if key == ("docker", "ps", "-a", "--format", "{{.Names}}"):
+            return "deer-flow-langgraph\nunrelated-service"
+        if key[0:3] == ("git", "merge-base", "--is-ancestor") or key == ("git", "status", "--porcelain"):
+            return ""
+        if key[0] == "bash":
+            return "OK: Forge Docker daemon provider=ubuntu-native; context=default; endpoint=/var/run/docker.sock"
+        raise AssertionError(key)
+
+    snapshot = runner.collect_preflight_snapshot(
+        manifest,
+        repo_root=REPO_ROOT,
+        host_evidence_directory=evidence_dir,
+        network_medium="wifi",
+        command_runner=fake_command,
+    )
+    assert snapshot["evidence_entries"] == 0
+    assert snapshot["managed_orphans"] == []
+    assert all(command[0] in {"git", "bash", "docker"} for command in commands)
+
+    with pytest.raises(runner.RuntimeGateError, match="not bound"):
+        runner.collect_preflight_snapshot(
+            manifest,
+            repo_root=REPO_ROOT,
+            host_evidence_directory=REPO_ROOT.parent / evidence_dir.name,
+            network_medium="wifi",
+            command_runner=fake_command,
+        )
+
+
+def test_execute_paths_are_mechanically_rejected_and_source_reads_no_credentials() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    with pytest.raises(runner.RuntimeGateError, match="not authorized"):
+        runner.execute_reachability(manifest)
+    with pytest.raises(runner.RuntimeGateError, match="not authorized"):
+        runner.execute_canary(manifest)
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    for forbidden in ("os.environ", "create_chat_model", "ChatOpenAI", "DEEPSEEK_API_KEY", "api_key="):
+        assert forbidden not in source
+
+
+def test_schema_and_semantics_reject_authorization_or_evidence_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    drifted = copy.deepcopy(manifest)
+    drifted["authorization"]["provider_calls_authorized"] = True
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(drifted)
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(drifted, REPO_ROOT)
+
+    drifted = copy.deepcopy(manifest)
+    drifted["evidence"]["canary_report"] = "reports/other.json"
+    with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+        protocol.validate_manifest(drifted, REPO_ROOT)

--- a/benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+  "schema_version": "forge-opaque-provenance-minimal-canary-authorized-1.0.0",
+  "document_type": "forge_opaque_provenance_minimal_canary_authorized_candidate",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/182",
+    "runtime_adapter_candidate_authorized": true,
+    "zero_provider_preflight_authorized": true,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "canary_collection_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json",
+    "schema_version": "forge-opaque-provenance-minimal-canary-1.0.0",
+    "canonical_sha256": "ad5a1ac989c4072ec097a3b0949d5e4393475d6df0896e108dbc313690dd3ee7",
+    "file_sha256": "c9280ce00094b6dee30aea4fb4b2a6ac4d3b33b0784015a628dacc3d00b05076",
+    "authorization_baseline_commit": "06ba008ddaa77956ce39e97f30f79e27a1a0639e",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "case": {
+    "case_id": "cppitertools-opaque-provenance-real-docker",
+    "repository_url": "https://github.com/ryanhaining/cppitertools",
+    "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+    "compile_image": "autocompiler:gcc13",
+    "build_system": "cmake",
+    "build_directory": "/workspace/repo/build",
+    "target": "accumulate_examples",
+    "staged_artifact": "accumulate_examples",
+    "checkpoint_source": "issue-178-real-docker-lifecycle",
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "provider": {
+    "status": "future_identity_only",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-cppitertools-pair-01",
+      "order": 1,
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "treatment_exposure_only": "repair_packet"
+    }
+  ],
+  "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "purpose": "mechanism_wiring_canary_only",
+    "unit_of_analysis": "single_failure_checkpoint_pair",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-minimal-canary-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1",
+    "preflight_snapshot": "preflight/preflight.json",
+    "reachability_marker": "markers/reachability.json",
+    "pair_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "marker_consumed_on_start": true,
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538"
+  },
+  "opportunities": {
+    "maximum_reachability_requests": 1,
+    "maximum_canary_pairs": 1,
+    "required_order": [
+      "reachability",
+      "opaque-provenance-cppitertools-pair-01"
+    ],
+    "retry_replacement_backfill_forbidden": true
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "require_authorization_baseline_ancestor": true,
+    "docker_provider": "ubuntu-native",
+    "docker_context": "default",
+    "docker_endpoint": "/var/run/docker.sock",
+    "allowed_network_media": [
+      "wired",
+      "wifi",
+      "mobile_hotspot"
+    ],
+    "require_empty_evidence_directory": true,
+    "managed_container_prefixes": [
+      "deerflow-compile-",
+      "deerflow-replay-"
+    ],
+    "require_zero_managed_orphans": true
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py",
+    "file_sha256": "2f5729e4793f523830cfd0da713fdf65e84485ca73c7940563933e3de0d02f32",
+    "commands": [
+      "validate",
+      "plan",
+      "preflight"
+    ],
+    "credential_read_supported": false,
+    "provider_model_creation_supported": false,
+    "reachability_execute_supported": false,
+    "canary_execute_supported": false
+  },
+  "frozen_parent_components": {
+    "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json": "c9280ce00094b6dee30aea4fb4b2a6ac4d3b33b0784015a628dacc3d00b05076",
+    "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md": "539b79793466c3419ad351715892048a910826fee14d9a2f871e669e79965737",
+    "benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json": "952713b70a77f015c4fbe7902158ed78f52abb3073a6cae51bf2bfe3216e7f6a",
+    "scripts/forge_opaque_provenance_minimal_canary_protocol.py": "a67cda050c97ee481b243e232884bbcd3b6bdf403b3671026f3121e98a6c22ad"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md
@@ -1,0 +1,30 @@
+# Opaque build provenance 最小 canary 授权候选与零 provider 接线门禁
+
+本协议承接 Issue #180 的未授权最小 canary 候选。Issue #182 只授权实现版本化 runtime adapter、冻结 evidence identity 和执行 0-provider preflight；不授权读取 AK、创建模型客户端、发送 reachability 请求或运行 baseline/treatment pair。
+
+## 父协议与研究单位
+
+父身份固定为 `main@06ba008ddaa77956ce39e97f30f79e27a1a0639e`、manifest canonical SHA-256 `ad5a1ac989c4072ec097a3b0949d5e4393475d6df0896e108dbc313690dd3ee7`。Case、provider、预算、顺序、停止规则和分析边界逐字段继承父协议，不在本阶段改写。
+
+研究单位仍是单个 `cppitertools` opaque-provenance checkpoint pair，顺序固定为 `baseline -> treatment`。该单 pair 未来只验证机制接线，不能估计 treatment effect、计算 p 值或排名模型。
+
+## Evidence identity
+
+独立逻辑目录固定为 `/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1`。其 preflight snapshot、reachability marker、pair ledger 和 canary report 路径全部进入 canonical evidence identity；marker 在请求开始时即消耗机会，文件只能 append/create-once，不得覆盖历史 evidence。
+
+本阶段 preflight 不写 evidence。目录必须不存在或为空，managed `deerflow-compile-*` / `deerflow-replay-*` orphan 必须为 0。
+
+## Runtime preflight
+
+只读 snapshot 必须证明：
+
+1. 当前分支为干净 `main`，`HEAD == origin/main`，且 #180 baseline 是 HEAD 祖先；
+2. Docker provider 为 WSL Ubuntu-native、context 为 `default`、endpoint 为 `/var/run/docker.sock`；
+3. 网络介质记录为 `wired`、`wifi` 或 `mobile_hotspot`，不记录 SSID、IP、运营商账户或凭据；
+4. 冻结 evidence 目录为 0 条目，managed orphan 为 0。
+
+Runtime adapter 只允许 `validate`、`plan` 和 `preflight`。`execute_reachability` 与 `execute_canary` 必须机械拒绝；源码不得读取 credential 或创建 provider model。
+
+## 下一授权门禁
+
+本协议合并并从干净主干完成真实 0-provider preflight 后，只形成一次真实授权的决策包。若实验负责人明确授权，下一版本才可增加一次 reachability 与固定单 pair execute path，并在请求开始前创建不可变 marker。未经该授权不得产生任何 provider/evidence 副作用，也不得扩大 behavioral pilot。

--- a/benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+  "title": "Forge opaque provenance minimal canary authorized candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+    "schema_version": "forge-opaque-provenance-minimal-canary-authorized-1.0.0",
+    "document_type": "forge_opaque_provenance_minimal_canary_authorized_candidate",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/182",
+      "runtime_adapter_candidate_authorized": true,
+      "zero_provider_preflight_authorized": true,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "canary_collection_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json",
+      "schema_version": "forge-opaque-provenance-minimal-canary-1.0.0",
+      "canonical_sha256": "ad5a1ac989c4072ec097a3b0949d5e4393475d6df0896e108dbc313690dd3ee7",
+      "file_sha256": "c9280ce00094b6dee30aea4fb4b2a6ac4d3b33b0784015a628dacc3d00b05076",
+      "authorization_baseline_commit": "06ba008ddaa77956ce39e97f30f79e27a1a0639e",
+      "release_revision_policy": "descendant-compatible"
+    },
+    "case": {
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "compile_image": "autocompiler:gcc13",
+      "build_system": "cmake",
+      "build_directory": "/workspace/repo/build",
+      "target": "accumulate_examples",
+      "staged_artifact": "accumulate_examples",
+      "checkpoint_source": "issue-178-real-docker-lifecycle",
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "provider": {
+      "status": "future_identity_only",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-cppitertools-pair-01",
+        "order": 1,
+        "case_id": "cppitertools-opaque-provenance-real-docker",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "treatment_exposure_only": "repair_packet"
+      }
+    ],
+    "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "purpose": "mechanism_wiring_canary_only",
+      "unit_of_analysis": "single_failure_checkpoint_pair",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-minimal-canary-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1",
+      "preflight_snapshot": "preflight/preflight.json",
+      "reachability_marker": "markers/reachability.json",
+      "pair_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "marker_consumed_on_start": true,
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538"
+    },
+    "opportunities": {
+      "maximum_reachability_requests": 1,
+      "maximum_canary_pairs": 1,
+      "required_order": [
+        "reachability",
+        "opaque-provenance-cppitertools-pair-01"
+      ],
+      "retry_replacement_backfill_forbidden": true
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "require_empty_evidence_directory": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py",
+      "file_sha256": "2f5729e4793f523830cfd0da713fdf65e84485ca73c7940563933e3de0d02f32",
+      "commands": [
+        "validate",
+        "plan",
+        "preflight"
+      ],
+      "credential_read_supported": false,
+      "provider_model_creation_supported": false,
+      "reachability_execute_supported": false,
+      "canary_execute_supported": false
+    },
+    "frozen_parent_components": {
+      "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json": "c9280ce00094b6dee30aea4fb4b2a6ac4d3b33b0784015a628dacc3d00b05076",
+      "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md": "539b79793466c3419ad351715892048a910826fee14d9a2f871e669e79965737",
+      "benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json": "952713b70a77f015c4fbe7902158ed78f52abb3073a6cae51bf2bfe3216e7f6a",
+      "scripts/forge_opaque_provenance_minimal_canary_protocol.py": "a67cda050c97ee481b243e232884bbcd3b6bdf403b3671026f3121e98a6c22ad"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py
+++ b/scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Issue #182 opaque provenance 最小 canary 授权候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py"
+
+SCHEMA_VERSION = "forge-opaque-provenance-minimal-canary-authorized-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_minimal_canary_authorized_candidate"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/182"
+AUTHORIZATION_BASELINE_COMMIT = "06ba008ddaa77956ce39e97f30f79e27a1a0639e"
+PARENT_MANIFEST_SHA256 = "ad5a1ac989c4072ec097a3b0949d5e4393475d6df0896e108dbc313690dd3ee7"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1"
+EVIDENCE_SCHEMA_VERSION = "forge-opaque-provenance-minimal-canary-evidence-1.0.0"
+
+FROZEN_PARENT_PATHS = {
+    "benchmarks/manifests/cpp-opaque-provenance-minimal-canary.json",
+    "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary.md",
+    "benchmarks/schemas/forge-opaque-provenance-minimal-canary.schema.json",
+    "scripts/forge_opaque_provenance_minimal_canary_protocol.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """授权候选、父协议或 evidence identity 发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_minimal_canary_protocol.py"
+    name = "forge_opaque_provenance_minimal_canary_authorized_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load parent minimal canary protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    manifest = parent.load_manifest(repo_root / PARENT_MANIFEST_PATH, repo_root)
+    if parent.canonical_sha256(manifest) != PARENT_MANIFEST_SHA256:
+        raise ProtocolError("parent minimal canary identity drifted")
+    return manifest, parent
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def _evidence_identity(parent_manifest: dict[str, Any]) -> dict[str, Any]:
+    identity = {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "directory": EVIDENCE_DIRECTORY,
+        "preflight_snapshot": "preflight/preflight.json",
+        "reachability_marker": "markers/reachability.json",
+        "pair_ledger": f"pairs/{parent_manifest['schedule'][0]['pair_id']}/events.jsonl",
+        "canary_report": "reports/canary.json",
+        "append_only": True,
+        "marker_consumed_on_start": True,
+        "zero_provider_preflight_writes_evidence": False,
+    }
+    return {**identity, "identity_sha256": canonical_sha256(identity)}
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent_manifest, parent = _parent_manifest(repo_root)
+    evidence = _evidence_identity(parent_manifest)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    if not runtime_path.is_file():
+        raise ProtocolError(f"runtime adapter missing: {RUNTIME_ADAPTER_PATH}")
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "runtime_adapter_candidate_authorized": True,
+            "zero_provider_preflight_authorized": True,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "canary_collection_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent_manifest["schema_version"],
+            "canonical_sha256": parent.canonical_sha256(parent_manifest),
+            "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "case": copy.deepcopy(parent_manifest["case"]),
+        "provider": copy.deepcopy(parent_manifest["provider"]),
+        "continuation": copy.deepcopy(parent_manifest["continuation"]),
+        "schedule": copy.deepcopy(parent_manifest["schedule"]),
+        "schedule_sha256": parent_manifest["schedule_sha256"],
+        "budget": copy.deepcopy(parent_manifest["budget"]),
+        "stopping": copy.deepcopy(parent_manifest["stopping"]),
+        "analysis": copy.deepcopy(parent_manifest["analysis"]),
+        "evidence": evidence,
+        "opportunities": {
+            "maximum_reachability_requests": 1,
+            "maximum_canary_pairs": 1,
+            "required_order": ["reachability", parent_manifest["schedule"][0]["pair_id"]],
+            "retry_replacement_backfill_forbidden": True,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "require_authorization_baseline_ancestor": True,
+            "docker_provider": "ubuntu-native",
+            "docker_context": "default",
+            "docker_endpoint": "/var/run/docker.sock",
+            "allowed_network_media": ["wired", "wifi", "mobile_hotspot"],
+            "require_empty_evidence_directory": True,
+            "managed_container_prefixes": ["deerflow-compile-", "deerflow-replay-"],
+            "require_zero_managed_orphans": True,
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "plan", "preflight"],
+            "credential_read_supported": False,
+            "provider_model_creation_supported": False,
+            "reachability_execute_supported": False,
+            "canary_execute_supported": False,
+        },
+        "frozen_parent_components": _hash_paths(repo_root, FROZEN_PARENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("opaque provenance authorized candidate manifest drifted")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read opaque provenance authorized candidate manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+        "title": "Forge opaque provenance minimal canary authorized candidate",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+                "evidence_writes": 0,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py
+++ b/scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Issue #182 授权候选的零 provider runtime adapter。"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+
+
+class RuntimeGateError(RuntimeError):
+    """Runtime preflight 或未授权执行入口被拒绝。"""
+
+
+def _load_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py"
+    name = "forge_opaque_provenance_minimal_canary_authorized_runtime_protocol"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeGateError("cannot load authorized candidate protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+CommandRunner = Callable[[Sequence[str], Path], str]
+
+
+def _run_command(command: Sequence[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeGateError(f"preflight command failed: {command[0]}") from exc
+    return result.stdout.strip()
+
+
+def build_plan(manifest: dict[str, Any]) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    return {
+        "schema_version": manifest["schema_version"],
+        "parent_manifest_sha256": manifest["parent"]["canonical_sha256"],
+        "case_id": manifest["case"]["case_id"],
+        "pair_id": manifest["schedule"][0]["pair_id"],
+        "arm_order": manifest["schedule"][0]["arm_order"],
+        "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+        "evidence_directory": manifest["evidence"]["directory"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+        "execution_authorized": False,
+    }
+
+
+def validate_preflight_snapshot(manifest: dict[str, Any], snapshot: Any) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    if not isinstance(snapshot, dict):
+        raise RuntimeGateError("preflight snapshot must be an object")
+    expected_keys = {
+        "schema_version",
+        "branch",
+        "head_commit",
+        "origin_main_commit",
+        "worktree_clean",
+        "authorization_baseline_ancestor",
+        "docker_provider",
+        "docker_context",
+        "docker_endpoint",
+        "network_medium",
+        "evidence_directory",
+        "evidence_entries",
+        "managed_orphans",
+    }
+    if set(snapshot) != expected_keys:
+        raise RuntimeGateError("preflight snapshot fields drifted")
+    if snapshot["schema_version"] != "forge-opaque-provenance-minimal-canary-preflight-1.0.0":
+        raise RuntimeGateError("preflight schema identity drifted")
+    if snapshot["branch"] != manifest["preflight"]["release_branch"]:
+        raise RuntimeGateError("preflight release branch drifted")
+    if not snapshot["head_commit"] or snapshot["head_commit"] != snapshot["origin_main_commit"]:
+        raise RuntimeGateError("preflight main/origin identity drifted")
+    if snapshot["worktree_clean"] is not True or snapshot["authorization_baseline_ancestor"] is not True:
+        raise RuntimeGateError("preflight release identity is not clean or descendant-compatible")
+    for key in ("docker_provider", "docker_context", "docker_endpoint"):
+        if snapshot[key] != manifest["preflight"][key]:
+            raise RuntimeGateError(f"preflight {key} drifted")
+    if snapshot["network_medium"] not in manifest["preflight"]["allowed_network_media"]:
+        raise RuntimeGateError("preflight network medium is missing or invalid")
+    if snapshot["evidence_directory"] != manifest["evidence"]["directory"] or snapshot["evidence_entries"] != 0:
+        raise RuntimeGateError("preflight evidence directory is not the frozen empty directory")
+    if snapshot["managed_orphans"] != []:
+        raise RuntimeGateError("preflight found managed Compile Session/replay orphans")
+    return snapshot
+
+
+def collect_preflight_snapshot(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+    host_evidence_directory: Path,
+    network_medium: str,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    expected_name = PurePosixPath(manifest["evidence"]["directory"]).name
+    expected_host_directory = repo_root / ".compile-sessions" / expected_name
+    if host_evidence_directory.resolve(strict=False) != expected_host_directory.resolve(strict=False):
+        raise RuntimeGateError("host evidence directory is not bound to the frozen identity")
+    if network_medium not in manifest["preflight"]["allowed_network_media"]:
+        raise RuntimeGateError("network medium is missing or invalid")
+
+    branch = command_runner(("git", "branch", "--show-current"), repo_root)
+    head = command_runner(("git", "rev-parse", "HEAD"), repo_root)
+    origin_main = command_runner(("git", "rev-parse", "origin/main"), repo_root)
+    status = command_runner(("git", "status", "--porcelain"), repo_root)
+    baseline_check = command_runner(
+        ("git", "merge-base", "--is-ancestor", manifest["parent"]["authorization_baseline_commit"], "HEAD"),
+        repo_root,
+    )
+    if baseline_check:
+        raise RuntimeGateError("git ancestry check produced unexpected output")
+
+    gate_output = command_runner(("bash", str(repo_root / "scripts/require-ubuntu-native-docker.sh")), repo_root)
+    expected_gate = "OK: Forge Docker daemon provider=ubuntu-native; context=default; endpoint=/var/run/docker.sock"
+    if gate_output != expected_gate:
+        raise RuntimeGateError("Ubuntu-native Docker gate output drifted")
+    names = command_runner(("docker", "ps", "-a", "--format", "{{.Names}}"), repo_root).splitlines()
+    prefixes = tuple(manifest["preflight"]["managed_container_prefixes"])
+    orphans = sorted(name for name in names if name.startswith(prefixes))
+    entries = len(tuple(host_evidence_directory.iterdir())) if host_evidence_directory.exists() else 0
+
+    snapshot = {
+        "schema_version": "forge-opaque-provenance-minimal-canary-preflight-1.0.0",
+        "branch": branch,
+        "head_commit": head,
+        "origin_main_commit": origin_main,
+        "worktree_clean": status == "",
+        "authorization_baseline_ancestor": True,
+        "docker_provider": "ubuntu-native",
+        "docker_context": "default",
+        "docker_endpoint": "/var/run/docker.sock",
+        "network_medium": network_medium,
+        "evidence_directory": manifest["evidence"]["directory"],
+        "evidence_entries": entries,
+        "managed_orphans": orphans,
+    }
+    return validate_preflight_snapshot(manifest, snapshot)
+
+
+def execute_reachability(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("reachability request is not authorized by Issue #182")
+
+
+def execute_canary(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("provider canary is not authorized by Issue #182")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "plan", "preflight"))
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--host-evidence-directory", type=Path)
+    parser.add_argument("--network-medium", choices=("wired", "wifi", "mobile_hotspot"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest, args.repo_root)
+    if args.command == "preflight":
+        if args.host_evidence_directory is None or args.network_medium is None:
+            raise RuntimeGateError("preflight requires host evidence directory and network medium")
+        result = collect_preflight_snapshot(
+            manifest,
+            repo_root=args.repo_root,
+            host_evidence_directory=args.host_evidence_directory,
+            network_medium=args.network_medium,
+        )
+    else:
+        result = (
+            build_plan(manifest)
+            if args.command == "plan"
+            else {
+                "manifest_sha256": protocol.canonical_sha256(manifest),
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+                "evidence_writes": 0,
+            }
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从 #180 父协议派生版本化的 opaque provenance 最小 canary 授权候选。
- 固定独立 evidence 目录、preflight snapshot、一次性 reachability marker、pair ledger、report 和 identity SHA-256。
- 新增轻量 runtime adapter，只允许 validate、plan 与只读 preflight。
- preflight 精确绑定仓库共享 .compile-sessions 路径，并核对干净主干、Ubuntu-native Docker、网络介质、空 evidence 与 0 managed orphan。
- reachability 与 canary 执行函数机械拒绝，不读取 credential、不创建 provider model、不写 evidence。

## 研究边界

本 PR 只证明授权边界和 runtime 接线可审计。它不授权真实 provider 请求，不产生模型效果证据，也不扩大 behavioral pilot。

## 验证

- 路线 P 聚焦及相邻静态回归：69 passed
- Ruff check/format、Python 语法、Schema、CLI、git diff --check 通过
- manifest canonical SHA-256：00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771
- evidence identity SHA-256：f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538
- 固定 0 provider call、0 formal attempt、0 model token、0 evidence write

Closes #182