### PR TITLE
研究：冻结 R2 Make 单配对未执行候选

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,13 +5,13 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 发布 Issue #204 R2 Make provenance 真实 lifecycle 零 provider 门禁
-  - GitHub: 中文 Issue #204 已创建并回读；分支为 `research/204-make-provenance-lifecycle`，基线为 `main@9b5448ed`。
-  - 实现: 新增 experiment-only Make lifecycle adapter、静态合同、opt-in Ubuntu-native Docker gate 和预注册；逐字段继承 #202 `hoextdown` identity 并冻结其 evaluator SHA-256，不修改 production、CMake evaluator 或历史 evidence。
-  - 真实门禁: `1 passed in 77.16s`。Parent opaque `sh -c` wrapper 生成真实 `libhoedown.a`，production submit 只因 `build_system_unproven` 失败且 post-build fence 释放；baseline 保持 0 replay，treatment append direct Make + stage 后转为 `proven/direct_make`，candidate 与 clean replay 通过。
-  - 完整性: 双臂 continuation image、workspace/artifact、parent history 与 budget canonical 同源，repair packet 是唯一 exposure；cleanup 删除 parent、双臂、replay、checkpoint helper 和 continuation image，独立容器清单无 compile/replay orphan。
-  - 验证与边界: 扩展静态回归 `105 passed, 1 skipped`，Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过；固定 0 provider、0 credential read、0 formal attempt、0 model token、0正式 evidence write。下一步为中文提交、WSL helper 推送、中文 PR/CI/合并。
-  - 文件: `scripts/forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md`
+- 2026-08-30 — 发布 Issue #206 R2 Make 单配对未执行候选
+  - GitHub: 中文 Issue #206 已创建并回读；分支为 `research/206-make-pair-candidate`，基线为 `main@b8092e6f`。
+  - 实现: 新增紧凑 protocol/generator、read-only runner、manifest、Draft 2020-12 const Schema、预注册与测试；逐字段继承 `hoextdown`，冻结 #202 reference、#204 lifecycle 和 R0 observability 组件哈希。
+  - 候选身份: `opaque-provenance-r2-hoextdown-pair-01`、新 evidence identity `c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4`；DeepSeek `deepseek-v4-flash`、300 秒/0 retry、单 pair token ceiling 245,000，保持 4/2/2/2 action limits 与 R0 companion。
+  - 授权边界: 只开放 `validate/plan/preflight`；checkpoint、reachability、provider、formal attempt、pair、credential、model、Docker、evidence write 全部机械关闭，model token 授权为 0。Manifest canonical SHA-256 为 `b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514`。
+  - 验证: 聚焦 `17 passed`，Make lifecycle/R0/CMake/R1 相邻回归 `99 passed, 1 skipped`；Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过。下一步为中文提交、WSL helper 推送、中文 PR/CI/合并，合并后只运行纯快照 preflight。
+  - 文件: `scripts/forge_opaque_provenance_make_candidate_protocol.py`, `scripts/forge_opaque_provenance_make_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_make_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -71,6 +71,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #204 R2 Make provenance 真实 lifecycle 零 provider 门禁
+  - 文件: `scripts/forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md`
+  - 发布: 中文 Issue #204 / PR #205 已完成，三项 CI 全绿后 squash 合并为 `main@b8092e6f58830690359b137b32031d3cc96361dc`；合并后静态 gate 通过，未重复真实 Docker gate。
+  - 真实门禁: Ubuntu-native Docker `1 passed in 77.16s`。Parent 真实生成 `libhoedown.a` 且只触发 `build_system_unproven`，post-build fence 释放；baseline 保持 0 replay，treatment append direct Make + stage 后转为 `proven/direct_make`，candidate 与 clean replay 通过。
+  - 完整性: 双臂 continuation image、workspace/artifact、parent history 与 budget canonical 同源，repair packet 是唯一 exposure；cleanup 后 parent/双臂/replay/checkpoint 为 0 orphan。固定 0 provider、0 credential read、0 formal attempt、0 model token、0正式 evidence write。
+  - 下一步: 先冻结单 pair 未执行候选，不直接调用 provider；真实 reachability/pair 必须使用独立 execution amendment。
 
 - 2026-08-30 — 完成 Issue #202 R2 Make provenance reference gate
   - 文件: `scripts/forge_opaque_provenance_make_reference_gate.py`, `backend/tests/test_forge_opaque_provenance_make_reference_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-reference-gate.md`

--- a/backend/tests/test_forge_opaque_provenance_make_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_make_candidate.py
@@ -1,0 +1,267 @@
+"""Issue #206 R2 Make 未执行候选的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_make_candidate_protocol.py"
+RUNNER_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_make_candidate_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_opaque_provenance_make_candidate_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_opaque_provenance_make_candidate_runner_test",
+    RUNNER_PATH,
+)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _valid_snapshot(manifest: dict) -> dict:
+    return {
+        "schema_version": "forge-opaque-provenance-r2-make-candidate-preflight-1.0.0",
+        "branch": "main",
+        "head_commit": "a" * 40,
+        "origin_main_commit": "a" * 40,
+        "worktree_clean": True,
+        "authorization_baseline_ancestor": True,
+        "frozen_component_sha256": manifest["frozen_components"],
+        "candidate_evidence_directory": manifest["evidence"]["directory"],
+        "candidate_evidence_entries": 0,
+        "checkpoint_status": "not_created",
+        "docker_executed": False,
+    }
+
+
+def test_generated_manifest_schema_runtime_and_preregistration_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    assert manifest["runtime_adapter"]["file_sha256"] == protocol.file_sha256(RUNNER_PATH)
+    preregistration = REPO_ROOT / manifest["preregistration"]["path"]
+    assert manifest["preregistration"]["file_sha256"] == protocol.file_sha256(preregistration)
+
+
+def test_hoextdown_case_is_result_blind_and_matches_make_lifecycle() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    source = manifest["source_protocol"]["source_case"]
+    case = manifest["case"]
+    artifact = source["artifact_oracle"]["required_artifacts"][0]
+    assert source["id"] == "hoextdown"
+    assert source["result_data_consulted"] is False
+    assert case["repository_url"] == source["repository_url"]
+    assert case["commit_sha"] == source["commit"]
+    assert case["build_system"] == "make"
+    assert case["target"] == artifact["producing_target"] == "libhoedown.a"
+    assert case["build_output"] == artifact["build_output_path"]
+    assert case["staged_artifact"] == artifact["staged_relative_path"]
+    assert case["artifact_type"] == "static_library"
+
+
+def test_frozen_components_are_current_and_include_make_lifecycle_and_r0() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["frozen_components"] == protocol.FROZEN_COMPONENT_SHA256
+    for path, expected in manifest["frozen_components"].items():
+        assert protocol.file_sha256(REPO_ROOT / path) == expected
+    assert manifest["repair_packet"]["origin_path"] == ("scripts/forge_opaque_provenance_make_lifecycle_gate.py")
+    assert manifest["r0_observability"]["companion_event"] == ("agent.tool_rejection_observed")
+    assert manifest["r0_observability"]["atomic_fields"] == (protocol.R0_OBSERVATION_FIELDS)
+
+
+def test_schedule_evidence_and_token_ceiling_are_new_and_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["schedule"] == [
+        {
+            "pair_id": protocol.PAIR_ID,
+            "order": 1,
+            "case_id": manifest["case"]["case_id"],
+            "arm_order": ["baseline", "treatment"],
+            "state_matched": True,
+            "treatment_exposure_only": "repair_packet",
+            "shared_measurement_policy": "runtime_parity_with_r0_observability_v1",
+        }
+    ]
+    assert manifest["schedule_sha256"] == protocol.canonical_sha256(manifest["schedule"])
+    evidence = manifest["evidence"]
+    identity = {key: value for key, value in evidence.items() if key != "identity_sha256"}
+    assert evidence["identity_sha256"] == protocol.canonical_sha256(identity)
+    assert evidence["status"] == "not_created"
+    budget = manifest["budget"]
+    assert budget["phase_recorded_token_ceiling"] == 245000
+    assert budget["phase_recorded_token_ceiling"] == (budget["reachability_recorded_tokens"] + budget["pair_recorded_tokens"])
+
+
+def test_all_execution_authorizations_and_capabilities_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    authorization = manifest["authorization"]
+    assert authorization["candidate_generation_authorized"] is True
+    assert authorization["zero_provider_preflight_authorized"] is True
+    for key in (
+        "checkpoint_creation_authorized",
+        "reachability_request_authorized",
+        "provider_calls_authorized",
+        "formal_attempts_authorized",
+        "pair_collection_authorized",
+        "credential_read_authorized",
+        "model_creation_authorized",
+        "docker_execution_authorized",
+        "evidence_write_authorized",
+    ):
+        assert authorization[key] is False
+    assert authorization["model_tokens_authorized"] == 0
+    runtime = manifest["runtime_adapter"]
+    assert runtime["commands"] == ["validate", "plan", "preflight"]
+    assert not any(value for key, value in runtime.items() if key.endswith("_supported"))
+
+
+def test_plan_and_preflight_snapshot_are_zero_provider_and_zero_docker() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    snapshot = runner.validate_preflight_snapshot(manifest, _valid_snapshot(manifest))
+    assert snapshot["checkpoint_status"] == "not_created"
+    plan = runner.build_plan(manifest)
+    assert plan["build_system"] == "make"
+    assert plan["phase_recorded_token_ceiling"] == 245000
+    assert plan["r0_companion_event"] == "agent.tool_rejection_observed"
+    assert (
+        plan["provider_calls"],
+        plan["formal_attempts"],
+        plan["model_tokens"],
+        plan["evidence_writes"],
+    ) == (0, 0, 0, 0)
+    assert plan["credential_read"] is False
+    assert plan["docker_executed"] is False
+    assert plan["execution_authorized"] is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("branch", "research/206"),
+        ("origin_main_commit", "b" * 40),
+        ("worktree_clean", False),
+        ("authorization_baseline_ancestor", False),
+        ("frozen_component_sha256", {}),
+        ("candidate_evidence_entries", 1),
+        ("checkpoint_status", "created"),
+        ("docker_executed", True),
+    ],
+)
+def test_preflight_drift_fails_closed(field: str, value: object) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    snapshot = _valid_snapshot(manifest)
+    snapshot[field] = value
+    with pytest.raises(runner.RuntimeGateError):
+        runner.validate_preflight_snapshot(manifest, snapshot)
+
+
+def test_collector_is_pure_snapshot_and_does_not_create_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    candidate = tmp_path / ".compile-sessions" / Path(manifest["evidence"]["directory"]).name
+    commands: list[tuple[str, ...]] = []
+
+    def fake_command(command, _cwd: Path) -> str:
+        key = tuple(command)
+        commands.append(key)
+        if key == ("git", "branch", "--show-current"):
+            return "main"
+        if key in (("git", "rev-parse", "HEAD"), ("git", "rev-parse", "origin/main")):
+            return "c" * 40
+        if key == ("git", "status", "--porcelain") or key[:3] == (
+            "git",
+            "merge-base",
+            "--is-ancestor",
+        ):
+            return ""
+        raise AssertionError(key)
+
+    monkeypatch.setattr(
+        runner.protocol,
+        "validate_manifest",
+        lambda _manifest, _repo_root=None: _manifest,
+    )
+    frozen_by_name = {Path(path).name: sha256 for path, sha256 in manifest["frozen_components"].items()}
+    monkeypatch.setattr(runner, "_file_sha256", lambda path: frozen_by_name[path.name])
+    snapshot = runner.collect_preflight_snapshot(
+        manifest,
+        repo_root=tmp_path,
+        host_candidate_evidence_directory=candidate,
+        command_runner=fake_command,
+    )
+    assert snapshot["candidate_evidence_entries"] == 0
+    assert snapshot["docker_executed"] is False
+    assert not candidate.exists()
+    assert commands and all(command[0] == "git" for command in commands)
+
+
+def test_execute_paths_are_rejected_and_source_reads_no_credentials_or_docker() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    for execute in (
+        runner.execute_checkpoint,
+        runner.execute_reachability,
+        runner.execute_pair,
+    ):
+        with pytest.raises(runner.RuntimeGateError, match="not authorized"):
+            execute(manifest)
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "os.environ",
+        "os.getenv",
+        "create_chat_model",
+        "ChatOpenAI",
+        "ChatDeepSeek",
+        "api_key=",
+        '("docker",',
+    ):
+        assert forbidden not in source
+
+
+def test_schema_and_protocol_reject_identity_authorization_or_budget_drift() -> None:
+    schema = _load(SCHEMA_PATH)
+    manifest = _load(MANIFEST_PATH)
+    mutations = (
+        ("case", "repository_url", "https://github.com/example/drift"),
+        ("case", "target", "drift"),
+        ("authorization", "provider_calls_authorized", True),
+        ("budget", "phase_recorded_token_ceiling", 245001),
+        ("r0_observability", "companion_required_for_classified_rejection", False),
+        ("checkpoint", "status", "created"),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)

--- a/benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-r2-make-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_r2_make_candidate",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/206",
+    "candidate_generation_authorized": true,
+    "zero_provider_preflight_authorized": true,
+    "checkpoint_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "pair_collection_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "frozen_components": {
+    "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a",
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md": "c7d52ab58cca98e0438574f77909044ab6ed4d4556c859a5eda1b16560543fbd",
+    "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+    "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+    "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e"
+  },
+  "source_protocol": {
+    "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+    "file_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+    "case_protocol_sha256": "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca",
+    "audit_mode": "result-blind-static-document-review",
+    "source_case": {
+      "id": "hoextdown",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "build_system": "make",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libhoedown.a"
+        ],
+        "required_system_packages": [
+          "build-essential"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "libhoedown.a",
+            "build_output_path": "libhoedown.a",
+            "artifact_type": "static_library",
+            "producing_target": "libhoedown.a"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "Makefile",
+          "url": "https://github.com/kjdev/hoextdown/blob/1ef9a71957570c2a65b7daa1b2f693ad87daf385/Makefile",
+          "supports": [
+            "build_path",
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "hoextdown/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/hoextdown/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    }
+  },
+  "case": {
+    "case_id": "hoextdown-opaque-provenance-r2-make",
+    "repository_url": "https://github.com/kjdev/hoextdown",
+    "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+    "build_system": "make",
+    "source_subdir": ".",
+    "target": "libhoedown.a",
+    "build_output": "libhoedown.a",
+    "staged_artifact": "libhoedown.a",
+    "artifact_type": "static_library",
+    "compile_image": "autocompiler:gcc13",
+    "build_directory": "/workspace/repo",
+    "required_system_packages": [
+      "build-essential"
+    ],
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "checkpoint": {
+    "status": "not_created",
+    "checkpoint_id": null,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "creation_requires_execution_amendment": true
+  },
+  "provider": {
+    "status": "candidate_not_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "budget": {
+    "reachability_recorded_tokens": 5000,
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000,
+    "pair_recorded_tokens": 240000,
+    "phase_recorded_token_ceiling": 245000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-r2-hoextdown-pair-01",
+      "order": 1,
+      "case_id": "hoextdown-opaque-provenance-r2-make",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "487233f1bfb73367c1145e2e4e81bdf2343a7ef7ebc392e5fd42be804f12d9cb",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "fields": [
+      "schema_version",
+      "primary_classification",
+      "mechanism_classification",
+      "expected_build_system",
+      "selected_build_system",
+      "build_directory",
+      "target",
+      "proof_status",
+      "repair_goal"
+    ],
+    "template": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "make",
+      "selected_build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libhoedown.a",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+    },
+    "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+    "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "forbidden_solution_fields": [
+      "command",
+      "argv",
+      "command_line",
+      "shell",
+      "credential",
+      "secret"
+    ]
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "repair_build_directory": "/workspace/repo",
+    "repair_build_target": "libhoedown.a",
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+    }
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-r2-make-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1",
+    "checkpoint_manifest": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/checkpoint.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+    "pair_ledger": "pairs/opaque-provenance-r2-hoextdown-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+    "reachability_marker": "markers/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "status": "not_created",
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_replacement_backfill_or_extension_forbidden": true
+  },
+  "analysis": {
+    "purpose": "cross_build_system_p2_conversion_replication_canary",
+    "unit_of_analysis": "single_state_matched_make_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "authorization_baseline_commit": "b8092e6f58830690359b137b32031d3cc96361dc",
+    "require_authorization_baseline_ancestor": true,
+    "require_frozen_component_hashes": true,
+    "require_empty_candidate_evidence_directory": true,
+    "require_checkpoint_not_created": true,
+    "docker_check_forbidden": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md",
+    "file_sha256": "85b2e15f34241b882e22887bc6e0083e8aa303e26be7745697e4680245107ee9"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_make_candidate_runner.py",
+    "file_sha256": "f8cf60572bf814a5072b28d18879d1843f655a662d0baa3f2774ecc2aec1e83e",
+    "commands": [
+      "validate",
+      "plan",
+      "preflight"
+    ],
+    "credential_read_supported": false,
+    "provider_model_creation_supported": false,
+    "checkpoint_execute_supported": false,
+    "reachability_execute_supported": false,
+    "pair_execute_supported": false,
+    "docker_execute_supported": false,
+    "evidence_write_supported": false
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md
@@ -1,0 +1,19 @@
+# Opaque build provenance R2 Make 单配对未执行候选
+
+本候选承接 Issue #202 的 Make P2 reference criterion 与 Issue #204 的真实零 provider lifecycle gate。当前只冻结一个新的 Make state-matched pair，不创建 checkpoint，不调用 provider，不启动 Docker，也不写正式 evidence。
+
+## Case 与机制
+
+- Result-blind case：`https://github.com/kjdev/hoextdown@1ef9a71957570c2a65b7daa1b2f693ad87daf385`。
+- Build system / directory / target：Make、`/workspace/repo`、`libhoedown.a`。
+- Output / staged artifact / type：`libhoedown.a` / `libhoedown.a` / `static_library`。
+- Parent 必须保持 `unproven / opaque_wrapper`；treatment 唯一额外 exposure 是原九字段 repair packet，不提供完整命令。
+- 双臂顺序固定为 `baseline -> treatment`，message/environment/budget state-matched；4/2/2/2 action limits、原子 claim、`parallel_tool_calls=false`、R0 companion、candidate、clean replay 与 cleanup 保持不变。
+
+## Provider 与预算候选
+
+为与 R1 yyjson 进行同模型、跨构建系统的描述性复制，候选固定 DeepSeek `deepseek-v4-flash`、`https://api.deepseek.com`、300 秒、0 retry、非 streaming、禁止 fallback。每臂最多 8 requests、8 model turns、24 graph steps、600 秒工作时间、120 秒 cleanup reserve 和 120,000 recorded tokens；reachability 5,000、pair 240,000、阶段 ceiling 245,000。
+
+## 当前边界
+
+Issue #206 只开放 `validate`、`plan` 和只读 `preflight`。Checkpoint、reachability、provider、formal attempt、pair、credential、model、Docker 与 evidence write 全部关闭，model token 授权为 0。未来真实执行必须另建 execution amendment；该单 pair 只描述 cross-build-system P2 conversion replication，不估计 treatment effect、不计算 p 值、不排名模型、不池化 #190/#200。

--- a/benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+  "title": "Forge opaque provenance R2 Make candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-r2-make-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_r2_make_candidate",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/206",
+      "candidate_generation_authorized": true,
+      "zero_provider_preflight_authorized": true,
+      "checkpoint_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "pair_collection_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a",
+      "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md": "c7d52ab58cca98e0438574f77909044ab6ed4d4556c859a5eda1b16560543fbd",
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+      "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e"
+    },
+    "source_protocol": {
+      "path": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "file_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "case_protocol_sha256": "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca",
+      "audit_mode": "result-blind-static-document-review",
+      "source_case": {
+        "id": "hoextdown",
+        "repository_url": "https://github.com/kjdev/hoextdown",
+        "commit": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+        "build_system": "make",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [],
+          "build_targets": [
+            "libhoedown.a"
+          ],
+          "required_system_packages": [
+            "build-essential"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "libhoedown.a",
+              "build_output_path": "libhoedown.a",
+              "artifact_type": "static_library",
+              "producing_target": "libhoedown.a"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "Makefile",
+            "url": "https://github.com/kjdev/hoextdown/blob/1ef9a71957570c2a65b7daa1b2f693ad87daf385/Makefile",
+            "supports": [
+              "build_path",
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "hoextdown/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/hoextdown/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      }
+    },
+    "case": {
+      "case_id": "hoextdown-opaque-provenance-r2-make",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "build_system": "make",
+      "source_subdir": ".",
+      "target": "libhoedown.a",
+      "build_output": "libhoedown.a",
+      "staged_artifact": "libhoedown.a",
+      "artifact_type": "static_library",
+      "compile_image": "autocompiler:gcc13",
+      "build_directory": "/workspace/repo",
+      "required_system_packages": [
+        "build-essential"
+      ],
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "checkpoint": {
+      "status": "not_created",
+      "checkpoint_id": null,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "creation_requires_execution_amendment": true
+    },
+    "provider": {
+      "status": "candidate_not_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "budget": {
+      "reachability_recorded_tokens": 5000,
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000,
+      "pair_recorded_tokens": 240000,
+      "phase_recorded_token_ceiling": 245000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-r2-hoextdown-pair-01",
+        "order": 1,
+        "case_id": "hoextdown-opaque-provenance-r2-make",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "487233f1bfb73367c1145e2e4e81bdf2343a7ef7ebc392e5fd42be804f12d9cb",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "fields": [
+        "schema_version",
+        "primary_classification",
+        "mechanism_classification",
+        "expected_build_system",
+        "selected_build_system",
+        "build_directory",
+        "target",
+        "proof_status",
+        "repair_goal"
+      ],
+      "template": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "libhoedown.a",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+      },
+      "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+      "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "forbidden_solution_fields": [
+        "command",
+        "argv",
+        "command_line",
+        "shell",
+        "credential",
+        "secret"
+      ]
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "repair_build_directory": "/workspace/repo",
+      "repair_build_target": "libhoedown.a",
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+      }
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-r2-make-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1",
+      "checkpoint_manifest": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/checkpoint.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+      "pair_ledger": "pairs/opaque-provenance-r2-hoextdown-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+      "reachability_marker": "markers/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "status": "not_created",
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_replacement_backfill_or_extension_forbidden": true
+    },
+    "analysis": {
+      "purpose": "cross_build_system_p2_conversion_replication_canary",
+      "unit_of_analysis": "single_state_matched_make_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "authorization_baseline_commit": "b8092e6f58830690359b137b32031d3cc96361dc",
+      "require_authorization_baseline_ancestor": true,
+      "require_frozen_component_hashes": true,
+      "require_empty_candidate_evidence_directory": true,
+      "require_checkpoint_not_created": true,
+      "docker_check_forbidden": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md",
+      "file_sha256": "85b2e15f34241b882e22887bc6e0083e8aa303e26be7745697e4680245107ee9"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_make_candidate_runner.py",
+      "file_sha256": "f8cf60572bf814a5072b28d18879d1843f655a662d0baa3f2774ecc2aec1e83e",
+      "commands": [
+        "validate",
+        "plan",
+        "preflight"
+      ],
+      "credential_read_supported": false,
+      "provider_model_creation_supported": false,
+      "checkpoint_execute_supported": false,
+      "reachability_execute_supported": false,
+      "pair_execute_supported": false,
+      "docker_execute_supported": false,
+      "evidence_write_supported": false
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_make_candidate_protocol.py
+++ b/scripts/forge_opaque_provenance_make_candidate_protocol.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Issue #206 R2 Make 单配对未执行候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json"
+SOURCE_PROTOCOL_PATH = "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_make_candidate_runner.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-r2-make-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_r2_make_candidate"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/206"
+AUTHORIZATION_BASELINE_COMMIT = "b8092e6f58830690359b137b32031d3cc96361dc"
+SOURCE_PROTOCOL_FILE_SHA256 = "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+SOURCE_CASES_SHA256 = "3adb51f7c4cee22219c6ef4035fa0bc1e1dc6764e6246ad0dc4f612a03bb31ca"
+PAIR_ID = "opaque-provenance-r2-hoextdown-pair-01"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1"
+
+FROZEN_COMPONENT_SHA256 = {
+    "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a",
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md": "c7d52ab58cca98e0438574f77909044ab6ed4d4556c859a5eda1b16560543fbd",
+    "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+    "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c",
+    "benchmarks/preregistrations/cpp-opaque-provenance-rejection-observability-gate.md": "650670b29c2c7d4858e4403c544febb424b81eba18afafea0f851d362a2f689e",
+}
+REPAIR_PACKET_FIELDS = [
+    "schema_version",
+    "primary_classification",
+    "mechanism_classification",
+    "expected_build_system",
+    "selected_build_system",
+    "build_directory",
+    "target",
+    "proof_status",
+    "repair_goal",
+]
+R0_OBSERVATION_FIELDS = [
+    "rejection_classification",
+    "action_kind",
+    "model_request_id",
+    "tool_ordinal",
+    "command_sha256",
+]
+
+
+class ProtocolError(RuntimeError):
+    """Make candidate 的 source、组件、manifest 或授权边界发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot load {label}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"{label} must be an object")
+    return value
+
+
+def _load_source_case(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / SOURCE_PROTOCOL_PATH
+    if file_sha256(path) != SOURCE_PROTOCOL_FILE_SHA256:
+        raise ProtocolError("formal v1 source protocol file drifted")
+    protocol = _load_object(path, "formal v1 source protocol")
+    metadata = protocol.get("protocolization")
+    if not isinstance(metadata, dict) or metadata.get("case_protocol_sha256") != SOURCE_CASES_SHA256:
+        raise ProtocolError("formal v1 case protocol identity drifted")
+    matches = [case for case in protocol.get("cases", []) if isinstance(case, dict) and case.get("id") == "hoextdown"]
+    if len(matches) != 1 or matches[0].get("result_data_consulted") is not False:
+        raise ProtocolError("result-blind hoextdown case is absent or ambiguous")
+    return copy.deepcopy(matches[0])
+
+
+def _verify_frozen_components(repo_root: Path) -> None:
+    for relative_path, expected_sha256 in FROZEN_COMPONENT_SHA256.items():
+        path = repo_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected_sha256:
+            raise ProtocolError(f"frozen component drifted: {relative_path}")
+
+
+def _case(source_case: dict[str, Any]) -> dict[str, Any]:
+    recipe = source_case["recipe"]
+    artifacts = source_case["artifact_oracle"]["required_artifacts"]
+    if len(artifacts) != 1:
+        raise ProtocolError("hoextdown must have one frozen artifact")
+    artifact = artifacts[0]
+    expected = {
+        "repository_url": "https://github.com/kjdev/hoextdown",
+        "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+        "build_system": "make",
+        "source_subdir": ".",
+        "target": "libhoedown.a",
+        "build_output": "libhoedown.a",
+        "staged_artifact": "libhoedown.a",
+        "artifact_type": "static_library",
+    }
+    actual = {
+        "repository_url": source_case["repository_url"],
+        "commit_sha": source_case["commit"],
+        "build_system": source_case["build_system"],
+        "source_subdir": recipe["source_subdir"],
+        "target": artifact["producing_target"],
+        "build_output": artifact["build_output_path"],
+        "staged_artifact": artifact["staged_relative_path"],
+        "artifact_type": artifact["artifact_type"],
+    }
+    if actual != expected:
+        raise ProtocolError("hoextdown candidate identity drifted")
+    return {
+        "case_id": "hoextdown-opaque-provenance-r2-make",
+        **actual,
+        "compile_image": "autocompiler:gcc13",
+        "build_directory": "/workspace/repo",
+        "required_system_packages": copy.deepcopy(recipe["required_system_packages"]),
+        "parent_proof_status": "opaque_wrapper",
+        "parent_expected_failure": "build_system_unproven",
+    }
+
+
+def _repair_packet(case: dict[str, Any]) -> dict[str, Any]:
+    template = {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": case["build_directory"],
+        "target": case["target"],
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again.",
+    }
+    if list(template) != REPAIR_PACKET_FIELDS:
+        raise ProtocolError("repair packet fields drifted")
+    return {
+        "schema_version": template["schema_version"],
+        "fields": REPAIR_PACKET_FIELDS,
+        "template": template,
+        "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+        "origin_file_sha256": FROZEN_COMPONENT_SHA256["scripts/forge_opaque_provenance_make_lifecycle_gate.py"],
+        "forbidden_solution_fields": [
+            "command",
+            "argv",
+            "command_line",
+            "shell",
+            "credential",
+            "secret",
+        ],
+    }
+
+
+def _evidence_identity() -> dict[str, Any]:
+    identity = {
+        "schema_version": "forge-opaque-provenance-r2-make-evidence-1.0.0",
+        "directory": EVIDENCE_DIRECTORY,
+        "checkpoint_manifest": f"checkpoints/{PAIR_ID}/checkpoint.json",
+        "parent_ledger": f"checkpoints/{PAIR_ID}/parent/events.jsonl",
+        "pair_ledger": f"pairs/{PAIR_ID}/events.jsonl",
+        "arm_ledger_directory": f"pairs/{PAIR_ID}/arms",
+        "reachability_marker": "markers/reachability.json",
+        "pair_marker": "markers/pair.json",
+        "canary_report": "reports/canary.json",
+        "append_only": True,
+        "status": "not_created",
+        "zero_provider_preflight_writes_evidence": False,
+    }
+    return {**identity, "identity_sha256": canonical_sha256(identity)}
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    _verify_frozen_components(repo_root)
+    source_case = _load_source_case(repo_root)
+    case = _case(source_case)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("runtime adapter or preregistration is missing")
+    schedule = [
+        {
+            "pair_id": PAIR_ID,
+            "order": 1,
+            "case_id": case["case_id"],
+            "arm_order": ["baseline", "treatment"],
+            "state_matched": True,
+            "treatment_exposure_only": "repair_packet",
+            "shared_measurement_policy": "runtime_parity_with_r0_observability_v1",
+        }
+    ]
+    r0_components = {path: sha256 for path, sha256 in FROZEN_COMPONENT_SHA256.items() if "rejection_observability" in path}
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "candidate_generation_authorized": True,
+            "zero_provider_preflight_authorized": True,
+            "checkpoint_creation_authorized": False,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "pair_collection_authorized": False,
+            "credential_read_authorized": False,
+            "model_creation_authorized": False,
+            "docker_execution_authorized": False,
+            "evidence_write_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "frozen_components": copy.deepcopy(FROZEN_COMPONENT_SHA256),
+        "source_protocol": {
+            "path": SOURCE_PROTOCOL_PATH,
+            "file_sha256": SOURCE_PROTOCOL_FILE_SHA256,
+            "case_protocol_sha256": SOURCE_CASES_SHA256,
+            "audit_mode": "result-blind-static-document-review",
+            "source_case": source_case,
+        },
+        "case": case,
+        "checkpoint": {
+            "status": "not_created",
+            "checkpoint_id": None,
+            "arm_state_matching": ["message", "environment", "budget"],
+            "creation_requires_execution_amendment": True,
+        },
+        "provider": {
+            "status": "candidate_not_authorized",
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "budget": {
+            "reachability_recorded_tokens": 5000,
+            "maximum_requests_per_arm": 8,
+            "maximum_model_turns_per_arm": 8,
+            "maximum_graph_steps_per_arm": 24,
+            "work_wall_clock_seconds_per_arm": 600,
+            "cleanup_reserve_seconds_per_arm": 120,
+            "maximum_recorded_tokens_per_arm": 120000,
+            "pair_recorded_tokens": 240000,
+            "phase_recorded_token_ceiling": 245000,
+        },
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "repair_packet": _repair_packet(case),
+        "runtime_parity": {
+            "action_limits": {
+                "inspection": 4,
+                "repair_build": 2,
+                "artifact_stage": 2,
+                "submit": 2,
+            },
+            "atomic_budget_claim": True,
+            "parallel_tool_calls": False,
+            "repair_build_directory": case["build_directory"],
+            "repair_build_target": case["target"],
+            "candidate_verification_required": True,
+            "clean_replay_required": True,
+            "cleanup_required": True,
+        },
+        "r0_observability": {
+            "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+            "legacy_failure_event": "agent.tool_failed",
+            "legacy_failure_schema_preserved": True,
+            "companion_event": "agent.tool_rejection_observed",
+            "companion_required_for_classified_rejection": True,
+            "failure_link_field": "failure_id",
+            "atomic_fields": R0_OBSERVATION_FIELDS,
+            "raw_command_error_model_text_and_credentials_forbidden": True,
+            "frozen_components": r0_components,
+        },
+        "evidence": _evidence_identity(),
+        "stopping": {
+            "reachability_failure_stops_before_pair": True,
+            "identity_evidence_budget_cleanup_or_unclassified_failure_stops": True,
+            "retry_replacement_backfill_or_extension_forbidden": True,
+        },
+        "analysis": {
+            "purpose": "cross_build_system_p2_conversion_replication_canary",
+            "unit_of_analysis": "single_state_matched_make_pair",
+            "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "require_authorization_baseline_ancestor": True,
+            "require_frozen_component_hashes": True,
+            "require_empty_candidate_evidence_directory": True,
+            "require_checkpoint_not_created": True,
+            "docker_check_forbidden": True,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "plan", "preflight"],
+            "credential_read_supported": False,
+            "provider_model_creation_supported": False,
+            "checkpoint_execute_supported": False,
+            "reachability_execute_supported": False,
+            "pair_execute_supported": False,
+            "docker_execute_supported": False,
+            "evidence_write_supported": False,
+        },
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("R2 Make candidate manifest drifted")
+    budget = value["budget"]
+    if budget["phase_recorded_token_ceiling"] != budget["reachability_recorded_tokens"] + budget["pair_recorded_tokens"]:
+        raise ProtocolError("R2 Make candidate token ceiling drifted")
+    if value["checkpoint"]["status"] != "not_created" or value["evidence"]["status"] != "not_created":
+        raise ProtocolError("R2 Make candidate unexpectedly created checkpoint evidence")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return validate_manifest(_load_object(path, "R2 Make candidate manifest"), repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+        "title": "Forge opaque provenance R2 Make candidate",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    print(json.dumps({"manifest_sha256": canonical_sha256(manifest), "authorization": manifest["authorization"]}, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_make_candidate_runner.py
+++ b/scripts/forge_opaque_provenance_make_candidate_runner.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Issue #206 R2 Make 候选的零 provider、零 Docker runner。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+
+
+class RuntimeGateError(RuntimeError):
+    """候选快照或未授权执行入口被拒绝。"""
+
+
+def _load_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_make_candidate_protocol.py"
+    name = "forge_opaque_provenance_make_candidate_runtime_protocol"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeGateError("cannot load R2 Make candidate protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+CommandRunner = Callable[[Sequence[str], Path], str]
+
+
+def _run_command(command: Sequence[str], cwd: Path) -> str:
+    if not command or command[0] != "git":
+        raise RuntimeGateError("candidate preflight only permits read-only git commands")
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeGateError("candidate preflight git command failed") from exc
+    return result.stdout.strip()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_plan(manifest: dict[str, Any]) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    return {
+        "schema_version": manifest["schema_version"],
+        "case_id": manifest["case"]["case_id"],
+        "build_system": manifest["case"]["build_system"],
+        "target": manifest["case"]["target"],
+        "pair_id": manifest["schedule"][0]["pair_id"],
+        "arm_order": manifest["schedule"][0]["arm_order"],
+        "provider": manifest["provider"]["model"],
+        "phase_recorded_token_ceiling": manifest["budget"]["phase_recorded_token_ceiling"],
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+        "r0_companion_event": manifest["r0_observability"]["companion_event"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "evidence_writes": 0,
+        "execution_authorized": False,
+    }
+
+
+def validate_preflight_snapshot(manifest: dict[str, Any], snapshot: Any) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    if not isinstance(snapshot, dict):
+        raise RuntimeGateError("preflight snapshot must be an object")
+    expected_keys = {
+        "schema_version",
+        "branch",
+        "head_commit",
+        "origin_main_commit",
+        "worktree_clean",
+        "authorization_baseline_ancestor",
+        "frozen_component_sha256",
+        "candidate_evidence_directory",
+        "candidate_evidence_entries",
+        "checkpoint_status",
+        "docker_executed",
+    }
+    if set(snapshot) != expected_keys:
+        raise RuntimeGateError("preflight snapshot fields drifted")
+    if snapshot["schema_version"] != "forge-opaque-provenance-r2-make-candidate-preflight-1.0.0":
+        raise RuntimeGateError("preflight schema identity drifted")
+    if snapshot["branch"] != manifest["preflight"]["release_branch"]:
+        raise RuntimeGateError("preflight release branch drifted")
+    if not snapshot["head_commit"] or snapshot["head_commit"] != snapshot["origin_main_commit"]:
+        raise RuntimeGateError("preflight main/origin identity drifted")
+    if snapshot["worktree_clean"] is not True or snapshot["authorization_baseline_ancestor"] is not True:
+        raise RuntimeGateError("preflight release identity is not clean or descendant-compatible")
+    if snapshot["frozen_component_sha256"] != manifest["frozen_components"]:
+        raise RuntimeGateError("preflight frozen component identity drifted")
+    if snapshot["candidate_evidence_directory"] != manifest["evidence"]["directory"] or snapshot["candidate_evidence_entries"] != 0:
+        raise RuntimeGateError("candidate evidence directory is not the frozen empty directory")
+    if snapshot["checkpoint_status"] != "not_created":
+        raise RuntimeGateError("R2 Make checkpoint already exists")
+    if snapshot["docker_executed"] is not False:
+        raise RuntimeGateError("candidate preflight must not execute Docker")
+    return snapshot
+
+
+def collect_preflight_snapshot(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+    host_candidate_evidence_directory: Path,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    candidate_name = PurePosixPath(manifest["evidence"]["directory"]).name
+    expected_candidate = repo_root / ".compile-sessions" / candidate_name
+    if host_candidate_evidence_directory.resolve(strict=False) != expected_candidate.resolve(strict=False):
+        raise RuntimeGateError("candidate evidence directory is not bound to the frozen identity")
+    branch = command_runner(("git", "branch", "--show-current"), repo_root)
+    head = command_runner(("git", "rev-parse", "HEAD"), repo_root)
+    origin_main = command_runner(("git", "rev-parse", "origin/main"), repo_root)
+    status = command_runner(("git", "status", "--porcelain"), repo_root)
+    ancestry = command_runner(
+        (
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            manifest["preflight"]["authorization_baseline_commit"],
+            "HEAD",
+        ),
+        repo_root,
+    )
+    if ancestry:
+        raise RuntimeGateError("git ancestry check produced unexpected output")
+    candidate_entries = len(tuple(host_candidate_evidence_directory.iterdir())) if host_candidate_evidence_directory.exists() else 0
+    snapshot = {
+        "schema_version": "forge-opaque-provenance-r2-make-candidate-preflight-1.0.0",
+        "branch": branch,
+        "head_commit": head,
+        "origin_main_commit": origin_main,
+        "worktree_clean": status == "",
+        "authorization_baseline_ancestor": True,
+        "frozen_component_sha256": {path: _file_sha256(repo_root / path) for path in sorted(manifest["frozen_components"])},
+        "candidate_evidence_directory": manifest["evidence"]["directory"],
+        "candidate_evidence_entries": candidate_entries,
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "docker_executed": False,
+    }
+    return validate_preflight_snapshot(manifest, snapshot)
+
+
+def execute_checkpoint(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("checkpoint creation is not authorized by Issue #206")
+
+
+def execute_reachability(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("reachability request is not authorized by Issue #206")
+
+
+def execute_pair(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("provider pair is not authorized by Issue #206")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "plan", "preflight"))
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--host-candidate-evidence-directory", type=Path)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest, args.repo_root)
+    if args.command == "preflight":
+        if args.host_candidate_evidence_directory is None:
+            raise RuntimeGateError("preflight requires the candidate evidence directory")
+        result = collect_preflight_snapshot(
+            manifest,
+            repo_root=args.repo_root,
+            host_candidate_evidence_directory=args.host_candidate_evidence_directory,
+        )
+    elif args.command == "plan":
+        result = build_plan(manifest)
+    else:
+        result = {
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "checkpoint_status": manifest["checkpoint"]["status"],
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+            "credential_read": False,
+            "docker_executed": False,
+            "evidence_writes": 0,
+        }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 冻结 result-blind `hoextdown` Make 单 pair 与新 evidence identity
- 固定 DeepSeek 同模型跨构建系统候选、300 秒/0 retry 和 245,000 token ceiling
- 冻结 #202 reference、#204 lifecycle 与 R0 observability 组件哈希
- 新增确定性 generator、manifest、Draft 2020-12 const Schema 和只读 runner
- Runner 只开放 `validate/plan/preflight`，全部真实执行入口硬拒绝

## 验证

- Manifest canonical SHA-256：`b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514`
- Evidence identity SHA-256：`c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4`
- 聚焦测试：`17 passed`
- Make lifecycle/R0/CMake/R1 相邻回归：`99 passed, 1 skipped`
- Ruff、format、`py_compile`、CLI、diff：通过
- 无实际 secret；测试仅包含用于禁止项断言的 `api_key=` 字面量

## 授权边界

Checkpoint、reachability、provider、formal attempt、pair、credential、model、Docker 和 evidence write 全部机械关闭，model token 授权为 0。本 PR 不执行模型实验；真实运行必须另建 execution amendment。

Closes #206