### PR TITLE
研究：验证 R1 yyjson 独立 checkpoint 生命周期

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,15 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 完成 Issue #198 R1 yyjson 独立 checkpoint 真实 Docker 零 provider 门禁
+  - 文件: `scripts/forge_opaque_provenance_r1_checkpoint_gate.py`, `backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py`, `backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md`
+  - 实现: 新 adapter 逐字段继承 #196 yyjson identity，使用可 replay 但不证明 CMake identity 的 opaque `sh -c` parent；静态合同同时冻结 repair packet、P2 append-only future treatment 和 #194 R0 companion observability。
+  - 真实门禁: Ubuntu-native Docker gate `1 passed in 64.56s`；真实 `libyyjson.a` static archive 只因 `build_system_unproven / opaque_wrapper` 失败，bound submit 后 post-build fence 三字段释放，candidate failed、replay not_run；message/environment/budget 双臂 canonical 同源，repair packet 是唯一 treatment exposure。
+  - Cleanup: parent/双臂 Compile Session、checkpoint helper、continuation image 和 snapshot 全部清理；capture label、`deerflow-compile-*`、`deerflow-replay-*` 与 continuation image 均为 0 orphan，#196 candidate evidence 目录仍不存在。
+  - 验证: 静态聚焦 `11 passed`，R1/R0/runtime-parity/real-lifecycle 相邻回归 `70 passed`；Ruff、format、语法和 diff 通过。固定 0 provider、0 formal attempt、0 model token、0 credential read、0 candidate evidence write。
+  - 踩坑: 首次 gate 的 parent policy 同时要求依赖与 CMake 参数可观察，opaque wrapper 因而额外产生 `dependency_setup_not_observed` 和 configuration 次级分类；cleanup 正常闭合。修复将 ExperimentPolicy 收敛为只隔离 provenance fault，source 参数仍由 candidate 与真实 parent command 冻结，replacement gate 通过。
+  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；合并后从干净主干重跑静态 gate，不重复真实 Docker gate。随后才能设计一次 reachability + 单 pair execution amendment。
+
 - 2026-08-30 — 冻结 Issue #196 opaque provenance R1 独立 checkpoint 未授权候选
   - 文件: `scripts/forge_opaque_provenance_r1_candidate_protocol.py`, `scripts/forge_opaque_provenance_r1_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md`
   - Case: 从 result-blind `cpp-formal-v1-cases.json` 逐字段冻结 `yyjson@9365ddc7`、CMake target `yyjson` 与 `libyyjson.a` static-library oracle；repository、commit、target 和 staged artifact 均不同于 #190 `cppitertools` exploratory pair。

--- a/backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py
@@ -1,0 +1,152 @@
+"""Issue #198 yyjson R1 checkpoint adapter 的零 provider 静态门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "forge_opaque_provenance_r1_checkpoint_gate.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location("forge_opaque_provenance_r1_checkpoint_gate_test", SCRIPT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+gate = _load_module()
+
+
+def _frozen():
+    return gate.build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r1-static-test",
+        build_tree_sha256="3" * 64,
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+
+
+def test_case_is_exactly_inherited_from_r1_candidate() -> None:
+    manifest = gate.candidate_protocol.load_manifest()
+    assert gate.CANDIDATE_MANIFEST_SHA256 == gate.candidate_protocol.canonical_sha256(manifest)
+    assert gate.CASE_ID == "yyjson-opaque-provenance-r1"
+    assert gate.REPOSITORY_URL == "https://github.com/ibireme/yyjson"
+    assert gate.COMMIT_SHA == "9365ddc7061033df656578bf86040048b5b5531a"
+    assert gate.BUILD_DIRECTORY == "/workspace/repo/build"
+    assert gate.TARGET == "yyjson"
+    assert gate.BUILD_OUTPUT == "build/libyyjson.a"
+    assert gate.STAGED_ARTIFACT == "libyyjson.a"
+    assert gate.ARTIFACT_TYPE == "static_library"
+    assert list(gate.CONFIGURE_ARGUMENTS) == manifest["case"]["configure_arguments"]
+
+
+def test_parent_wrapper_is_replayable_but_does_not_prove_cmake_identity() -> None:
+    assert gate.validate_parent_command_contract() == {
+        "roles": ["artifact_stage", "build", "configure"],
+        "top_level_executable": "sh",
+        "cmake_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+    assert "cmake -S . -B build -G Ninja" in gate.PARENT_COMMAND
+    assert "cmake --build build --target yyjson" in gate.PARENT_COMMAND
+    assert "cp build/libyyjson.a /artifacts/libyyjson.a" in gate.PARENT_COMMAND
+
+
+def test_repair_packet_is_case_bound_and_does_not_leak_a_command() -> None:
+    packet = gate.validate_repair_packet(gate.build_repair_packet())
+    assert packet == gate.candidate_protocol.load_manifest()["repair_packet"]["template"]
+    assert packet["build_directory"] == gate.BUILD_DIRECTORY
+    assert packet["target"] == gate.TARGET
+    serialized = json.dumps(packet, sort_keys=True).lower()
+    for forbidden in ("cmake --build", "sh -c", "argv", "api_key"):
+        assert forbidden not in serialized
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(command="cmake --build build"),
+        lambda value: value.update(build_directory="/workspace/repo/other"),
+        lambda value: value.update(target="other"),
+    ],
+)
+def test_repair_packet_drift_fails_closed(mutation) -> None:
+    packet = gate.build_repair_packet()
+    mutation(packet)
+    with pytest.raises(gate.CheckpointGateError, match="identity or whitelist drifted"):
+        gate.validate_repair_packet(packet)
+
+
+def test_parent_is_unproven_and_future_treatment_contract_is_append_only() -> None:
+    frozen = _frozen()
+    parent, parent_history = gate.evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = gate.evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-build",
+        treatment_stage_command_id="treatment-stage",
+    )
+    assert parent.status == "unproven"
+    assert parent.classification == "opaque_build_provenance"
+    assert parent.reason == "opaque_wrapper"
+    assert treatment.status == "proven"
+    assert treatment.proof_mode == "direct_cmake"
+    assert treatment_history[: len(parent_history)] == parent_history
+
+
+def test_artifact_identity_drift_fails_closed() -> None:
+    with pytest.raises(gate.CheckpointGateError, match="R1 frozen case identity drifted"):
+        gate.evaluate_parent(replace(_frozen(), artifact_type="executable"), parent_command_id="parent-wrapper")
+
+
+def test_r0_observability_is_a_required_zero_provider_gate() -> None:
+    report = gate.validate_gate_contract()
+    r0 = report["r0_observability"]
+    assert r0["companion_event"] == "agent.tool_rejection_observed"
+    assert r0["legacy_tool_failed_schema_preserved"] is True
+    assert r0["raw_command_persisted"] is False
+    assert r0["atomic_fields"] == gate.candidate_protocol.R0_OBSERVATION_FIELDS
+
+
+def test_cli_reports_zero_external_counts_and_no_checkpoint() -> None:
+    completed = subprocess.run([sys.executable, str(SCRIPT_PATH), "validate"], check=True, capture_output=True, text=True)
+    report = json.loads(completed.stdout)
+    assert report["parent"]["status"] == "unproven"
+    assert report["treatment_contract_only"]["status"] == "proven"
+    assert report["parent_history_prefix_preserved"] is True
+    assert report["checkpoint_created"] is False
+    assert report["docker_executed"] is False
+    assert report["credential_read"] is False
+    assert report["candidate_evidence_writes"] == 0
+    assert (report["provider_calls"], report["formal_attempts"], report["model_tokens"]) == (0, 0, 0)
+
+
+def test_source_has_no_provider_credential_or_formal_execution_entrypoint() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "create_chat_model",
+        "openai_ak",
+        "deepseek_api_key",
+        "os.getenv",
+        "execute_reachability",
+        "execute_pair",
+        "docker.from_env",
+        "benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+    ):
+        assert forbidden not in source

--- a/backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py
@@ -1,0 +1,410 @@
+"""Issue #198 yyjson R1 checkpoint 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import ExperimentLedger, ExperimentPolicy, activate_experiment, deactivate_experiment, new_evidence_id
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.compile.paths import get_host_artifacts_dir, get_host_logs_dir, get_host_repro_dir, get_host_workspace_dir
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+from deerflow.tools import bound_compile_tools
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_R1_CHECKPOINT_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_R1_CHECKPOINT_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_module(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+adapter = _load_module("forge_opaque_provenance_r1_checkpoint_docker_adapter", "forge_opaque_provenance_r1_checkpoint_gate.py")
+lifecycle = _load_module("forge_opaque_provenance_r1_checkpoint_lifecycle", "forge_real_lifecycle_checkpoint_gate.py")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_ubuntu_native_docker():
+    if not DOCKER_ENABLED:
+        yield
+        return
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Ubuntu native Docker is unavailable: {daemon.stderr.strip()}")
+    image = subprocess.run(
+        ["docker", "image", "inspect", adapter.COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {adapter.COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _record_command(*, manager: CompileSessionManager, runtime: CompileDockerRuntime, session: Any, command: str, role: str) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(session, command, workdir=adapter.WORKDIR, timeout_seconds=300)
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir=adapter.WORKDIR,
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=300,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination="timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed"),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def _policy(*, image_id: str) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-r1-checkpoint-gate",
+        manifest_sha256=adapter.CANDIDATE_MANIFEST_SHA256,
+        case_id=adapter.CASE_ID,
+        condition="r1-independent-checkpoint-zero-provider",
+        repetition=1,
+        expected_repo_url=adapter.REPOSITORY_URL,
+        expected_commit_sha=adapter.COMMIT_SHA,
+        expected_build_system="cmake",
+        compile_image=adapter.COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_ZERO_PROVIDER_CREDENTIAL",
+        request_timeout_seconds=300,
+        model_max_retries=0,
+        compiler_max_turns=8,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        # Source protocol 和真实 parent command 已冻结这些字段；本 policy 只隔离 provenance fault。
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir=adapter.SOURCE_SUBDIR,
+        build_targets=(adapter.TARGET,),
+        artifact_instructions=((adapter.STAGED_ARTIFACT, adapter.BUILD_OUTPUT, adapter.ARTIFACT_TYPE),),
+    )
+
+
+def _budget_manifest(capture_id: str, _message_sha256: str) -> dict[str, Any]:
+    return lifecycle.budget_checkpoint.build_manifest(
+        checkpoint_id=capture_id,
+        limits={
+            "provider_requests": 8,
+            "compiler_invocations": 2,
+            "compiler_model_turns": 8,
+            "graph_recursion_steps": 24,
+            "attempt_wall_clock_seconds": 900,
+            "attempt_cleanup_reserve_seconds": 120,
+            "compiler_wall_clock_seconds": 720,
+            "compiler_post_build_reserve_seconds": 120,
+            "post_build_commands": 2,
+        },
+        consumed_before_capture={
+            "provider_requests": 0,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 0,
+            "graph_recursion_steps": 3,
+            "attempt_wall_clock_seconds": 10,
+            "compiler_wall_clock_seconds": 5,
+            "post_build_commands": 0,
+            "tokens": 0,
+        },
+        post_build_started=False,
+    )
+
+
+def _arm_plan(capture_id: str) -> dict[str, dict[str, str]]:
+    return {
+        arm: {
+            "thread_id": f"{arm}-{capture_id}-thread",
+            "session_id": f"{arm}-{capture_id}-session",
+            "environment_id": f"{arm}-{capture_id}-environment",
+        }
+        for arm in ("baseline", "treatment")
+    }
+
+
+def _failure_event(ledger: ExperimentLedger) -> dict[str, Any]:
+    failures = [event for event in ledger.read() if event["event"] == "failure.recorded"]
+    assert len(failures) == 1
+    return failures[0]
+
+
+def _constraint_failures(session: Any) -> list[str]:
+    assert session.verification is not None
+    benchmark = [check for check in session.verification.checks if check.name == "benchmark_constraints"]
+    return [] if not benchmark else list(benchmark[0].actual)
+
+
+def _feedback(message_runtime: Any, config: dict[str, Any]) -> dict[str, Any]:
+    messages = message_runtime.graph.get_state(config).values["messages"]
+    return json.loads(messages[-1].content)
+
+
+def _without_arm(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in snapshot.items() if key != "arm"}
+
+
+def test_real_yyjson_parent_checkpoint_state_matching_and_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    static_report = adapter.validate_gate_contract()
+    assert static_report["r0_observability"]["companion_event"] == "agent.tool_rejection_observed"
+    assert not (REPO_ROOT / ".compile-sessions" / Path(adapter._MANIFEST["evidence"]["directory"]).name).exists()
+    capture_id = f"issue198-{uuid.uuid4().hex[:10]}"
+    workspace = tmp_path / "workspace"
+    paths = Paths(base_dir=tmp_path / ".deer-flow", workspace_root=workspace, host_workspace_root=str(workspace))
+    manager = CompileSessionManager(paths=paths, default_image=adapter.COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    docker = lifecycle.environment_checkpoint.DockerCLI()
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=adapter.REPOSITORY_URL,
+        image=adapter.COMPILE_IMAGE,
+    )
+    parent_ledger = ExperimentLedger.create(
+        tmp_path / "parent-ledger.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-198-r1-yyjson-checkpoint"},
+    )
+    active_threads: set[str] = set()
+    arm_sessions: list[Any] = []
+    continuation_images: set[str] = set()
+    known_container_ids: set[str] = set()
+    gate = None
+    cleaned = False
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        assert parent.image_id is not None and parent.container_id is not None
+        known_container_ids.add(parent.container_id)
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {adapter.REPOSITORY_URL} && git fetch --depth 1 origin {adapter.COMMIT_SHA} && git checkout --detach FETCH_HEAD",
+            workdir=adapter.WORKDIR,
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        parent.commit_sha = adapter.COMMIT_SHA
+        parent.build_system = "cmake"
+        parent.build_system_capabilities = ["cmake"]
+        parent.selected_build_system = "cmake"
+        parent.status = "inspected"
+        manager.save_session(parent)
+
+        supporting = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=parent,
+            command=adapter.PARENT_COMMAND,
+            role="build",
+        )
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        workspace_artifact = Path(parent.leadagent_repo_dir) / adapter.BUILD_OUTPUT
+        build_tree = Path(parent.leadagent_repo_dir) / "build" / "build.ninja"
+        assert workspace_artifact.is_file() and workspace_artifact.stat().st_size > 0 and build_tree.is_file()
+        parent_frozen = adapter.build_frozen_identity(
+            image_id=parent.image_id,
+            physical_attempt_id=f"{capture_id}-parent",
+            build_tree_sha256=lifecycle.sha256_file(build_tree),
+            artifact_size=workspace_artifact.stat().st_size,
+            artifact_sha256=lifecycle.sha256_file(workspace_artifact),
+        )
+        parent_p2, parent_history = adapter.evaluate_parent(parent_frozen, parent_command_id=supporting.command_id)
+        assert parent_p2.reason == "opaque_wrapper"
+
+        activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_policy(image_id=parent.image_id),
+        )
+        active_threads.add(parent.thread_id)
+        submit_results: list[str] = []
+
+        def submit_parent() -> str:
+            result = bound_compile_tools._submit_with_post_build_phase(parent, supporting_command_id=supporting.command_id)
+            submit_results.append(result)
+            return result
+
+        def capture_evidence() -> dict[str, Any]:
+            failure = _failure_event(parent_ledger)
+            return {
+                "classification": failure["payload"]["classification"],
+                "failure_id": failure["payload"]["failure_id"],
+                "submit_attempt_id": failure["payload"]["submit_attempt_id"],
+                "session_sha256": lifecycle.sha256_file(Path(parent.metadata_path)),
+                "parent_p2": asdict(parent_p2),
+                "parent_command_history_sha256": adapter.provenance.command_history_sha256(parent_history),
+                "r0_companion_event": "agent.tool_rejection_observed",
+            }
+
+        snapshot = tmp_path / "snapshot"
+        coordinator = lifecycle.CaptureCoordinator(tmp_path / "coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(tmp_path / "messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = lifecycle.LifecycleMessageRuntime(saver, submit_parent, repair_packet=adapter.build_repair_packet())
+            environment = lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=str(snapshot),
+            )
+            gate = lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=_budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="issue-198-r1-checkpoint-gate",
+            )
+            capture = gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="freeze the independent yyjson opaque provenance failure before continuation",
+                arm_plan=_arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(parent.session_id, parent.thread_id, paths),
+                    "artifacts": get_host_artifacts_dir(parent.session_id, parent.thread_id, paths),
+                    "logs": get_host_logs_dir(parent.session_id, parent.thread_id, paths),
+                    "repro": get_host_repro_dir(parent.session_id, parent.thread_id, paths),
+                },
+                evidence=capture_evidence,
+            )
+            continuation_images.add(capture["environment"]["continuation_image_id"])
+            parent_payload = json.loads(submit_results[0])
+            parent_failure = _failure_event(parent_ledger)["payload"]
+            assert parent_payload["status"] == "failed"
+            assert parent_payload["candidate_status"] == "failed"
+            assert parent_payload["replay_status"] == "not_run"
+            assert parent.replay_attempts == []
+            assert parent_failure["classification"] == "build_system_unproven"
+            assert parent_failure["secondary_classifications"] == []
+            assert _constraint_failures(parent) == ["build_system_unproven"]
+            assert len(parent.artifacts) == 1 and parent.artifacts[0].artifact_type == "static_library"
+            assert parent.post_build_supporting_command_id is None
+            assert parent.post_build_started_at is None
+            assert parent.post_build_commands_remaining is None
+            deactivate_experiment(parent.thread_id)
+            active_threads.remove(parent.thread_id)
+
+            baseline = gate.provision_arm(capture_id, "baseline", parent_session=parent)
+            treatment = gate.provision_arm(capture_id, "treatment", parent_session=parent)
+            arm_sessions.extend([baseline.session, treatment.session])
+            known_container_ids.update(session.container_id for session in arm_sessions if session.container_id is not None)
+            assert gate.canonical_arm_environment("baseline") == gate.canonical_arm_environment("treatment")
+            baseline_feedback = _feedback(message_runtime, baseline.message_config)
+            treatment_feedback = _feedback(message_runtime, treatment.message_config)
+            assert baseline_feedback.get("repair_packet") is None
+            assert adapter.validate_repair_packet(treatment_feedback["repair_packet"]) == adapter.build_repair_packet()
+            assert {key: value for key, value in treatment_feedback.items() if key != "repair_packet"} == baseline_feedback
+            assert baseline.session.image_id == treatment.session.image_id
+            assert _without_arm(baseline.budget.snapshot()) == _without_arm(treatment.budget.snapshot())
+            assert coordinator.get(capture_id).phase == "committed"
+            assert gate.external_counts() == {"provider_calls": 0, "formal_physical_attempts": 0, "model_tokens": 0}
+
+            record = gate.cleanup(capture_id, parent_session=parent)
+            cleaned = True
+            assert record.phase == "cleaned"
+            assert record.payload["cleanup"]["succeeded"] is True
+    finally:
+        for thread_id in tuple(active_threads):
+            deactivate_experiment(thread_id)
+        if gate is not None and not cleaned:
+            try:
+                gate.cleanup(capture_id, parent_session=parent)
+            except Exception:
+                pass
+        for session in arm_sessions:
+            runtime.stop_and_remove_container(session)
+        runtime.stop_and_remove_container(parent)
+        for container_id in docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split():
+            docker.run(["rm", "-f", container_id], check=False, timeout_seconds=30)
+        continuation_images.update(
+            docker.run(
+                ["image", "ls", "-q", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+                check=False,
+                timeout_seconds=30,
+            ).stdout.split()
+        )
+        for image_id in continuation_images:
+            docker.run(["image", "rm", "-f", image_id], check=False, timeout_seconds=60)
+
+    for container_id in known_container_ids:
+        assert docker.run(["container", "inspect", container_id], check=False, timeout_seconds=20).returncode != 0
+    assert (
+        docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )
+    names = docker.run(["ps", "-a", "--format", "{{.Names}}"], check=False, timeout_seconds=30).stdout.splitlines()
+    assert [name for name in names if name.startswith(("deerflow-compile-", "deerflow-replay-"))] == []
+    assert not (REPO_ROOT / ".compile-sessions" / Path(adapter._MANIFEST["evidence"]["directory"]).name).exists()

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md
@@ -1,0 +1,26 @@
+# Opaque build provenance R1 独立 checkpoint 真实 Docker 零 provider 门禁
+
+本门禁承接 Issue #196 / PR #197 已发布的 `yyjson` 未授权候选。当前只验证一个真实 controlled parent 能否形成可复用的 message/environment/budget checkpoint，并在派生 state-matched 双臂后完成 cleanup；不执行模型 continuation，不写 #196 候选 evidence。
+
+## 冻结 case 与 parent
+
+- 仓库与 exact commit：`https://github.com/ibireme/yyjson@9365ddc7061033df656578bf86040048b5b5531a`。
+- CMake build directory / target：`/workspace/repo/build` / `yyjson`。
+- Output / staged artifact / type：`build/libyyjson.a` / `libyyjson.a` / `static_library`。
+- Parent 使用单一顶层 `sh -c` wrapper 完成 configure、build 和 stage。Wrapper 可进入候选 replay，但不提供 trusted direct-CMake identity，因此 P2 必须保持 `unproven / opaque_wrapper`。
+- Parent submit 必须通过真实 bound `_submit_with_post_build_phase`；失败后 fence 三字段全部释放，candidate 为 failed、replay 为 not_run。
+
+## Checkpoint 与 R0
+
+Checkpoint 捕获点保持 `after-neutral-tool-message-before-continuation`。Message、environment 与 budget 绑定到同一 capture ID；双臂的 workspace/artifacts/image 和剩余预算必须 canonical 相同，唯一 treatment exposure 是原 repair packet。
+
+Issue #194 R0 observability 是本门禁的前置条件。静态 gate 必须重新证明 `agent.tool_rejection_observed`、历史七字段兼容、五个原子 observation 字段和 raw-command 禁止规则；真实 Docker gate 不伪造模型 tool call，也不为未执行的 arm 写 companion event。
+
+## 执行与停止规则
+
+- 只允许 WSL Ubuntu 原生 Docker Engine；环境变量 `FORGE_RUN_OPAQUE_PROVENANCE_R1_CHECKPOINT_DOCKER=1` 显式开启唯一真实 gate。
+- 固定 0 provider、0 formal attempt、0 model token、0 credential read、0 #196 candidate evidence write。
+- Clone、parent build、submit、capture、arm provisioning 或 cleanup 任一失败即停止；禁止 replacement/backfill。
+- Cleanup 必须删除 parent/arm Compile Session 容器、checkpoint helper、continuation image 和 snapshot，最终 capture label 及 `deerflow-compile-*` / `deerflow-replay-*` 均为 0 orphan。
+
+本门禁成功只证明独立 checkpoint 和未来 intervention delivery 的基础设施可达，不构成 repair packet 或模型效果证据。Reachability 与单 pair 仍须另建 execution amendment。

--- a/scripts/forge_opaque_provenance_r1_checkpoint_gate.py
+++ b/scripts/forge_opaque_provenance_r1_checkpoint_gate.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Issue #198 yyjson opaque provenance R1 真实 checkpoint 零 provider 门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shlex
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from deerflow.compile import operations
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_build_provenance_gate as provenance  # noqa: E402
+import forge_opaque_provenance_r1_candidate_protocol as candidate_protocol  # noqa: E402
+
+SCHEMA_VERSION = "forge-opaque-provenance-r1-checkpoint-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/198"
+WORKDIR = "/workspace/repo"
+GENERATOR = "Ninja"
+PROOF_STATUS = "opaque_wrapper"
+REPAIR_GOAL = "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+
+
+class CheckpointGateError(RuntimeError):
+    """R1 candidate、parent command、repair packet 或 P2 identity 无效。"""
+
+
+def _load_module(name: str, filename: str):
+    path = SCRIPT_ROOT / filename
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise CheckpointGateError(f"cannot load frozen component: {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+observability = _load_module(
+    "forge_opaque_provenance_r1_checkpoint_observability",
+    "forge_opaque_provenance_rejection_observability_gate.py",
+)
+
+
+def _candidate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return candidate_protocol.load_manifest(
+        candidate_protocol.DEFAULT_MANIFEST, repo_root
+    )
+
+
+_MANIFEST = _candidate_manifest()
+_CASE = _MANIFEST["case"]
+CASE_ID = _CASE["case_id"]
+REPOSITORY_URL = _CASE["repository_url"]
+COMMIT_SHA = _CASE["commit_sha"]
+COMPILE_IMAGE = _CASE["compile_image"]
+SOURCE_SUBDIR = _CASE["source_subdir"]
+BUILD_DIRECTORY = _CASE["build_directory"]
+BUILD_OUTPUT = _CASE["build_output"]
+STAGED_ARTIFACT = _CASE["staged_artifact"]
+ARTIFACT_TYPE = _CASE["artifact_type"]
+TARGET = _CASE["target"]
+CONFIGURE_ARGUMENTS = tuple(_CASE["configure_arguments"])
+REQUIRED_SYSTEM_PACKAGES = tuple(_CASE["required_system_packages"])
+CANDIDATE_MANIFEST_SHA256 = candidate_protocol.canonical_sha256(_MANIFEST)
+
+_CONFIGURE = " ".join(
+    ["cmake", "-S", SOURCE_SUBDIR, "-B", "build", "-G", GENERATOR, *CONFIGURE_ARGUMENTS]
+)
+_PARENT_INNER_COMMAND = (
+    f"rm -rf build && {_CONFIGURE} && "
+    f"cmake --build build --target {TARGET} -j2 && "
+    f"cp {BUILD_OUTPUT} /artifacts/{STAGED_ARTIFACT}"
+)
+PARENT_COMMAND = f"sh -c {shlex.quote(_PARENT_INNER_COMMAND)}"
+TREATMENT_BUILD_COMMAND = f"cmake --build {BUILD_DIRECTORY} --target {TARGET} -j2"
+TREATMENT_STAGE_COMMAND = (
+    f"cp /workspace/repo/{BUILD_OUTPUT} /artifacts/{STAGED_ARTIFACT}"
+)
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def build_repair_packet() -> dict[str, str]:
+    packet = dict(_candidate_manifest()["repair_packet"]["template"])
+    if list(packet) != candidate_protocol.REPAIR_PACKET_FIELDS:
+        raise CheckpointGateError("repair packet fields drifted")
+    return packet
+
+
+def validate_repair_packet(value: dict[str, Any]) -> dict[str, str]:
+    expected = build_repair_packet()
+    if value != expected:
+        raise CheckpointGateError("repair packet identity or whitelist drifted")
+    serialized = canonical_bytes(value).decode("utf-8").lower()
+    for forbidden in (
+        "cmake --build",
+        "bash -lc",
+        "sh -c",
+        "argv",
+        "command_line",
+        "shell",
+        "secret",
+        "api_key",
+    ):
+        if forbidden in serialized:
+            raise CheckpointGateError("repair packet leaked a forbidden solution field")
+    return expected
+
+
+def validate_parent_command_contract() -> dict[str, Any]:
+    roles = operations.infer_command_roles(PARENT_COMMAND)
+    expected_roles = {"configure", "build", "artifact_stage"}
+    if roles != expected_roles:
+        raise CheckpointGateError(f"parent wrapper roles drifted: {sorted(roles)}")
+    if operations._command_invokes(PARENT_COMMAND, "cmake"):
+        raise CheckpointGateError("parent wrapper unexpectedly proves CMake identity")
+    if (
+        not operations._command_invokes(PARENT_COMMAND, "sh")
+        or operations.infer_command_role(PARENT_COMMAND) != "build"
+    ):
+        raise CheckpointGateError("parent wrapper top-level identity drifted")
+    return {
+        "roles": sorted(roles),
+        "top_level_executable": "sh",
+        "cmake_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+
+
+def build_frozen_identity(
+    *,
+    image_id: str,
+    physical_attempt_id: str,
+    build_tree_sha256: str,
+    artifact_size: int,
+    artifact_sha256: str,
+):
+    return provenance.FrozenIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        case_id=CASE_ID,
+        repository_url=REPOSITORY_URL,
+        commit_sha=COMMIT_SHA,
+        image_id=image_id,
+        physical_attempt_id=physical_attempt_id,
+        workdir=WORKDIR,
+        build_directory=BUILD_DIRECTORY,
+        generator=GENERATOR,
+        build_tree_sha256=build_tree_sha256,
+        target=TARGET,
+        artifact_relative_path=BUILD_OUTPUT,
+        artifact_type=ARTIFACT_TYPE,
+        artifact_size=artifact_size,
+        artifact_sha256=artifact_sha256,
+    ).validate()
+
+
+def _parent_invocation(frozen: Any, command_id: str):
+    return provenance.record_invocation(
+        command_id=command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", _PARENT_INNER_COMMAND),
+        workdir=frozen.workdir,
+        previous_hash=provenance.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def _validate_case_identity(frozen: Any) -> None:
+    frozen.validate()
+    expected = {
+        "case_id": CASE_ID,
+        "repository_url": REPOSITORY_URL,
+        "commit_sha": COMMIT_SHA,
+        "workdir": WORKDIR,
+        "build_directory": BUILD_DIRECTORY,
+        "generator": GENERATOR,
+        "target": TARGET,
+        "artifact_relative_path": BUILD_OUTPUT,
+        "artifact_type": ARTIFACT_TYPE,
+    }
+    if any(getattr(frozen, field) != value for field, value in expected.items()):
+        raise CheckpointGateError("R1 frozen case identity drifted")
+
+
+def evaluate_parent(frozen: Any, *, parent_command_id: str):
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    artifact = provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=parent.command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=2,
+    )
+    decision = provenance.evaluate_p2(frozen, (parent,), artifact)
+    if (
+        decision.status != "unproven"
+        or decision.classification != provenance.FAULT_FAMILY
+        or decision.reason != PROOF_STATUS
+    ):
+        raise CheckpointGateError(
+            "parent did not produce the frozen opaque-wrapper P2 failure"
+        )
+    return decision, (parent,)
+
+
+def evaluate_treatment(
+    frozen: Any,
+    *,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    build = provenance.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cmake",
+        argv=("--build", frozen.build_directory, "--target", frozen.target, "-j2"),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = provenance.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(
+            f"/workspace/repo/{frozen.artifact_relative_path}",
+            f"/artifacts/{STAGED_ARTIFACT}",
+        ),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    artifact = provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=build.command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=4,
+    )
+    invocations = (parent, build, stage)
+    decision = provenance.evaluate_p2(frozen, invocations, artifact)
+    if decision.status != "proven" or decision.proof_mode != "direct_cmake":
+        raise CheckpointGateError("treatment did not convert the frozen P2 outcome")
+    return decision, invocations
+
+
+def validate_gate_contract() -> dict[str, Any]:
+    manifest = _candidate_manifest()
+    if (
+        manifest["checkpoint"]["status"] != "not_created"
+        or manifest["authorization"]["docker_execution_authorized"] is not False
+    ):
+        raise CheckpointGateError("#196 candidate authorization boundary drifted")
+    frozen = build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r1-checkpoint-contract",
+        build_tree_sha256="3" * 64,
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+    parent, parent_history = evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-cmake-build",
+        treatment_stage_command_id="treatment-artifact-stage",
+    )
+    r0 = observability.validate_gate()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "candidate_manifest_sha256": candidate_protocol.canonical_sha256(manifest),
+        "case_id": CASE_ID,
+        "case": manifest["case"],
+        "command_contract": validate_parent_command_contract(),
+        "repair_packet": validate_repair_packet(build_repair_packet()),
+        "parent": asdict(parent),
+        "treatment_contract_only": asdict(treatment),
+        "parent_history_sha256": provenance.command_history_sha256(parent_history),
+        "treatment_history_sha256": provenance.command_history_sha256(
+            treatment_history
+        ),
+        "parent_history_prefix_preserved": treatment_history[: len(parent_history)]
+        == parent_history,
+        "r0_observability": {
+            "schema_version": r0["schema_version"],
+            "companion_event": r0["observation_event"],
+            "atomic_fields": r0["atomic_observability_fields"],
+            "legacy_tool_failed_schema_preserved": r0[
+                "legacy_tool_failed_schema_preserved"
+            ],
+            "raw_command_persisted": r0["raw_command_persisted"],
+        },
+        "checkpoint_created": False,
+        "docker_executed": False,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "credential_read": False,
+        "candidate_evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(
+        json.dumps(
+            validate_gate_contract(), ensure_ascii=False, indent=2, sort_keys=True
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 case-specific adapter，逐字段继承 #196 的 yyjson repo/commit/CMake target/static-library oracle
- 使用 opaque `sh -c` parent 构造独立 `build_system_unproven / opaque_wrapper`，同时冻结 future treatment 的 append-only P2 conversion 合同
- 接入 #194 R0 companion observability 静态门禁
- 新增 opt-in Ubuntu-native Docker gate，验证真实 bound submit、三层 checkpoint、state-matched 双臂和完整 cleanup

## 真实结果

- Docker gate：`1 passed in 64.56s`
- `libyyjson.a` 结构验证通过；parent candidate failed、replay not_run，唯一约束失败为 `build_system_unproven`
- bound submit 后 post-build fence 三字段全部释放
- baseline/treatment 的 message、environment、budget canonical 同源，repair packet 是唯一 treatment exposure
- parent/arm/checkpoint helper/continuation image 清理完成，0 compile/replay/capture orphan

## 其他验证

- 静态聚焦：`11 passed`
- R1/R0/runtime-parity/real-lifecycle 相邻回归：`70 passed`
- Ruff check/format、Python 语法、diff 与 staged secret scan 通过
- #196 candidate evidence 目录仍不存在
- 固定 `0 provider / 0 formal attempt / 0 model token / 0 credential read / 0 candidate evidence write`

Closes #198