### PR TITLE
研究：授权 R1 yyjson 单配对执行

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-30 — 执行 R1 yyjson 独立 checkpoint 单配对实验
+  - GitHub: 中文 Issue #200 已创建并回读；分支为 `research/200-r1-yyjson-execution`，基线为 `main@6e0abe14`。
+  - 实现: 新增版本化 execution protocol/runner/manifest/Schema/预注册与测试，冻结一次 DeepSeek reachability、一个 `baseline -> treatment` pair、300 秒/0 retry、245,000 recorded-token ceiling 和 fail-closed marker；不修改 #196/#198 冻结文件或历史 evidence。
+  - R0 接线: continuation 使用 `ObservableRuntimeParityToolAdapter + RejectionObservationRegistry`，从真实 model request identity 关联 tool-call origin；classified runtime-parity rejection 必须产生 `agent.tool_rejection_observed` companion evidence，报告不保存原始命令或模型正文。
+  - 当前验证: canonical manifest SHA-256 为 `bc4149b8f14c5f29ec56d7d70568200d72cfe8a40a56dd49c80ef9ca092dc079`；聚焦 `9 passed`、R1/R0/runtime-parity 相邻回归 `72 passed`，Ruff、format、`py_compile`、Schema、确定性再生成和 diff 通过。
+  - 边界: 当前仍为 0 provider、0 Docker、0 formal attempt、0 model token、0 R1 evidence write；下一步是中文提交、WSL helper 推送、中文 PR/CI/合并，之后才能在干净主干执行 preflight、唯一 reachability 和唯一 pair。
+  - 文件: `scripts/forge_opaque_provenance_r1_execution_protocol.py`, `scripts/forge_opaque_provenance_r1_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md`
+
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
   - 实现: 新增实验专用 `forge-combined-checkpoint-1.0.0` manifest，把 message、environment、budget 绑定到同一 `capture_id` 与 message state SHA-256；三层全部校验后才发布父 manifest。

--- a/backend/tests/test_forge_opaque_provenance_r1_execution.py
+++ b/backend/tests/test_forge_opaque_provenance_r1_execution.py
@@ -1,0 +1,262 @@
+"""Issue #200 R1 yyjson execution amendment 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r1_execution_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r1_execution_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r1-execution.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_opaque_provenance_r1_execution_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_opaque_provenance_r1_execution_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_generated_manifest_schema_parent_runtime_and_preregistration_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["parent"]["canonical_sha256"] == protocol.PARENT_MANIFEST_SHA256
+    assert manifest["parent"]["evidence_identity_sha256"] == protocol.PARENT_EVIDENCE_IDENTITY_SHA256
+    assert manifest["runtime_adapter"]["file_sha256"] == protocol.file_sha256(RUNNER_PATH)
+
+
+def test_authorization_provider_budget_and_single_opportunity_are_exact() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["authorization"] == {
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/200",
+        "checkpoint_creation_authorized": True,
+        "reachability_request_authorized": True,
+        "provider_calls_authorized": True,
+        "formal_attempts_authorized": True,
+        "pair_collection_authorized": True,
+        "credential_read_authorized": True,
+        "model_creation_authorized": True,
+        "docker_execution_authorized": True,
+        "evidence_write_authorized": True,
+        "model_tokens_authorized": 245_000,
+    }
+    assert manifest["provider"] == {
+        "status": "active_authorized",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": False,
+    }
+    assert manifest["budget"] == {
+        "maximum_reachability_requests": 1,
+        "reachability_maximum_recorded_tokens": 5_000,
+        "recorded_tokens_per_arm": 120_000,
+        "recorded_tokens_per_pair": 240_000,
+        "stage_maximum_recorded_tokens": 245_000,
+        "enforcement": "after_reachability_and_each_arm_before_continuation",
+    }
+    assert manifest["opportunities"]["maximum_reachability_requests"] == 1
+    assert manifest["opportunities"]["maximum_pairs"] == 1
+    assert manifest["opportunities"]["marker_consumed_on_start"] is True
+    assert manifest["opportunities"]["retry_replacement_backfill_forbidden"] is True
+
+
+def test_r1_case_policy_and_r0_observability_are_bound() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["case"]["case_id"] == "yyjson-opaque-provenance-r1"
+    assert manifest["case"]["target"] == "yyjson"
+    assert manifest["case"]["artifact_type"] == "static_library"
+    assert manifest["schedule"][0]["arm_order"] == ["baseline", "treatment"]
+    assert manifest["schedule"][0]["treatment_exposure_only"] == "repair_packet"
+    assert manifest["runtime_parity"]["observable_adapter"] == ("ObservableRuntimeParityToolAdapter")
+    assert manifest["runtime_parity"]["rejection_registry"] == ("RejectionObservationRegistry")
+    assert manifest["runtime_parity"]["parallel_tool_calls"] is False
+    assert manifest["r0_observability"]["companion_required_for_classified_rejection"] is True
+    policy = runner._policy(manifest, arm="treatment", image_id="sha256:" + "1" * 64)
+    assert policy.source_subdir == "."
+    assert policy.build_targets == ("yyjson",)
+    assert policy.artifact_instructions == (("libyyjson.a", "build/libyyjson.a", "static_library"),)
+    assert policy.required_system_packages == ()
+    assert policy.cmake_arguments == ()
+
+
+def test_execution_hooks_install_r1_lifecycle_and_restore_on_failure(
+    tmp_path: Path,
+) -> None:
+    from deerflow.compile import operations
+
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    originals = (
+        runner.legacy.protocol,
+        runner.legacy.collect_preflight,
+        runner.legacy.opaque,
+        runner.legacy._policy,
+        runner.primary.run_arm_continuation,
+        operations.submit_build_result_impl,
+    )
+
+    def operation() -> None:
+        assert runner.legacy.protocol is runner.protocol
+        assert runner.legacy.collect_preflight is runner.collect_preflight
+        assert runner.legacy.opaque is runner.checkpoint_gate
+        assert runner.legacy._policy is runner._policy
+        assert runner.primary.run_arm_continuation is not originals[4]
+        assert operations.submit_build_result_impl is not originals[5]
+        raise RuntimeError("expected")
+
+    with pytest.raises(RuntimeError, match="expected"):
+        runner._with_execution_hooks(manifest, tmp_path, operation)
+    assert (
+        runner.legacy.protocol,
+        runner.legacy.collect_preflight,
+        runner.legacy.opaque,
+        runner.legacy._policy,
+        runner.primary.run_arm_continuation,
+        operations.submit_build_result_impl,
+    ) == originals
+
+
+def test_r0_summary_requires_companion_for_each_classified_rejection() -> None:
+    failure = {
+        "event": "agent.tool_failed",
+        "payload": {
+            "failure_id": "failure_" + "1" * 32,
+            "exception_class": "ObservableRuntimeParityGateError",
+        },
+    }
+    observation = {
+        "event": runner.observability.OBSERVATION_EVENT,
+        "payload": {
+            "failure_id": "failure_" + "1" * 32,
+            "rejection_classification": "compound_shell_forbidden",
+        },
+    }
+    summary = runner._r0_summary(SimpleNamespace(read=lambda: [failure, observation]))
+    assert summary == {
+        "classified_rejections": 1,
+        "companion_events": 1,
+        "companion_complete": True,
+        "rejection_classifications": ["compound_shell_forbidden"],
+        "raw_command_persisted": False,
+    }
+    with pytest.raises(runner.ExecutionGateError, match="缺少唯一 R0 companion"):
+        runner._r0_summary(SimpleNamespace(read=lambda: [failure]))
+
+
+def test_report_hook_adds_runtime_and_r0_evidence(tmp_path: Path) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    report_path = tmp_path / manifest["evidence"]["canary_report"]
+    original_writer = runner.legacy.v3_runner._write_once
+
+    def operation() -> str:
+        runner.legacy.v3_runner._write_once(
+            report_path,
+            {"schema_version": "old", "document_type": "old", "arms": []},
+        )
+        return "ok"
+
+    assert runner._with_execution_hooks(manifest, tmp_path, operation) == "ok"
+    report = _load(report_path)
+    assert report["schema_version"] == manifest["execution"]["report_schema_version"]
+    assert report["document_type"] == manifest["execution"]["report_document_type"]
+    assert report["runtime_parity"] == manifest["runtime_parity"]
+    assert report["runtime_parity_action_budgets"] == {}
+    assert report["r0_rejection_observability"] == {
+        "baseline": {
+            "classified_rejections": 0,
+            "companion_events": 0,
+            "companion_complete": True,
+            "rejection_classifications": [],
+            "raw_command_persisted": False,
+        },
+        "treatment": {
+            "classified_rejections": 0,
+            "companion_events": 0,
+            "companion_complete": True,
+            "rejection_classifications": [],
+            "raw_command_persisted": False,
+        },
+    }
+    assert runner.legacy.v3_runner._write_once is original_writer
+
+
+def test_preflight_checks_empty_identity_and_zero_provider(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    output = tmp_path / Path(manifest["evidence"]["directory"]).name
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_: None)
+    monkeypatch.setattr(runner, "_output_dir", lambda _manifest, value: value)
+    monkeypatch.setattr(
+        runner.legacy,
+        "_release_identity",
+        lambda *_args: {"revision": "a" * 40},
+    )
+    monkeypatch.setattr(runner.legacy, "_network_medium", lambda _manifest: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner.legacy.v3_runner, "require_zero_managed_containers", lambda: None)
+    monkeypatch.setattr(runner.legacy, "_provider_preflight", lambda _manifest: None)
+    result = runner.collect_preflight(
+        manifest,
+        output_dir=output,
+        repo_root=tmp_path,
+        require_empty=True,
+    )
+    assert result["ready"] is True
+    assert result["network_access_medium"] == "wifi"
+    assert result["evidence_files"] == []
+    assert (result["provider_calls"], result["formal_attempts"], result["model_tokens"]) == (0, 0, 0)
+
+
+def test_schema_and_semantics_reject_authorization_or_observability_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    for section, field, value in (
+        ("authorization", "model_tokens_authorized", 245_001),
+        ("runtime_parity", "parallel_tool_calls", True),
+        ("opportunities", "maximum_pairs", 2),
+        ("r0_observability", "companion_required_for_classified_rejection", False),
+    ):
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_runner_uses_r0_adapter_and_never_embeds_credentials() -> None:
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert "ObservableRuntimeParityToolAdapter" in source
+    assert "RejectionObservationRegistry" in source
+    assert "agent.tool_rejection_observed" not in source
+    assert "RuntimeParityToolAdapter(" not in source.replace("ObservableRuntimeParityToolAdapter(", "")
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "os.environ["):
+        assert forbidden not in source

--- a/benchmarks/manifests/cpp-opaque-provenance-r1-execution.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-r1-execution.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-r1-execution.schema.json",
+  "schema_version": "forge-opaque-provenance-r1-execution-1.0.0",
+  "document_type": "forge_opaque_provenance_r1_execution_amendment",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/200",
+    "checkpoint_creation_authorized": true,
+    "reachability_request_authorized": true,
+    "provider_calls_authorized": true,
+    "formal_attempts_authorized": true,
+    "pair_collection_authorized": true,
+    "credential_read_authorized": true,
+    "model_creation_authorized": true,
+    "docker_execution_authorized": true,
+    "evidence_write_authorized": true,
+    "model_tokens_authorized": 245000
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json",
+    "schema_version": "forge-opaque-provenance-r1-checkpoint-candidate-1.0.0",
+    "canonical_sha256": "b89e63c4362befcdc409c60fe0334c1e9e4f62a26e369d55b676f23c1ffd202b",
+    "file_sha256": "bb9a50adaa5089556f7f9e99ff2eca956f63678bb03ba47212070e03661623b4",
+    "evidence_identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077",
+    "authorization_baseline_commit": "6e0abe1483ace50174574b7405e26ad8bda2f845",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "case": {
+    "case_id": "yyjson-opaque-provenance-r1",
+    "repository_url": "https://github.com/ibireme/yyjson",
+    "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+    "compile_image": "autocompiler:gcc13",
+    "build_system": "cmake",
+    "source_subdir": ".",
+    "build_directory": "/workspace/repo/build",
+    "configure_arguments": [
+      "-DCMAKE_BUILD_TYPE=Release",
+      "-DBUILD_SHARED_LIBS=OFF",
+      "-DYYJSON_BUILD_TESTS=OFF",
+      "-DYYJSON_BUILD_FUZZER=OFF"
+    ],
+    "target": "yyjson",
+    "build_output": "build/libyyjson.a",
+    "staged_artifact": "libyyjson.a",
+    "artifact_type": "static_library",
+    "required_system_packages": [
+      "build-essential",
+      "cmake"
+    ],
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "independence": {
+    "historical_pair": "opaque-provenance-cppitertools-runtime-parity-pair-01",
+    "historical_repository_url": "https://github.com/ryanhaining/cppitertools",
+    "historical_commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+    "historical_target": "accumulate_examples",
+    "historical_staged_artifact": "accumulate_examples",
+    "repository_commit_target_and_artifact_all_distinct": true,
+    "historical_pair_pooled": false,
+    "retry_replacement_backfill_or_extension": false
+  },
+  "checkpoint": {
+    "source_gate": "issue-198-real-docker-zero-provider",
+    "creation_timing": "after_reachability_before_arm_continuation",
+    "capture_point": "after-neutral-tool-message-before-continuation",
+    "identity_materialized_during_pair": true,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "preexisting_checkpoint_reuse_forbidden": true
+  },
+  "provider": {
+    "status": "active_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-r1-yyjson-pair-01",
+      "order": 1,
+      "case_id": "yyjson-opaque-provenance-r1",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "420e0f129086aff5eec604444733301420ea504a474965776ec4ca945f5a13ef",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "fields": [
+      "schema_version",
+      "primary_classification",
+      "mechanism_classification",
+      "expected_build_system",
+      "selected_build_system",
+      "build_directory",
+      "target",
+      "proof_status",
+      "repair_goal"
+    ],
+    "template": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "cmake",
+      "selected_build_system": "cmake",
+      "build_directory": "/workspace/repo/build",
+      "target": "yyjson",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+    },
+    "origin_path": "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+    "origin_file_sha256": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+    "forbidden_solution_fields": [
+      "command",
+      "argv",
+      "command_line",
+      "shell",
+      "credential",
+      "secret"
+    ]
+  },
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "stopping": {
+    "checkpoint_creation_failure_stops": true,
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_forbidden": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "schedule_extension_forbidden": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true
+  },
+  "analysis": {
+    "purpose": "independent_checkpoint_intervention_delivery_and_p2_conversion_canary",
+    "unit_of_analysis": "single_independent_state_matched_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "repair_build_directory": "/workspace/repo/build",
+    "repair_build_target": "yyjson",
+    "build_output": "build/libyyjson.a",
+    "staged_artifact": "libyyjson.a",
+    "forbidden_actions": [
+      "clone",
+      "configure",
+      "dependency",
+      "housekeeping",
+      "manual_replay",
+      "compound_build_stage"
+    ],
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true,
+    "parent_submit_uses_bound_wrapper": true,
+    "fence_released_before_capture": true,
+    "observable_adapter": "ObservableRuntimeParityToolAdapter",
+    "rejection_registry": "RejectionObservationRegistry"
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "unknown_or_ambiguous_tool_call_keeps_legacy_event_only": true,
+    "frozen_components": {
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+      "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158"
+    }
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-r1-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+    "checkpoint_manifest": "checkpoints/opaque-provenance-r1-yyjson-pair-01/checkpoint.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+    "pair_ledger": "pairs/opaque-provenance-r1-yyjson-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+    "reachability_marker": "markers/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "status": "authorized_not_created",
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077"
+  },
+  "opportunities": {
+    "maximum_reachability_requests": 1,
+    "maximum_pairs": 1,
+    "required_order": [
+      "reachability",
+      "opaque-provenance-r1-yyjson-pair-01"
+    ],
+    "marker_consumed_on_start": true,
+    "retry_replacement_backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "require_authorization_baseline_ancestor": true,
+    "docker_provider": "ubuntu-native",
+    "docker_context": "default",
+    "docker_endpoint": "/var/run/docker.sock",
+    "control_plane": "compose-dood-on-ubuntu-native-engine",
+    "allowed_network_media": [
+      "wired",
+      "wifi",
+      "mobile_hotspot"
+    ],
+    "require_empty_evidence_directory": true,
+    "managed_container_prefixes": [
+      "deerflow-compile-",
+      "deerflow-replay-"
+    ],
+    "require_zero_managed_orphans": true
+  },
+  "execution": {
+    "release_branch": "main",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+    "reachability_expected_response": "CANARY_OK",
+    "reachability_report": "reports/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+    "report_schema_version": "forge-opaque-provenance-r1-report-1.0.0",
+    "report_document_type": "forge_opaque_provenance_r1_report"
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md",
+    "file_sha256": "2d25c8ff51f8dc090788086475a0a0a1bcd8fac0d2a3e8b04d8ef4f8e62b8b91"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_r1_execution_runner.py",
+    "file_sha256": "eb782230560a6e8ca20a973c7a8e89c0dc20e57cf22a5294d2fd8030a7fdcd49",
+    "commands": [
+      "validate",
+      "preflight",
+      "reachability",
+      "pair"
+    ],
+    "credential_read_supported": true,
+    "provider_model_creation_supported": true,
+    "checkpoint_execute_supported": true,
+    "reachability_execute_supported": true,
+    "pair_execute_supported": true,
+    "r0_companion_evidence_supported": true
+  },
+  "frozen_parent_components": {
+    "backend/tests/test_forge_opaque_provenance_r1_candidate.py": "6e12b18aa869ac18eb1cfce0ead0acf9a38937afaaabdadb10f491b2c3710494",
+    "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py": "fa6c12fadf4dae8d7a455f119d60c26b411869d9127ce4068c10df1f3509bf7c",
+    "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py": "d6398f1c293eb847124b601d615cf92e4a439f60202155bd9909c8bb61379ef7",
+    "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json": "bb9a50adaa5089556f7f9e99ff2eca956f63678bb03ba47212070e03661623b4",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md": "984794477d7a5e6271960a36e9f513a2aa049d950bfe9f6966fb5de5642772ba",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md": "dc22969b5ea173672260f9a642aed213f480dcde097c55cf6a5e8733f7356feb",
+    "benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json": "837c945956e508392f24b30bbb0e1386adfa1916d5a23183ab7e4ca642d74c01",
+    "scripts/forge_opaque_provenance_r1_candidate_protocol.py": "82a629cc46d987fecf2894c5e87000eecfd31797b789bcc642f5817baba4f299",
+    "scripts/forge_opaque_provenance_r1_candidate_runner.py": "51a9a03214bc7afeb4c4c6187b76b323119ba214e1d4e4024c9d8b3689b65cf5",
+    "scripts/forge_opaque_provenance_r1_checkpoint_gate.py": "b733ebb70d62c8b38484362dcc7fd810b1330f03af6e2cf408af31efdc2cd3c3"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md
@@ -1,0 +1,36 @@
+# Opaque build provenance R1 yyjson 一次性 execution amendment
+
+本 amendment 承接 Issue #196 的 result-blind `yyjson` 候选和 Issue #198 的真实 Docker 零 provider checkpoint 生命周期门禁。它只授权一次 reachability 和一个 state-matched `baseline -> treatment` pair，不修改任何历史协议或 evidence，不把 #184/#190 exploratory pair 纳入 R1 分析池。
+
+## 冻结身份
+
+- Case：`https://github.com/ibireme/yyjson@9365ddc7061033df656578bf86040048b5b5531a`。
+- CMake build directory / target：`/workspace/repo/build` / `yyjson`。
+- Output / staged artifact / type：`build/libyyjson.a` / `libyyjson.a` / `static_library`。
+- Provider：DeepSeek `deepseek-v4-flash`，endpoint `https://api.deepseek.com`，credential 仅允许从 `DEEPSEEK_API_KEY` 读取。
+- 请求策略：300 秒、0 retry、非 streaming、禁止 fallback。
+- 机会：一次 reachability，随后至多一个 `baseline -> treatment` pair；marker 在开始时消耗，禁止 retry、replacement、backfill 和 schedule extension。
+- Recorded-token ceiling：reachability 5,000、每臂 120,000、单 pair 240,000、全阶段 245,000。
+
+## Checkpoint 与 intervention
+
+真实 pair 在 reachability 通过后重新创建 Issue #198 已验证的 controlled parent：顶层 `sh -c` wrapper 完成 configure、build 和 stage，但不提供 trusted direct-CMake identity，因此 parent 必须只形成 `build_system_unproven / opaque_wrapper`。Parent submit 继续走真实 bound post-build wrapper，并在 capture 前释放 fence。
+
+Message、environment、budget 绑定同一 capture ID；两臂从同一 neutral checkpoint 派生，初始 workspace、artifact、image 和剩余预算 canonical 同源。Baseline 只收到原 verifier feedback；treatment 唯一额外 exposure 是冻结 repair packet。Packet 不提供完整命令、argv、模型正文或 credential。
+
+## Runtime parity 与 R0 可观测性
+
+两臂共享 4/2/2/2 的 inspection、repair build、artifact stage、submit 原子预算，并强制 `parallel_tool_calls=false`。Repair build 只允许 direct `cmake --build /workspace/repo/build --target yyjson`；artifact stage 只允许把 `build/libyyjson.a` 复制为 `/artifacts/libyyjson.a`。Clone、configure、dependency、housekeeping、manual replay 和 compound build+stage 全部 fail closed。
+
+Continuation 必须使用 Issue #194 的 `ObservableRuntimeParityToolAdapter` 和 `RejectionObservationRegistry`。每个可稳定分类且具有唯一 model/tool-call origin 的拒绝，必须同时留下历史七字段 `agent.tool_failed` 与通过 `failure_id` 关联的 `agent.tool_rejection_observed`；后者只记录 classification、action kind、model request ID、tool ordinal 和 command SHA-256。原始命令、错误文本、模型正文、工具参数与 credential 不得持久化。未知或歧义 origin 只保留历史事件。
+
+## 执行顺序与停止规则
+
+1. 在合并后的干净 `main == origin/main` 上验证 Ubuntu WSL2 原生 Docker endpoint、Compose/DooD control plane、provider 配置、网络介质和 0 managed orphan；preflight 不写 evidence。
+2. 仅一次 reachability。开始即写 fail-closed marker；失败立即停止，不执行 pair。
+3. Reachability 通过后仅一次 pair。开始即写 fail-closed marker；identity、checkpoint、evidence、budget、Docker、cleanup 或未分类失败立即停止。
+4. 已分类 arm outcome 可继续另一臂；endpoint timeout 记为删失而非重试。最终 cleanup 必须闭合并恢复 0 managed orphan。
+
+## 结果边界
+
+主要结果是单个独立 checkpoint pair 中的 post-checkpoint P2 conversion，并同时要求 candidate verification、clean replay 和 cleanup。报告描述两臂 conversion、请求数、token、延迟、动作预算及拒绝 companion evidence。单 pair 只提供 intervention delivery 和机制可达性的描述性证据，不估计 treatment effect、不计算 p 值、不排名模型，也不与历史 pair 池化。

--- a/benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json",
+  "title": "Forge opaque provenance R1 execution amendment",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-r1-execution.schema.json",
+    "schema_version": "forge-opaque-provenance-r1-execution-1.0.0",
+    "document_type": "forge_opaque_provenance_r1_execution_amendment",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/200",
+      "checkpoint_creation_authorized": true,
+      "reachability_request_authorized": true,
+      "provider_calls_authorized": true,
+      "formal_attempts_authorized": true,
+      "pair_collection_authorized": true,
+      "credential_read_authorized": true,
+      "model_creation_authorized": true,
+      "docker_execution_authorized": true,
+      "evidence_write_authorized": true,
+      "model_tokens_authorized": 245000
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json",
+      "schema_version": "forge-opaque-provenance-r1-checkpoint-candidate-1.0.0",
+      "canonical_sha256": "b89e63c4362befcdc409c60fe0334c1e9e4f62a26e369d55b676f23c1ffd202b",
+      "file_sha256": "bb9a50adaa5089556f7f9e99ff2eca956f63678bb03ba47212070e03661623b4",
+      "evidence_identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077",
+      "authorization_baseline_commit": "6e0abe1483ace50174574b7405e26ad8bda2f845",
+      "release_revision_policy": "descendant-compatible"
+    },
+    "case": {
+      "case_id": "yyjson-opaque-provenance-r1",
+      "repository_url": "https://github.com/ibireme/yyjson",
+      "commit_sha": "9365ddc7061033df656578bf86040048b5b5531a",
+      "compile_image": "autocompiler:gcc13",
+      "build_system": "cmake",
+      "source_subdir": ".",
+      "build_directory": "/workspace/repo/build",
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DYYJSON_BUILD_TESTS=OFF",
+        "-DYYJSON_BUILD_FUZZER=OFF"
+      ],
+      "target": "yyjson",
+      "build_output": "build/libyyjson.a",
+      "staged_artifact": "libyyjson.a",
+      "artifact_type": "static_library",
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "independence": {
+      "historical_pair": "opaque-provenance-cppitertools-runtime-parity-pair-01",
+      "historical_repository_url": "https://github.com/ryanhaining/cppitertools",
+      "historical_commit_sha": "531b3d753d2bbfe3b0ababe61c2e95e965c54a66",
+      "historical_target": "accumulate_examples",
+      "historical_staged_artifact": "accumulate_examples",
+      "repository_commit_target_and_artifact_all_distinct": true,
+      "historical_pair_pooled": false,
+      "retry_replacement_backfill_or_extension": false
+    },
+    "checkpoint": {
+      "source_gate": "issue-198-real-docker-zero-provider",
+      "creation_timing": "after_reachability_before_arm_continuation",
+      "capture_point": "after-neutral-tool-message-before-continuation",
+      "identity_materialized_during_pair": true,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "preexisting_checkpoint_reuse_forbidden": true
+    },
+    "provider": {
+      "status": "active_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-r1-yyjson-pair-01",
+        "order": 1,
+        "case_id": "yyjson-opaque-provenance-r1",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "420e0f129086aff5eec604444733301420ea504a474965776ec4ca945f5a13ef",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "fields": [
+        "schema_version",
+        "primary_classification",
+        "mechanism_classification",
+        "expected_build_system",
+        "selected_build_system",
+        "build_directory",
+        "target",
+        "proof_status",
+        "repair_goal"
+      ],
+      "template": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "yyjson",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen build directory and target, then submit again."
+      },
+      "origin_path": "scripts/forge_opaque_build_provenance_real_docker_gate.py",
+      "origin_file_sha256": "cfaac00042a623083f351e5e1b82c7b0b497bb923aea6f02b35174a40cf949e4",
+      "forbidden_solution_fields": [
+        "command",
+        "argv",
+        "command_line",
+        "shell",
+        "credential",
+        "secret"
+      ]
+    },
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "stopping": {
+      "checkpoint_creation_failure_stops": true,
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_forbidden": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "schedule_extension_forbidden": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true
+    },
+    "analysis": {
+      "purpose": "independent_checkpoint_intervention_delivery_and_p2_conversion_canary",
+      "unit_of_analysis": "single_independent_state_matched_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "repair_build_directory": "/workspace/repo/build",
+      "repair_build_target": "yyjson",
+      "build_output": "build/libyyjson.a",
+      "staged_artifact": "libyyjson.a",
+      "forbidden_actions": [
+        "clone",
+        "configure",
+        "dependency",
+        "housekeeping",
+        "manual_replay",
+        "compound_build_stage"
+      ],
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true,
+      "parent_submit_uses_bound_wrapper": true,
+      "fence_released_before_capture": true,
+      "observable_adapter": "ObservableRuntimeParityToolAdapter",
+      "rejection_registry": "RejectionObservationRegistry"
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "unknown_or_ambiguous_tool_call_keeps_legacy_event_only": true,
+      "frozen_components": {
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+        "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158"
+      }
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-r1-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+      "checkpoint_manifest": "checkpoints/opaque-provenance-r1-yyjson-pair-01/checkpoint.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+      "pair_ledger": "pairs/opaque-provenance-r1-yyjson-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+      "reachability_marker": "markers/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "status": "authorized_not_created",
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077"
+    },
+    "opportunities": {
+      "maximum_reachability_requests": 1,
+      "maximum_pairs": 1,
+      "required_order": [
+        "reachability",
+        "opaque-provenance-r1-yyjson-pair-01"
+      ],
+      "marker_consumed_on_start": true,
+      "retry_replacement_backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "control_plane": "compose-dood-on-ubuntu-native-engine",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "require_empty_evidence_directory": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true
+    },
+    "execution": {
+      "release_branch": "main",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "reachability_expected_response": "CANARY_OK",
+      "reachability_report": "reports/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r1-yyjson-pair-01/parent/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r1-yyjson-pair-01/arms",
+      "report_schema_version": "forge-opaque-provenance-r1-report-1.0.0",
+      "report_document_type": "forge_opaque_provenance_r1_report"
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md",
+      "file_sha256": "2d25c8ff51f8dc090788086475a0a0a1bcd8fac0d2a3e8b04d8ef4f8e62b8b91"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_r1_execution_runner.py",
+      "file_sha256": "eb782230560a6e8ca20a973c7a8e89c0dc20e57cf22a5294d2fd8030a7fdcd49",
+      "commands": [
+        "validate",
+        "preflight",
+        "reachability",
+        "pair"
+      ],
+      "credential_read_supported": true,
+      "provider_model_creation_supported": true,
+      "checkpoint_execute_supported": true,
+      "reachability_execute_supported": true,
+      "pair_execute_supported": true,
+      "r0_companion_evidence_supported": true
+    },
+    "frozen_parent_components": {
+      "backend/tests/test_forge_opaque_provenance_r1_candidate.py": "6e12b18aa869ac18eb1cfce0ead0acf9a38937afaaabdadb10f491b2c3710494",
+      "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py": "fa6c12fadf4dae8d7a455f119d60c26b411869d9127ce4068c10df1f3509bf7c",
+      "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py": "d6398f1c293eb847124b601d615cf92e4a439f60202155bd9909c8bb61379ef7",
+      "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json": "bb9a50adaa5089556f7f9e99ff2eca956f63678bb03ba47212070e03661623b4",
+      "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md": "984794477d7a5e6271960a36e9f513a2aa049d950bfe9f6966fb5de5642772ba",
+      "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md": "dc22969b5ea173672260f9a642aed213f480dcde097c55cf6a5e8733f7356feb",
+      "benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json": "837c945956e508392f24b30bbb0e1386adfa1916d5a23183ab7e4ca642d74c01",
+      "scripts/forge_opaque_provenance_r1_candidate_protocol.py": "82a629cc46d987fecf2894c5e87000eecfd31797b789bcc642f5817baba4f299",
+      "scripts/forge_opaque_provenance_r1_candidate_runner.py": "51a9a03214bc7afeb4c4c6187b76b323119ba214e1d4e4024c9d8b3689b65cf5",
+      "scripts/forge_opaque_provenance_r1_checkpoint_gate.py": "b733ebb70d62c8b38484362dcc7fd810b1330f03af6e2cf408af31efdc2cd3c3"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_r1_execution_protocol.py
+++ b/scripts/forge_opaque_provenance_r1_execution_protocol.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Issue #200 yyjson opaque provenance R1 一次性 execution amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r1-execution.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-r1-checkpoint-candidate.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_r1_execution_runner.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-r1-execution-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_r1_execution_amendment"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/200"
+AUTHORIZATION_BASELINE_COMMIT = "6e0abe1483ace50174574b7405e26ad8bda2f845"
+PARENT_MANIFEST_SHA256 = "b89e63c4362befcdc409c60fe0334c1e9e4f62a26e369d55b676f23c1ffd202b"
+PARENT_EVIDENCE_IDENTITY_SHA256 = "d4b5f051bde5c66e5a1b4c67da72c91443d15c614b209941f71d7a02c4f57077"
+
+FROZEN_PARENT_PATHS = {
+    PARENT_MANIFEST_PATH,
+    "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-candidate.md",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md",
+    "benchmarks/schemas/forge-opaque-provenance-r1-checkpoint-candidate.schema.json",
+    "scripts/forge_opaque_provenance_r1_candidate_protocol.py",
+    "scripts/forge_opaque_provenance_r1_candidate_runner.py",
+    "scripts/forge_opaque_provenance_r1_checkpoint_gate.py",
+    "backend/tests/test_forge_opaque_provenance_r1_candidate.py",
+    "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py",
+    "backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """R1 execution 身份、父组件、预算或授权发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_r1_candidate_protocol.py"
+    name = "forge_opaque_provenance_r1_execution_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load R1 checkpoint candidate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    manifest = parent.load_manifest(repo_root / PARENT_MANIFEST_PATH, repo_root)
+    if parent.canonical_sha256(manifest) != PARENT_MANIFEST_SHA256:
+        raise ProtocolError("R1 candidate manifest identity drifted")
+    if manifest["evidence"]["identity_sha256"] != PARENT_EVIDENCE_IDENTITY_SHA256:
+        raise ProtocolError("R1 candidate evidence identity drifted")
+    return manifest, parent
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent_manifest, parent = _parent_manifest(repo_root)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("runtime adapter or preregistration missing")
+
+    provider = copy.deepcopy(parent_manifest["provider"])
+    provider["status"] = "active_authorized"
+    runtime_parity = copy.deepcopy(parent_manifest["runtime_parity"])
+    runtime_parity.update(
+        parent_submit_uses_bound_wrapper=True,
+        fence_released_before_capture=True,
+        observable_adapter="ObservableRuntimeParityToolAdapter",
+        rejection_registry="RejectionObservationRegistry",
+    )
+    evidence = copy.deepcopy(parent_manifest["evidence"])
+    evidence["status"] = "authorized_not_created"
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-r1-execution.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "checkpoint_creation_authorized": True,
+            "reachability_request_authorized": True,
+            "provider_calls_authorized": True,
+            "formal_attempts_authorized": True,
+            "pair_collection_authorized": True,
+            "credential_read_authorized": True,
+            "model_creation_authorized": True,
+            "docker_execution_authorized": True,
+            "evidence_write_authorized": True,
+            "model_tokens_authorized": 245_000,
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent_manifest["schema_version"],
+            "canonical_sha256": parent.canonical_sha256(parent_manifest),
+            "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+            "evidence_identity_sha256": parent_manifest["evidence"]["identity_sha256"],
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "case": copy.deepcopy(parent_manifest["case"]),
+        "independence": copy.deepcopy(parent_manifest["independence"]),
+        "checkpoint": {
+            "source_gate": "issue-198-real-docker-zero-provider",
+            "creation_timing": "after_reachability_before_arm_continuation",
+            "capture_point": "after-neutral-tool-message-before-continuation",
+            "identity_materialized_during_pair": True,
+            "arm_state_matching": ["message", "environment", "budget"],
+            "preexisting_checkpoint_reuse_forbidden": True,
+        },
+        "provider": provider,
+        "continuation": copy.deepcopy(parent_manifest["continuation"]),
+        "schedule": copy.deepcopy(parent_manifest["schedule"]),
+        "schedule_sha256": parent_manifest["schedule_sha256"],
+        "repair_packet": copy.deepcopy(parent_manifest["repair_packet"]),
+        "budget": {
+            "maximum_reachability_requests": 1,
+            "reachability_maximum_recorded_tokens": 5_000,
+            "recorded_tokens_per_arm": 120_000,
+            "recorded_tokens_per_pair": 240_000,
+            "stage_maximum_recorded_tokens": 245_000,
+            "enforcement": "after_reachability_and_each_arm_before_continuation",
+        },
+        "stopping": {
+            **copy.deepcopy(parent_manifest["stopping"]),
+            "classified_arm_outcome_continues_other_arm": True,
+            "endpoint_timeout_censors_arm_and_continues": True,
+        },
+        "analysis": copy.deepcopy(parent_manifest["analysis"]),
+        "runtime_parity": runtime_parity,
+        "r0_observability": copy.deepcopy(parent_manifest["r0_observability"]),
+        "evidence": evidence,
+        "opportunities": {
+            "maximum_reachability_requests": 1,
+            "maximum_pairs": 1,
+            "required_order": ["reachability", parent_manifest["schedule"][0]["pair_id"]],
+            "marker_consumed_on_start": True,
+            "retry_replacement_backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "require_authorization_baseline_ancestor": True,
+            "docker_provider": "ubuntu-native",
+            "docker_context": "default",
+            "docker_endpoint": "/var/run/docker.sock",
+            "control_plane": "compose-dood-on-ubuntu-native-engine",
+            "allowed_network_media": ["wired", "wifi", "mobile_hotspot"],
+            "require_empty_evidence_directory": True,
+            "managed_container_prefixes": ["deerflow-compile-", "deerflow-replay-"],
+            "require_zero_managed_orphans": True,
+        },
+        "execution": {
+            "release_branch": "main",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+            "reachability_expected_response": "CANARY_OK",
+            "reachability_report": "reports/reachability.json",
+            "pair_marker": evidence["pair_marker"],
+            "parent_ledger": evidence["parent_ledger"],
+            "arm_ledger_directory": evidence["arm_ledger_directory"],
+            "report_schema_version": "forge-opaque-provenance-r1-report-1.0.0",
+            "report_document_type": "forge_opaque_provenance_r1_report",
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "preflight", "reachability", "pair"],
+            "credential_read_supported": True,
+            "provider_model_creation_supported": True,
+            "checkpoint_execute_supported": True,
+            "reachability_execute_supported": True,
+            "pair_execute_supported": True,
+            "r0_companion_evidence_supported": True,
+        },
+        "frozen_parent_components": _hash_paths(repo_root, FROZEN_PARENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("R1 execution amendment manifest drifted")
+    budget = value["budget"]
+    if budget["recorded_tokens_per_pair"] + budget["reachability_maximum_recorded_tokens"] != budget["stage_maximum_recorded_tokens"]:
+        raise ProtocolError("stage token budget is not closed")
+    if value["runtime_parity"]["parallel_tool_calls"] is not False:
+        raise ProtocolError("parallel tool calls must remain disabled")
+    if value["r0_observability"]["companion_required_for_classified_rejection"] is not True:
+        raise ProtocolError("classified rejection companion evidence is required")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read R1 execution manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def verify_frozen_components(manifest: dict[str, Any], repo_root: Path = REPO_ROOT) -> None:
+    validate_manifest(manifest, repo_root)
+    if manifest["frozen_parent_components"] != _hash_paths(repo_root, FROZEN_PARENT_PATHS):
+        raise ProtocolError("frozen parent components drifted")
+    for section in ("runtime_adapter", "preregistration"):
+        path = repo_root / manifest[section]["path"]
+        if file_sha256(path) != manifest[section]["file_sha256"]:
+            raise ProtocolError(f"{section} drifted")
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json",
+        "title": "Forge opaque provenance R1 execution amendment",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        verify_frozen_components(manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_r1_execution_runner.py
+++ b/scripts/forge_opaque_provenance_r1_execution_runner.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""执行 Issue #200 授权的 R1 reachability 与 yyjson 单 pair。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_minimal_canary_execution_runner as legacy  # noqa: E402
+import forge_opaque_provenance_r1_checkpoint_gate as checkpoint_gate  # noqa: E402
+import forge_opaque_provenance_r1_execution_protocol as protocol  # noqa: E402
+import forge_opaque_provenance_rejection_observability_gate as observability  # noqa: E402
+import forge_opaque_provenance_runtime_parity_gate as parity  # noqa: E402
+
+primary = legacy.primary
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r1-yyjson-v1")
+ARMS = ("baseline", "treatment")
+
+
+class ExecutionGateError(RuntimeError):
+    """R1 execution identity、R0 evidence、预算或 cleanup 无效。"""
+
+
+def _output_dir(manifest: dict[str, Any], output_dir: Path) -> Path:
+    expected = Path(manifest["evidence"]["directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise ExecutionGateError("evidence 必须写入 #196 冻结的 R1 目录")
+    return output_dir
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _output_dir(manifest, output_dir)
+    release = legacy._release_identity(manifest, repo_root)
+    medium = legacy._network_medium(manifest)
+    primary.require_compose_dood()
+    try:
+        legacy.v3_runner.require_zero_managed_containers()
+    except legacy.v3_runner.AuthorizedPilotError as exc:
+        raise ExecutionGateError(str(exc)) from exc
+    legacy._provider_preflight(manifest)
+    entries = sorted(str(path.relative_to(output_dir)).replace("\\", "/") for path in output_dir.rglob("*") if path.is_file()) if output_dir.exists() else []
+    if require_empty and entries:
+        raise ExecutionGateError("reachability 前要求 R1 evidence 目录为空")
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": medium,
+        "evidence_files": entries,
+        "zero_managed_containers": True,
+        "docker_provider": manifest["preflight"]["docker_provider"],
+        "docker_endpoint": manifest["preflight"]["docker_endpoint"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _policy(manifest: dict[str, Any], *, arm: str, image_id: str) -> Any:
+    case = manifest["case"]
+    provider = manifest["provider"]
+    continuation = manifest["continuation"]
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-r1-yyjson",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=case["case_id"],
+        condition=arm,
+        repetition=1,
+        expected_repo_url=case["repository_url"],
+        expected_commit_sha=case["commit_sha"],
+        expected_build_system=case["build_system"],
+        compile_image=case["compile_image"],
+        image_id=image_id,
+        model_name=provider["model"],
+        endpoint=provider["endpoint"],
+        credential_env=provider["credential_env"],
+        request_timeout_seconds=provider["request_timeout_seconds"],
+        model_max_retries=provider["max_retries"],
+        compiler_max_turns=continuation["maximum_model_turns_per_arm"],
+        subagent_timeout_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=continuation["maximum_model_turns_per_arm"],
+        compiler_graph_recursion_limit=continuation["maximum_graph_steps_per_arm"],
+        compiler_wall_clock_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        compiler_post_build_reserve_seconds=continuation["cleanup_reserve_seconds_per_arm"],
+        source_subdir=case["source_subdir"],
+        build_targets=(case["target"],),
+        artifact_instructions=(
+            (
+                case["staged_artifact"],
+                case["build_output"],
+                case["artifact_type"],
+            ),
+        ),
+    )
+
+
+def _r0_summary(ledger: Any) -> dict[str, Any]:
+    events = ledger.read()
+    failures = [event for event in events if event["event"] == "agent.tool_failed" and event["payload"].get("exception_class") == "ObservableRuntimeParityGateError"]
+    observations = [event for event in events if event["event"] == observability.OBSERVATION_EVENT]
+    failure_ids = {event["payload"]["failure_id"] for event in failures}
+    observed_ids = {event["payload"]["failure_id"] for event in observations}
+    if failure_ids != observed_ids:
+        raise ExecutionGateError("classified runtime-parity rejection 缺少唯一 R0 companion evidence")
+    if len(observed_ids) != len(observations):
+        raise ExecutionGateError("R0 companion evidence 重复关联同一 failure")
+    return {
+        "classified_rejections": len(failures),
+        "companion_events": len(observations),
+        "companion_complete": failure_ids == observed_ids,
+        "rejection_classifications": sorted({event["payload"]["rejection_classification"] for event in observations}),
+        "raw_command_persisted": False,
+    }
+
+
+def _r0_summary_from_path(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {
+            "classified_rejections": 0,
+            "companion_events": 0,
+            "companion_complete": True,
+            "rejection_classifications": [],
+            "raw_command_persisted": False,
+        }
+    return _r0_summary(primary.ExperimentLedger.open(path))
+
+
+def _install_model_origin_observer(middlewares: list[Any], registry: Any) -> tuple[Any, Any]:
+    from deerflow.agents.middlewares.llm_error_handling_middleware import (
+        LLMErrorHandlingMiddleware,
+    )
+
+    middleware = next(
+        (item for item in middlewares if isinstance(item, LLMErrorHandlingMiddleware)),
+        None,
+    )
+    if middleware is None:
+        raise ExecutionGateError("continuation 缺少 LLM evidence middleware")
+    original = middleware._request_completed
+
+    def observed(
+        self: Any,
+        thread_id: str | None,
+        response: Any,
+        *,
+        model_call_id: str,
+        model_request_id: str,
+        attempt: int,
+        latency_seconds: float,
+    ) -> None:
+        original(
+            thread_id,
+            response,
+            model_call_id=model_call_id,
+            model_request_id=model_request_id,
+            attempt=attempt,
+            latency_seconds=latency_seconds,
+        )
+        registry.register_model_tool_calls(
+            thread_id,
+            response,
+            model_request_id=model_request_id,
+        )
+
+    middleware._request_completed = MethodType(observed, middleware)
+    return middleware, original
+
+
+async def run_arm_continuation(
+    manifest: dict[str, Any],
+    *,
+    arm: str,
+    lifecycle_arm: Any,
+    message_state: dict[str, Any],
+    ledger: Any,
+    model_factory: Any | None = None,
+    budget_sink: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    from langchain.agents import create_agent
+    from langchain_core.tools import tool
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from deerflow.agents.middlewares import tool_error_handling_middleware
+    from deerflow.agents.middlewares.tool_error_handling_middleware import (
+        build_subagent_runtime_middlewares,
+    )
+    from deerflow.agents.thread_state import ThreadState
+    from deerflow.compile.operations import get_compile_services
+    from deerflow.subagents.builtins.compiler_agent import COMPILER_AGENT_CONFIG
+    from deerflow.tools.bound_compile_tools import get_bound_compile_tools
+
+    if arm not in ARMS:
+        raise ExecutionGateError("unknown checkpoint arm")
+    session = lifecycle_arm.session
+    policy = _policy(manifest, arm=arm, image_id=session.image_id)
+    attempt_budget = primary.ExperimentAttemptBudget(
+        total_wall_clock_seconds=720,
+        cleanup_reserve_seconds=120,
+        max_compiler_invocations=1,
+        max_model_requests=manifest["continuation"]["maximum_requests_per_arm"],
+    )
+    primary.activate_experiment(
+        thread_id=session.thread_id,
+        experiment_id=ledger.experiment_id,
+        physical_attempt_id=ledger.physical_attempt_id,
+        ledger=ledger,
+        policy=policy,
+        attempt_budget=attempt_budget,
+    )
+    adapter: Any | None = None
+    original_failure_recorder = tool_error_handling_middleware.record_agent_tool_failure
+    observed_middleware: Any | None = None
+    original_request_completed: Any | None = None
+    registry = observability.RejectionObservationRegistry()
+    try:
+        model = model_factory(manifest["provider"], session.thread_id) if model_factory is not None else primary._create_provider_model(manifest["provider"], experiment_thread_id=session.thread_id)
+        tools = get_bound_compile_tools(session)
+        run_tool = next(item for item in tools if item.name == "run_container_bash")
+        submit_tool = next(item for item in tools if item.name == "submit_build_result")
+        action_policy = parity.FrozenActionPolicy(
+            workdir=checkpoint_gate.WORKDIR,
+            build_directory=checkpoint_gate.BUILD_DIRECTORY,
+            target=checkpoint_gate.TARGET,
+            build_output=(f"{checkpoint_gate.WORKDIR}/{checkpoint_gate.BUILD_OUTPUT}"),
+            staged_artifact=f"/artifacts/{checkpoint_gate.STAGED_ARTIFACT}",
+        )
+        adapter = observability.ObservableRuntimeParityToolAdapter(
+            run_tool=run_tool,
+            submit_tool=submit_tool,
+            policy=action_policy,
+            staged_artifacts_present=lambda: any(path.is_file() and not path.is_symlink() for path in Path(session.leadagent_artifacts_dir).rglob("*")),
+        )
+
+        @tool("run_container_bash", parse_docstring=True)
+        def observable_run_container_bash(
+            command: str,
+            timeout_seconds: int = 300,
+            workdir: str | None = None,
+            command_role: str = "other",
+        ) -> str:
+            """在当前 R1 arm 中执行 runtime-parity 白名单动作。
+
+            Args:
+                command: 要执行的单一 bash 命令。
+                timeout_seconds: 单条命令超时，最多 300 秒。
+                workdir: 容器内工作目录。
+                command_role: evidence 命令角色。
+            """
+            return adapter.run(
+                command,
+                timeout_seconds=timeout_seconds,
+                workdir=workdir,
+                command_role=command_role,
+            )
+
+        @tool("submit_build_result", parse_docstring=True)
+        def observable_submit_build_result(
+            supporting_command_id: str | None = None,
+        ) -> str:
+            """提交当前 R1 arm 的 staged artifact。
+
+            Args:
+                supporting_command_id: 可选的成功构建命令 ID。
+            """
+            return adapter.submit(supporting_command_id)
+
+        middlewares = [
+            parity.SerialToolCallMiddleware(),
+            *build_subagent_runtime_middlewares(lazy_init=True),
+        ]
+        observed_middleware, original_request_completed = _install_model_origin_observer(middlewares, registry)
+
+        def observed_failure(request: Any, exc: Exception, *, execution_mode: str) -> dict[str, Any] | None:
+            failure, _observation = registry.record_tool_failure(
+                request,
+                exc,
+                execution_mode=execution_mode,
+            )
+            return failure
+
+        tool_error_handling_middleware.record_agent_tool_failure = observed_failure
+        agent = create_agent(
+            model=model,
+            tools=[observable_run_container_bash, observable_submit_build_result],
+            middleware=middlewares,
+            system_prompt=COMPILER_AGENT_CONFIG.system_prompt,
+            state_schema=ThreadState,
+            checkpointer=InMemorySaver(),
+        )
+        state = {
+            "messages": message_state["messages"],
+            "artifacts": [],
+            "viewed_images": {},
+        }
+        config = {
+            "configurable": {"thread_id": session.thread_id},
+            "recursion_limit": manifest["continuation"]["maximum_graph_steps_per_arm"],
+        }
+        await asyncio.wait_for(
+            agent.ainvoke(
+                state,
+                config=config,
+                context={"thread_id": session.thread_id, "agent_name": "compiler"},
+            ),
+            timeout=manifest["continuation"]["work_wall_clock_seconds_per_arm"],
+        )
+        primary.record_experiment_attempt_budget_completion(session.thread_id)
+    finally:
+        tool_error_handling_middleware.record_agent_tool_failure = original_failure_recorder
+        if observed_middleware is not None and original_request_completed is not None:
+            observed_middleware._request_completed = original_request_completed
+        if adapter is not None:
+            budget_sink[arm] = adapter.budget.snapshot()
+        primary.deactivate_experiment(session.thread_id)
+
+    authoritative = get_compile_services().manager.load_session(session.session_id, session.thread_id)
+    result = primary.validate_arm_evidence(
+        manifest,
+        arm=arm,
+        ledger=ledger,
+        session=authoritative,
+    )
+    result["runtime_parity_action_budget"] = budget_sink[arm]
+    result["r0_rejection_observability"] = _r0_summary(ledger)
+    ledger.append("experiment.completed", {"status": "passed"})
+    return result
+
+
+def _with_execution_hooks(manifest: dict[str, Any], output_dir: Path, operation: Any) -> Any:
+    from deerflow.compile import operations
+    from deerflow.tools import bound_compile_tools
+
+    original_protocol = legacy.protocol
+    original_collect = legacy.collect_preflight
+    original_opaque = legacy.opaque
+    original_policy = legacy._policy
+    original_continuation = primary.run_arm_continuation
+    original_submit_impl = operations.submit_build_result_impl
+    original_write_once = legacy.v3_runner._write_once
+    action_budgets: dict[str, dict[str, Any]] = {}
+    report_path = output_dir / manifest["evidence"]["canary_report"]
+
+    def parent_submit_through_bound_wrapper(*, session: Any, supporting_command_id: str | None = None) -> str:
+        return bound_compile_tools._submit_with_post_build_phase(
+            session,
+            supporting_command_id=supporting_command_id,
+        )
+
+    async def continuation(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return await run_arm_continuation(
+            *args,
+            **kwargs,
+            budget_sink=action_budgets,
+        )
+
+    def write_once(path: Path, value: Any) -> None:
+        if path.resolve(strict=False) == report_path.resolve(strict=False):
+            arm_root = output_dir / manifest["execution"]["arm_ledger_directory"]
+            r0_by_arm = {arm: _r0_summary_from_path(arm_root / f"{arm}.jsonl") for arm in ARMS}
+            value = {
+                **value,
+                "schema_version": manifest["execution"]["report_schema_version"],
+                "document_type": manifest["execution"]["report_document_type"],
+                "runtime_parity": manifest["runtime_parity"],
+                "runtime_parity_action_budgets": action_budgets,
+                "r0_rejection_observability": r0_by_arm,
+                "historical_pairs_pooled": False,
+            }
+        original_write_once(path, value)
+
+    legacy.protocol = protocol
+    legacy.collect_preflight = collect_preflight
+    legacy.opaque = checkpoint_gate
+    legacy._policy = _policy
+    primary.run_arm_continuation = continuation
+    operations.submit_build_result_impl = parent_submit_through_bound_wrapper
+    legacy.v3_runner._write_once = write_once
+    try:
+        return operation()
+    finally:
+        legacy.protocol = original_protocol
+        legacy.collect_preflight = original_collect
+        legacy.opaque = original_opaque
+        legacy._policy = original_policy
+        primary.run_arm_continuation = original_continuation
+        operations.submit_build_result_impl = original_submit_impl
+        legacy.v3_runner._write_once = original_write_once
+
+
+def execute_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    return _with_execution_hooks(
+        manifest,
+        output_dir,
+        lambda: legacy.execute_reachability(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        ),
+    )
+
+
+def execute_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    _with_execution_hooks(
+        manifest,
+        output_dir,
+        lambda: legacy.execute_pair(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        ),
+    )
+    return legacy.v3_runner._load_json(output_dir / manifest["evidence"]["canary_report"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "preflight", "reachability", "pair"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        result: Any = {
+            "status": "valid",
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    elif args.command == "preflight":
+        result = collect_preflight(
+            manifest,
+            output_dir=args.output_dir,
+            require_empty=True,
+        )
+    elif args.command == "reachability":
+        result = execute_reachability(manifest, output_dir=args.output_dir)
+    else:
+        result = execute_pair(manifest, output_dir=args.output_dir)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 派生 Issue #200 专属 R1 execution protocol、runner、manifest、Schema 与预注册；
- 冻结一次 DeepSeek reachability、一个 `baseline -> treatment` pair、300 秒/0 retry 和 245,000 recorded-token ceiling；
- 复用 Issue #198 的 yyjson checkpoint lifecycle，不修改 #196/#198 冻结组件或历史 evidence；
- continuation 显式接入 Issue #194 的 `ObservableRuntimeParityToolAdapter + RejectionObservationRegistry`；
- classified runtime-parity rejection 通过 `failure_id` 关联 companion evidence，报告不持久化原始命令或模型正文；
- marker 开始即 fail closed，禁止 retry、replacement、backfill 和 schedule extension。

## 验证

- 聚焦测试：`9 passed`
- R1/R0/runtime-parity 相邻回归：`72 passed`
- Ruff check / format：通过
- `py_compile`、Schema、确定性再生成、`git diff --check`：通过
- canonical manifest SHA-256：`bc4149b8f14c5f29ec56d7d70568200d72cfe8a40a56dd49c80ef9ca092dc079`

## 边界

当前提交仍为 0 provider、0 Docker、0 formal attempt、0 model token、0 R1 evidence write。真实 preflight、唯一 reachability 与唯一 pair 只能在 CI 全绿并合并到干净主干后按预注册顺序执行。

Closes #200