### PR TITLE
研究：执行 opaque provenance 最小 canary

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-30 — 执行 opaque provenance 最小 provider canary
+  - GitHub: 中文 Issue #184 已创建并回读；分支为 `research/issue-184-opaque-provenance-execution`，基线为 `main@323430f1`。
+  - 实现: 新增一次性 execution amendment、const Schema、runner、预注册和聚焦测试；冻结 DeepSeek `deepseek-v4-flash`、300 秒/0 retry、单次 reachability、成功后唯一 `baseline -> treatment` pair 与 245,000 recorded-token 总上限。
+  - 机制: Parent 使用 #178 opaque wrapper，只允许 production `build_system_unproven` 与 P2 `unproven/opaque_wrapper`；双臂同源，treatment 唯一额外 exposure 是白名单 repair packet，arm outcome 同时核对 production candidate/clean replay 与动态 P2 conversion。
+  - 当前验证: manifest canonical SHA-256 为 `bbb50851419ec8c1e1efb4bc5612cb13e4ab0154df574dc7359009e2fb90529a`；路线 P 相邻静态回归 `77 passed`，Ruff check/format、Schema、CLI 和 `git diff --check` 通过；尚未调用 provider 或 Docker。
+  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；从干净主干执行 0-provider preflight，随后只运行唯一 reachability，成功才运行单 pair，最后审计 token、ledger、P2、candidate/replay、cleanup 与 orphan。
+  - 文件: `scripts/forge_opaque_provenance_minimal_canary_execution_protocol.py`, `scripts/forge_opaque_provenance_minimal_canary_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_minimal_canary_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-minimal-canary-execution.json`, `benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md`
+
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
   - 实现: 新增实验专用 `forge-combined-checkpoint-1.0.0` manifest，把 message、environment、budget 绑定到同一 `capture_id` 与 message state SHA-256；三层全部校验后才发布父 manifest。

--- a/backend/tests/test_forge_opaque_provenance_minimal_canary_execution.py
+++ b/backend/tests/test_forge_opaque_provenance_minimal_canary_execution.py
@@ -1,0 +1,188 @@
+"""Issue #184 一次性执行 amendment 的零 provider 契约测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS / "forge_opaque_provenance_minimal_canary_execution_protocol.py"
+RUNNER_PATH = SCRIPTS / "forge_opaque_provenance_minimal_canary_execution_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-execution.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS))
+
+
+protocol = _load_module("forge_opaque_provenance_minimal_canary_execution_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_opaque_provenance_minimal_canary_execution_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_parent_evidence_and_runtime_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["parent"]["canonical_sha256"] == protocol.PARENT_MANIFEST_SHA256
+    assert manifest["parent"]["evidence_identity_sha256"] == protocol.PARENT_EVIDENCE_IDENTITY_SHA256
+    assert manifest["runtime_adapter"]["file_sha256"] == protocol.file_sha256(RUNNER_PATH)
+    assert manifest["preregistration"]["file_sha256"] == protocol.file_sha256(REPO_ROOT / manifest["preregistration"]["path"])
+
+
+def test_authorization_order_and_stage_budget_are_exact() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    authorization = manifest["authorization"]
+    assert authorization == {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/184",
+        "reachability_request_authorized": True,
+        "provider_calls_authorized": True,
+        "formal_attempts_authorized": True,
+        "canary_collection_authorized": True,
+        "model_tokens_authorized": 245000,
+    }
+    assert manifest["opportunities"]["required_order"] == ["reachability", "opaque-provenance-cppitertools-pair-01"]
+    assert manifest["schedule"][0]["arm_order"] == ["baseline", "treatment"]
+    assert manifest["budget"]["reachability_maximum_recorded_tokens"] + manifest["budget"]["recorded_tokens_per_pair"] == 245000
+
+
+class _Model:
+    def __init__(self, text: str, *, tokens: int = 7):
+        self.text = text
+        self.tokens = tokens
+
+    def invoke(self, _prompt: str):
+        return SimpleNamespace(
+            content=self.text,
+            response_metadata={"model_name": "deepseek-v4-flash"},
+            usage_metadata={"input_tokens": 3, "output_tokens": self.tokens - 3, "total_tokens": self.tokens},
+        )
+
+
+def _preflight(manifest: dict) -> dict:
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": "a" * 40,
+        "network_access_medium": "wifi",
+        "evidence_files": [],
+        "zero_managed_containers": True,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def test_reachability_is_create_once_and_records_no_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(runner, "collect_preflight", lambda *args, **kwargs: _preflight(manifest))
+    report = runner.execute_reachability(manifest, output_dir=tmp_path, model_factory=lambda _manifest: _Model("CANARY_OK"))
+    assert report["passed"] is True
+    assert report["recorded_tokens"] == 7
+    serialized = json.dumps(report, sort_keys=True)
+    assert report["credential_env"] == "DEEPSEEK_API_KEY"
+    assert "credential_value" not in report
+    assert "sk-test-secret" not in serialized
+    with pytest.raises(RuntimeError):
+        runner.execute_reachability(manifest, output_dir=tmp_path, model_factory=lambda _manifest: _Model("CANARY_OK"))
+
+
+def test_failed_reachability_consumes_marker_and_pair_gate_rejects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(runner, "collect_preflight", lambda *args, **kwargs: _preflight(manifest))
+    with pytest.raises(runner.ExecutionGateError, match="reachability"):
+        runner.execute_reachability(manifest, output_dir=tmp_path, model_factory=lambda _manifest: _Model("WRONG"))
+    marker = _load(tmp_path / manifest["evidence"]["reachability_marker"])
+    assert marker["status"] == "failed"
+    with pytest.raises(runner.ExecutionGateError, match="未形成"):
+        runner._passed_reachability(manifest, tmp_path, "a" * 40)
+
+
+def test_pair_gate_rejects_extra_evidence_after_passed_reachability(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(runner, "collect_preflight", lambda *args, **kwargs: _preflight(manifest))
+    runner.execute_reachability(manifest, output_dir=tmp_path, model_factory=lambda _manifest: _Model("CANARY_OK"))
+    extra = tmp_path / "unexpected.json"
+    extra.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(runner.ExecutionGateError, match="唯一 reachability"):
+        runner._passed_reachability(manifest, tmp_path, "a" * 40)
+
+
+def test_arm_budget_is_checked_before_each_continuation() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    runner.require_arm_budget(manifest, reachability_tokens=5000, completed_arm_tokens=[])
+    runner.require_arm_budget(manifest, reachability_tokens=5000, completed_arm_tokens=[120000])
+    with pytest.raises(runner.ExecutionGateError, match="预算不足"):
+        runner.require_arm_budget(manifest, reachability_tokens=5001, completed_arm_tokens=[120000])
+    with pytest.raises(runner.ExecutionGateError, match="evidence"):
+        runner.require_arm_budget(manifest, reachability_tokens=-1, completed_arm_tokens=[])
+
+
+def test_dynamic_p2_requires_runtime_recorded_direct_cmake(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "build").mkdir(parents=True)
+    artifact = repo / runner.opaque.BUILD_OUTPUT
+    tree = repo / "build/build.ninja"
+    artifact.write_bytes(b"frozen-artifact")
+    tree.write_bytes(b"frozen-tree")
+    image_id = "sha256:" + "2" * 64
+    frozen = runner.opaque.build_frozen_identity(
+        image_id=image_id,
+        physical_attempt_id="attempt-arm",
+        build_tree_sha256=runner.primary.lifecycle.sha256_file(tree),
+        artifact_size=artifact.stat().st_size,
+        artifact_sha256=runner.primary.lifecycle.sha256_file(artifact),
+    )
+    parent = SimpleNamespace(command_id="parent", command=runner.opaque.PARENT_COMMAND, stage="bash")
+    direct = SimpleNamespace(
+        command_id="direct",
+        command=f"cmake --build {runner.opaque.BUILD_DIRECTORY} --target {runner.opaque.TARGET} -j2",
+        stage="bash",
+        workdir=runner.opaque.WORKDIR,
+        exit_code=0,
+        timed_out=False,
+        role="build",
+    )
+    session = SimpleNamespace(
+        leadagent_repo_dir=str(repo),
+        post_build_supporting_command_id="direct",
+        commands=[parent, direct],
+    )
+    decision, history = runner._evaluate_arm_p2(session, frozen, "parent")
+    assert decision.status == "proven"
+    assert decision.proof_mode == "direct_cmake"
+    assert len(history) == 2
+
+
+def test_parent_policy_and_packet_keep_non_estimand_constraints_neutral() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    policy = runner._parent_policy(manifest, image_id="sha256:" + "2" * 64)
+    assert policy.model_name == "deterministic-no-provider"
+    assert policy.cmake_arguments == ()
+    assert policy.configure_arguments == ()
+    assert runner.opaque.validate_repair_packet(runner.opaque.build_repair_packet()) == runner.opaque.build_repair_packet()

--- a/benchmarks/manifests/cpp-opaque-provenance-minimal-canary-execution.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-minimal-canary-execution.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-minimal-canary-execution.schema.json",
+  "schema_version": "forge-opaque-provenance-minimal-canary-execution-1.0.0",
+  "document_type": "forge_opaque_provenance_minimal_canary_execution_amendment",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/184",
+    "reachability_request_authorized": true,
+    "provider_calls_authorized": true,
+    "formal_attempts_authorized": true,
+    "canary_collection_authorized": true,
+    "model_tokens_authorized": 245000
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json",
+    "schema_version": "forge-opaque-provenance-minimal-canary-authorized-1.0.0",
+    "canonical_sha256": "00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771",
+    "file_sha256": "98f2d5d23b576285a9adcacfcd0e9d315df65bdf86389ef1400807a57922a303",
+    "evidence_identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538",
+    "authorization_baseline_commit": "323430f1fb3f3fb7ac09c6ea1aefa801298e5619",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "case": {
+    "case_id": "cppitertools-opaque-provenance-real-docker",
+    "repository_url": "https://github.com/ryanhaining/cppitertools",
+    "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+    "compile_image": "autocompiler:gcc13",
+    "build_system": "cmake",
+    "build_directory": "/workspace/repo/build",
+    "target": "accumulate_examples",
+    "staged_artifact": "accumulate_examples",
+    "checkpoint_source": "issue-178-real-docker-lifecycle",
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "provider": {
+    "status": "active_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-cppitertools-pair-01",
+      "order": 1,
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "treatment_exposure_only": "repair_packet"
+    }
+  ],
+  "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "purpose": "mechanism_wiring_canary_only",
+    "unit_of_analysis": "single_failure_checkpoint_pair",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-minimal-canary-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1",
+    "preflight_snapshot": "preflight/preflight.json",
+    "reachability_marker": "markers/reachability.json",
+    "pair_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "marker_consumed_on_start": true,
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538"
+  },
+  "opportunities": {
+    "maximum_reachability_requests": 1,
+    "maximum_canary_pairs": 1,
+    "required_order": [
+      "reachability",
+      "opaque-provenance-cppitertools-pair-01"
+    ],
+    "retry_replacement_backfill_forbidden": true
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "require_authorization_baseline_ancestor": true,
+    "docker_provider": "ubuntu-native",
+    "docker_context": "default",
+    "docker_endpoint": "/var/run/docker.sock",
+    "allowed_network_media": [
+      "wired",
+      "wifi",
+      "mobile_hotspot"
+    ],
+    "require_empty_evidence_directory": true,
+    "managed_container_prefixes": [
+      "deerflow-compile-",
+      "deerflow-replay-"
+    ],
+    "require_zero_managed_orphans": true
+  },
+  "execution": {
+    "release_branch": "main",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+    "reachability_expected_response": "CANARY_OK",
+    "reachability_report": "reports/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "parent_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-cppitertools-pair-01/arms"
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md",
+    "file_sha256": "6220846cea0596586ffda30a379a2e54f7b4f3b5a467db09dc4baad28d9e5027"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py",
+    "file_sha256": "9f3cdd0ad3faa210b0ee5adcda9c18f37047b7fa6c3e264cd3b280b02b4ccca0",
+    "commands": [
+      "validate",
+      "preflight",
+      "reachability",
+      "pair"
+    ],
+    "credential_read_supported": true,
+    "provider_model_creation_supported": true,
+    "reachability_execute_supported": true,
+    "canary_execute_supported": true
+  },
+  "frozen_parent_components": {
+    "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json": "98f2d5d23b576285a9adcacfcd0e9d315df65bdf86389ef1400807a57922a303",
+    "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md": "00d18e71f18cb7d52d000a1dd6de17231bddf9be7358985a76f53192e8953aa4",
+    "benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json": "addfc949482f2fd7a7d325db78e838d774cd25239602f0a3976ba25ca87c04be",
+    "scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py": "31d62705ff4b86fd51eee3c8d1a44697e6a629b609f05eb85e4c14ddbc96dd91",
+    "scripts/forge_opaque_build_provenance_real_docker_gate.py": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+    "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py": "10fbd2fbe909cde30f0d538ed25f96d9de8cfad69d33c527b2a8af9e31207390",
+    "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py": "2f5729e4793f523830cfd0da713fdf65e84485ca73c7940563933e3de0d02f32"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md
@@ -1,0 +1,32 @@
+# Opaque build provenance 最小 canary 一次性执行 amendment
+
+本 amendment 承接 Issue #182 已合并的授权候选与真实 0-provider preflight。实验负责人回复“继续执行”，据此只授权 Issue #184 所述的一次 DeepSeek reachability；只有 reachability 通过，才执行一个固定 `baseline -> treatment` pair。
+
+## 冻结身份
+
+- 父基线：`main@323430f1fb3f3fb7ac09c6ea1aefa801298e5619`。
+- 父 manifest canonical SHA-256：`00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771`。
+- Evidence identity SHA-256：`f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538`。
+- Provider：DeepSeek `deepseek-v4-flash`，endpoint `https://api.deepseek.com`，credential env `DEEPSEEK_API_KEY`。
+- 请求策略：300 秒、0 retry、非 streaming、禁止 fallback。
+- Pair：`opaque-provenance-cppitertools-pair-01`，顺序固定 `baseline -> treatment`。
+
+## 一次性机会与预算
+
+Reachability marker 在请求开始前 create-once；started、failed 或 passed 都消耗唯一机会。Reachability 最多 1 次、5,000 recorded tokens。失败时 pair 必须机械拒绝。
+
+每臂最多 8 requests、8 model turns、24 graph steps、600 秒工作时间、120 秒 cleanup reserve 和 120,000 recorded tokens。Pair 上限 240,000，阶段总上限 245,000。启动每一臂前按已记录 token 重新检查能否容纳完整下一臂；禁止 retry、replacement、backfill 或追加 pair。
+
+## Checkpoint 与 treatment
+
+Parent 使用 Issue #178 冻结的自包含 opaque `sh -c` wrapper，真实完成 CMake/Ninja configure、target build 与 artifact staging。Production submit 必须只有 `build_system_unproven`，P2 必须为 `unproven/opaque_wrapper`，且 candidate/replay 不启动。
+
+双臂从同一个 committed message、environment 和 budget checkpoint 派生。Baseline 只看到原始 submit 失败；treatment 唯一额外 exposure 是 Issue #178 白名单 repair packet。Packet 不包含命令、argv、shell、prompt、secret 或完整解法。
+
+主要 outcome 是 post-checkpoint P2 provenance conversion。Production candidate verification 与 clean replay 通过但 P2 未证明时 fail closed；artifact、build tree、source、image、ledger、token 或 cleanup identity 漂移时停止。
+
+## 执行与解释边界
+
+真实执行只允许从干净 `main == origin/main`、Wi-Fi 记录、Ubuntu-native Docker `/var/run/docker.sock`、0 managed orphan 的 Compose/DooD control plane 发起。Evidence 写入 #182 冻结目录，marker 与报告不可覆盖；AK 值不得进入日志、报告或 Git。
+
+该单 pair 只验证真实 provider 与机制测量链能否接线。无论结果如何，都不估计 treatment effect，不计算 p 值、不排名模型、不与 `artifact_staging_missing` 历史 pair 池化，也不自动授权多 pair pilot。

--- a/benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json",
+  "title": "Forge opaque provenance minimal canary execution amendment",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-minimal-canary-execution.schema.json",
+    "schema_version": "forge-opaque-provenance-minimal-canary-execution-1.0.0",
+    "document_type": "forge_opaque_provenance_minimal_canary_execution_amendment",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/184",
+      "reachability_request_authorized": true,
+      "provider_calls_authorized": true,
+      "formal_attempts_authorized": true,
+      "canary_collection_authorized": true,
+      "model_tokens_authorized": 245000
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json",
+      "schema_version": "forge-opaque-provenance-minimal-canary-authorized-1.0.0",
+      "canonical_sha256": "00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771",
+      "file_sha256": "98f2d5d23b576285a9adcacfcd0e9d315df65bdf86389ef1400807a57922a303",
+      "evidence_identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538",
+      "authorization_baseline_commit": "323430f1fb3f3fb7ac09c6ea1aefa801298e5619",
+      "release_revision_policy": "descendant-compatible"
+    },
+    "case": {
+      "case_id": "cppitertools-opaque-provenance-real-docker",
+      "repository_url": "https://github.com/ryanhaining/cppitertools",
+      "commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "compile_image": "autocompiler:gcc13",
+      "build_system": "cmake",
+      "build_directory": "/workspace/repo/build",
+      "target": "accumulate_examples",
+      "staged_artifact": "accumulate_examples",
+      "checkpoint_source": "issue-178-real-docker-lifecycle",
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "provider": {
+      "status": "active_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-cppitertools-pair-01",
+        "order": 1,
+        "case_id": "cppitertools-opaque-provenance-real-docker",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "treatment_exposure_only": "repair_packet"
+      }
+    ],
+    "schedule_sha256": "d26e8e31aa1830973be89a8337dbff6a24852333968c55a649df359de567b375",
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "purpose": "mechanism_wiring_canary_only",
+      "unit_of_analysis": "single_failure_checkpoint_pair",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-minimal-canary-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1",
+      "preflight_snapshot": "preflight/preflight.json",
+      "reachability_marker": "markers/reachability.json",
+      "pair_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "marker_consumed_on_start": true,
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538"
+    },
+    "opportunities": {
+      "maximum_reachability_requests": 1,
+      "maximum_canary_pairs": 1,
+      "required_order": [
+        "reachability",
+        "opaque-provenance-cppitertools-pair-01"
+      ],
+      "retry_replacement_backfill_forbidden": true
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "require_empty_evidence_directory": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true
+    },
+    "execution": {
+      "release_branch": "main",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "reachability_expected_response": "CANARY_OK",
+      "reachability_report": "reports/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "parent_ledger": "pairs/opaque-provenance-cppitertools-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-cppitertools-pair-01/arms"
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md",
+      "file_sha256": "6220846cea0596586ffda30a379a2e54f7b4f3b5a467db09dc4baad28d9e5027"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py",
+      "file_sha256": "9f3cdd0ad3faa210b0ee5adcda9c18f37047b7fa6c3e264cd3b280b02b4ccca0",
+      "commands": [
+        "validate",
+        "preflight",
+        "reachability",
+        "pair"
+      ],
+      "credential_read_supported": true,
+      "provider_model_creation_supported": true,
+      "reachability_execute_supported": true,
+      "canary_execute_supported": true
+    },
+    "frozen_parent_components": {
+      "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json": "98f2d5d23b576285a9adcacfcd0e9d315df65bdf86389ef1400807a57922a303",
+      "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md": "00d18e71f18cb7d52d000a1dd6de17231bddf9be7358985a76f53192e8953aa4",
+      "benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json": "addfc949482f2fd7a7d325db78e838d774cd25239602f0a3976ba25ca87c04be",
+      "scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py": "31d62705ff4b86fd51eee3c8d1a44697e6a629b609f05eb85e4c14ddbc96dd91",
+      "scripts/forge_opaque_build_provenance_real_docker_gate.py": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+      "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py": "10fbd2fbe909cde30f0d538ed25f96d9de8cfad69d33c527b2a8af9e31207390",
+      "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py": "2f5729e4793f523830cfd0da713fdf65e84485ca73c7940563933e3de0d02f32"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_minimal_canary_execution_protocol.py
+++ b/scripts/forge_opaque_provenance_minimal_canary_execution_protocol.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Issue #184 opaque provenance 最小 canary 一次性执行 amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-execution.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-minimal-canary-authorized.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-execution.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-minimal-canary-execution-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_minimal_canary_execution_amendment"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/184"
+AUTHORIZATION_BASELINE_COMMIT = "323430f1fb3f3fb7ac09c6ea1aefa801298e5619"
+PARENT_MANIFEST_SHA256 = "00ce7eaadda3e89b63d093f4e360473fe372850dd39290d69e1a4a7e675e7771"
+PARENT_EVIDENCE_IDENTITY_SHA256 = "f83fb4a3d228c82839df68905ee603c79095c919fe0cc8ab0c52ce4debaeb538"
+
+FROZEN_PARENT_PATHS = {
+    PARENT_MANIFEST_PATH,
+    "benchmarks/preregistrations/cpp-opaque-provenance-minimal-canary-authorized.md",
+    "benchmarks/schemas/forge-opaque-provenance-minimal-canary-authorized.schema.json",
+    "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py",
+    "scripts/forge_opaque_provenance_minimal_canary_authorized_runner.py",
+    "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+    "scripts/forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """执行 amendment、父身份或预算发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_minimal_canary_authorized_protocol.py"
+    name = "forge_opaque_provenance_minimal_canary_execution_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load authorized candidate protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    manifest = parent.load_manifest(repo_root / PARENT_MANIFEST_PATH, repo_root)
+    if parent.canonical_sha256(manifest) != PARENT_MANIFEST_SHA256:
+        raise ProtocolError("authorized candidate manifest identity drifted")
+    if manifest["evidence"]["identity_sha256"] != PARENT_EVIDENCE_IDENTITY_SHA256:
+        raise ProtocolError("authorized evidence identity drifted")
+    return manifest, parent
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent_manifest, parent = _parent_manifest(repo_root)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    if not runtime_path.is_file():
+        raise ProtocolError(f"runtime adapter missing: {RUNTIME_ADAPTER_PATH}")
+    provider = copy.deepcopy(parent_manifest["provider"])
+    provider["status"] = "active_authorized"
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-minimal-canary-execution.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "reachability_request_authorized": True,
+            "provider_calls_authorized": True,
+            "formal_attempts_authorized": True,
+            "canary_collection_authorized": True,
+            "model_tokens_authorized": parent_manifest["budget"]["stage_maximum_recorded_tokens"],
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent_manifest["schema_version"],
+            "canonical_sha256": parent.canonical_sha256(parent_manifest),
+            "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+            "evidence_identity_sha256": parent_manifest["evidence"]["identity_sha256"],
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "case": copy.deepcopy(parent_manifest["case"]),
+        "provider": provider,
+        "continuation": copy.deepcopy(parent_manifest["continuation"]),
+        "schedule": copy.deepcopy(parent_manifest["schedule"]),
+        "schedule_sha256": parent_manifest["schedule_sha256"],
+        "budget": copy.deepcopy(parent_manifest["budget"]),
+        "stopping": copy.deepcopy(parent_manifest["stopping"]),
+        "analysis": copy.deepcopy(parent_manifest["analysis"]),
+        "evidence": copy.deepcopy(parent_manifest["evidence"]),
+        "opportunities": copy.deepcopy(parent_manifest["opportunities"]),
+        "preflight": copy.deepcopy(parent_manifest["preflight"]),
+        "execution": {
+            "release_branch": "main",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+            "reachability_expected_response": "CANARY_OK",
+            "reachability_report": "reports/reachability.json",
+            "pair_marker": "markers/pair.json",
+            "parent_ledger": parent_manifest["evidence"]["pair_ledger"],
+            "arm_ledger_directory": f"pairs/{parent_manifest['schedule'][0]['pair_id']}/arms",
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(repo_root / PREREGISTRATION_PATH),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "preflight", "reachability", "pair"],
+            "credential_read_supported": True,
+            "provider_model_creation_supported": True,
+            "reachability_execute_supported": True,
+            "canary_execute_supported": True,
+        },
+        "frozen_parent_components": _hash_paths(repo_root, FROZEN_PARENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("opaque provenance execution amendment manifest drifted")
+    budget = value["budget"]
+    if budget["recorded_tokens_per_pair"] + budget["reachability_maximum_recorded_tokens"] != budget["stage_maximum_recorded_tokens"]:
+        raise ProtocolError("stage token budget is not closed")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read opaque provenance execution manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    if manifest["frozen_parent_components"] != _hash_paths(repo_root, FROZEN_PARENT_PATHS):
+        raise ProtocolError("frozen parent components drifted")
+    runtime = repo_root / manifest["runtime_adapter"]["path"]
+    if file_sha256(runtime) != manifest["runtime_adapter"]["file_sha256"]:
+        raise ProtocolError("runtime adapter drifted")
+    preregistration = repo_root / manifest["preregistration"]["path"]
+    if file_sha256(preregistration) != manifest["preregistration"]["file_sha256"]:
+        raise ProtocolError("preregistration drifted")
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-minimal-canary-execution.schema.json",
+        "title": "Forge opaque provenance minimal canary execution amendment",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        verify_frozen_components(manifest)
+    print(json.dumps({"manifest_sha256": canonical_sha256(manifest), "provider_calls": 0, "formal_attempts": 0, "model_tokens": 0}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_minimal_canary_execution_runner.py
+++ b/scripts/forge_opaque_provenance_minimal_canary_execution_runner.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""执行 Issue #184 授权的一次 DeepSeek reachability 与 opaque provenance 单 pair。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shlex
+import sys
+import time
+import uuid
+from dataclasses import asdict, replace
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_multi_checkpoint_behavioral_pilot_v3_authorized_runner as v3_runner  # noqa: E402
+import forge_opaque_build_provenance_real_docker_gate as opaque  # noqa: E402
+import forge_opaque_provenance_minimal_canary_execution_protocol as protocol  # noqa: E402
+
+primary = v3_runner.primary
+v2_runner = v3_runner.v2_runner
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-minimal-canary-authorized-v1")
+ARMS = ("baseline", "treatment")
+
+
+class ExecutionGateError(RuntimeError):
+    """授权 identity、预算、evidence、P2 或 cleanup 无效。"""
+
+
+def _output_dir(manifest: dict[str, Any], output_dir: Path) -> Path:
+    expected = Path(manifest["evidence"]["directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise ExecutionGateError("evidence 必须写入 #182 冻结目录")
+    return output_dir
+
+
+def _release_identity(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    branch = v3_runner._git(repo_root, "branch", "--show-current")
+    revision = v3_runner._git(repo_root, "rev-parse", "HEAD")
+    origin_main = v3_runner._git(repo_root, "rev-parse", "origin/main")
+    if branch != manifest["execution"]["release_branch"] or revision != origin_main:
+        raise ExecutionGateError("真实执行要求 main == origin/main")
+    if v3_runner._git(repo_root, "status", "--porcelain"):
+        raise ExecutionGateError("真实执行要求干净工作树")
+    try:
+        v3_runner._git(repo_root, "merge-base", "--is-ancestor", manifest["parent"]["authorization_baseline_commit"], revision)
+    except v3_runner.AuthorizedPilotError as exc:
+        raise ExecutionGateError("release revision 不是 #182 基线的后代") from exc
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+def _network_medium(manifest: dict[str, Any]) -> str:
+    medium = os.environ.get(manifest["execution"]["network_access_medium_env"])
+    if medium not in manifest["preflight"]["allowed_network_media"]:
+        raise ExecutionGateError("必须通过 FORGE_NETWORK_ACCESS_MEDIUM 记录当前网络介质")
+    return medium
+
+
+def _provider_preflight(manifest: dict[str, Any]) -> None:
+    try:
+        v3_runner._provider_config_preflight(manifest)
+    except v3_runner.AuthorizedPilotError as exc:
+        raise ExecutionGateError(str(exc)) from exc
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _output_dir(manifest, output_dir)
+    release = _release_identity(manifest, repo_root)
+    medium = _network_medium(manifest)
+    primary.require_compose_dood()
+    try:
+        v3_runner.require_zero_managed_containers()
+    except v3_runner.AuthorizedPilotError as exc:
+        raise ExecutionGateError(str(exc)) from exc
+    _provider_preflight(manifest)
+    entries = sorted(str(path.relative_to(output_dir)) for path in output_dir.rglob("*") if path.is_file()) if output_dir.exists() else []
+    if require_empty and entries:
+        raise ExecutionGateError("reachability 前要求冻结 evidence 目录为空")
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": medium,
+        "evidence_files": entries,
+        "zero_managed_containers": True,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _create_model(manifest: dict[str, Any], *, experiment_thread_id: str | None = None) -> Any:
+    model = primary._create_provider_model(manifest["provider"], experiment_thread_id=experiment_thread_id)
+    if bool(getattr(model, "streaming", False)):
+        raise ExecutionGateError("冻结 provider 必须使用非 streaming 请求")
+    return model
+
+
+def execute_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    preflight = collect_preflight(manifest, output_dir=output_dir, repo_root=repo_root, require_empty=True)
+    digest = protocol.canonical_sha256(manifest)
+    marker = output_dir / manifest["evidence"]["reachability_marker"]
+    v3_runner._claim_marker(
+        marker,
+        kind="forge_opaque_provenance_reachability_attempt",
+        manifest_sha256=digest,
+        revision=preflight["release_revision"],
+    )
+    started = time.perf_counter()
+    try:
+        model = (model_factory or (lambda value: _create_model(value)))(manifest)
+        response = model.invoke(manifest["execution"]["reachability_prompt"])
+        text = primary._response_text(response).strip()
+        actual_model, usage = primary.model_response_metadata(response)
+        tokens = usage.get("total_tokens")
+        passed = text == manifest["execution"]["reachability_expected_response"] and actual_model == manifest["provider"]["model"] and type(tokens) is int and 0 <= tokens <= manifest["budget"]["reachability_maximum_recorded_tokens"]
+        report = {
+            "schema_version": "forge-opaque-provenance-reachability-1.0.0",
+            "document_type": "forge_opaque_provenance_reachability",
+            "manifest_sha256": digest,
+            "release_revision": preflight["release_revision"],
+            "provider": manifest["provider"]["id"],
+            "endpoint": manifest["provider"]["endpoint"],
+            "credential_env": manifest["provider"]["credential_env"],
+            "network_access_medium": preflight["network_access_medium"],
+            "request_count": 1,
+            "request_timeout_seconds": manifest["provider"]["request_timeout_seconds"],
+            "max_retries": 0,
+            "streaming": False,
+            "fallback_used": False,
+            "duration_ms": round((time.perf_counter() - started) * 1000),
+            "response_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "actual_model": actual_model,
+            "recorded_tokens": tokens,
+            "passed": passed,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        v3_runner._write_once(output_dir / manifest["execution"]["reachability_report"], report)
+        if not passed:
+            raise ExecutionGateError("reachability 响应、模型 identity 或 token evidence 无效")
+    except BaseException as exc:
+        v3_runner._finish_marker(marker, status="failed", error_class=type(exc).__name__)
+        raise
+    v3_runner._finish_marker(marker, status="passed")
+    return report
+
+
+def _passed_reachability(manifest: dict[str, Any], output_dir: Path, revision: str) -> dict[str, Any]:
+    expected_files = sorted(
+        (
+            manifest["evidence"]["reachability_marker"],
+            manifest["execution"]["reachability_report"],
+        )
+    )
+    actual_files = sorted(str(path.relative_to(output_dir)).replace("\\", "/") for path in output_dir.rglob("*") if path.is_file())
+    if actual_files != expected_files:
+        raise ExecutionGateError("pair 前 evidence 不是唯一 reachability 终态")
+    marker = v3_runner._load_json(output_dir / manifest["evidence"]["reachability_marker"])
+    report = v3_runner._load_json(output_dir / manifest["execution"]["reachability_report"])
+    digest = protocol.canonical_sha256(manifest)
+    if (
+        marker.get("status") != "passed"
+        or marker.get("manifest_sha256") != digest
+        or marker.get("release_revision") != revision
+        or report.get("passed") is not True
+        or report.get("manifest_sha256") != digest
+        or report.get("release_revision") != revision
+        or type(report.get("recorded_tokens")) is not int
+        or report["recorded_tokens"] > manifest["budget"]["reachability_maximum_recorded_tokens"]
+    ):
+        raise ExecutionGateError("唯一 reachability 未形成同 revision 通过终态")
+    return report
+
+
+def require_arm_budget(manifest: dict[str, Any], *, reachability_tokens: int, completed_arm_tokens: list[int]) -> None:
+    values = [reachability_tokens, *completed_arm_tokens]
+    if any(type(value) is not int or value < 0 for value in values):
+        raise ExecutionGateError("recorded-token evidence 无效")
+    used = sum(values)
+    if used + manifest["continuation"]["maximum_recorded_tokens_per_arm"] > manifest["budget"]["stage_maximum_recorded_tokens"]:
+        raise ExecutionGateError("剩余总预算不足以启动下一臂")
+
+
+def _policy(manifest: dict[str, Any], *, arm: str, image_id: str) -> Any:
+    continuation = manifest["continuation"]
+    provider = manifest["provider"]
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-minimal-canary",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=opaque.CASE_ID,
+        condition=arm,
+        repetition=1,
+        expected_repo_url=opaque.REPOSITORY_URL,
+        expected_commit_sha=opaque.COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=opaque.COMPILE_IMAGE,
+        image_id=image_id,
+        model_name=provider["model"],
+        endpoint=provider["endpoint"],
+        credential_env=provider["credential_env"],
+        request_timeout_seconds=provider["request_timeout_seconds"],
+        model_max_retries=0,
+        compiler_max_turns=continuation["maximum_model_turns_per_arm"],
+        subagent_timeout_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=continuation["maximum_model_turns_per_arm"],
+        compiler_graph_recursion_limit=continuation["maximum_graph_steps_per_arm"],
+        compiler_wall_clock_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        compiler_post_build_reserve_seconds=continuation["cleanup_reserve_seconds_per_arm"],
+        source_subdir="examples",
+        build_targets=(opaque.TARGET,),
+        artifact_instructions=((opaque.STAGED_ARTIFACT, opaque.BUILD_OUTPUT, "executable"),),
+    )
+
+
+def _parent_policy(manifest: dict[str, Any], *, image_id: str) -> Any:
+    policy = _policy(manifest, arm="controlled-parent", image_id=image_id)
+    return replace(
+        policy,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        compiler_max_turns=1,
+    )
+
+
+def _constraint_failures(session: Any) -> list[str]:
+    if session.verification is None:
+        return []
+    checks = [check for check in session.verification.checks if check.name == "benchmark_constraints"]
+    return [] if not checks else list(checks[0].actual)
+
+
+def _failure_event(ledger: Any) -> dict[str, Any]:
+    failures = [event for event in ledger.read() if event["event"] == "failure.recorded"]
+    if len(failures) != 1:
+        raise ExecutionGateError("opaque parent 必须恰有一个 failure.recorded")
+    return failures[0]
+
+
+def _command_tokens(command: str) -> tuple[str, tuple[str, ...]]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ExecutionGateError("trusted command 无法规范化") from exc
+    if not tokens:
+        raise ExecutionGateError("trusted command 为空")
+    return PurePosixPath(tokens[0]).name, tuple(tokens[1:])
+
+
+def _evaluate_arm_p2(session: Any, frozen: Any, parent_command_id: str) -> tuple[Any, tuple[Any, ...]]:
+    artifact = Path(session.leadagent_repo_dir) / opaque.BUILD_OUTPUT
+    tree = Path(session.leadagent_repo_dir) / "build/build.ninja"
+    if not artifact.is_file() or not tree.is_file():
+        raise ExecutionGateError("arm 丢失冻结 build tree 或 workspace artifact")
+    if artifact.stat().st_size != frozen.artifact_size or primary.lifecycle.sha256_file(artifact) != frozen.artifact_sha256:
+        raise ExecutionGateError("arm workspace artifact identity 漂移")
+    if primary.lifecycle.sha256_file(tree) != frozen.build_tree_sha256:
+        raise ExecutionGateError("arm build tree identity 漂移")
+
+    parent = opaque._parent_invocation(frozen, parent_command_id)
+    invocations = [parent]
+    previous_hash = parent.ledger_hash
+    producer_id = session.post_build_supporting_command_id or parent_command_id
+    seen_parent = False
+    for record in session.commands:
+        if record.command_id == parent_command_id:
+            seen_parent = True
+            continue
+        if not seen_parent or record.stage != "bash":
+            continue
+        executable, argv = _command_tokens(record.command)
+        output_paths = (opaque.BUILD_OUTPUT,) if record.command_id == producer_id else ()
+        invocation = opaque.provenance.record_invocation(
+            command_id=record.command_id,
+            physical_attempt_id=frozen.physical_attempt_id,
+            sequence=len(invocations) + 1,
+            repository_url=frozen.repository_url,
+            commit_sha=frozen.commit_sha,
+            image_id=frozen.image_id,
+            executable=executable,
+            argv=argv,
+            workdir=record.workdir,
+            previous_hash=previous_hash,
+            exit_code=record.exit_code if record.exit_code is not None else 1,
+            timed_out=record.timed_out,
+            output_paths=output_paths,
+            model_declared_role=record.role,
+        )
+        invocations.append(invocation)
+        previous_hash = invocation.ledger_hash
+    commands = {item.command_id: item for item in invocations}
+    if producer_id not in commands:
+        producer_id = parent_command_id
+    identity = opaque.provenance.ArtifactIdentity(
+        schema_version=opaque.provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=len(invocations) + 1,
+    )
+    return opaque.provenance.evaluate_p2(frozen, tuple(invocations), identity), tuple(invocations)
+
+
+def _run_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+    repo_root: Path,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+
+    from deerflow.compile import operations
+    from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_workspace_dir
+    from deerflow.compile.schemas import utc_now_iso
+
+    preflight = collect_preflight(manifest, output_dir=output_dir, repo_root=repo_root, require_empty=False)
+    reachability = _passed_reachability(manifest, output_dir, preflight["release_revision"])
+    digest = protocol.canonical_sha256(manifest)
+    marker = output_dir / manifest["execution"]["pair_marker"]
+    v3_runner._claim_marker(marker, kind="forge_opaque_provenance_pair_attempt", manifest_sha256=digest, revision=preflight["release_revision"])
+
+    capture_id = f"opaque-{uuid.uuid4().hex[:12]}"
+    services = operations.get_compile_services()
+    manager = services.manager
+    runtime = services.runtime
+    docker = primary.lifecycle.environment_checkpoint.DockerCLI()
+    snapshot = output_dir / "checkpoint" / capture_id
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=opaque.REPOSITORY_URL,
+        image=opaque.COMPILE_IMAGE,
+    )
+    parent_ledger = primary.ExperimentLedger.create(
+        output_dir / manifest["execution"]["parent_ledger"],
+        experiment_id=primary.new_evidence_id("experiment"),
+        physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+        context={"scope": "opaque-provenance-controlled-parent", "manifest_sha256": digest, "case_id": opaque.CASE_ID},
+    )
+    gate = None
+    parent_active = False
+    cleanup_succeeded = False
+    arm_results: list[dict[str, Any]] = []
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {opaque.REPOSITORY_URL} && git fetch --depth 1 origin {opaque.COMMIT_SHA} && git checkout --detach FETCH_HEAD",
+            workdir=opaque.WORKDIR,
+            timeout_seconds=180,
+        )
+        if clone.exit_code != 0:
+            raise ExecutionGateError("parent 无法检出冻结 commit")
+        parent.commit_sha = opaque.COMMIT_SHA
+        parent.build_system = "cmake"
+        parent.build_system_capabilities = ["cmake"]
+        parent.selected_build_system = "cmake"
+        parent.status = "inspected"
+        manager.save_session(parent)
+        supporting = primary._record_command(manager=manager, runtime=runtime, session=parent, command=opaque.PARENT_COMMAND, role="build")
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        workspace_artifact = Path(parent.leadagent_repo_dir) / opaque.BUILD_OUTPUT
+        build_tree = Path(parent.leadagent_repo_dir) / "build/build.ninja"
+        frozen_values = {
+            "build_tree_sha256": primary.lifecycle.sha256_file(build_tree),
+            "artifact_size": workspace_artifact.stat().st_size,
+            "artifact_sha256": primary.lifecycle.sha256_file(workspace_artifact),
+        }
+        parent_frozen = opaque.build_frozen_identity(
+            image_id=parent.image_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            **frozen_values,
+        )
+        parent_p2, parent_history = opaque.evaluate_parent(parent_frozen, parent_command_id=supporting.command_id)
+        primary.activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_parent_policy(manifest, image_id=parent.image_id),
+        )
+        parent_active = True
+        submit_result: str | None = None
+
+        def submit_parent() -> str:
+            nonlocal submit_result
+            if submit_result is not None:
+                raise ExecutionGateError("parent submit 不得重复执行")
+            submit_result = operations.submit_build_result_impl(session=parent, supporting_command_id=supporting.command_id)
+            return submit_result
+
+        def capture_evidence() -> dict[str, Any]:
+            failure = _failure_event(parent_ledger)["payload"]
+            payload = json.loads(submit_result or "{}")
+            if (
+                payload.get("status") != "failed"
+                or payload.get("replay_status") != "not_run"
+                or failure.get("classification") != "build_system_unproven"
+                or failure.get("secondary_classifications") != []
+                or _constraint_failures(parent) != ["build_system_unproven"]
+                or parent.replay_attempts
+            ):
+                raise ExecutionGateError("parent 未形成单一 opaque provenance failure")
+            return {
+                "classification": failure["classification"],
+                "failure_id": failure["failure_id"],
+                "submit_attempt_id": failure["submit_attempt_id"],
+                "session_sha256": primary.lifecycle.sha256_file(Path(parent.metadata_path)),
+                "parent_p2": asdict(parent_p2),
+                "parent_command_history_sha256": opaque.provenance.command_history_sha256(parent_history),
+            }
+
+        coordinator = primary.lifecycle.CaptureCoordinator(output_dir / "checkpoint/coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(output_dir / "checkpoint/messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = primary.lifecycle.LifecycleMessageRuntime(saver, submit_parent, repair_packet=opaque.build_repair_packet())
+            environment = primary.lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=primary.host_snapshot_root(snapshot),
+            )
+            gate = primary.lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=primary._budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="opaque-provenance-minimal-canary",
+            )
+            gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="Continue from the failed submit and satisfy the verifier without changing the frozen repository or target.",
+                arm_plan=primary._arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "artifacts": get_host_artifacts_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "logs": get_host_logs_dir(parent.session_id, parent.thread_id, manager.paths),
+                    "repro": get_host_repro_dir(parent.session_id, parent.thread_id, manager.paths),
+                },
+                evidence=capture_evidence,
+            )
+            primary.deactivate_experiment(parent.thread_id)
+            parent_active = False
+            parent_ledger.append("experiment.completed", {"status": "passed"})
+            provisioned = {arm: gate.provision_arm(capture_id, arm, parent_session=parent) for arm in ARMS}
+            if gate.canonical_arm_environment("baseline") != gate.canonical_arm_environment("treatment"):
+                raise ExecutionGateError("baseline/treatment 初始环境不同源")
+
+            with asyncio.Runner() as async_runner:
+                original_policy = primary._policy
+                primary._policy = lambda _value, *, arm, image_id: _policy(manifest, arm=arm, image_id=image_id)
+                try:
+                    for arm in manifest["schedule"][0]["arm_order"]:
+                        require_arm_budget(
+                            manifest,
+                            reachability_tokens=reachability["recorded_tokens"],
+                            completed_arm_tokens=[result["recorded_tokens"] for result in arm_results],
+                        )
+                        current = provisioned[arm]
+                        ledger = primary.ExperimentLedger.create(
+                            output_dir / manifest["execution"]["arm_ledger_directory"] / f"{arm}.jsonl",
+                            experiment_id=primary.new_evidence_id("experiment"),
+                            physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+                            context={"scope": "opaque-provenance-arm", "manifest_sha256": digest, "arm": arm, "capture_id": capture_id},
+                        )
+                        message_state = primary._message_state(gate, current)
+                        try:
+                            result = async_runner.run(
+                                primary.run_arm_continuation(
+                                    manifest,
+                                    arm=arm,
+                                    lifecycle_arm=current,
+                                    message_state=message_state,
+                                    ledger=ledger,
+                                    model_factory=model_factory,
+                                )
+                            )
+                        except Exception as exc:
+                            result = v2_runner.classify_arm_terminal(manifest, arm=arm, ledger=ledger, error=exc)
+                        else:
+                            result = v2_runner._passed_arm(result, ledger)
+                        authoritative = manager.load_session(current.session.session_id, current.session.thread_id)
+                        arm_frozen = opaque.build_frozen_identity(
+                            image_id=authoritative.image_id,
+                            physical_attempt_id=ledger.physical_attempt_id,
+                            **frozen_values,
+                        )
+                        p2, history = _evaluate_arm_p2(authoritative, arm_frozen, supporting.command_id)
+                        result["p2"] = asdict(p2)
+                        result["command_history_sha256"] = opaque.provenance.command_history_sha256(history)
+                        result["post_checkpoint_provenance_conversion"] = p2.status == "proven"
+                        if result["verification_outcome"]["status"] == "passed" and p2.status != "proven":
+                            raise ExecutionGateError(f"{arm} production verification 通过但 P2 未证明")
+                        arm_results.append(result)
+                finally:
+                    primary._policy = original_policy
+            cleaned = gate.cleanup(capture_id, parent_session=parent)
+            cleanup_succeeded = cleaned.phase == "cleaned"
+            if not cleanup_succeeded:
+                raise ExecutionGateError("pair cleanup 未闭合")
+            try:
+                v3_runner.require_zero_managed_containers()
+            except v3_runner.AuthorizedPilotError as exc:
+                raise ExecutionGateError("pair cleanup 后仍存在 managed container") from exc
+
+        total_tokens = reachability["recorded_tokens"] + sum(item["recorded_tokens"] for item in arm_results)
+        if total_tokens > manifest["budget"]["stage_maximum_recorded_tokens"]:
+            raise ExecutionGateError("阶段 recorded-token 超过机械上限")
+        report = {
+            "schema_version": "forge-opaque-provenance-minimal-canary-report-1.0.0",
+            "document_type": "forge_opaque_provenance_minimal_canary_report",
+            "manifest_sha256": digest,
+            "release_revision": preflight["release_revision"],
+            "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+            "case_id": opaque.CASE_ID,
+            "pair_id": manifest["schedule"][0]["pair_id"],
+            "arm_order": manifest["schedule"][0]["arm_order"],
+            "provider": manifest["provider"]["id"],
+            "network_access_medium": preflight["network_access_medium"],
+            "reachability_recorded_tokens": reachability["recorded_tokens"],
+            "arms": arm_results,
+            "recorded_tokens": total_tokens,
+            "maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+            "complete_pair": len(arm_results) == 2,
+            "cleanup_succeeded": cleanup_succeeded,
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        v3_runner._write_once(output_dir / manifest["evidence"]["canary_report"], report)
+    except BaseException as exc:
+        if parent_active:
+            primary.deactivate_experiment(parent.thread_id)
+        if gate is not None and not cleanup_succeeded:
+            try:
+                record = gate.coordinator.get(capture_id)
+                if record.phase not in {"committed", "aborted", "cleanup_pending", "cleaned"}:
+                    record = gate.reconcile(capture_id)
+                cleanup_succeeded = record.phase == "cleaned" or gate.cleanup(capture_id, parent_session=parent).phase == "cleaned"
+            except Exception:
+                cleanup_succeeded = False
+        else:
+            runtime.stop_and_remove_container(parent)
+        v3_runner._finish_marker(marker, status="failed", error_class=type(exc).__name__)
+        raise
+    v3_runner._finish_marker(marker, status="passed")
+    return report
+
+
+def execute_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    return _run_pair(manifest, output_dir=output_dir, repo_root=repo_root, model_factory=model_factory)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "preflight", "reachability", "pair"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        result: Any = {"status": "valid", "manifest_sha256": protocol.canonical_sha256(manifest), "provider_calls": 0, "formal_attempts": 0, "model_tokens": 0}
+    elif args.command == "preflight":
+        result = collect_preflight(manifest, output_dir=args.output_dir, require_empty=True)
+    elif args.command == "reachability":
+        result = execute_reachability(manifest, output_dir=args.output_dir)
+    else:
+        result = execute_pair(manifest, output_dir=args.output_dir)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从 #182 冻结父身份派生一次性 execution amendment，授权 1 次 DeepSeek reachability；只有通过才允许固定 `baseline -> treatment` 单 pair。
- 接入 #178 opaque wrapper checkpoint、白名单 repair packet、真实模型 continuation、P2 conversion、candidate verification、clean replay 与 cleanup/orphan 门禁。
- 冻结 245,000 recorded-token 总上限、300 秒/0 retry、非 streaming、禁止 fallback/retry/replacement/backfill。
- 新增 const Schema、预注册、append-only marker/report/ledger 契约与聚焦测试；不修改 production Compiler、Oracle、`operations.py` 或历史 evidence。

## 验证

- 路线 P 相邻静态回归：`77 passed`
- Ruff check：通过
- Ruff format check：通过
- Schema / protocol / runner CLI validate：通过
- `git diff --check`：通过
- 当前副作用：0 provider call、0 formal attempt、0 model token、0 Docker

## 研究边界

单 pair 仅验证 opaque provenance repair 的真实 provider 接线，不估计 treatment effect，不计算 p 值、不排名模型，也不与 `artifact_staging_missing` 历史 pair 池化。

Closes #184