### PR TITLE
研究：建立 R2 Make provenance reference gate

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,13 +5,12 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 执行 R1 yyjson 独立 checkpoint 单配对实验
-  - GitHub: 中文 Issue #200 已创建并回读；分支为 `research/200-r1-yyjson-execution`，基线为 `main@6e0abe14`。
-  - 实现: 新增版本化 execution protocol/runner/manifest/Schema/预注册与测试，冻结一次 DeepSeek reachability、一个 `baseline -> treatment` pair、300 秒/0 retry、245,000 recorded-token ceiling 和 fail-closed marker；不修改 #196/#198 冻结文件或历史 evidence。
-  - R0 接线: continuation 使用 `ObservableRuntimeParityToolAdapter + RejectionObservationRegistry`，从真实 model request identity 关联 tool-call origin；classified runtime-parity rejection 必须产生 `agent.tool_rejection_observed` companion evidence，报告不保存原始命令或模型正文。
-  - 当前验证: canonical manifest SHA-256 为 `bc4149b8f14c5f29ec56d7d70568200d72cfe8a40a56dd49c80ef9ca092dc079`；聚焦 `9 passed`、R1/R0/runtime-parity 相邻回归 `72 passed`，Ruff、format、`py_compile`、Schema、确定性再生成和 diff 通过。
-  - 边界: 当前仍为 0 provider、0 Docker、0 formal attempt、0 model token、0 R1 evidence write；下一步是中文提交、WSL helper 推送、中文 PR/CI/合并，之后才能在干净主干执行 preflight、唯一 reachability 和唯一 pair。
-  - 文件: `scripts/forge_opaque_provenance_r1_execution_protocol.py`, `scripts/forge_opaque_provenance_r1_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md`
+- 2026-08-30 — 发布 Issue #202 R2 Make provenance reference gate
+  - GitHub: 中文 Issue #202 已创建并回读；分支为 `research/202-make-provenance-reference`，基线为 `main@201b0078`。
+  - 实现: 从 result-blind formal v1 source protocol 冻结 `hoextdown@1ef9a719`、Make target/artifact `libhoedown.a`，新增 experiment-only Make P2 evaluator、聚焦测试和预注册；冻结 CMake evaluator保持逐字不变。
+  - 当前验证: direct `make/gmake` 只在 effective directory、单 target、允许的 jobs 参数和 artifact producer identity 全部一致时转为 `proven/direct_make`；opaque wrapper、变量赋值、额外 target、未知选项、失败 producer 和 identity drift 均 fail closed。聚焦与相邻 CMake lifecycle 静态回归 `69 passed`，Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过。
+  - 边界: 固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；下一步为中文提交、WSL helper 推送、中文 PR/CI/合并，合并后只运行静态 gate，再设计真实 Make lifecycle 零 provider 门禁。
+  - 文件: `scripts/forge_opaque_provenance_make_reference_gate.py`, `backend/tests/test_forge_opaque_provenance_make_reference_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -71,6 +70,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #200 R1 yyjson 独立 checkpoint 单配对实验
+  - 文件: `scripts/forge_opaque_provenance_r1_execution_protocol.py`, `scripts/forge_opaque_provenance_r1_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md`
+  - 发布: 中文 Issue #200 / PR #201 已完成，三项 CI 全绿后 squash 合并为 `main@201b00780b2c85751bacc477c6ca1c31a2dec809`；manifest canonical SHA-256 为 `bc4149b8f14c5f29ec56d7d70568200d72cfe8a40a56dd49c80ef9ca092dc079`。
+  - 结果: 唯一 DeepSeek reachability 以 17 tokens、1.582 秒通过；baseline 为 8 requests / 30,753 tokens / 0 submit / P2 unproven，treatment 为 6 requests / 19,555 tokens / 1 submit，candidate 与 clean replay 通过并转为 `proven/direct_cmake`。
+  - 完整性: 总计 50,325 recorded tokens；R0 companion baseline 7/7、treatment 3/3，cleanup 成功，0 container/image orphan，evidence hash chain 和敏感值扫描通过；结果已回帖 Issue #200。
+  - 解释边界: 与 #190 CMake pair 方向一致但不能池化、估计 treatment effect 或排名模型；下一步优先验证跨构建系统的 Make provenance reference criterion。
 
 - 2026-08-30 — 完成 Issue #198 R1 yyjson 独立 checkpoint 真实 Docker 零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_r1_checkpoint_gate.py`, `backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate.py`, `backend/tests/test_forge_opaque_provenance_r1_checkpoint_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-checkpoint-zero-provider-gate.md`

--- a/backend/tests/test_forge_opaque_provenance_make_reference_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_make_reference_gate.py
@@ -1,0 +1,257 @@
+"""Issue #202 Make opaque provenance R2 reference gate 测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "forge_opaque_provenance_make_reference_gate.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location("forge_opaque_provenance_make_reference_gate_test", SCRIPT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+gate = _load_module()
+
+
+def _invocation(
+    frozen,
+    *,
+    executable: str = "make",
+    argv: tuple[str, ...] | None = None,
+    workdir: str | None = None,
+    exit_code: int = 0,
+    timed_out: bool = False,
+    repository_url: str | None = None,
+):
+    return gate.provenance.record_invocation(
+        command_id="direct-make",
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=repository_url or frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable=executable,
+        argv=argv or (frozen.target, "-j2"),
+        workdir=workdir or frozen.workdir,
+        previous_hash=gate.provenance.ZERO_HASH,
+        exit_code=exit_code,
+        timed_out=timed_out,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def _artifact(frozen, producer_id: str = "direct-make"):
+    return gate.provenance.ArtifactIdentity(
+        schema_version=gate.provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("executable", "argv", "workdir", "jobs"),
+    [
+        ("make", ("libhoedown.a", "-j2"), "/workspace/repo", "2"),
+        (
+            "/usr/bin/gmake",
+            ("-C", "/workspace/repo", "--jobs=3", "libhoedown.a"),
+            "/workspace",
+            "3",
+        ),
+        (
+            "make",
+            ("--directory=repo", "libhoedown.a", "-j", "4"),
+            "/workspace",
+            "4",
+        ),
+        (
+            "make",
+            ("-C", "/workspace", "-C", "repo", "libhoedown.a", "--jobs"),
+            "/tmp",
+            "unbounded",
+        ),
+    ],
+)
+def test_parse_make_invocation_normalizes_directory_target_and_jobs(
+    executable: str,
+    argv: tuple[str, ...],
+    workdir: str,
+    jobs: str,
+) -> None:
+    parsed = gate.parse_make_invocation(executable, argv, workdir=workdir)
+    assert parsed == gate.MakeInvocation(
+        effective_directory="/workspace/repo",
+        target="libhoedown.a",
+        jobs=jobs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (("CC=clang", "libhoedown.a"), "variable assignments"),
+        (("libhoedown.a", "all"), "exactly one target"),
+        (("-k", "libhoedown.a"), "unregistered option"),
+        (("-C",), "missing a value"),
+        (("--directory=", "libhoedown.a"), "missing a value"),
+        (("libhoedown.a", "-jmany"), "-j value"),
+        (("libhoedown.a", "--jobs=many"), "--jobs value"),
+    ],
+)
+def test_parse_make_invocation_rejects_unregistered_semantics(argv: tuple[str, ...], message: str) -> None:
+    with pytest.raises(gate.MakeReferenceError, match=message):
+        gate.parse_make_invocation("make", argv, workdir=gate.WORKDIR)
+
+
+def test_reference_gate_freezes_result_blind_case_and_expected_outcomes() -> None:
+    report = gate.validate_gate(REPO_ROOT)
+    assert report["schema_version"] == ("forge-opaque-provenance-make-reference-gate-1.0.0")
+    assert report["source_protocol"]["source_case"] == gate.HOEXTDOWN_SOURCE_CASE
+    assert report["source_protocol"]["source_case"]["result_data_consulted"] is False
+    assert report["parent"]["status"] == "unproven"
+    assert report["parent"]["reason"] == "opaque_wrapper"
+    assert report["treatment_contract"]["status"] == "proven"
+    assert report["treatment_contract"]["proof_mode"] == "direct_make"
+    assert report["parent_prefix_preserved"] is True
+    assert report["mature_conventions"]["upstream_makefile_sha256"] == ("534aa41e0ec89d2fcce9de0513a1f241ba965af568e801e089470301cc66288d")
+
+
+def test_direct_make_proves_exact_target_and_artifact() -> None:
+    frozen = gate.build_frozen_identity()
+    invocation = _invocation(frozen)
+    decision = gate.evaluate_make_p2(frozen, (invocation,), _artifact(frozen))
+    assert decision == gate.MakeProvenanceDecision(
+        schema_version=gate.SCHEMA_VERSION,
+        status="proven",
+        classification=None,
+        reason="trusted_direct_make_target",
+        proof_mode="direct_make",
+        producer_command_id="direct-make",
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "workdir", "reason"),
+    [
+        (("libhoedown.a",), "/workspace/other", "trusted_make_directory_mismatch"),
+        (("all",), "/workspace/repo", "trusted_make_target_mismatch"),
+        (
+            ("CC=clang", "libhoedown.a"),
+            "/workspace/repo",
+            "trusted_make_invocation_invalid",
+        ),
+    ],
+)
+def test_make_directory_target_or_parameters_drift_fail_closed(argv: tuple[str, ...], workdir: str, reason: str) -> None:
+    frozen = gate.build_frozen_identity()
+    invocation = _invocation(frozen, argv=argv, workdir=workdir)
+    decision = gate.evaluate_make_p2(frozen, (invocation,), _artifact(frozen))
+    assert decision.status == "unproven"
+    assert decision.classification == gate.provenance.FAULT_FAMILY
+    assert decision.reason == reason
+
+
+def test_failed_or_timed_out_make_producer_is_unproven() -> None:
+    frozen = gate.build_frozen_identity()
+    for invocation in (
+        _invocation(frozen, exit_code=2),
+        _invocation(frozen, exit_code=124, timed_out=True),
+    ):
+        decision = gate.evaluate_make_p2(frozen, (invocation,), _artifact(frozen))
+        assert decision.status == "unproven"
+        assert decision.reason == "producer_invocation_failed"
+
+
+def test_run_or_artifact_identity_drift_is_invalid_evidence() -> None:
+    frozen = gate.build_frozen_identity()
+    invocation = _invocation(frozen, repository_url="https://github.com/example/drift")
+    with pytest.raises(gate.MakeReferenceError, match="invocation identity drifted"):
+        gate.evaluate_make_p2(frozen, (invocation,), _artifact(frozen))
+
+    valid = _invocation(frozen)
+    drifted_artifact = replace(_artifact(frozen), sha256="4" * 64)
+    with pytest.raises(gate.MakeReferenceError, match="artifact identity drifted"):
+        gate.evaluate_make_p2(frozen, (valid,), drifted_artifact)
+
+
+def test_artifact_must_be_bound_to_existing_producer() -> None:
+    frozen = gate.build_frozen_identity()
+    invocation = _invocation(frozen)
+    with pytest.raises(gate.MakeReferenceError, match="producer is absent"):
+        gate.evaluate_make_p2(
+            frozen,
+            (invocation,),
+            _artifact(frozen, producer_id="missing-producer"),
+        )
+    early = replace(_artifact(frozen), observed_after_sequence=1)
+    with pytest.raises(gate.MakeReferenceError, match="not bound"):
+        gate.evaluate_make_p2(frozen, (invocation,), early)
+
+
+def test_frozen_cmake_reference_gate_remains_unchanged() -> None:
+    assert gate.file_sha256(REPO_ROOT / gate.CMAKE_EVALUATOR_PATH) == (gate.CMAKE_EVALUATOR_SHA256)
+    report = gate.provenance.validate_gate()
+    assert report["fault"]["decision"]["status"] == "unproven"
+    assert report["reference"]["direct_cmake"]["proof_mode"] == "direct_cmake"
+
+
+def test_cli_is_zero_provider_and_does_not_write_evidence() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "validate"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(completed.stdout)
+    assert (
+        report["provider_calls"],
+        report["credential_read"],
+        report["docker_executed"],
+        report["checkpoint_created"],
+        report["formal_attempts"],
+        report["model_tokens"],
+        report["evidence_writes"],
+    ) == (0, False, False, False, 0, 0, 0)
+
+
+def test_source_has_no_provider_docker_or_result_evidence_entrypoint() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "create_chat_model",
+        "deepseek_api_key",
+        "openai_ak",
+        "os.getenv",
+        "docker.from_env",
+        "execute_reachability",
+        "execute_pair",
+        "benchmark-evidence-opaque-provenance-r1-yyjson-v1",
+    ):
+        assert forbidden not in source

--- a/benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md
@@ -1,0 +1,35 @@
+# Opaque build provenance R2 Make reference gate
+
+本门禁承接 Issue #200 的 R1 结果，但不读取 #190/#200 的模型正文或把两个 CMake pair 纳入新分析。目标是先定义 Make 的可信 provenance reference criterion，再决定是否值得创建第三个 checkpoint。当前固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token 和 0 evidence write。
+
+## Result-blind case
+
+- 来源：`benchmarks/preregistrations/cpp-formal-v1-cases.json`，文件 SHA-256 `55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee`。
+- Case：`https://github.com/kjdev/hoextdown@1ef9a71957570c2a65b7daa1b2f693ad87daf385`。
+- Build system / workdir / target：Make、`/workspace/repo`、`libhoedown.a`。
+- Build output / staged artifact / type：`libhoedown.a` / `libhoedown.a` / `static_library`。
+- 依赖只有 `build-essential`。选择它是为了改变构建系统，同时减少依赖安装和 executable smoke-test 混杂。
+
+固定提交的 upstream Makefile SHA-256 为 `534aa41e0ec89d2fcce9de0513a1f241ba965af568e801e089470301cc66288d`，明确声明 `libhoedown.a` target，并以 `ar rcs libhoedown.a $^` 生成产物。
+
+## 成熟约定
+
+GNU Make 官方 Options Summary 定义 `-C dir` / `--directory=dir` 为 Makefile 与 recipe 的有效目录，`-j [jobs]` / `--jobs[=jobs]` 只控制并发。SLSA Provenance v1.1 要求把外部构建参数纳入 provenance，并把 Git URI 解析到 exact commit。由此，Make P2 不能只相信模型声明的 `build` role，必须绑定 trusted executable、完整 argv、effective directory、target、repository、commit、image、physical attempt 与 artifact producer。
+
+## P2 接受规则
+
+可信 direct Make 必须满足：
+
+- leaf executable 是 `make` 或 `gmake`；
+- invocation workdir 与 `-C` / `--directory` 规范化后的 effective directory 精确等于 `/workspace/repo`；
+- 只声明一个 target，且精确等于 `libhoedown.a`；
+- 只额外允许 `-jN`、`-j N`、`--jobs=N` 或 `--jobs N`；
+- 禁止变量赋值、额外 target 和未预注册选项；
+- invocation 成功、未超时，artifact identity 与 output path 绑定到该 producer；
+- repository、exact commit、image 和 physical attempt 与冻结 identity 一致。
+
+满足全部规则时 P2 为 `proven / direct_make / trusted_direct_make_target`。顶层 `sh -c` wrapper 没有可信 leaf identity，必须保持 `unproven / opaque_wrapper`。目录、target 或 invocation 语义漂移均 fail closed；artifact/run identity 漂移属于证据无效，不降级为普通模型失败。
+
+## 阶段边界
+
+本 gate 复用现有版本化 invocation hash chain，但不修改冻结 CMake evaluator。成功只证明 Make reference criterion 与 result-blind candidate 在静态合同层成立，不证明真实 parent 能形成纯 fault，也不授权 reachability、模型 continuation 或 pair。下一阶段必须先做真实 Make lifecycle 的 0-provider fault-purity 与 cleanup 门禁。

--- a/scripts/forge_opaque_provenance_make_reference_gate.py
+++ b/scripts/forge_opaque_provenance_make_reference_gate.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Issue #202 Make opaque provenance 的 R2 零 provider reference gate。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import posixpath
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_build_provenance_gate as provenance  # noqa: E402
+
+SCHEMA_VERSION = "forge-opaque-provenance-make-reference-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/202"
+SOURCE_PROTOCOL_PATH = "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+SOURCE_PROTOCOL_FILE_SHA256 = "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+SOURCE_CASES_SHA256 = "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca"
+CMAKE_EVALUATOR_PATH = "scripts/forge_opaque_build_provenance_gate.py"
+CMAKE_EVALUATOR_SHA256 = "0f21ece5f3419a477925515f5312a009b0d447c1fa982f9e7fb626bf0f30e07a"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md"
+
+WORKDIR = "/workspace/repo"
+TARGET = "libhoedown.a"
+BUILD_OUTPUT = "libhoedown.a"
+STAGED_ARTIFACT = "libhoedown.a"
+ARTIFACT_TYPE = "static_library"
+PARENT_COMMAND = "sh -c 'make libhoedown.a -j2 && cp libhoedown.a /artifacts/libhoedown.a'"
+TREATMENT_COMMAND = "make libhoedown.a -j2"
+
+GNU_MAKE_OPTIONS_URL = "https://www.gnu.org/software/make/manual/html_node/Options-Summary.html"
+SLSA_PROVENANCE_URL = "https://slsa.dev/spec/v1.1/provenance"
+UPSTREAM_MAKEFILE_URL = "https://raw.githubusercontent.com/kjdev/hoextdown/1ef9a71957570c2a65b7daa1b2f693ad87daf385/Makefile"
+UPSTREAM_MAKEFILE_SHA256 = "534aa41e0ec89d2fcce9de0513a1f241ba965af568e801e089470301cc66288d"
+
+HOEXTDOWN_SOURCE_CASE = {
+    "id": "hoextdown",
+    "repository_url": "https://github.com/kjdev/hoextdown",
+    "commit": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+    "build_system": "make",
+    "review_state": "reviewed",
+    "result_data_consulted": False,
+    "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [TARGET],
+        "required_system_packages": ["build-essential"],
+    },
+    "artifact_oracle": {
+        "required_artifacts": [
+            {
+                "staged_relative_path": STAGED_ARTIFACT,
+                "build_output_path": BUILD_OUTPUT,
+                "artifact_type": ARTIFACT_TYPE,
+                "producing_target": TARGET,
+            }
+        ]
+    },
+    "evidence": [
+        {
+            "kind": "upstream_exact_commit",
+            "path": "Makefile",
+            "url": "https://github.com/kjdev/hoextdown/blob/1ef9a71957570c2a65b7daa1b2f693ad87daf385/Makefile",
+            "supports": ["build_path", "artifact_identity"],
+        },
+        {
+            "kind": "oss_fuzz_snapshot",
+            "path": "hoextdown/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/hoextdown/build.sh",
+            "supports": ["build_path"],
+        },
+    ],
+}
+
+
+class MakeReferenceError(RuntimeError):
+    """Make case、invocation、artifact 或 reference identity 无效。"""
+
+
+@dataclass(frozen=True)
+class MakeFrozenIdentity:
+    schema_version: str
+    case_id: str
+    repository_url: str
+    commit_sha: str
+    image_id: str
+    physical_attempt_id: str
+    workdir: str
+    target: str
+    artifact_relative_path: str
+    artifact_type: str
+    artifact_size: int
+    artifact_sha256: str
+
+    def validate(self) -> MakeFrozenIdentity:
+        if self.schema_version != SCHEMA_VERSION or not self.case_id or not self.physical_attempt_id or not self.target:
+            raise MakeReferenceError("frozen Make identity is incomplete")
+        if not provenance.COMMIT_PATTERN.fullmatch(self.commit_sha):
+            raise MakeReferenceError("frozen Make commit is invalid")
+        if not provenance.SHA256_PATTERN.fullmatch(self.image_id.removeprefix("sha256:")):
+            raise MakeReferenceError("frozen Make image is invalid")
+        _require_absolute_path(self.workdir, "frozen workdir")
+        _require_relative_path(self.artifact_relative_path, "frozen artifact")
+        if self.artifact_type not in {
+            "executable",
+            "shared_library",
+            "static_library",
+            "object",
+        }:
+            raise MakeReferenceError("frozen artifact type is invalid")
+        if self.artifact_size <= 0 or not provenance.SHA256_PATTERN.fullmatch(self.artifact_sha256):
+            raise MakeReferenceError("frozen artifact content identity is invalid")
+        return self
+
+
+@dataclass(frozen=True)
+class MakeInvocation:
+    effective_directory: str
+    target: str
+    jobs: str | None
+
+
+@dataclass(frozen=True)
+class MakeProvenanceDecision:
+    schema_version: str
+    status: str
+    classification: str | None
+    reason: str
+    proof_mode: str | None
+    producer_command_id: str
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_absolute_path(value: str, label: str) -> None:
+    path = PurePosixPath(value)
+    if not value or not path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise MakeReferenceError(f"{label} must be a normalized absolute path")
+
+
+def _require_relative_path(value: str, label: str) -> None:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise MakeReferenceError(f"{label} must be a normalized relative path")
+
+
+def load_source_case(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    path = repo_root / SOURCE_PROTOCOL_PATH
+    if file_sha256(path) != SOURCE_PROTOCOL_FILE_SHA256:
+        raise MakeReferenceError("formal v1 source protocol file drifted")
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MakeReferenceError("cannot load formal v1 source protocol") from exc
+    if not isinstance(document, dict) or document.get("protocolization", {}).get("case_protocol_sha256") != SOURCE_CASES_SHA256:
+        raise MakeReferenceError("formal v1 case protocol identity drifted")
+    matches = [case for case in document.get("cases", []) if isinstance(case, dict) and case.get("id") == "hoextdown"]
+    if matches != [HOEXTDOWN_SOURCE_CASE]:
+        raise MakeReferenceError("result-blind hoextdown case fields drifted")
+    return copy.deepcopy(matches[0])
+
+
+def _effective_directory(current: str, value: str) -> str:
+    if not value:
+        raise MakeReferenceError("Make directory option is missing a value")
+    path = value if value.startswith("/") else posixpath.join(current, value)
+    normalized = posixpath.normpath(path)
+    _require_absolute_path(normalized, "Make effective directory")
+    return normalized
+
+
+def parse_make_invocation(
+    executable: str,
+    argv: tuple[str, ...],
+    *,
+    workdir: str,
+) -> MakeInvocation:
+    leaf = PurePosixPath(executable).name
+    if leaf not in {"make", "gmake"}:
+        raise MakeReferenceError("trusted invocation is not GNU-compatible Make")
+    _require_absolute_path(workdir, "Make invocation workdir")
+    effective_directory = workdir
+    targets: list[str] = []
+    jobs: str | None = None
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument in {"-C", "--directory"}:
+            index += 1
+            if index >= len(argv):
+                raise MakeReferenceError("Make directory option is missing a value")
+            effective_directory = _effective_directory(effective_directory, argv[index])
+        elif argument.startswith("--directory="):
+            effective_directory = _effective_directory(effective_directory, argument.split("=", 1)[1])
+        elif argument == "-j" or argument == "--jobs":
+            value = None
+            if index + 1 < len(argv) and argv[index + 1].isdigit():
+                index += 1
+                value = argv[index]
+            jobs = value or "unbounded"
+        elif argument.startswith("-j") and argument != "-j":
+            value = argument[2:]
+            if not value.isdigit():
+                raise MakeReferenceError("Make -j value is invalid")
+            jobs = value
+        elif argument.startswith("--jobs="):
+            value = argument.split("=", 1)[1]
+            if not value.isdigit():
+                raise MakeReferenceError("Make --jobs value is invalid")
+            jobs = value
+        elif argument.startswith("-"):
+            raise MakeReferenceError("Make invocation contains an unregistered option")
+        else:
+            if "=" in argument:
+                raise MakeReferenceError("Make variable assignments are forbidden")
+            targets.append(argument)
+        index += 1
+    if len(targets) != 1:
+        raise MakeReferenceError("Make invocation must name exactly one target")
+    return MakeInvocation(effective_directory, targets[0], jobs)
+
+
+def _assert_run_identity(
+    frozen: MakeFrozenIdentity,
+    invocation: provenance.InvocationEvidence,
+) -> None:
+    actual = (
+        invocation.repository_url,
+        invocation.commit_sha,
+        invocation.image_id,
+        invocation.physical_attempt_id,
+    )
+    expected = (
+        frozen.repository_url,
+        frozen.commit_sha,
+        frozen.image_id,
+        frozen.physical_attempt_id,
+    )
+    if actual != expected:
+        raise MakeReferenceError("trusted Make invocation identity drifted")
+
+
+def _assert_artifact_identity(
+    frozen: MakeFrozenIdentity,
+    artifact: provenance.ArtifactIdentity,
+) -> None:
+    artifact.validate()
+    actual_run = (
+        artifact.repository_url,
+        artifact.commit_sha,
+        artifact.image_id,
+        artifact.physical_attempt_id,
+    )
+    expected_run = (
+        frozen.repository_url,
+        frozen.commit_sha,
+        frozen.image_id,
+        frozen.physical_attempt_id,
+    )
+    actual_artifact = (
+        artifact.relative_path,
+        artifact.artifact_type,
+        artifact.size,
+        artifact.sha256,
+    )
+    expected_artifact = (
+        frozen.artifact_relative_path,
+        frozen.artifact_type,
+        frozen.artifact_size,
+        frozen.artifact_sha256,
+    )
+    if actual_run != expected_run or actual_artifact != expected_artifact:
+        raise MakeReferenceError("Make artifact identity drifted")
+
+
+def _unproven(producer: provenance.InvocationEvidence, reason: str) -> MakeProvenanceDecision:
+    return MakeProvenanceDecision(
+        SCHEMA_VERSION,
+        "unproven",
+        provenance.FAULT_FAMILY,
+        reason,
+        None,
+        producer.command_id,
+    )
+
+
+def evaluate_make_p2(
+    frozen: MakeFrozenIdentity,
+    invocations: tuple[provenance.InvocationEvidence, ...],
+    artifact: provenance.ArtifactIdentity,
+) -> MakeProvenanceDecision:
+    """按冻结的 Make reference criterion 判定 artifact provenance。"""
+
+    frozen.validate()
+    provenance.verify_ledger(invocations)
+    for invocation in invocations:
+        _assert_run_identity(frozen, invocation)
+    _assert_artifact_identity(frozen, artifact)
+    commands = {item.command_id: item for item in invocations}
+    producer = commands.get(artifact.producer_command_id)
+    if producer is None:
+        raise MakeReferenceError("artifact producer is absent from the trusted ledger")
+    if artifact.observed_after_sequence <= producer.sequence or artifact.relative_path not in producer.output_paths:
+        raise MakeReferenceError("artifact is not bound to its producer invocation")
+    if producer.exit_code != 0 or producer.timed_out:
+        return _unproven(producer, "producer_invocation_failed")
+    if producer.leaf_executable is None or producer.leaf_argv is None or producer.leaf_workdir is None:
+        return _unproven(producer, "opaque_wrapper")
+    try:
+        parsed = parse_make_invocation(
+            producer.leaf_executable,
+            producer.leaf_argv,
+            workdir=producer.leaf_workdir,
+        )
+    except MakeReferenceError:
+        return _unproven(producer, "trusted_make_invocation_invalid")
+    if parsed.effective_directory != frozen.workdir:
+        return _unproven(producer, "trusted_make_directory_mismatch")
+    if parsed.target != frozen.target:
+        return _unproven(producer, "trusted_make_target_mismatch")
+    return MakeProvenanceDecision(
+        SCHEMA_VERSION,
+        "proven",
+        None,
+        "trusted_direct_make_target",
+        "direct_make",
+        producer.command_id,
+    )
+
+
+def build_frozen_identity() -> MakeFrozenIdentity:
+    return MakeFrozenIdentity(
+        schema_version=SCHEMA_VERSION,
+        case_id="hoextdown-opaque-provenance-r2",
+        repository_url=HOEXTDOWN_SOURCE_CASE["repository_url"],
+        commit_sha=HOEXTDOWN_SOURCE_CASE["commit"],
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r2-make-reference",
+        workdir=WORKDIR,
+        target=TARGET,
+        artifact_relative_path=BUILD_OUTPUT,
+        artifact_type=ARTIFACT_TYPE,
+        artifact_size=4096,
+        artifact_sha256="3" * 64,
+    ).validate()
+
+
+def _artifact(
+    frozen: MakeFrozenIdentity,
+    producer_command_id: str,
+    *,
+    observed_after_sequence: int,
+) -> provenance.ArtifactIdentity:
+    return provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=observed_after_sequence,
+    )
+
+
+def validate_gate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    source_case = load_source_case(repo_root)
+    if file_sha256(repo_root / CMAKE_EVALUATOR_PATH) != CMAKE_EVALUATOR_SHA256:
+        raise MakeReferenceError("frozen CMake evaluator drifted")
+    preregistration_sha256 = file_sha256(repo_root / PREREGISTRATION_PATH)
+    frozen = build_frozen_identity()
+    parent = provenance.record_invocation(
+        command_id="parent-opaque-wrapper",
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", "make libhoedown.a -j2 && cp libhoedown.a /artifacts/libhoedown.a"),
+        workdir=frozen.workdir,
+        previous_hash=provenance.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    parent_decision = evaluate_make_p2(
+        frozen,
+        (parent,),
+        _artifact(frozen, parent.command_id, observed_after_sequence=2),
+    )
+    direct = provenance.record_invocation(
+        command_id="treatment-direct-make",
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="make",
+        argv=(frozen.target, "-j2"),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    treatment_decision = evaluate_make_p2(
+        frozen,
+        (parent, direct),
+        _artifact(frozen, direct.command_id, observed_after_sequence=3),
+    )
+    if parent_decision.status != "unproven" or parent_decision.reason != "opaque_wrapper" or treatment_decision.status != "proven" or treatment_decision.proof_mode != "direct_make":
+        raise MakeReferenceError("Make parent/treatment reference outcome drifted")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "source_protocol": {
+            "path": SOURCE_PROTOCOL_PATH,
+            "file_sha256": SOURCE_PROTOCOL_FILE_SHA256,
+            "case_protocol_sha256": SOURCE_CASES_SHA256,
+            "audit_mode": "result-blind-static-document-review",
+            "source_case": source_case,
+        },
+        "case_id": frozen.case_id,
+        "mature_conventions": {
+            "gnu_make_options": GNU_MAKE_OPTIONS_URL,
+            "slsa_provenance": SLSA_PROVENANCE_URL,
+            "upstream_makefile": UPSTREAM_MAKEFILE_URL,
+            "upstream_makefile_sha256": UPSTREAM_MAKEFILE_SHA256,
+        },
+        "frozen_identity": asdict(frozen),
+        "parent": asdict(parent_decision),
+        "treatment_contract": asdict(treatment_decision),
+        "parent_history_sha256": provenance.command_history_sha256((parent,)),
+        "treatment_history_sha256": provenance.command_history_sha256((parent, direct)),
+        "parent_prefix_preserved": True,
+        "preregistration_sha256": preregistration_sha256,
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(json.dumps(validate_gate(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从 result-blind formal v1 source protocol 冻结 `hoextdown@1ef9a719` Make case
- 新增 experiment-only Make P2 reference evaluator，绑定 trusted executable、effective directory、单 target、jobs 参数和 artifact producer identity
- 新增 opaque wrapper、目录/target/参数/identity 漂移的 fail-closed 回归与预注册
- 保持冻结 CMake evaluator 不变

## 验证

- 聚焦及相邻 CMake provenance/lifecycle 静态回归：`69 passed`
- Ruff check / format check：通过
- `py_compile`、CLI validate、`git diff --check`：通过
- 敏感值扫描：无命中
- 固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write

## 研究边界

本 PR 只建立跨构建系统的 Make reference criterion，不证明真实 Make parent 能形成单一 provenance fault，也不授权 reachability、provider continuation 或实验 pair。合并后只运行静态 gate，下一阶段另建真实 Make lifecycle 零 provider 门禁。

Closes #202