### PR TITLE
研究：冻结 opaque provenance R1 独立 checkpoint 候选

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,14 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 冻结 Issue #196 opaque provenance R1 独立 checkpoint 未授权候选
+  - 文件: `scripts/forge_opaque_provenance_r1_candidate_protocol.py`, `scripts/forge_opaque_provenance_r1_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md`
+  - Case: 从 result-blind `cpp-formal-v1-cases.json` 逐字段冻结 `yyjson@9365ddc7`、CMake target `yyjson` 与 `libyyjson.a` static-library oracle；repository、commit、target 和 staged artifact 均不同于 #190 `cppitertools` exploratory pair。
+  - 机制: 保持原 repair packet Schema、4/2/2/2 原子动作预算、300 秒/0 retry、state-matched 双臂以及 candidate/replay/cleanup；未来 classified rejection 必须记录 #194 `agent.tool_rejection_observed` companion event。
+  - 边界: checkpoint/evidence 固定为 `not_created`，只开放 `validate/plan/preflight`；provider、credential、model、Docker、checkpoint/pair execute 与 evidence write 机械关闭，新增 evidence 目录未创建。
+  - 验证: manifest canonical SHA-256 为 `b89e63c4362befcdc409c60fe0334c1e9e4f62a26e369d55b676f23c1ffd202b`，evidence identity 为 `d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077`；聚焦 `19 passed`，路线 P/R0/formal source 相邻回归 `156 passed, 1 deselected`，Ruff、format、语法、确定性再生成、diff 与敏感信息审计通过。
+  - 下一步: 中文提交并通过 WSL helper 推送，创建中文 PR、等待三项 CI 后合并；合并后只运行一次干净主干的纯快照 preflight，真实 checkpoint 或 provider 请求必须另建 execution amendment。
+
 - 2026-08-30 — 实现 Issue #194 runtime-parity 拒绝原因零 provider 可观测性门禁
   - 文件: `backend/packages/harness/deerflow/compile/evidence.py`, `backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py`, `scripts/forge_opaque_provenance_rejection_observability_gate.py`, `backend/tests/test_experiment_evidence.py`, `backend/tests/test_llm_error_handling_middleware.py`, `backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md`
   - 动机: #192 只能观察 exception class，无法从 #190 冻结 evidence 逐条区分 runtime-parity 拒绝；R0 在不记录原始命令、错误文本或模型正文的前提下补齐下一轮 trajectory 所需的有界字段。

--- a/backend/tests/test_forge_opaque_provenance_r1_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_r1_candidate.py
@@ -1,0 +1,254 @@
+"""Issue #196 opaque provenance R1 未授权候选的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r1_candidate_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r1_candidate_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json"
+SOURCE_PATH = REPO_ROOT / "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_opaque_provenance_r1_candidate_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_opaque_provenance_r1_candidate_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _valid_snapshot(manifest: dict) -> dict:
+    return {
+        "schema_version": "forge-opaque-provenance-r1-candidate-preflight-1.0.0",
+        "branch": "main",
+        "head_commit": "a" * 40,
+        "origin_main_commit": "a" * 40,
+        "worktree_clean": True,
+        "authorization_baseline_ancestor": True,
+        "source_protocol_file_sha256": manifest["source_protocol"]["file_sha256"],
+        "r0_component_sha256": manifest["r0_observability"]["frozen_components"],
+        "candidate_evidence_directory": manifest["evidence"]["directory"],
+        "candidate_evidence_entries": 0,
+        "checkpoint_status": "not_created",
+        "docker_executed": False,
+    }
+
+
+def test_generated_manifest_schema_runtime_and_preregistration_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["runtime_adapter"]["file_sha256"] == protocol.file_sha256(RUNNER_PATH)
+    preregistration = REPO_ROOT / manifest["preregistration"]["path"]
+    assert manifest["preregistration"]["file_sha256"] == protocol.file_sha256(preregistration)
+
+
+def test_yyjson_case_matches_result_blind_source_protocol_field_for_field() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    source_case = protocol._load_source_case(SOURCE_PATH)
+    assert source_case == protocol.YYJSON_SOURCE_CASE
+    assert manifest["source_protocol"]["source_case"] == source_case
+    artifact = source_case["artifact_oracle"]["required_artifacts"][0]
+    assert manifest["case"]["repository_url"] == source_case["repository_url"]
+    assert manifest["case"]["commit_sha"] == source_case["commit"]
+    assert manifest["case"]["configure_arguments"] == source_case["recipe"]["configure_arguments"]
+    assert manifest["case"]["target"] == artifact["producing_target"]
+    assert manifest["case"]["build_output"] == artifact["build_output_path"]
+    assert manifest["case"]["staged_artifact"] == artifact["staged_relative_path"]
+    assert manifest["case"]["artifact_type"] == artifact["artifact_type"]
+
+
+def test_source_protocol_byte_or_case_drift_fails_closed(tmp_path: Path) -> None:
+    drifted = tmp_path / "cases.json"
+    drifted.write_bytes(SOURCE_PATH.read_bytes() + b"\n")
+    with pytest.raises(protocol.ProtocolError, match="source protocol file drifted"):
+        protocol._load_source_case(drifted)
+
+
+def test_case_is_independent_from_190_and_checkpoint_is_not_created() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    case = manifest["case"]
+    independence = manifest["independence"]
+    assert case["repository_url"] != independence["historical_repository_url"]
+    assert case["commit_sha"] != independence["historical_commit_sha"]
+    assert case["target"] != independence["historical_target"]
+    assert case["staged_artifact"] != independence["historical_staged_artifact"]
+    assert manifest["checkpoint"] == {
+        "status": "not_created",
+        "checkpoint_id": None,
+        "parent_ledger_sha256": None,
+        "message_state_sha256": None,
+        "environment_identity_sha256": None,
+        "budget_identity_sha256": None,
+        "arm_state_matching": ["message", "environment", "budget"],
+        "creation_requires_separate_authorization": True,
+    }
+    evidence = manifest["evidence"]
+    identity = {key: value for key, value in evidence.items() if key != "identity_sha256"}
+    assert evidence["identity_sha256"] == protocol.canonical_sha256(identity)
+    assert evidence["status"] == "not_created"
+
+
+def test_repair_packet_runtime_parity_and_r0_observability_are_frozen() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    packet = manifest["repair_packet"]
+    assert packet["fields"] == protocol.REPAIR_PACKET_FIELDS
+    assert list(packet["template"]) == protocol.REPAIR_PACKET_FIELDS
+    assert packet["template"]["build_directory"] == manifest["case"]["build_directory"]
+    assert packet["template"]["target"] == manifest["case"]["target"]
+    parity = manifest["runtime_parity"]
+    assert parity["action_limits"] == {"inspection": 4, "repair_build": 2, "artifact_stage": 2, "submit": 2}
+    assert parity["candidate_verification_required"] is True
+    assert parity["clean_replay_required"] is True
+    assert parity["cleanup_required"] is True
+    r0 = manifest["r0_observability"]
+    assert r0["legacy_failure_schema_preserved"] is True
+    assert r0["companion_event"] == "agent.tool_rejection_observed"
+    assert r0["atomic_fields"] == protocol.R0_OBSERVATION_FIELDS
+    assert r0["companion_required_for_classified_rejection"] is True
+
+
+def test_all_execution_authorizations_and_capabilities_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    authorization = manifest["authorization"]
+    assert authorization["candidate_generation_authorized"] is True
+    assert authorization["zero_provider_preflight_authorized"] is True
+    for key in (
+        "checkpoint_creation_authorized",
+        "reachability_request_authorized",
+        "provider_calls_authorized",
+        "formal_attempts_authorized",
+        "pair_collection_authorized",
+        "credential_read_authorized",
+        "model_creation_authorized",
+        "docker_execution_authorized",
+        "evidence_write_authorized",
+    ):
+        assert authorization[key] is False
+    assert authorization["model_tokens_authorized"] == 0
+    runtime = manifest["runtime_adapter"]
+    assert runtime["commands"] == ["validate", "plan", "preflight"]
+    assert not any(value for key, value in runtime.items() if key.endswith("_supported"))
+
+
+def test_valid_preflight_snapshot_and_plan_are_zero_provider_and_zero_docker() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    snapshot = runner.validate_preflight_snapshot(manifest, _valid_snapshot(manifest))
+    assert snapshot["checkpoint_status"] == "not_created"
+    plan = runner.build_plan(manifest)
+    assert plan["case_id"] == "yyjson-opaque-provenance-r1"
+    assert plan["action_limits"] == manifest["runtime_parity"]["action_limits"]
+    assert plan["r0_companion_event"] == "agent.tool_rejection_observed"
+    assert (plan["provider_calls"], plan["formal_attempts"], plan["model_tokens"], plan["evidence_writes"]) == (0, 0, 0, 0)
+    assert plan["credential_read"] is False
+    assert plan["docker_executed"] is False
+    assert plan["execution_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("branch", "research/196"),
+        ("origin_main_commit", "b" * 40),
+        ("worktree_clean", False),
+        ("authorization_baseline_ancestor", False),
+        ("source_protocol_file_sha256", "0" * 64),
+        ("r0_component_sha256", {}),
+        ("candidate_evidence_entries", 1),
+        ("checkpoint_status", "created"),
+        ("docker_executed", True),
+    ],
+)
+def test_preflight_drift_fails_closed(field: str, value: object) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    snapshot = _valid_snapshot(manifest)
+    snapshot[field] = value
+    with pytest.raises(runner.RuntimeGateError):
+        runner.validate_preflight_snapshot(manifest, snapshot)
+
+
+def test_collector_is_pure_snapshot_and_does_not_create_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    candidate = tmp_path / ".compile-sessions" / Path(manifest["evidence"]["directory"]).name
+    commands: list[tuple[str, ...]] = []
+
+    def fake_command(command, _cwd: Path) -> str:
+        key = tuple(command)
+        commands.append(key)
+        if key == ("git", "branch", "--show-current"):
+            return "main"
+        if key in (("git", "rev-parse", "HEAD"), ("git", "rev-parse", "origin/main")):
+            return "c" * 40
+        if key == ("git", "status", "--porcelain") or key[:3] == ("git", "merge-base", "--is-ancestor"):
+            return ""
+        raise AssertionError(key)
+
+    monkeypatch.setattr(runner.protocol, "validate_manifest", lambda _manifest, _repo_root=None: _manifest)
+    frozen_by_name = {Path(path).name: sha256 for path, sha256 in manifest["r0_observability"]["frozen_components"].items()}
+    frozen_by_name[Path(manifest["source_protocol"]["path"]).name] = manifest["source_protocol"]["file_sha256"]
+    monkeypatch.setattr(runner, "_file_sha256", lambda path: frozen_by_name[path.name])
+    snapshot = runner.collect_preflight_snapshot(
+        manifest,
+        repo_root=tmp_path,
+        host_candidate_evidence_directory=candidate,
+        command_runner=fake_command,
+    )
+    assert snapshot["candidate_evidence_entries"] == 0
+    assert snapshot["docker_executed"] is False
+    assert not candidate.exists()
+    assert commands and all(command[0] == "git" for command in commands)
+
+
+def test_execute_paths_are_rejected_and_source_reads_no_credentials_or_docker() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    for execute in (runner.execute_checkpoint, runner.execute_reachability, runner.execute_pair):
+        with pytest.raises(runner.RuntimeGateError, match="not authorized"):
+            execute(manifest)
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    for forbidden in ("os.environ", "os.getenv", "create_chat_model", "ChatOpenAI", "ChatDeepSeek", "api_key=", '("docker",'):
+        assert forbidden not in source
+
+
+def test_schema_and_protocol_reject_case_authorization_r0_or_checkpoint_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    mutations = (
+        ("case", "repository_url", "https://github.com/example/drift"),
+        ("case", "commit_sha", "0" * 40),
+        ("case", "target", "drift"),
+        ("case", "staged_artifact", "drift.a"),
+        ("authorization", "provider_calls_authorized", True),
+        ("r0_observability", "companion_required_for_classified_rejection", False),
+        ("checkpoint", "status", "created"),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)

--- a/benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-r1-checkpoint-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_r1_checkpoint_candidate",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/196",
+    "candidate_generation_authorized": true,
+    "zero_provider_preflight_authorized": true,
+    "checkpoint_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "pair_collection_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "source_protocol": {
+    "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+    "file_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+    "case_protocol_sha256": "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca",
+    "audit_mode": "result-blind-static-document-review",
+    "source_case": {
+      "id": "yyjson",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit": "9365ddc7061033df656578bf86040048b5b5531a",
+      "build_system": "cmake",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DYYJSON_BUILD_TESTS=OFF",
+          "-DYYJSON_BUILD_FUZZER=OFF"
+        ],
+        "build_targets": [
+          "yyjson"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "libyyjson.a",
+            "build_output_path": "build/libyyjson.a",
+            "artifact_type": "static_library",
+            "producing_target": "yyjson"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "CMakeLists.txt",
+          "url": "https://github.com/ibireme/yyjson/blob/9365ddc7061033df656578bf86040048b5b5531a/CMakeLists.txt",
+          "supports": [
+            "build_path",
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "yyjson/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/yyjson/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    }
+  },
+  "case": {
+    "case_id": "yyjson-opaque-provenance-r1",
+    "repository_url": "https://github.com/ibireme/yyjson",
+    "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+    "compile_image": "autocompiler:gcc13",
+    "build_system": "cmake",
+    "source_subdir": ".",
+    "build_directory": "/workspace/repo/build",
+    "configure_arguments": [
+      "-DCMAKE_BUILD_TYPE=Release",
+      "-DBUILD_SHARED_LIBS=OFF",
+      "-DYYJSON_BUILD_TESTS=OFF",
+      "-DYYJSON_BUILD_FUZZER=OFF"
+    ],
+    "target": "yyjson",
+    "build_output": "build/libyyjson.a",
+    "staged_artifact": "libyyjson.a",
+    "artifact_type": "static_library",
+    "required_system_packages": [
+      "build-essential",
+      "cmake"
+    ],
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "independence": {
+    "historical_pair": "opaque-provenance-cppitertools-runtime-parity-pair-01",
+    "historical_repository_url": "https://github.com/ryanhaining/cppitertools",
+    "historical_commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+    "historical_target": "accumulate_examples",
+    "historical_staged_artifact": "accumulate_examples",
+    "repository_commit_target_and_artifact_all_distinct": true,
+    "historical_pair_pooled": false,
+    "retry_replacement_backfill_or_extension": false
+  },
+  "checkpoint": {
+    "status": "not_created",
+    "checkpoint_id": null,
+    "parent_ledger_sha256": null,
+    "message_state_sha256": null,
+    "environment_identity_sha256": null,
+    "budget_identity_sha256": null,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "creation_requires_separate_authorization": true
+  },
+  "provider": {
+    "status": "candidate_not_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-r1-yyjson-pair-01",
+      "order": 1,
+      "case_id": "yyjson-opaque-provenance-r1",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "420e0f129086aff5eec604444733301420ea504a474965776ec4ca945f5a13ef",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "fields": [
+      "schema_version",
+      "primary_classification",
+      "mechanism_classification",
+      "expected_build_system",
+      "selected_build_system",
+      "build_directory",
+      "target",
+      "proof_status",
+      "repair_goal"
+    ],
+    "template": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "cmake",
+      "selected_build_system": "cmake",
+      "build_directory": "/workspace/repo/build",
+      "target": "yyjson",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+    },
+    "origin_path": "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+    "origin_file_sha256": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+    "forbidden_solution_fields": [
+      "command",
+      "argv",
+      "command_line",
+      "shell",
+      "credential",
+      "secret"
+    ]
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "repair_build_directory": "/workspace/repo/build",
+    "repair_build_target": "yyjson",
+    "build_output": "build/libyyjson.a",
+    "staged_artifact": "libyyjson.a",
+    "forbidden_actions": [
+      "clone",
+      "configure",
+      "dependency",
+      "housekeeping",
+      "manual_replay",
+      "compound_build_stage"
+    ],
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "unknown_or_ambiguous_tool_call_keeps_legacy_event_only": true,
+    "frozen_components": {
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+      "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158"
+    }
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-r1-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+    "checkpoint_manifest": "checkpoints/opaque-provenance-r1-yyjson-pair-01/checkpoint.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+    "pair_ledger": "pairs/opaque-provenance-r1-yyjson-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+    "reachability_marker": "markers/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "status": "not_created",
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077"
+  },
+  "stopping": {
+    "checkpoint_creation_failure_stops": true,
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "purpose": "independent_checkpoint_intervention_delivery_and_p2_conversion_canary",
+    "unit_of_analysis": "single_independent_state_matched_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "authorization_baseline_commit": "7fe33b2bde6cbed5d42110eb74434b029a754fa7",
+    "require_authorization_baseline_ancestor": true,
+    "require_source_protocol_hash": true,
+    "require_r0_component_hashes": true,
+    "require_empty_candidate_evidence_directory": true,
+    "require_checkpoint_not_created": true,
+    "docker_check_forbidden": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md",
+    "file_sha256": "984794477d7a5e6271960a36e9f513a2aa049d950bfe9f6966fb5de5642772ba"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_r1_candidate_runner.py",
+    "file_sha256": "51a9a03214bc7afeb4c4c6187b76b323119ba214e1d4e4024c9d8b3689b65cf5",
+    "commands": [
+      "validate",
+      "plan",
+      "preflight"
+    ],
+    "credential_read_supported": false,
+    "provider_model_creation_supported": false,
+    "checkpoint_execute_supported": false,
+    "reachability_execute_supported": false,
+    "pair_execute_supported": false,
+    "docker_execute_supported": false,
+    "evidence_write_supported": false
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md
@@ -1,0 +1,28 @@
+# Opaque build provenance R1 独立 checkpoint 候选
+
+本候选承接 Issue #192 的 replication 决策和 Issue #194 的 R0 拒绝原因可观测性门禁。当前只冻结一个新的独立 checkpoint 设计，不创建 checkpoint，不调用 provider，不启动 Docker，也不写实验 evidence。
+
+## 独立 case
+
+- 仓库：`https://github.com/ibireme/yyjson`。
+- Exact commit：`9365ddc7061033df656578bf86040048b5b5531a`。
+- 构建系统、目录与目标：CMake、`/workspace/repo/build`、`yyjson`。
+- 构建输出与 staged artifact：`build/libyyjson.a`、`libyyjson.a`，类型为 `static_library`。
+- 依赖：`build-essential`、`cmake`。
+- 来源：已审阅且 result-blind 的 `cpp-formal-v1-cases.json`，文件 SHA-256 为 `55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee`。
+
+该 case 的 repository、commit、target 与 staged artifact 均不同于 #190 的 `cppitertools` exploratory pair。#184 和 #190 不进入本 R1 的分析池，本候选也不是 retry、replacement、backfill 或 schedule extension。
+
+## 冻结机制
+
+未来双臂必须从同一个 message、environment 与 budget checkpoint 派生，顺序固定为 `baseline -> treatment`，唯一 treatment exposure 是 `forge-opaque-provenance-repair-packet-1.0.0`。Packet 继续只提供 fault/build-system/build-directory/target/proof status 和抽象 repair goal，不提供完整 shell 命令、argv 或 credential。
+
+双臂共享 runtime-parity policy：inspection、repair build、artifact stage、submit 上限分别为 4/2/2/2，budget claim 原子化，`parallel_tool_calls=False`。Repair build 只允许冻结目录与 target；clone、configure、dependency、housekeeping、manual replay 和 compound build+stage 继续 fail closed。成功终态必须同时通过 candidate verification、clean replay 与 cleanup。
+
+R0 `agent.tool_rejection_observed` 是未来 R1 classified rejection 的必需 companion evidence。它必须通过 `failure_id` 关联历史七字段 `agent.tool_failed`，原子记录 rejection classification、action kind、model request ID、tool ordinal 与 command SHA-256；原始命令、错误文本、模型正文、工具参数和 credential 不得持久化。未知或重复 tool-call ID 只保留旧失败事件。
+
+## 当前授权边界
+
+Checkpoint 与 evidence 状态固定为 `not_created`。Issue #196 只开放 `validate`、`plan` 和纯快照 `preflight`；checkpoint creation、reachability、provider call、formal attempt、pair collection、credential read、model creation、Docker execution 和 evidence write 均机械关闭，model token 上限为 0。
+
+未来如需真实 R1，必须另建独立 execution amendment，预先冻结 checkpoint identity、provider opportunity、token ceiling 和停止规则。单 pair 仍只提供 intervention delivery 与 P2 conversion 的描述性机制证据，不估计 treatment effect、不计算 p 值、不排名模型。

--- a/benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+  "title": "Forge opaque provenance R1 independent checkpoint candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-r1-checkpoint-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_r1_checkpoint_candidate",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/196",
+      "candidate_generation_authorized": true,
+      "zero_provider_preflight_authorized": true,
+      "checkpoint_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "pair_collection_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "source_protocol": {
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "file_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "case_protocol_sha256": "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca",
+      "audit_mode": "result-blind-static-document-review",
+      "source_case": {
+        "id": "yyjson",
+        "repository_url": "https://github.com/ibireme/yyjson",
+        "commit": "9365ddc7061033df656578bf86040048b5b5531a",
+        "build_system": "cmake",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF"
+          ],
+          "build_targets": [
+            "yyjson"
+          ],
+          "required_system_packages": [
+            "build-essential",
+            "cmake"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "libyyjson.a",
+              "build_output_path": "build/libyyjson.a",
+              "artifact_type": "static_library",
+              "producing_target": "yyjson"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "CMakeLists.txt",
+            "url": "https://github.com/ibireme/yyjson/blob/9365ddc7061033df656578bf86040048b5b5531a/CMakeLists.txt",
+            "supports": [
+              "build_path",
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "yyjson/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/yyjson/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      }
+    },
+    "case": {
+      "case_id": "yyjson-opaque-provenance-r1",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "compile_image": "autocompiler:gcc13",
+      "build_system": "cmake",
+      "source_subdir": ".",
+      "build_directory": "/workspace/repo/build",
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DYYJSON_BUILD_TESTS=OFF",
+        "-DYYJSON_BUILD_FUZZER=OFF"
+      ],
+      "target": "yyjson",
+      "build_output": "build/libyyjson.a",
+      "staged_artifact": "libyyjson.a",
+      "artifact_type": "static_library",
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "independence": {
+      "historical_pair": "opaque-provenance-cppitertools-runtime-parity-pair-01",
+      "historical_repository_url": "https://github.com/ryanhaining/cppitertools",
+      "historical_commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "historical_target": "accumulate_examples",
+      "historical_staged_artifact": "accumulate_examples",
+      "repository_commit_target_and_artifact_all_distinct": true,
+      "historical_pair_pooled": false,
+      "retry_replacement_backfill_or_extension": false
+    },
+    "checkpoint": {
+      "status": "not_created",
+      "checkpoint_id": null,
+      "parent_ledger_sha256": null,
+      "message_state_sha256": null,
+      "environment_identity_sha256": null,
+      "budget_identity_sha256": null,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "creation_requires_separate_authorization": true
+    },
+    "provider": {
+      "status": "candidate_not_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-r1-yyjson-pair-01",
+        "order": 1,
+        "case_id": "yyjson-opaque-provenance-r1",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "420e0f129086aff5eec604444733301420ea504a474965776ec4ca945f5a13ef",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "fields": [
+        "schema_version",
+        "primary_classification",
+        "mechanism_classification",
+        "expected_build_system",
+        "selected_build_system",
+        "build_directory",
+        "target",
+        "proof_status",
+        "repair_goal"
+      ],
+      "template": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "yyjson",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+      },
+      "origin_path": "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+      "origin_file_sha256": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+      "forbidden_solution_fields": [
+        "command",
+        "argv",
+        "command_line",
+        "shell",
+        "credential",
+        "secret"
+      ]
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "repair_build_directory": "/workspace/repo/build",
+      "repair_build_target": "yyjson",
+      "build_output": "build/libyyjson.a",
+      "staged_artifact": "libyyjson.a",
+      "forbidden_actions": [
+        "clone",
+        "configure",
+        "dependency",
+        "housekeeping",
+        "manual_replay",
+        "compound_build_stage"
+      ],
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "unknown_or_ambiguous_tool_call_keeps_legacy_event_only": true,
+      "frozen_components": {
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+        "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158"
+      }
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-r1-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+      "checkpoint_manifest": "checkpoints/opaque-provenance-r1-yyjson-pair-01/checkpoint.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+      "pair_ledger": "pairs/opaque-provenance-r1-yyjson-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+      "reachability_marker": "markers/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "status": "not_created",
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077"
+    },
+    "stopping": {
+      "checkpoint_creation_failure_stops": true,
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "purpose": "independent_checkpoint_intervention_delivery_and_p2_conversion_canary",
+      "unit_of_analysis": "single_independent_state_matched_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "authorization_baseline_commit": "7fe33b2bde6cbed5d42110eb74434b029a754fa7",
+      "require_authorization_baseline_ancestor": true,
+      "require_source_protocol_hash": true,
+      "require_r0_component_hashes": true,
+      "require_empty_candidate_evidence_directory": true,
+      "require_checkpoint_not_created": true,
+      "docker_check_forbidden": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md",
+      "file_sha256": "984794477d7a5e6271960a36e9f513a2aa049d950bfe9f6966fb5de5642772ba"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_r1_candidate_runner.py",
+      "file_sha256": "51a9a03214bc7afeb4c4c6187b76b323119ba214e1d4e4024c9d8b3689b65cf5",
+      "commands": [
+        "validate",
+        "plan",
+        "preflight"
+      ],
+      "credential_read_supported": false,
+      "provider_model_creation_supported": false,
+      "checkpoint_execute_supported": false,
+      "reachability_execute_supported": false,
+      "pair_execute_supported": false,
+      "docker_execute_supported": false,
+      "evidence_write_supported": false
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_r1_candidate_protocol.py
+++ b/scripts/forge_opaque_provenance_r1_candidate_protocol.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Issue #196 opaque provenance R1 独立 checkpoint 未授权候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = (
+    REPO_ROOT
+    / "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json"
+)
+DEFAULT_SCHEMA = (
+    REPO_ROOT
+    / "benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json"
+)
+SOURCE_PROTOCOL_PATH = "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_r1_candidate_runner.py"
+PREREGISTRATION_PATH = (
+    "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md"
+)
+
+SCHEMA_VERSION = "forge-opaque-provenance-r1-checkpoint-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_r1_checkpoint_candidate"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/196"
+AUTHORIZATION_BASELINE_COMMIT = "7fe33b2bde6cbed5d42110eb74434b029a754fa7"
+SOURCE_PROTOCOL_FILE_SHA256 = (
+    "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+)
+SOURCE_CASES_SHA256 = "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca"
+PAIR_ID = "opaque-provenance-r1-yyjson-pair-01"
+EVIDENCE_DIRECTORY = (
+    "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1"
+)
+EVIDENCE_SCHEMA_VERSION = "forge-opaque-provenance-r1-evidence-1.0.0"
+
+R0_COMPONENT_SHA256 = {
+    "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+    "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+    "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+}
+REPAIR_PACKET_ORIGIN = "scripts/forge_opaque_build_provenance_real_docker_gate.py"
+REPAIR_PACKET_ORIGIN_SHA256 = (
+    "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4"
+)
+REPAIR_PACKET_FIELDS = [
+    "schema_version",
+    "primary_classification",
+    "mechanism_classification",
+    "expected_build_system",
+    "selected_build_system",
+    "build_directory",
+    "target",
+    "proof_status",
+    "repair_goal",
+]
+R0_OBSERVATION_FIELDS = [
+    "rejection_classification",
+    "action_kind",
+    "model_request_id",
+    "tool_ordinal",
+    "command_sha256",
+]
+
+YYJSON_SOURCE_CASE = {
+    "id": "yyjson",
+    "repository_url": "https://github.com/ibireme/yyjson",
+    "commit": "9365ddc7061033df656578bf86040048b5b5531a",
+    "build_system": "cmake",
+    "review_state": "reviewed",
+    "result_data_consulted": False,
+    "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DYYJSON_BUILD_TESTS=OFF",
+            "-DYYJSON_BUILD_FUZZER=OFF",
+        ],
+        "build_targets": ["yyjson"],
+        "required_system_packages": ["build-essential", "cmake"],
+    },
+    "artifact_oracle": {
+        "required_artifacts": [
+            {
+                "staged_relative_path": "libyyjson.a",
+                "build_output_path": "build/libyyjson.a",
+                "artifact_type": "static_library",
+                "producing_target": "yyjson",
+            }
+        ]
+    },
+    "evidence": [
+        {
+            "kind": "upstream_exact_commit",
+            "path": "CMakeLists.txt",
+            "url": "https://github.com/ibireme/yyjson/blob/9365ddc7061033df656578bf86040048b5b5531a/CMakeLists.txt",
+            "supports": ["build_path", "artifact_identity"],
+        },
+        {
+            "kind": "oss_fuzz_snapshot",
+            "path": "yyjson/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/yyjson/build.sh",
+            "supports": ["build_path"],
+        },
+    ],
+}
+
+
+class ProtocolError(RuntimeError):
+    """R1 候选、source case、R0 或授权边界发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot load {label}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"{label} must be an object")
+    return value
+
+
+def _load_source_case(path: Path) -> dict[str, Any]:
+    if file_sha256(path) != SOURCE_PROTOCOL_FILE_SHA256:
+        raise ProtocolError("formal v1 source protocol file drifted")
+    protocol = _load_object(path, "formal v1 source protocol")
+    metadata = protocol.get("protocolization")
+    if (
+        not isinstance(metadata, dict)
+        or metadata.get("case_protocol_sha256") != SOURCE_CASES_SHA256
+    ):
+        raise ProtocolError("formal v1 source case identity drifted")
+    matches = [
+        case
+        for case in protocol.get("cases", [])
+        if isinstance(case, dict) and case.get("id") == "yyjson"
+    ]
+    if matches != [YYJSON_SOURCE_CASE]:
+        raise ProtocolError("yyjson source case fields drifted")
+    return copy.deepcopy(matches[0])
+
+
+def _verify_frozen_components(repo_root: Path) -> None:
+    expected = {
+        SOURCE_PROTOCOL_PATH: SOURCE_PROTOCOL_FILE_SHA256,
+        REPAIR_PACKET_ORIGIN: REPAIR_PACKET_ORIGIN_SHA256,
+        **R0_COMPONENT_SHA256,
+    }
+    for relative_path, expected_sha256 in expected.items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected_sha256:
+            raise ProtocolError(f"frozen component drifted: {relative_path}")
+
+
+def _case(source_case: dict[str, Any]) -> dict[str, Any]:
+    artifact = source_case["artifact_oracle"]["required_artifacts"][0]
+    return {
+        "case_id": "yyjson-opaque-provenance-r1",
+        "repository_url": source_case["repository_url"],
+        "commit_sha": source_case["commit"],
+        "compile_image": "autocompiler:gcc13",
+        "build_system": source_case["build_system"],
+        "source_subdir": source_case["recipe"]["source_subdir"],
+        "build_directory": "/workspace/repo/build",
+        "configure_arguments": copy.deepcopy(
+            source_case["recipe"]["configure_arguments"]
+        ),
+        "target": artifact["producing_target"],
+        "build_output": artifact["build_output_path"],
+        "staged_artifact": artifact["staged_relative_path"],
+        "artifact_type": artifact["artifact_type"],
+        "required_system_packages": copy.deepcopy(
+            source_case["recipe"]["required_system_packages"]
+        ),
+        "parent_proof_status": "opaque_wrapper",
+        "parent_expected_failure": "build_system_unproven",
+    }
+
+
+def _evidence_identity() -> dict[str, Any]:
+    identity = {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "directory": EVIDENCE_DIRECTORY,
+        "checkpoint_manifest": f"checkpoints/{PAIR_ID}/checkpoint.json",
+        "parent_ledger": f"checkpoints/{PAIR_ID}/parent/events.jsonl",
+        "pair_ledger": f"pairs/{PAIR_ID}/events.jsonl",
+        "arm_ledger_directory": f"pairs/{PAIR_ID}/arms",
+        "reachability_marker": "markers/reachability.json",
+        "pair_marker": "markers/pair.json",
+        "canary_report": "reports/canary.json",
+        "append_only": True,
+        "status": "not_created",
+        "zero_provider_preflight_writes_evidence": False,
+    }
+    return {**identity, "identity_sha256": canonical_sha256(identity)}
+
+
+def _repair_packet(case: dict[str, Any]) -> dict[str, Any]:
+    template = {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": case["build_directory"],
+        "target": case["target"],
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again.",
+    }
+    if list(template) != REPAIR_PACKET_FIELDS:
+        raise ProtocolError("repair packet schema fields drifted")
+    return {
+        "schema_version": template["schema_version"],
+        "fields": REPAIR_PACKET_FIELDS,
+        "template": template,
+        "origin_path": REPAIR_PACKET_ORIGIN,
+        "origin_file_sha256": REPAIR_PACKET_ORIGIN_SHA256,
+        "forbidden_solution_fields": [
+            "command",
+            "argv",
+            "command_line",
+            "shell",
+            "credential",
+            "secret",
+        ],
+    }
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    _verify_frozen_components(repo_root)
+    source_case = _load_source_case(repo_root / SOURCE_PROTOCOL_PATH)
+    case = _case(source_case)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("R1 runtime adapter or preregistration is missing")
+    schedule = [
+        {
+            "pair_id": PAIR_ID,
+            "order": 1,
+            "case_id": case["case_id"],
+            "arm_order": ["baseline", "treatment"],
+            "state_matched": True,
+            "treatment_exposure_only": "repair_packet",
+            "shared_measurement_policy": "runtime_parity_with_r0_observability_v1",
+        }
+    ]
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "candidate_generation_authorized": True,
+            "zero_provider_preflight_authorized": True,
+            "checkpoint_creation_authorized": False,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "pair_collection_authorized": False,
+            "credential_read_authorized": False,
+            "model_creation_authorized": False,
+            "docker_execution_authorized": False,
+            "evidence_write_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "source_protocol": {
+            "path": SOURCE_PROTOCOL_PATH,
+            "file_sha256": SOURCE_PROTOCOL_FILE_SHA256,
+            "case_protocol_sha256": SOURCE_CASES_SHA256,
+            "audit_mode": "result-blind-static-document-review",
+            "source_case": source_case,
+        },
+        "case": case,
+        "independence": {
+            "historical_pair": "opaque-provenance-cppitertools-runtime-parity-pair-01",
+            "historical_repository_url": "https://github.com/ryanhaining/cppitertools",
+            "historical_commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+            "historical_target": "accumulate_examples",
+            "historical_staged_artifact": "accumulate_examples",
+            "repository_commit_target_and_artifact_all_distinct": True,
+            "historical_pair_pooled": False,
+            "retry_replacement_backfill_or_extension": False,
+        },
+        "checkpoint": {
+            "status": "not_created",
+            "checkpoint_id": None,
+            "parent_ledger_sha256": None,
+            "message_state_sha256": None,
+            "environment_identity_sha256": None,
+            "budget_identity_sha256": None,
+            "arm_state_matching": ["message", "environment", "budget"],
+            "creation_requires_separate_authorization": True,
+        },
+        "provider": {
+            "status": "candidate_not_authorized",
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "continuation": {
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": 120000,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "repair_packet": _repair_packet(case),
+        "runtime_parity": {
+            "action_limits": {
+                "inspection": 4,
+                "repair_build": 2,
+                "artifact_stage": 2,
+                "submit": 2,
+            },
+            "atomic_budget_claim": True,
+            "parallel_tool_calls": False,
+            "repair_build_directory": case["build_directory"],
+            "repair_build_target": case["target"],
+            "build_output": case["build_output"],
+            "staged_artifact": case["staged_artifact"],
+            "forbidden_actions": [
+                "clone",
+                "configure",
+                "dependency",
+                "housekeeping",
+                "manual_replay",
+                "compound_build_stage",
+            ],
+            "candidate_verification_required": True,
+            "clean_replay_required": True,
+            "cleanup_required": True,
+        },
+        "r0_observability": {
+            "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+            "legacy_failure_event": "agent.tool_failed",
+            "legacy_failure_schema_preserved": True,
+            "companion_event": "agent.tool_rejection_observed",
+            "companion_required_for_classified_rejection": True,
+            "failure_link_field": "failure_id",
+            "atomic_fields": R0_OBSERVATION_FIELDS,
+            "raw_command_error_model_text_and_credentials_forbidden": True,
+            "unknown_or_ambiguous_tool_call_keeps_legacy_event_only": True,
+            "frozen_components": copy.deepcopy(R0_COMPONENT_SHA256),
+        },
+        "evidence": _evidence_identity(),
+        "stopping": {
+            "checkpoint_creation_failure_stops": True,
+            "reachability_failure_stops_before_pair": True,
+            "identity_evidence_budget_cleanup_or_unclassified_failure_stops": True,
+            "retry_forbidden": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "analysis": {
+            "purpose": "independent_checkpoint_intervention_delivery_and_p2_conversion_canary",
+            "unit_of_analysis": "single_independent_state_matched_pair",
+            "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "require_authorization_baseline_ancestor": True,
+            "require_source_protocol_hash": True,
+            "require_r0_component_hashes": True,
+            "require_empty_candidate_evidence_directory": True,
+            "require_checkpoint_not_created": True,
+            "docker_check_forbidden": True,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "plan", "preflight"],
+            "credential_read_supported": False,
+            "provider_model_creation_supported": False,
+            "checkpoint_execute_supported": False,
+            "reachability_execute_supported": False,
+            "pair_execute_supported": False,
+            "docker_execute_supported": False,
+            "evidence_write_supported": False,
+        },
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("R1 checkpoint candidate manifest drifted")
+    case = value["case"]
+    independence = value["independence"]
+    if not all(
+        (
+            case["repository_url"] != independence["historical_repository_url"],
+            case["commit_sha"] != independence["historical_commit_sha"],
+            case["target"] != independence["historical_target"],
+            case["staged_artifact"] != independence["historical_staged_artifact"],
+        )
+    ):
+        raise ProtocolError("R1 case is not independent from the exploratory pair")
+    if (
+        value["checkpoint"]["status"] != "not_created"
+        or value["evidence"]["status"] != "not_created"
+    ):
+        raise ProtocolError("R1 candidate unexpectedly created checkpoint evidence")
+    if value["runtime_parity"]["action_limits"] != {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2,
+    }:
+        raise ProtocolError("runtime-parity action limits drifted")
+    return value
+
+
+def load_manifest(
+    path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT
+) -> dict[str, Any]:
+    return validate_manifest(
+        _load_object(path, "R1 checkpoint candidate manifest"), repo_root
+    )
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+        "title": "Forge opaque provenance R1 independent checkpoint candidate",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "checkpoint_status": manifest["checkpoint"]["status"],
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+                "credential_read": False,
+                "docker_executed": False,
+                "evidence_writes": 0,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_r1_candidate_runner.py
+++ b/scripts/forge_opaque_provenance_r1_candidate_runner.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Issue #196 R1 独立 checkpoint 候选的零 provider、零 Docker adapter。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+
+
+class RuntimeGateError(RuntimeError):
+    """候选快照或未授权执行入口被拒绝。"""
+
+
+def _load_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_r1_candidate_protocol.py"
+    name = "forge_opaque_provenance_r1_candidate_runtime_protocol"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeGateError("cannot load R1 candidate protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+CommandRunner = Callable[[Sequence[str], Path], str]
+
+
+def _run_command(command: Sequence[str], cwd: Path) -> str:
+    if not command or command[0] != "git":
+        raise RuntimeGateError(
+            "R1 candidate preflight only permits read-only git commands"
+        )
+    try:
+        result = subprocess.run(
+            command, cwd=cwd, check=True, capture_output=True, text=True, timeout=30
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeGateError("R1 candidate preflight git command failed") from exc
+    return result.stdout.strip()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_plan(manifest: dict[str, Any]) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    return {
+        "schema_version": manifest["schema_version"],
+        "case_id": manifest["case"]["case_id"],
+        "repository_url": manifest["case"]["repository_url"],
+        "commit_sha": manifest["case"]["commit_sha"],
+        "target": manifest["case"]["target"],
+        "staged_artifact": manifest["case"]["staged_artifact"],
+        "pair_id": manifest["schedule"][0]["pair_id"],
+        "arm_order": manifest["schedule"][0]["arm_order"],
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+        "action_limits": manifest["runtime_parity"]["action_limits"],
+        "r0_companion_event": manifest["r0_observability"]["companion_event"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "evidence_writes": 0,
+        "execution_authorized": False,
+    }
+
+
+def validate_preflight_snapshot(
+    manifest: dict[str, Any], snapshot: Any
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    if not isinstance(snapshot, dict):
+        raise RuntimeGateError("preflight snapshot must be an object")
+    expected_keys = {
+        "schema_version",
+        "branch",
+        "head_commit",
+        "origin_main_commit",
+        "worktree_clean",
+        "authorization_baseline_ancestor",
+        "source_protocol_file_sha256",
+        "r0_component_sha256",
+        "candidate_evidence_directory",
+        "candidate_evidence_entries",
+        "checkpoint_status",
+        "docker_executed",
+    }
+    if set(snapshot) != expected_keys:
+        raise RuntimeGateError("preflight snapshot fields drifted")
+    if (
+        snapshot["schema_version"]
+        != "forge-opaque-provenance-r1-candidate-preflight-1.0.0"
+    ):
+        raise RuntimeGateError("preflight schema identity drifted")
+    if snapshot["branch"] != manifest["preflight"]["release_branch"]:
+        raise RuntimeGateError("preflight release branch drifted")
+    if (
+        not snapshot["head_commit"]
+        or snapshot["head_commit"] != snapshot["origin_main_commit"]
+    ):
+        raise RuntimeGateError("preflight main/origin identity drifted")
+    if (
+        snapshot["worktree_clean"] is not True
+        or snapshot["authorization_baseline_ancestor"] is not True
+    ):
+        raise RuntimeGateError(
+            "preflight release identity is not clean or descendant-compatible"
+        )
+    if (
+        snapshot["source_protocol_file_sha256"]
+        != manifest["source_protocol"]["file_sha256"]
+    ):
+        raise RuntimeGateError("preflight source protocol identity drifted")
+    if (
+        snapshot["r0_component_sha256"]
+        != manifest["r0_observability"]["frozen_components"]
+    ):
+        raise RuntimeGateError("preflight R0 observability components drifted")
+    if (
+        snapshot["candidate_evidence_directory"] != manifest["evidence"]["directory"]
+        or snapshot["candidate_evidence_entries"] != 0
+    ):
+        raise RuntimeGateError(
+            "candidate evidence directory is not the frozen empty directory"
+        )
+    if snapshot["checkpoint_status"] != "not_created":
+        raise RuntimeGateError("R1 checkpoint already exists")
+    if snapshot["docker_executed"] is not False:
+        raise RuntimeGateError("R1 candidate preflight must not execute Docker")
+    return snapshot
+
+
+def collect_preflight_snapshot(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+    host_candidate_evidence_directory: Path,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    sessions_root = repo_root / ".compile-sessions"
+    candidate_name = PurePosixPath(manifest["evidence"]["directory"]).name
+    expected_candidate = sessions_root / candidate_name
+    if host_candidate_evidence_directory.resolve(
+        strict=False
+    ) != expected_candidate.resolve(strict=False):
+        raise RuntimeGateError(
+            "candidate evidence directory is not bound to the frozen identity"
+        )
+
+    branch = command_runner(("git", "branch", "--show-current"), repo_root)
+    head = command_runner(("git", "rev-parse", "HEAD"), repo_root)
+    origin_main = command_runner(("git", "rev-parse", "origin/main"), repo_root)
+    status = command_runner(("git", "status", "--porcelain"), repo_root)
+    ancestry = command_runner(
+        (
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            manifest["preflight"]["authorization_baseline_commit"],
+            "HEAD",
+        ),
+        repo_root,
+    )
+    if ancestry:
+        raise RuntimeGateError("git ancestry check produced unexpected output")
+    candidate_entries = (
+        len(tuple(host_candidate_evidence_directory.iterdir()))
+        if host_candidate_evidence_directory.exists()
+        else 0
+    )
+    snapshot = {
+        "schema_version": "forge-opaque-provenance-r1-candidate-preflight-1.0.0",
+        "branch": branch,
+        "head_commit": head,
+        "origin_main_commit": origin_main,
+        "worktree_clean": status == "",
+        "authorization_baseline_ancestor": True,
+        "source_protocol_file_sha256": _file_sha256(
+            repo_root / manifest["source_protocol"]["path"]
+        ),
+        "r0_component_sha256": {
+            path: _file_sha256(repo_root / path)
+            for path in sorted(manifest["r0_observability"]["frozen_components"])
+        },
+        "candidate_evidence_directory": manifest["evidence"]["directory"],
+        "candidate_evidence_entries": candidate_entries,
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "docker_executed": False,
+    }
+    return validate_preflight_snapshot(manifest, snapshot)
+
+
+def execute_checkpoint(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("checkpoint creation is not authorized by Issue #196")
+
+
+def execute_reachability(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("reachability request is not authorized by Issue #196")
+
+
+def execute_pair(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("provider pair is not authorized by Issue #196")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "plan", "preflight"))
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--host-candidate-evidence-directory", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest, args.repo_root)
+    if args.command == "preflight":
+        if args.host_candidate_evidence_directory is None:
+            raise RuntimeGateError(
+                "preflight requires the candidate evidence directory"
+            )
+        result = collect_preflight_snapshot(
+            manifest,
+            repo_root=args.repo_root,
+            host_candidate_evidence_directory=args.host_candidate_evidence_directory,
+        )
+    elif args.command == "plan":
+        result = build_plan(manifest)
+    else:
+        result = {
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "checkpoint_status": manifest["checkpoint"]["status"],
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+            "credential_read": False,
+            "docker_executed": False,
+            "evidence_writes": 0,
+        }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从已审阅且 result-blind 的 formal v1 source protocol 逐字段冻结 `yyjson@9365ddc7`、CMake target `yyjson` 和 `libyyjson.a` static-library oracle
- 新增 R1 版本化 manifest、完整 const Schema、protocol、纯快照 preflight、预注册和聚焦测试
- 冻结 #194 R0 companion observability、原 repair packet Schema、4/2/2/2 动作预算、300 秒/0 retry 及 candidate/replay/cleanup 要求
- checkpoint 与 evidence 固定为 `not_created`，所有 provider、credential、model、Docker、checkpoint/pair execute 和 evidence write 能力机械关闭

## 验证

- 聚焦回归：`19 passed`
- 路线 P、R0 与 formal source 相邻回归：`156 passed, 1 deselected`
- Ruff check/format、Python 语法、manifest/Schema 确定性再生成、diff 与 staged secret scan 通过
- 已知 deselect 是 #184 正式采集后不再成立的旧 #182 “evidence 目录为空”前提；未删除或修改历史 evidence
- 固定 `0 provider / 0 formal attempt / 0 model token / 0 credential read / 0 Docker / 0 evidence write`

Closes #196