### PR TITLE
研究：验证 R2 Make provenance 真实生命周期

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,12 +5,13 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 发布 Issue #202 R2 Make provenance reference gate
-  - GitHub: 中文 Issue #202 已创建并回读；分支为 `research/202-make-provenance-reference`，基线为 `main@201b0078`。
-  - 实现: 从 result-blind formal v1 source protocol 冻结 `hoextdown@1ef9a719`、Make target/artifact `libhoedown.a`，新增 experiment-only Make P2 evaluator、聚焦测试和预注册；冻结 CMake evaluator保持逐字不变。
-  - 当前验证: direct `make/gmake` 只在 effective directory、单 target、允许的 jobs 参数和 artifact producer identity 全部一致时转为 `proven/direct_make`；opaque wrapper、变量赋值、额外 target、未知选项、失败 producer 和 identity drift 均 fail closed。聚焦与相邻 CMake lifecycle 静态回归 `69 passed`，Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过。
-  - 边界: 固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；下一步为中文提交、WSL helper 推送、中文 PR/CI/合并，合并后只运行静态 gate，再设计真实 Make lifecycle 零 provider 门禁。
-  - 文件: `scripts/forge_opaque_provenance_make_reference_gate.py`, `backend/tests/test_forge_opaque_provenance_make_reference_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md`
+- 2026-08-30 — 发布 Issue #204 R2 Make provenance 真实 lifecycle 零 provider 门禁
+  - GitHub: 中文 Issue #204 已创建并回读；分支为 `research/204-make-provenance-lifecycle`，基线为 `main@9b5448ed`。
+  - 实现: 新增 experiment-only Make lifecycle adapter、静态合同、opt-in Ubuntu-native Docker gate 和预注册；逐字段继承 #202 `hoextdown` identity 并冻结其 evaluator SHA-256，不修改 production、CMake evaluator 或历史 evidence。
+  - 真实门禁: `1 passed in 77.16s`。Parent opaque `sh -c` wrapper 生成真实 `libhoedown.a`，production submit 只因 `build_system_unproven` 失败且 post-build fence 释放；baseline 保持 0 replay，treatment append direct Make + stage 后转为 `proven/direct_make`，candidate 与 clean replay 通过。
+  - 完整性: 双臂 continuation image、workspace/artifact、parent history 与 budget canonical 同源，repair packet 是唯一 exposure；cleanup 删除 parent、双臂、replay、checkpoint helper 和 continuation image，独立容器清单无 compile/replay orphan。
+  - 验证与边界: 扩展静态回归 `105 passed, 1 skipped`，Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过；固定 0 provider、0 credential read、0 formal attempt、0 model token、0正式 evidence write。下一步为中文提交、WSL helper 推送、中文 PR/CI/合并。
+  - 文件: `scripts/forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -70,6 +71,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #202 R2 Make provenance reference gate
+  - 文件: `scripts/forge_opaque_provenance_make_reference_gate.py`, `backend/tests/test_forge_opaque_provenance_make_reference_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md`
+  - 发布: 中文 Issue #202 / PR #203 已完成，三项 CI 全绿后 squash 合并为 `main@9b5448ed665ee5fbf614ab25f2fcb22f847c4bb4`；合并后干净主干静态 gate 通过。
+  - 实现: 从 result-blind formal v1 source protocol 冻结 `hoextdown@1ef9a719`、Make target/artifact `libhoedown.a`；direct `make/gmake` 只在 effective directory、单 target、允许的 jobs 参数和 artifact producer identity 全部一致时转为 `proven/direct_make`。
+  - Fail closed: opaque wrapper、变量赋值、额外 target、未知选项、失败 producer 与 run/artifact identity drift 均拒绝；冻结 CMake evaluator 保持逐字不变。
+  - 边界: 聚焦及相邻 CMake lifecycle 静态回归 `69 passed`；固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write。下一阶段单独验证真实 Make fault purity、candidate/replay 与 cleanup。
 
 - 2026-08-30 — 完成 Issue #200 R1 yyjson 独立 checkpoint 单配对实验
   - 文件: `scripts/forge_opaque_provenance_r1_execution_protocol.py`, `scripts/forge_opaque_provenance_r1_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_r1_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r1-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r1-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r1-execution.md`

--- a/backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py
@@ -1,0 +1,155 @@
+"""Issue #204 Make opaque provenance lifecycle adapter 的静态门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPT_PATH = SCRIPTS_DIR / "forge_opaque_provenance_make_lifecycle_gate.py"
+
+
+def _load_module():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "forge_opaque_provenance_make_lifecycle_gate_test",
+            SCRIPT_PATH,
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+gate = _load_module()
+
+
+def _frozen():
+    return gate.build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r2-make-lifecycle-test",
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+
+
+def test_case_is_exactly_inherited_from_make_reference_gate() -> None:
+    report = gate.validate_gate_contract(REPO_ROOT)
+    assert gate.file_sha256(REPO_ROOT / gate.REFERENCE_GATE_PATH) == gate.REFERENCE_GATE_SHA256
+    assert report["source_case"] == gate.reference.HOEXTDOWN_SOURCE_CASE
+    assert report["source_case"]["result_data_consulted"] is False
+    assert gate.CASE_ID == "hoextdown-opaque-provenance-r2-make-lifecycle"
+    assert gate.REPOSITORY_URL == "https://github.com/kjdev/hoextdown"
+    assert gate.COMMIT_SHA == "1ef9a71957570c2a65b7daa1b2f693ad87daf385"
+    assert gate.TARGET == gate.BUILD_OUTPUT == gate.STAGED_ARTIFACT == "libhoedown.a"
+    assert gate.ARTIFACT_TYPE == "static_library"
+
+
+def test_parent_wrapper_is_replayable_but_does_not_prove_make_identity() -> None:
+    assert gate.validate_parent_command_contract() == {
+        "roles": ["artifact_stage", "build", "housekeeping"],
+        "top_level_executable": "sh",
+        "make_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+    assert "make clean" in gate.PARENT_COMMAND
+    assert "make libhoedown.a -j2" in gate.PARENT_COMMAND
+    assert "cp libhoedown.a /artifacts/libhoedown.a" in gate.PARENT_COMMAND
+
+
+def test_repair_packet_is_make_bound_and_does_not_leak_a_command() -> None:
+    packet = gate.validate_repair_packet(gate.build_repair_packet())
+    assert packet["expected_build_system"] == packet["selected_build_system"] == "make"
+    assert packet["build_directory"] == gate.WORKDIR
+    assert packet["target"] == gate.TARGET
+    serialized = json.dumps(packet, sort_keys=True).lower()
+    for forbidden in ("make libhoedown.a", "sh -c", "argv", "api_key"):
+        assert forbidden not in serialized
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(command="make libhoedown.a"),
+        lambda value: value.update(build_directory="/workspace/repo/other"),
+        lambda value: value.update(target="other"),
+        lambda value: value.update(expected_build_system="cmake"),
+    ],
+)
+def test_repair_packet_drift_fails_closed(mutation) -> None:
+    packet = gate.build_repair_packet()
+    mutation(packet)
+    with pytest.raises(gate.MakeLifecycleGateError, match="identity or whitelist drifted"):
+        gate.validate_repair_packet(packet)
+
+
+def test_parent_is_unproven_and_treatment_is_append_only_direct_make() -> None:
+    frozen = _frozen()
+    parent, parent_history = gate.evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = gate.evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-build",
+        treatment_stage_command_id="treatment-stage",
+    )
+    assert parent.status == "unproven"
+    assert parent.classification == "opaque_build_provenance"
+    assert parent.reason == "opaque_wrapper"
+    assert treatment.status == "proven"
+    assert treatment.proof_mode == "direct_make"
+    assert treatment_history[: len(parent_history)] == parent_history
+
+
+def test_artifact_identity_drift_fails_closed() -> None:
+    with pytest.raises(gate.MakeLifecycleGateError, match="case identity drifted"):
+        gate.evaluate_parent(
+            replace(_frozen(), artifact_type="executable"),
+            parent_command_id="parent-wrapper",
+        )
+
+
+def test_cli_reports_zero_external_counts_and_no_docker() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "validate"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(completed.stdout)
+    assert report["parent"]["status"] == "unproven"
+    assert report["treatment_contract"]["proof_mode"] == "direct_make"
+    assert report["parent_history_prefix_preserved"] is True
+    assert (
+        report["provider_calls"],
+        report["credential_read"],
+        report["docker_executed"],
+        report["formal_attempts"],
+        report["model_tokens"],
+        report["evidence_writes"],
+    ) == (0, False, False, 0, 0, 0)
+
+
+def test_source_has_no_provider_credential_or_formal_execution_entrypoint() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in (
+        "create_chat_model",
+        "openai_ak",
+        "deepseek_api_key",
+        "os.getenv",
+        "execute_reachability",
+        "execute_pair",
+        "docker.from_env",
+        "benchmark-evidence-opaque-provenance-r1",
+    ):
+        assert forbidden not in source

--- a/backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py
@@ -1,0 +1,583 @@
+"""Issue #204 Make opaque provenance lifecycle 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import (
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.compile.paths import (
+    get_host_artifacts_dir,
+    get_host_logs_dir,
+    get_host_repro_dir,
+    get_host_workspace_dir,
+)
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+from deerflow.tools import bound_compile_tools
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_MAKE_LIFECYCLE_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_MAKE_LIFECYCLE_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_module(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+
+
+adapter = _load_module(
+    "forge_opaque_provenance_make_lifecycle_docker_adapter",
+    "forge_opaque_provenance_make_lifecycle_gate.py",
+)
+lifecycle = _load_module(
+    "forge_opaque_provenance_make_lifecycle_checkpoint",
+    "forge_real_lifecycle_checkpoint_gate.py",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_ubuntu_native_docker():
+    if not DOCKER_ENABLED:
+        yield
+        return
+    daemon = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if daemon.returncode != 0:
+        pytest.fail(f"Ubuntu native Docker is unavailable: {daemon.stderr.strip()}")
+    image = subprocess.run(
+        ["docker", "image", "inspect", adapter.COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {adapter.COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _record_command(
+    *,
+    manager: CompileSessionManager,
+    runtime: CompileDockerRuntime,
+    session: Any,
+    command: str,
+    role: str,
+) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(
+        session,
+        command,
+        workdir=adapter.WORKDIR,
+        timeout_seconds=300,
+    )
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir=adapter.WORKDIR,
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=300,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination=("timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed")),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def _policy(*, image_id: str) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-make-lifecycle-gate",
+        manifest_sha256="8" * 64,
+        case_id=adapter.CASE_ID,
+        condition="make-lifecycle-zero-provider",
+        repetition=1,
+        expected_repo_url=adapter.REPOSITORY_URL,
+        expected_commit_sha=adapter.COMMIT_SHA,
+        expected_build_system="make",
+        compile_image=adapter.COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_ZERO_PROVIDER_CREDENTIAL",
+        request_timeout_seconds=300,
+        model_max_retries=0,
+        compiler_max_turns=8,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        # Source protocol 和真实 parent command 已冻结依赖；本 policy 只隔离 provenance fault。
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir=".",
+        build_targets=(adapter.TARGET,),
+        artifact_instructions=(
+            (
+                adapter.STAGED_ARTIFACT,
+                adapter.BUILD_OUTPUT,
+                adapter.ARTIFACT_TYPE,
+            ),
+        ),
+    )
+
+
+def _budget_manifest(capture_id: str, _message_sha256: str) -> dict[str, Any]:
+    return lifecycle.budget_checkpoint.build_manifest(
+        checkpoint_id=capture_id,
+        limits={
+            "provider_requests": 8,
+            "compiler_invocations": 2,
+            "compiler_model_turns": 8,
+            "graph_recursion_steps": 24,
+            "attempt_wall_clock_seconds": 900,
+            "attempt_cleanup_reserve_seconds": 120,
+            "compiler_wall_clock_seconds": 720,
+            "compiler_post_build_reserve_seconds": 120,
+            "post_build_commands": 2,
+        },
+        consumed_before_capture={
+            "provider_requests": 0,
+            "compiler_invocations": 1,
+            "compiler_model_turns": 0,
+            "graph_recursion_steps": 3,
+            "attempt_wall_clock_seconds": 10,
+            "compiler_wall_clock_seconds": 5,
+            "post_build_commands": 0,
+            "tokens": 0,
+        },
+        post_build_started=False,
+    )
+
+
+def _arm_plan(capture_id: str) -> dict[str, dict[str, str]]:
+    return {
+        arm: {
+            "thread_id": f"{arm}-{capture_id}-thread",
+            "session_id": f"{arm}-{capture_id}-session",
+            "environment_id": f"{arm}-{capture_id}-environment",
+        }
+        for arm in ("baseline", "treatment")
+    }
+
+
+def _failure_event(ledger: ExperimentLedger) -> dict[str, Any]:
+    failures = [event for event in ledger.read() if event["event"] == "failure.recorded"]
+    assert len(failures) == 1
+    return failures[0]
+
+
+def _constraint_failures(session: Any) -> list[str]:
+    assert session.verification is not None
+    benchmark = [check for check in session.verification.checks if check.name == "benchmark_constraints"]
+    return [] if not benchmark else list(benchmark[0].actual)
+
+
+def _feedback(message_runtime: Any, config: dict[str, Any]) -> dict[str, Any]:
+    messages = message_runtime.graph.get_state(config).values["messages"]
+    return json.loads(messages[-1].content)
+
+
+def _without_arm(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in snapshot.items() if key != "arm"}
+
+
+def test_real_make_parent_treatment_replay_and_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter.validate_gate_contract()
+    capture_id = f"issue204-{uuid.uuid4().hex[:10]}"
+    workspace = tmp_path / "workspace"
+    paths = Paths(
+        base_dir=tmp_path / ".deer-flow",
+        workspace_root=workspace,
+        host_workspace_root=str(workspace),
+    )
+    manager = CompileSessionManager(paths=paths, default_image=adapter.COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    docker = lifecycle.environment_checkpoint.DockerCLI()
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=adapter.REPOSITORY_URL,
+        image=adapter.COMPILE_IMAGE,
+    )
+    parent_ledger = ExperimentLedger.create(
+        tmp_path / "parent-ledger.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-204-make-lifecycle-gate"},
+    )
+    active_threads: set[str] = set()
+    arm_sessions: list[Any] = []
+    continuation_images: set[str] = set()
+    known_container_ids: set[str] = set()
+    known_replay_container_ids: set[str] = set()
+    gate = None
+    cleaned = False
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        assert parent.image_id is not None and parent.container_id is not None
+        known_container_ids.add(parent.container_id)
+        clone = runtime.exec(
+            parent,
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {adapter.REPOSITORY_URL} && git fetch --depth 1 origin {adapter.COMMIT_SHA} && git checkout --detach FETCH_HEAD",
+            workdir=adapter.WORKDIR,
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        parent.commit_sha = adapter.COMMIT_SHA
+        parent.build_system = "make"
+        parent.build_system_capabilities = ["make"]
+        parent.selected_build_system = "make"
+        parent.status = "inspected"
+        manager.save_session(parent)
+
+        supporting = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=parent,
+            command=adapter.PARENT_COMMAND,
+            role="build",
+        )
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        workspace_artifact = Path(parent.leadagent_repo_dir) / adapter.BUILD_OUTPUT
+        assert workspace_artifact.is_file() and workspace_artifact.stat().st_size > 0
+        parent_frozen = adapter.build_frozen_identity(
+            image_id=parent.image_id,
+            physical_attempt_id=f"{capture_id}-parent",
+            artifact_size=workspace_artifact.stat().st_size,
+            artifact_sha256=lifecycle.sha256_file(workspace_artifact),
+        )
+        parent_p2, parent_history = adapter.evaluate_parent(
+            parent_frozen,
+            parent_command_id=supporting.command_id,
+        )
+        assert parent_p2.reason == "opaque_wrapper"
+
+        activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_policy(image_id=parent.image_id),
+        )
+        active_threads.add(parent.thread_id)
+        submit_results: list[str] = []
+
+        def submit_parent() -> str:
+            result = bound_compile_tools._submit_with_post_build_phase(
+                parent,
+                supporting_command_id=supporting.command_id,
+            )
+            submit_results.append(result)
+            return result
+
+        def capture_evidence() -> dict[str, Any]:
+            failure = _failure_event(parent_ledger)
+            return {
+                "classification": failure["payload"]["classification"],
+                "failure_id": failure["payload"]["failure_id"],
+                "submit_attempt_id": failure["payload"]["submit_attempt_id"],
+                "session_sha256": lifecycle.sha256_file(Path(parent.metadata_path)),
+                "parent_p2": asdict(parent_p2),
+                "parent_command_history_sha256": adapter.provenance.command_history_sha256(parent_history),
+            }
+
+        snapshot = tmp_path / "snapshot"
+        coordinator = lifecycle.CaptureCoordinator(tmp_path / "coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(tmp_path / "messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = lifecycle.LifecycleMessageRuntime(
+                saver,
+                submit_parent,
+                repair_packet=adapter.build_repair_packet(),
+            )
+            environment = lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=str(snapshot),
+            )
+            gate = lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=_budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="issue-204-make-lifecycle-gate",
+            )
+            capture = gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction="freeze the Make opaque provenance failure before continuation",
+                arm_plan=_arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "artifacts": get_host_artifacts_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "logs": get_host_logs_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                    "repro": get_host_repro_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        paths,
+                    ),
+                },
+                evidence=capture_evidence,
+            )
+            continuation_images.add(capture["environment"]["continuation_image_id"])
+            parent_payload = json.loads(submit_results[0])
+            parent_failure = _failure_event(parent_ledger)["payload"]
+            assert parent_payload["status"] == "failed"
+            assert parent_payload["candidate_status"] == "failed"
+            assert parent_payload["replay_status"] == "not_run"
+            assert parent.replay_attempts == []
+            assert parent_failure["classification"] == "build_system_unproven"
+            assert parent_failure["secondary_classifications"] == []
+            assert _constraint_failures(parent) == ["build_system_unproven"]
+            assert len(parent.artifacts) == 1
+            assert parent.artifacts[0].artifact_type == adapter.ARTIFACT_TYPE
+            assert parent.post_build_supporting_command_id is None
+            assert parent.post_build_started_at is None
+            assert parent.post_build_commands_remaining is None
+            deactivate_experiment(parent.thread_id)
+            active_threads.remove(parent.thread_id)
+
+            baseline = gate.provision_arm(capture_id, "baseline", parent_session=parent)
+            treatment = gate.provision_arm(capture_id, "treatment", parent_session=parent)
+            arm_sessions.extend([baseline.session, treatment.session])
+            known_container_ids.update(session.container_id for session in arm_sessions if session.container_id is not None)
+            assert gate.canonical_arm_environment("baseline") == gate.canonical_arm_environment("treatment")
+            baseline_feedback = _feedback(message_runtime, baseline.message_config)
+            treatment_feedback = _feedback(message_runtime, treatment.message_config)
+            assert baseline_feedback.get("repair_packet") is None
+            assert adapter.validate_repair_packet(treatment_feedback["repair_packet"]) == adapter.build_repair_packet()
+            assert {key: value for key, value in treatment_feedback.items() if key != "repair_packet"} == baseline_feedback
+            assert baseline.session.image_id == treatment.session.image_id
+            assert _without_arm(baseline.budget.snapshot()) == _without_arm(treatment.budget.snapshot())
+
+            branch_artifact = Path(treatment.session.leadagent_repo_dir) / adapter.BUILD_OUTPUT
+            assert branch_artifact.is_file()
+            branch_frozen = adapter.build_frozen_identity(
+                image_id=treatment.session.image_id,
+                physical_attempt_id=f"{capture_id}-branches",
+                artifact_size=branch_artifact.stat().st_size,
+                artifact_sha256=lifecycle.sha256_file(branch_artifact),
+            )
+            baseline_p2, baseline_history = adapter.evaluate_parent(
+                branch_frozen,
+                parent_command_id=supporting.command_id,
+            )
+            assert baseline_p2.status == "unproven"
+
+            arm_ledgers: dict[str, ExperimentLedger] = {}
+            for arm in (baseline, treatment):
+                ledger = ExperimentLedger.create(
+                    tmp_path / f"{arm.arm}-ledger.jsonl",
+                    experiment_id=new_evidence_id("experiment"),
+                    physical_attempt_id=new_evidence_id("physical_attempt"),
+                    context={"scope": "issue-204-make-arm", "arm": arm.arm},
+                )
+                arm_ledgers[arm.arm] = ledger
+                activate_experiment(
+                    thread_id=arm.session.thread_id,
+                    experiment_id=ledger.experiment_id,
+                    physical_attempt_id=ledger.physical_attempt_id,
+                    ledger=ledger,
+                    policy=_policy(image_id=arm.session.image_id),
+                )
+                active_threads.add(arm.session.thread_id)
+
+            baseline_payload = json.loads(
+                bound_compile_tools._submit_with_post_build_phase(
+                    baseline.session,
+                    supporting_command_id=supporting.command_id,
+                )
+            )
+            assert baseline_payload["status"] == "failed"
+            assert baseline_payload["replay_status"] == "not_run"
+            assert baseline.session.replay_attempts == []
+            assert _failure_event(arm_ledgers["baseline"])["payload"]["classification"] == "build_system_unproven"
+            assert _constraint_failures(baseline.session) == ["build_system_unproven"]
+
+            treatment_build = _record_command(
+                manager=manager,
+                runtime=runtime,
+                session=treatment.session,
+                command=adapter.TREATMENT_BUILD_COMMAND,
+                role="build",
+            )
+            treatment_stage = _record_command(
+                manager=manager,
+                runtime=runtime,
+                session=treatment.session,
+                command=adapter.TREATMENT_STAGE_COMMAND,
+                role="artifact_stage",
+            )
+            assert branch_artifact.stat().st_size == branch_frozen.artifact_size
+            assert lifecycle.sha256_file(branch_artifact) == branch_frozen.artifact_sha256
+            treatment_p2, treatment_history = adapter.evaluate_treatment(
+                branch_frozen,
+                parent_command_id=supporting.command_id,
+                treatment_build_command_id=treatment_build.command_id,
+                treatment_stage_command_id=treatment_stage.command_id,
+            )
+            assert treatment_p2.status == "proven"
+            assert treatment_p2.proof_mode == "direct_make"
+            assert treatment_history[: len(baseline_history)] == baseline_history
+
+            treatment_payload = json.loads(
+                bound_compile_tools._submit_with_post_build_phase(
+                    treatment.session,
+                    supporting_command_id=treatment_build.command_id,
+                )
+            )
+            assert treatment_payload["status"] == "passed", treatment_payload
+            assert treatment_payload["candidate_status"] == "passed"
+            assert treatment_payload["replay_status"] == "passed"
+            assert len(treatment.session.replay_attempts) == 1
+            replay = treatment.session.replay_attempts[0]
+            assert replay.status == "passed" and replay.cleanup_succeeded is True
+            if replay.container_id is not None:
+                known_replay_container_ids.add(replay.container_id)
+
+            for thread_id in tuple(active_threads):
+                deactivate_experiment(thread_id)
+                active_threads.remove(thread_id)
+            record = gate.cleanup(capture_id, parent_session=parent)
+            cleaned = True
+            assert record.phase == "cleaned"
+            assert record.payload["cleanup"]["succeeded"] is True
+            assert gate.external_counts() == {
+                "provider_calls": 0,
+                "formal_physical_attempts": 0,
+                "model_tokens": 0,
+            }
+    finally:
+        for thread_id in tuple(active_threads):
+            deactivate_experiment(thread_id)
+        if gate is not None and not cleaned:
+            try:
+                gate.cleanup(capture_id, parent_session=parent)
+            except Exception:
+                pass
+        for session in arm_sessions:
+            runtime.stop_and_remove_container(session)
+        runtime.stop_and_remove_container(parent)
+        for container_id in docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split():
+            docker.run(["rm", "-f", container_id], check=False, timeout_seconds=30)
+        continuation_images.update(
+            docker.run(
+                [
+                    "image",
+                    "ls",
+                    "-q",
+                    "--filter",
+                    f"label={lifecycle.CAPTURE_LABEL}={capture_id}",
+                ],
+                check=False,
+                timeout_seconds=30,
+            ).stdout.split()
+        )
+        for image_id in continuation_images:
+            docker.run(["image", "rm", "-f", image_id], check=False, timeout_seconds=60)
+
+    for container_id in known_container_ids | known_replay_container_ids:
+        assert (
+            docker.run(
+                ["container", "inspect", container_id],
+                check=False,
+                timeout_seconds=20,
+            ).returncode
+            != 0
+        )
+    assert (
+        docker.run(
+            ["ps", "-aq", "--filter", f"label={lifecycle.CAPTURE_LABEL}={capture_id}"],
+            check=False,
+            timeout_seconds=30,
+        ).stdout.split()
+        == []
+    )
+    names = docker.run(
+        ["ps", "-a", "--format", "{{.Names}}"],
+        check=False,
+        timeout_seconds=30,
+    ).stdout.splitlines()
+    assert [name for name in names if name.startswith(("deerflow-compile-", "deerflow-replay-"))] == []

--- a/benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md
@@ -1,0 +1,36 @@
+# Opaque build provenance R2 Make 真实 lifecycle 零 provider 门禁
+
+本门禁承接 Issue #202 / PR #203 已发布的 Make P2 reference criterion。目标是验证真实 Compile Session 中的 Make opaque-provenance parent、state-matched 双臂、candidate verification、clean replay 和 cleanup 能否闭合；不执行模型 continuation，不创建正式实验 evidence。
+
+## 冻结 case
+
+- 仓库与 exact commit：`https://github.com/kjdev/hoextdown@1ef9a71957570c2a65b7daa1b2f693ad87daf385`。
+- Build system / workdir / target：Make、`/workspace/repo`、`libhoedown.a`。
+- Output / staged artifact / type：`libhoedown.a` / `libhoedown.a` / `static_library`。
+- Case 逐字段继承 result-blind formal v1 source protocol；#202 Make evaluator SHA-256 固定为 `5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a`。
+
+## Controlled parent
+
+Parent 在 trusted runtime 中执行单一顶层 `sh -c` wrapper。Wrapper 内先 `make clean`，再构建真实 `libhoedown.a` target 并 staging 到 `/artifacts/libhoedown.a`。该步骤包含 clean replay 所需的完整构建与 staging 行为，但 trusted top-level executable 是 `sh`，因此不能证明 direct Make identity。
+
+Parent 的 production submit 必须只因 `build_system_unproven` 失败；static P2 必须为 `unproven / opaque_wrapper`，candidate 与 replay 不启动。Submit 必须经过真实 bound post-build wrapper，失败后 supporting command、started-at 和 remaining-command fence 全部释放。
+
+## 双臂与 treatment
+
+Baseline 与 treatment 从同一个 message/environment/budget checkpoint 派生。两臂的 continuation image、workspace、artifact、parent command records 和剩余 budget 必须 canonical 相同；treatment 唯一额外 exposure 是白名单 repair packet。
+
+Packet 固定 expected/selected build system、effective directory、target、`proof_status=opaque_wrapper` 与抽象 repair goal；禁止完整 Make 命令、argv、shell、prompt、solution 和 secret。
+
+- Baseline 不追加 invocation，再次 submit 必须仍为 `build_system_unproven` 且 0 replay。
+- Treatment append-only 执行 direct `make libhoedown.a -j2`，再 staging 同一 artifact；不得删除、重排或改写 parent history。
+- Treatment 必须转为 P2 `proven / direct_make`，production candidate verification 和独立 clean replay 同时通过。
+
+## 执行边界与停止规则
+
+- 固定 0 provider、0 credential read、0 formal attempt、0 model token 和 0正式 evidence write。
+- 只允许 Ubuntu WSL2 原生 Docker Engine；环境变量 `FORGE_RUN_OPAQUE_PROVENANCE_MAKE_LIFECYCLE_DOCKER=1` 显式开启唯一真实 gate。
+- 不修改 production Compiler、Oracle、`operations.py`、#202 Make evaluator、冻结 CMake evaluator、历史 runner/manifest/evidence。
+- Clone、parent build、submit、capture、arm provisioning、candidate/replay 或 cleanup 任一失败即停止；禁止 replacement/backfill。
+- Cleanup 必须删除 parent、双臂、replay、checkpoint helper、continuation image 和 snapshot；capture label 与 `deerflow-compile-*` / `deerflow-replay-*` 最终为 0 orphan。
+
+本门禁成功只证明 Make checkpoint 与确定性 treatment lifecycle 可达，不构成 repair packet 或模型效果证据。Reachability 与单 pair 必须另建 execution amendment。

--- a/scripts/forge_opaque_provenance_make_lifecycle_gate.py
+++ b/scripts/forge_opaque_provenance_make_lifecycle_gate.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Issue #204 Make opaque provenance 的真实 lifecycle 零 provider 适配器。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import shlex
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from deerflow.compile import operations
+
+SCHEMA_VERSION = "forge-opaque-provenance-make-lifecycle-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/204"
+REFERENCE_GATE_PATH = "scripts/forge_opaque_provenance_make_reference_gate.py"
+REFERENCE_GATE_SHA256 = "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a"
+CASE_ID = "hoextdown-opaque-provenance-r2-make-lifecycle"
+REPOSITORY_URL = "https://github.com/kjdev/hoextdown"
+COMMIT_SHA = "1ef9a71957570c2a65b7daa1b2f693ad87daf385"
+COMPILE_IMAGE = "autocompiler:gcc13"
+WORKDIR = "/workspace/repo"
+BUILD_OUTPUT = "libhoedown.a"
+STAGED_ARTIFACT = "libhoedown.a"
+ARTIFACT_TYPE = "static_library"
+TARGET = "libhoedown.a"
+PROOF_STATUS = "opaque_wrapper"
+REPAIR_GOAL = "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+
+_PARENT_INNER_COMMAND = "make clean && make libhoedown.a -j2 && cp libhoedown.a /artifacts/libhoedown.a"
+PARENT_COMMAND = f"sh -c {shlex.quote(_PARENT_INNER_COMMAND)}"
+TREATMENT_BUILD_COMMAND = "make libhoedown.a -j2"
+TREATMENT_STAGE_COMMAND = "cp libhoedown.a /artifacts/libhoedown.a"
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+
+
+class MakeLifecycleGateError(RuntimeError):
+    """Make lifecycle identity、packet 或 P2 合同无效。"""
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_reference_module():
+    module_path = SCRIPTS_DIR / Path(REFERENCE_GATE_PATH).name
+    module_name = "forge_opaque_provenance_make_lifecycle_reference"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise MakeLifecycleGateError("cannot load the Make P2 reference evaluator")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+reference = _load_reference_module()
+provenance = reference.provenance
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def build_repair_packet() -> dict[str, str]:
+    return {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": provenance.EXPECTED_CLASSIFICATION,
+        "mechanism_classification": provenance.FAULT_FAMILY,
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": WORKDIR,
+        "target": TARGET,
+        "proof_status": PROOF_STATUS,
+        "repair_goal": REPAIR_GOAL,
+    }
+
+
+def validate_repair_packet(value: dict[str, Any]) -> dict[str, str]:
+    expected = build_repair_packet()
+    if value != expected:
+        raise MakeLifecycleGateError("repair packet identity or whitelist drifted")
+    serialized = canonical_bytes(value).decode("utf-8").lower()
+    for forbidden in (
+        "make libhoedown.a",
+        "bash -lc",
+        "sh -c",
+        "argv",
+        "command_line",
+        "shell",
+        "secret",
+        "api_key",
+    ):
+        if forbidden in serialized:
+            raise MakeLifecycleGateError("repair packet leaked a forbidden solution field")
+    return expected
+
+
+def validate_parent_command_contract() -> dict[str, Any]:
+    roles = operations.infer_command_roles(PARENT_COMMAND)
+    expected_roles = {"artifact_stage", "build", "housekeeping"}
+    if roles != expected_roles:
+        raise MakeLifecycleGateError(f"parent wrapper roles drifted: {sorted(roles)}")
+    if operations._command_invokes(PARENT_COMMAND, "make"):
+        raise MakeLifecycleGateError("parent wrapper unexpectedly proves Make identity")
+    if not operations._command_invokes(PARENT_COMMAND, "sh"):
+        raise MakeLifecycleGateError("parent wrapper top-level identity drifted")
+    if operations.infer_command_role(PARENT_COMMAND) != "build":
+        raise MakeLifecycleGateError("parent wrapper no longer resolves to a build command")
+    return {
+        "roles": sorted(roles),
+        "top_level_executable": "sh",
+        "make_identity_proven": False,
+        "self_contained_replay_step": True,
+    }
+
+
+def build_frozen_identity(
+    *,
+    image_id: str,
+    physical_attempt_id: str,
+    artifact_size: int,
+    artifact_sha256: str,
+):
+    return reference.MakeFrozenIdentity(
+        schema_version=reference.SCHEMA_VERSION,
+        case_id=CASE_ID,
+        repository_url=REPOSITORY_URL,
+        commit_sha=COMMIT_SHA,
+        image_id=image_id,
+        physical_attempt_id=physical_attempt_id,
+        workdir=WORKDIR,
+        target=TARGET,
+        artifact_relative_path=BUILD_OUTPUT,
+        artifact_type=ARTIFACT_TYPE,
+        artifact_size=artifact_size,
+        artifact_sha256=artifact_sha256,
+    ).validate()
+
+
+def _parent_invocation(frozen: Any, command_id: str):
+    return provenance.record_invocation(
+        command_id=command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", _PARENT_INNER_COMMAND),
+        workdir=frozen.workdir,
+        previous_hash=provenance.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def _validate_case_identity(frozen: Any) -> None:
+    actual = (
+        frozen.schema_version,
+        frozen.case_id,
+        frozen.repository_url,
+        frozen.commit_sha,
+        frozen.workdir,
+        frozen.target,
+        frozen.artifact_relative_path,
+        frozen.artifact_type,
+    )
+    expected = (
+        reference.SCHEMA_VERSION,
+        CASE_ID,
+        REPOSITORY_URL,
+        COMMIT_SHA,
+        WORKDIR,
+        TARGET,
+        BUILD_OUTPUT,
+        ARTIFACT_TYPE,
+    )
+    if actual != expected:
+        raise MakeLifecycleGateError("frozen Make lifecycle case identity drifted")
+
+
+def _artifact(frozen: Any, producer_command_id: str, *, observed_after_sequence: int):
+    return provenance.ArtifactIdentity(
+        schema_version=provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=observed_after_sequence,
+    )
+
+
+def evaluate_parent(frozen: Any, *, parent_command_id: str):
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    decision = reference.evaluate_make_p2(
+        frozen,
+        (parent,),
+        _artifact(frozen, parent.command_id, observed_after_sequence=2),
+    )
+    if decision.status != "unproven" or decision.classification != provenance.FAULT_FAMILY or decision.reason != PROOF_STATUS:
+        raise MakeLifecycleGateError("parent did not produce the frozen opaque-wrapper P2 failure")
+    return decision, (parent,)
+
+
+def evaluate_treatment(
+    frozen: Any,
+    *,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    build = provenance.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="make",
+        argv=(frozen.target, "-j2"),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = provenance.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(frozen.artifact_relative_path, f"/artifacts/{STAGED_ARTIFACT}"),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    invocations = (parent, build, stage)
+    decision = reference.evaluate_make_p2(
+        frozen,
+        invocations,
+        _artifact(frozen, build.command_id, observed_after_sequence=4),
+    )
+    if decision.status != "proven" or decision.proof_mode != "direct_make":
+        raise MakeLifecycleGateError("treatment did not convert the frozen Make P2 outcome")
+    if invocations[:1] != (parent,):
+        raise MakeLifecycleGateError("treatment rewrote parent command history")
+    return decision, invocations
+
+
+def validate_gate_contract(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if file_sha256(repo_root / REFERENCE_GATE_PATH) != REFERENCE_GATE_SHA256:
+        raise MakeLifecycleGateError("frozen Make reference evaluator drifted")
+    source_case = reference.load_source_case(repo_root)
+    command_contract = validate_parent_command_contract()
+    packet = validate_repair_packet(build_repair_packet())
+    frozen = build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r2-make-lifecycle-contract",
+        artifact_size=4096,
+        artifact_sha256="4" * 64,
+    )
+    parent, parent_history = evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-make-build",
+        treatment_stage_command_id="treatment-artifact-stage",
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "case_id": CASE_ID,
+        "source_case": source_case,
+        "reference_gate_sha256": REFERENCE_GATE_SHA256,
+        "command_contract": command_contract,
+        "repair_packet": packet,
+        "parent": asdict(parent),
+        "treatment_contract": asdict(treatment),
+        "parent_history_sha256": provenance.command_history_sha256(parent_history),
+        "treatment_history_sha256": provenance.command_history_sha256(treatment_history),
+        "parent_history_prefix_preserved": treatment_history[: len(parent_history)] == parent_history,
+        "docker_executed": False,
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(json.dumps(validate_gate_contract(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 逐字段继承 #202 result-blind `hoextdown` Make case并冻结 reference evaluator 哈希
- 新增 Make lifecycle adapter，定义 replayable opaque parent、白名单 repair packet 和 append-only direct Make treatment
- 新增静态合同与 opt-in Ubuntu-native Docker gate
- 复用现有 message/environment/budget checkpoint、production candidate verifier 与 clean replay，不修改 production 或历史 evidence

## 真实门禁

- Ubuntu WSL2 原生 Docker Engine：`1 passed in 77.16s`
- Parent 真实生成 `libhoedown.a`，只触发 `build_system_unproven`，candidate/replay 不启动，post-build fence 释放
- Baseline 保持 P2 unproven、0 replay
- Treatment append direct Make + stage 后转为 `proven/direct_make`，candidate 与 clean replay 均通过
- 双臂环境/budget 同源，repair packet 是唯一 exposure
- Cleanup 后无 compile/replay/checkpoint orphan

## 验证

- 扩展静态回归：`105 passed, 1 skipped`（唯一 skip 为默认关闭的真实 Docker test）
- Ruff check / format check、`py_compile`、CLI、diff：通过
- #202 evaluator SHA-256 未漂移，敏感值扫描无命中
- 固定 0 provider、0 credential read、0 formal attempt、0 model token、0正式 evidence write

## 研究边界

本 PR 只证明确定性 Make checkpoint lifecycle 可达，不构成 repair packet 或模型效果证据，也不授权 reachability 或新 pair。

Closes #204