### PR TITLE
研究：实现 R2 Make 一次性执行修订

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,13 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 发布 Issue #206 R2 Make 单配对未执行候选
-  - GitHub: 中文 Issue #206 已创建并回读；分支为 `research/206-make-pair-candidate`，基线为 `main@b8092e6f`。
-  - 实现: 新增紧凑 protocol/generator、read-only runner、manifest、Draft 2020-12 const Schema、预注册与测试；逐字段继承 `hoextdown`，冻结 #202 reference、#204 lifecycle 和 R0 observability 组件哈希。
-  - 候选身份: `opaque-provenance-r2-hoextdown-pair-01`、新 evidence identity `c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4`；DeepSeek `deepseek-v4-flash`、300 秒/0 retry、单 pair token ceiling 245,000，保持 4/2/2/2 action limits 与 R0 companion。
-  - 授权边界: 只开放 `validate/plan/preflight`；checkpoint、reachability、provider、formal attempt、pair、credential、model、Docker、evidence write 全部机械关闭，model token 授权为 0。Manifest canonical SHA-256 为 `b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514`。
-  - 验证: 聚焦 `17 passed`，Make lifecycle/R0/CMake/R1 相邻回归 `99 passed, 1 skipped`；Ruff、format、`py_compile`、CLI、diff 与敏感信息审计通过。下一步为中文提交、WSL helper 推送、中文 PR/CI/合并，合并后只运行纯快照 preflight。
-  - 文件: `scripts/forge_opaque_provenance_make_candidate_protocol.py`, `scripts/forge_opaque_provenance_make_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_make_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md`
+- 2026-08-30 — 发布并执行 Issue #208 R2 Make runtime-parity 一次性修订
+  - GitHub: 中文 Issue #208 已创建并回读；分支为 `research/208-make-runtime-amendment`，授权基线为 `main@6f1118db`。
+  - 实现: 新增 Make direct-action validator、#194 R0 observable 版本层、execution protocol/runner、manifest、Draft 2020-12 const Schema、中文预注册与测试；旧 CMake `_run_pair`、production Compiler/Oracle、#202/#204/#206 与历史 evidence 均未修改。
+  - 身份: `hoextdown@1ef9a719`、target/artifact `libhoedown.a`；direct `make/gmake` 必须绑定 effective directory `/workspace/repo`、唯一 target 与 jobs `2`。Manifest canonical SHA-256 为 `113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e`。
+  - 授权边界: execution amendment 只允许一次 reachability 与一个 `baseline -> treatment` pair，阶段上限 245,000 recorded tokens；当前尚未调用 provider、未启动 Docker、未创建 evidence 或 marker。
+  - 验证: 聚焦 `19 passed`，Make reference/lifecycle/candidate、CMake runtime-parity、R0 与 R1 execution 相邻回归 `95 passed`；Ruff、format、compileall、CLI validate 与 diff 检查通过。全程 0 provider、0 Docker、0 formal attempt、0 model token、0 evidence write。
+  - 下一步: 完成敏感信息审计、中文提交、WSL helper 推送、中文 PR/CI/合并；合并后从干净主干记录实际网络介质并运行唯一 reachability 与唯一 pair，禁止 retry/replacement/backfill。
+  - 文件: `scripts/forge_opaque_provenance_make_runtime_parity_gate.py`, `scripts/forge_opaque_provenance_make_rejection_observability_gate.py`, `scripts/forge_opaque_provenance_r2_make_execution_protocol.py`, `scripts/forge_opaque_provenance_r2_make_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_make_runtime_parity_gate.py`, `backend/tests/test_forge_opaque_provenance_r2_make_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。

--- a/backend/tests/test_forge_opaque_provenance_make_runtime_parity_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_make_runtime_parity_gate.py
@@ -1,0 +1,120 @@
+"""Issue #208 Make runtime-parity 与 R0 observable 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load(name: str, filename: str):
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    path = SCRIPTS_DIR / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load(
+    "forge_opaque_provenance_make_runtime_parity_gate_test",
+    "forge_opaque_provenance_make_runtime_parity_gate.py",
+)
+observable = _load(
+    "forge_opaque_provenance_make_rejection_observability_gate_test",
+    "forge_opaque_provenance_make_rejection_observability_gate.py",
+)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "make libhoedown.a -j2",
+        "gmake -j2 libhoedown.a",
+        "make -C /workspace/repo --jobs=2 libhoedown.a",
+    ],
+)
+def test_direct_make_accepts_only_frozen_effective_identity(command: str) -> None:
+    policy = gate.FrozenActionPolicy()
+    gate.validate_repair_build(command, workdir=policy.workdir, policy=policy)
+
+
+@pytest.mark.parametrize(
+    ("command", "message"),
+    [
+        ("cmake --build build --target libhoedown.a", "direct make"),
+        ("make -C /workspace/repo/other libhoedown.a -j2", "directory drifted"),
+        ("make other -j2", "target drifted"),
+        ("make libhoedown.a", "jobs drifted"),
+        ("make libhoedown.a -j8", "jobs drifted"),
+        ("make CFLAGS=-O3 libhoedown.a -j2", "non-preregistered"),
+    ],
+)
+def test_direct_make_rejects_identity_or_argument_drift(
+    command: str,
+    message: str,
+) -> None:
+    policy = gate.FrozenActionPolicy()
+    with pytest.raises(gate.RuntimeParityGateError, match=message):
+        gate.validate_repair_build(command, workdir=policy.workdir, policy=policy)
+
+
+def test_compound_make_and_stage_is_forbidden() -> None:
+    with pytest.raises(gate.RuntimeParityGateError, match="must be separate actions"):
+        gate.classify_action(
+            "make libhoedown.a -j2 && cp libhoedown.a /artifacts/libhoedown.a",
+            workdir=gate.make_lifecycle.WORKDIR,
+            command_role="build",
+            policy=gate.FrozenActionPolicy(),
+        )
+
+
+def test_observable_adapter_translates_make_rejection() -> None:
+    adapter = observable.ObservableRuntimeParityToolAdapter(
+        run_tool=lambda **_kwargs: "unused",
+        submit_tool=lambda **_kwargs: "unused",
+    )
+    with pytest.raises(observable.ObservableRuntimeParityGateError) as raised:
+        adapter.run(
+            "make libhoedown.a -j8",
+            workdir="/workspace/repo",
+            command_role="build",
+        )
+    assert raised.value.evidence_rejection_classification == ("repair_build_arguments_invalid")
+    assert raised.value.evidence_action_kind == "repair_build"
+
+
+def test_action_budget_remains_atomic_4_2_2_2() -> None:
+    budget = gate.AtomicActionBudget()
+    before = budget.snapshot()
+    with pytest.raises(gate.RuntimeParityGateError, match="submit budget exhausted"):
+        budget.claim("repair_build", "submit", "submit", "submit")
+    assert budget.snapshot() == before
+    assert before["limits"] == {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2,
+    }
+
+
+def test_gate_contract_is_zero_provider_and_make_bound() -> None:
+    report = gate.validate_gate_contract()
+    assert report["build_system"] == "make"
+    assert report["effective_directory"] == "/workspace/repo"
+    assert report["target"] == "libhoedown.a"
+    assert report["jobs"] == "2"
+    assert (
+        report["provider_calls"],
+        report["formal_attempts"],
+        report["model_tokens"],
+        report["docker_executed"],
+    ) == (0, 0, 0, False)

--- a/backend/tests/test_forge_opaque_provenance_r2_make_execution.py
+++ b/backend/tests/test_forge_opaque_provenance_r2_make_execution.py
@@ -1,0 +1,219 @@
+"""Issue #208 R2 Make execution amendment 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS_DIR / "forge_opaque_provenance_r2_make_execution_protocol.py"
+RUNNER_PATH = SCRIPTS_DIR / "forge_opaque_provenance_r2_make_execution_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_opaque_provenance_r2_make_execution_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_opaque_provenance_r2_make_execution_runner_test",
+    RUNNER_PATH,
+)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_and_all_component_hashes_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(manifest, REPO_ROOT)
+    assert manifest["parent"]["canonical_sha256"] == protocol.PARENT_MANIFEST_SHA256
+    assert manifest["parent"]["evidence_identity_sha256"] == (protocol.PARENT_EVIDENCE_IDENTITY_SHA256)
+
+
+def test_authorization_budget_schedule_and_make_identity_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["authorization"]["model_tokens_authorized"] == 245_000
+    assert all(value is True for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["budget"] == {
+        "maximum_reachability_requests": 1,
+        "reachability_maximum_recorded_tokens": 5_000,
+        "recorded_tokens_per_arm": 120_000,
+        "recorded_tokens_per_pair": 240_000,
+        "stage_maximum_recorded_tokens": 245_000,
+        "enforcement": "after_reachability_and_each_arm_before_continuation",
+    }
+    assert manifest["schedule"][0]["arm_order"] == ["baseline", "treatment"]
+    assert manifest["case"]["build_system"] == "make"
+    assert manifest["runtime_parity"]["repair_build_directory"] == ("/workspace/repo")
+    assert manifest["runtime_parity"]["repair_build_target"] == "libhoedown.a"
+    assert manifest["runtime_parity"]["repair_build_jobs"] == "2"
+    assert manifest["independence"]["cross_build_system_replication"] is True
+    assert manifest["independence"]["historical_pairs_pooled"] is False
+
+
+def test_preflight_is_zero_provider_before_any_evidence_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_: None)
+    monkeypatch.setattr(runner, "_output_dir", lambda _manifest, value: value)
+    monkeypatch.setattr(
+        runner.legacy,
+        "_release_identity",
+        lambda *_args: {"revision": "a" * 40},
+    )
+    monkeypatch.setattr(runner.legacy, "_network_medium", lambda _manifest: "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner.v3_runner, "require_zero_managed_containers", lambda: None)
+    monkeypatch.setattr(runner.legacy, "_provider_preflight", lambda _manifest: None)
+    result = runner.collect_preflight(
+        manifest,
+        output_dir=tmp_path / "absent-evidence",
+        repo_root=tmp_path,
+        require_empty=True,
+    )
+    assert result["ready"] is True
+    assert result["network_access_medium"] == "wifi"
+    assert result["evidence_files"] == []
+    assert (
+        result["provider_calls"],
+        result["formal_attempts"],
+        result["model_tokens"],
+    ) == (0, 0, 0)
+    assert not (tmp_path / "absent-evidence").exists()
+
+
+def _record(
+    command_id: str,
+    command: str,
+    role: str,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        command_id=command_id,
+        command=command,
+        stage="bash",
+        workdir="/workspace/repo",
+        exit_code=0,
+        timed_out=False,
+        role=role,
+    )
+
+
+def test_make_p2_session_projection_converts_only_after_direct_make(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / runner.make_lifecycle.BUILD_OUTPUT
+    content = b"!<arch>\n" + b"frozen-make-artifact"
+    artifact.write_bytes(content)
+    frozen = runner.make_lifecycle.build_frozen_identity(
+        image_id="sha256:" + "2" * 64,
+        physical_attempt_id="attempt-r2-make-execution-test",
+        artifact_size=len(content),
+        artifact_sha256=hashlib.sha256(content).hexdigest(),
+    )
+    parent_id = "parent-wrapper"
+    parent_record = _record(
+        parent_id,
+        runner.make_lifecycle.PARENT_COMMAND,
+        "build",
+    )
+    baseline = SimpleNamespace(
+        leadagent_repo_dir=str(tmp_path),
+        post_build_supporting_command_id=parent_id,
+        commands=[parent_record],
+    )
+    baseline_p2, baseline_history = runner._evaluate_arm_p2(
+        baseline,
+        frozen,
+        parent_id,
+    )
+    assert baseline_p2.status == "unproven"
+    assert baseline_p2.reason == "opaque_wrapper"
+    assert len(baseline_history) == 1
+
+    treatment = SimpleNamespace(
+        leadagent_repo_dir=str(tmp_path),
+        post_build_supporting_command_id="direct-make",
+        commands=[
+            parent_record,
+            _record(
+                "direct-make",
+                "make libhoedown.a -j2",
+                "build",
+            ),
+            _record(
+                "artifact-stage",
+                "cp libhoedown.a /artifacts/libhoedown.a",
+                "artifact_stage",
+            ),
+        ],
+    )
+    treatment_p2, treatment_history = runner._evaluate_arm_p2(
+        treatment,
+        frozen,
+        parent_id,
+    )
+    assert treatment_p2.status == "proven"
+    assert treatment_p2.proof_mode == "direct_make"
+    assert treatment_history[:1] == baseline_history
+
+
+def test_runner_uses_make_pair_path_and_does_not_embed_credentials() -> None:
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert "legacy._run_pair" not in source
+    assert "build/build.ninja" not in source
+    assert 'parent.build_system = "make"' in source
+    assert "evaluate_make_p2" in source
+    assert "ObservableRuntimeParityToolAdapter" not in source
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "os.environ["):
+        assert forbidden not in source
+
+
+def test_schema_and_protocol_reject_authorization_budget_or_make_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    mutations = (
+        ("authorization", "provider_calls_authorized", False),
+        ("authorization", "model_tokens_authorized", 245_001),
+        ("budget", "stage_maximum_recorded_tokens", 245_001),
+        ("runtime_parity", "repair_build_jobs", "8"),
+        ("runtime_parity", "parallel_tool_calls", True),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)

--- a/benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-r2-make-execution.schema.json",
+  "schema_version": "forge-opaque-provenance-r2-make-execution-1.0.0",
+  "document_type": "forge_opaque_provenance_r2_make_execution_amendment",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/208",
+    "checkpoint_creation_authorized": true,
+    "reachability_request_authorized": true,
+    "provider_calls_authorized": true,
+    "formal_attempts_authorized": true,
+    "pair_collection_authorized": true,
+    "credential_read_authorized": true,
+    "model_creation_authorized": true,
+    "docker_execution_authorized": true,
+    "evidence_write_authorized": true,
+    "model_tokens_authorized": 245000
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json",
+    "schema_version": "forge-opaque-provenance-r2-make-candidate-1.0.0",
+    "canonical_sha256": "b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514",
+    "file_sha256": "95b44a5923ebb41d8320531d735998a4e2ddceef7ff51d8cc3c16d61ec65776a",
+    "evidence_identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4",
+    "authorization_baseline_commit": "6f1118db689bbc3329962fb341eb765b16a28ee7",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "case": {
+    "case_id": "hoextdown-opaque-provenance-r2-make",
+    "repository_url": "https://github.com/kjdev/hoextdown",
+    "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+    "build_system": "make",
+    "source_subdir": ".",
+    "target": "libhoedown.a",
+    "build_output": "libhoedown.a",
+    "staged_artifact": "libhoedown.a",
+    "artifact_type": "static_library",
+    "compile_image": "autocompiler:gcc13",
+    "build_directory": "/workspace/repo",
+    "required_system_packages": [
+      "build-essential"
+    ],
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "independence": {
+    "historical_pairs": [
+      "opaque-provenance-cppitertools-runtime-parity-pair-01",
+      "opaque-provenance-r1-yyjson-pair-01"
+    ],
+    "historical_build_system": "cmake",
+    "current_build_system": "make",
+    "cross_build_system_replication": true,
+    "historical_pairs_pooled": false,
+    "retry_replacement_backfill_or_extension": false
+  },
+  "checkpoint": {
+    "source_gate": "issue-204-real-make-lifecycle-zero-provider",
+    "creation_timing": "after_reachability_before_arm_continuation",
+    "capture_point": "after-neutral-tool-message-before-continuation",
+    "identity_materialized_during_pair": true,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "preexisting_checkpoint_reuse_forbidden": true
+  },
+  "provider": {
+    "status": "active_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-r2-hoextdown-pair-01",
+      "order": 1,
+      "case_id": "hoextdown-opaque-provenance-r2-make",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "487233f1bfb73367c1145e2e4e81bdf2343a7ef7ebc392e5fd42be804f12d9cb",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "fields": [
+      "schema_version",
+      "primary_classification",
+      "mechanism_classification",
+      "expected_build_system",
+      "selected_build_system",
+      "build_directory",
+      "target",
+      "proof_status",
+      "repair_goal"
+    ],
+    "template": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "make",
+      "selected_build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libhoedown.a",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+    },
+    "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+    "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "forbidden_solution_fields": [
+      "command",
+      "argv",
+      "command_line",
+      "shell",
+      "credential",
+      "secret"
+    ]
+  },
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_replacement_backfill_or_extension_forbidden": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true
+  },
+  "analysis": {
+    "purpose": "cross_build_system_p2_conversion_replication_canary",
+    "unit_of_analysis": "single_state_matched_make_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "repair_build_directory": "/workspace/repo",
+    "repair_build_target": "libhoedown.a",
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true,
+    "repair_build_jobs": "2",
+    "forbidden_actions": [
+      "clone",
+      "configure",
+      "dependency",
+      "housekeeping",
+      "manual_replay",
+      "compound_build_stage"
+    ],
+    "parent_submit_uses_bound_wrapper": true,
+    "fence_released_before_capture": true,
+    "action_validator": "Make RuntimeParityToolAdapter",
+    "observable_adapter": "Make ObservableRuntimeParityToolAdapter",
+    "rejection_registry": "RejectionObservationRegistry"
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+    }
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-r2-make-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1",
+    "checkpoint_manifest": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/checkpoint.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+    "pair_ledger": "pairs/opaque-provenance-r2-hoextdown-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+    "reachability_marker": "markers/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "status": "authorized_not_created",
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+  },
+  "opportunities": {
+    "maximum_reachability_requests": 1,
+    "maximum_pairs": 1,
+    "required_order": [
+      "reachability",
+      "opaque-provenance-r2-hoextdown-pair-01"
+    ],
+    "marker_consumed_on_start": true,
+    "retry_replacement_backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "require_authorization_baseline_ancestor": true,
+    "docker_provider": "ubuntu-native",
+    "docker_context": "default",
+    "docker_endpoint": "/var/run/docker.sock",
+    "control_plane": "compose-dood-on-ubuntu-native-engine",
+    "allowed_network_media": [
+      "wired",
+      "wifi",
+      "mobile_hotspot"
+    ],
+    "require_empty_evidence_directory": true,
+    "managed_container_prefixes": [
+      "deerflow-compile-",
+      "deerflow-replay-"
+    ],
+    "require_zero_managed_orphans": true
+  },
+  "execution": {
+    "release_branch": "main",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+    "reachability_expected_response": "CANARY_OK",
+    "reachability_report": "reports/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+    "report_schema_version": "forge-opaque-provenance-r2-make-report-1.0.0",
+    "report_document_type": "forge_opaque_provenance_r2_make_report"
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md",
+    "file_sha256": "2dcc2e5fd28acc5dff2026a5adce387b105ccd36763e959254e96f02f831904e"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_r2_make_execution_runner.py",
+    "file_sha256": "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0",
+    "commands": [
+      "validate",
+      "preflight",
+      "reachability",
+      "pair"
+    ],
+    "credential_read_supported": true,
+    "provider_model_creation_supported": true,
+    "checkpoint_execute_supported": true,
+    "reachability_execute_supported": true,
+    "pair_execute_supported": true,
+    "r0_companion_evidence_supported": true
+  },
+  "make_runtime_components": {
+    "scripts/forge_opaque_provenance_make_runtime_parity_gate.py": "146e7b83d1a0afbe31928308d2a63ec000021a63755751df8ae59628a4071075",
+    "scripts/forge_opaque_provenance_make_rejection_observability_gate.py": "2148b8a80ba25e95baa7e1e20c6d5209bc07bb89675026f78320f5636d1737c1"
+  },
+  "frozen_parent_components": {
+    "backend/tests/test_forge_opaque_provenance_make_candidate.py": "5bc185a40c93f2f365c71547892a27d9c07e60063753e9fdfcc512f15bec5074",
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py": "ed7205ff490c5a7381da8f7c57320c015f5dca115aa61a0690d96633a65d26f4",
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py": "5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652",
+    "backend/tests/test_forge_opaque_provenance_make_reference_gate.py": "698cc7da3038e70e201b9ed03e5e6e6f77f7f06efaa478223d804b23d773db1f",
+    "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json": "95b44a5923ebb41d8320531d735998a4e2ddceef7ff51d8cc3c16d61ec65776a",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md": "85b2e15f34241b882e22887bc6e0083e8aa303e26be7745697e4680245107ee9",
+    "benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json": "58561d6af20223eb117f5ccfa09355361a5a0e1d2704b65a621236fef559ae5f",
+    "scripts/forge_opaque_provenance_make_candidate_protocol.py": "3cb229c57ff2e6d921bdf5003b6f78e03adb6940a7ef2c9a900e0036c87f360d",
+    "scripts/forge_opaque_provenance_make_candidate_runner.py": "f8cf60572bf814a5072b28d18879d1843f655a662d0baa3f2774ecc2aec1e83e",
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md
@@ -1,0 +1,50 @@
+# C/C++ opaque provenance R2 Make 一次性执行修订
+
+状态：授权但未执行。追踪 Issue：[#208](https://github.com/WWFXL/Forge-AutoCompiler/issues/208)。
+
+## 研究问题
+
+在一个独立、result-blind 的 GNU Make case 上，结构化 verifier repair packet 是否能让 Agent 从同一 failure checkpoint 选择可信 direct Make 动作，并把 P2 provenance 从 `unproven/opaque_wrapper` 转为 `proven/direct_make`？
+
+本次只采集一个 `baseline -> treatment` state-matched pair，属于跨构建系统机制复制，不估计 treatment effect、不计算 p 值、不排名模型，也不与历史 CMake pair 池化。
+
+## 冻结 case
+
+- Repository：`https://github.com/kjdev/hoextdown`
+- Commit：`1ef9a71957570c2a65b7daa1b2f693ad87daf385`
+- Build system：GNU-compatible Make
+- Container workdir / effective directory：`/workspace/repo`
+- Target / build output / staged artifact：`libhoedown.a`
+- Artifact type：`static_library`
+- Direct Make jobs：`2`
+
+Parent 只允许由冻结的 opaque `sh -c` wrapper 创建真实产物；其顶层 trusted identity 不能证明 Make。Treatment packet 不包含命令、argv、shell 或完整解法。
+
+## Runtime-parity
+
+每臂动作上限固定为 inspection/build/stage/submit = `4/2/2/2`，claim 必须原子完成。合法 repair build 必须是 direct `make` 或 `gmake`，结构化解析后的 effective directory、target 和 jobs 必须分别为 `/workspace/repo`、`libhoedown.a`、`2`。Build 与 stage 必须分开，禁止 clone、configure、dependency、housekeeping、manual replay 与 compound build/stage。
+
+所有可分类拒绝必须保留历史 `agent.tool_failed`，并以 `failure_id` 关联 `agent.tool_rejection_observed`。Companion 只记录 bounded classification、action kind、model request ID、tool ordinal 与 command SHA-256，不记录原始命令、错误文本、模型正文、工具参数或凭据。
+
+## Provider 与预算
+
+- Provider/model：DeepSeek `deepseek-v4-flash`
+- Endpoint：`https://api.deepseek.com`
+- Credential env：`DEEPSEEK_API_KEY`
+- Timeout：300 秒；0 retry；非 streaming；禁止 fallback
+- Reachability：最多 1 request / 5,000 recorded tokens
+- 每臂：最多 8 requests、8 model turns、24 graph steps、600 秒工作时间、120 秒 cleanup reserve、120,000 recorded tokens
+- Pair：240,000 recorded tokens；阶段总上限：245,000
+
+## 执行顺序与停止规则
+
+1. 从已合并、干净且与 `origin/main` 一致的主干运行 preflight。
+2. 只使用 Ubuntu WSL2 原生 `docker.service` 的 default context 与 `/var/run/docker.sock`；禁止 Docker Desktop。
+3. 在空 evidence 目录消耗唯一 reachability marker；失败即停止。
+4. 创建唯一 parent checkpoint，再依次运行 baseline、treatment。两臂 message/environment/budget 必须同源，唯一 treatment exposure 为 repair packet。
+5. Classified arm outcome 或 endpoint timeout 可继续另一臂；identity、evidence、budget、cleanup 或 unclassified failure 漂移立即停止。
+6. 禁止 retry、replacement、backfill 和 schedule extension。
+
+## 主要 outcome
+
+主要 outcome 是 paired post-checkpoint P2 conversion，并要求 production candidate verification 与独立 clean replay 同时通过。请求数、recorded tokens、动作预算、R0 rejection 分布与墙钟仅作描述性指标。Artifact 正确但 P2 未证明仍记为失败。

--- a/benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json",
+  "title": "Forge opaque provenance R2 Make execution amendment",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-r2-make-execution.schema.json",
+    "schema_version": "forge-opaque-provenance-r2-make-execution-1.0.0",
+    "document_type": "forge_opaque_provenance_r2_make_execution_amendment",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/208",
+      "checkpoint_creation_authorized": true,
+      "reachability_request_authorized": true,
+      "provider_calls_authorized": true,
+      "formal_attempts_authorized": true,
+      "pair_collection_authorized": true,
+      "credential_read_authorized": true,
+      "model_creation_authorized": true,
+      "docker_execution_authorized": true,
+      "evidence_write_authorized": true,
+      "model_tokens_authorized": 245000
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json",
+      "schema_version": "forge-opaque-provenance-r2-make-candidate-1.0.0",
+      "canonical_sha256": "b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514",
+      "file_sha256": "95b44a5923ebb41d8320531d735998a4e2ddceef7ff51d8cc3c16d61ec65776a",
+      "evidence_identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4",
+      "authorization_baseline_commit": "6f1118db689bbc3329962fb341eb765b16a28ee7",
+      "release_revision_policy": "descendant-compatible"
+    },
+    "case": {
+      "case_id": "hoextdown-opaque-provenance-r2-make",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "build_system": "make",
+      "source_subdir": ".",
+      "target": "libhoedown.a",
+      "build_output": "libhoedown.a",
+      "staged_artifact": "libhoedown.a",
+      "artifact_type": "static_library",
+      "compile_image": "autocompiler:gcc13",
+      "build_directory": "/workspace/repo",
+      "required_system_packages": [
+        "build-essential"
+      ],
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "independence": {
+      "historical_pairs": [
+        "opaque-provenance-cppitertools-runtime-parity-pair-01",
+        "opaque-provenance-r1-yyjson-pair-01"
+      ],
+      "historical_build_system": "cmake",
+      "current_build_system": "make",
+      "cross_build_system_replication": true,
+      "historical_pairs_pooled": false,
+      "retry_replacement_backfill_or_extension": false
+    },
+    "checkpoint": {
+      "source_gate": "issue-204-real-make-lifecycle-zero-provider",
+      "creation_timing": "after_reachability_before_arm_continuation",
+      "capture_point": "after-neutral-tool-message-before-continuation",
+      "identity_materialized_during_pair": true,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "preexisting_checkpoint_reuse_forbidden": true
+    },
+    "provider": {
+      "status": "active_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-r2-hoextdown-pair-01",
+        "order": 1,
+        "case_id": "hoextdown-opaque-provenance-r2-make",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "runtime_parity_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "487233f1bfb73367c1145e2e4e81bdf2343a7ef7ebc392e5fd42be804f12d9cb",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "fields": [
+        "schema_version",
+        "primary_classification",
+        "mechanism_classification",
+        "expected_build_system",
+        "selected_build_system",
+        "build_directory",
+        "target",
+        "proof_status",
+        "repair_goal"
+      ],
+      "template": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "libhoedown.a",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+      },
+      "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+      "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "forbidden_solution_fields": [
+        "command",
+        "argv",
+        "command_line",
+        "shell",
+        "credential",
+        "secret"
+      ]
+    },
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_replacement_backfill_or_extension_forbidden": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true
+    },
+    "analysis": {
+      "purpose": "cross_build_system_p2_conversion_replication_canary",
+      "unit_of_analysis": "single_state_matched_make_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "repair_build_directory": "/workspace/repo",
+      "repair_build_target": "libhoedown.a",
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true,
+      "repair_build_jobs": "2",
+      "forbidden_actions": [
+        "clone",
+        "configure",
+        "dependency",
+        "housekeeping",
+        "manual_replay",
+        "compound_build_stage"
+      ],
+      "parent_submit_uses_bound_wrapper": true,
+      "fence_released_before_capture": true,
+      "action_validator": "Make RuntimeParityToolAdapter",
+      "observable_adapter": "Make ObservableRuntimeParityToolAdapter",
+      "rejection_registry": "RejectionObservationRegistry"
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+      }
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-r2-make-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1",
+      "checkpoint_manifest": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/checkpoint.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+      "pair_ledger": "pairs/opaque-provenance-r2-hoextdown-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+      "reachability_marker": "markers/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "status": "authorized_not_created",
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+    },
+    "opportunities": {
+      "maximum_reachability_requests": 1,
+      "maximum_pairs": 1,
+      "required_order": [
+        "reachability",
+        "opaque-provenance-r2-hoextdown-pair-01"
+      ],
+      "marker_consumed_on_start": true,
+      "retry_replacement_backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "control_plane": "compose-dood-on-ubuntu-native-engine",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "require_empty_evidence_directory": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true
+    },
+    "execution": {
+      "release_branch": "main",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "reachability_expected_response": "CANARY_OK",
+      "reachability_report": "reports/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "parent_ledger": "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-r2-hoextdown-pair-01/arms",
+      "report_schema_version": "forge-opaque-provenance-r2-make-report-1.0.0",
+      "report_document_type": "forge_opaque_provenance_r2_make_report"
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md",
+      "file_sha256": "2dcc2e5fd28acc5dff2026a5adce387b105ccd36763e959254e96f02f831904e"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_r2_make_execution_runner.py",
+      "file_sha256": "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0",
+      "commands": [
+        "validate",
+        "preflight",
+        "reachability",
+        "pair"
+      ],
+      "credential_read_supported": true,
+      "provider_model_creation_supported": true,
+      "checkpoint_execute_supported": true,
+      "reachability_execute_supported": true,
+      "pair_execute_supported": true,
+      "r0_companion_evidence_supported": true
+    },
+    "make_runtime_components": {
+      "scripts/forge_opaque_provenance_make_runtime_parity_gate.py": "146e7b83d1a0afbe31928308d2a63ec000021a63755751df8ae59628a4071075",
+      "scripts/forge_opaque_provenance_make_rejection_observability_gate.py": "2148b8a80ba25e95baa7e1e20c6d5209bc07bb89675026f78320f5636d1737c1"
+    },
+    "frozen_parent_components": {
+      "backend/tests/test_forge_opaque_provenance_make_candidate.py": "5bc185a40c93f2f365c71547892a27d9c07e60063753e9fdfcc512f15bec5074",
+      "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py": "ed7205ff490c5a7381da8f7c57320c015f5dca115aa61a0690d96633a65d26f4",
+      "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py": "5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652",
+      "backend/tests/test_forge_opaque_provenance_make_reference_gate.py": "698cc7da3038e70e201b9ed03e5e6e6f77f7f06efaa478223d804b23d773db1f",
+      "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json": "95b44a5923ebb41d8320531d735998a4e2ddceef7ff51d8cc3c16d61ec65776a",
+      "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md": "85b2e15f34241b882e22887bc6e0083e8aa303e26be7745697e4680245107ee9",
+      "benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json": "58561d6af20223eb117f5ccfa09355361a5a0e1d2704b65a621236fef559ae5f",
+      "scripts/forge_opaque_provenance_make_candidate_protocol.py": "3cb229c57ff2e6d921bdf5003b6f78e03adb6940a7ef2c9a900e0036c87f360d",
+      "scripts/forge_opaque_provenance_make_candidate_runner.py": "f8cf60572bf814a5072b28d18879d1843f655a662d0baa3f2774ecc2aec1e83e",
+      "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_make_rejection_observability_gate.py
+++ b/scripts/forge_opaque_provenance_make_rejection_observability_gate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Issue #208 Make runtime-parity 拒绝的 R0 observable 版本层。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import forge_opaque_provenance_make_runtime_parity_gate as make_parity
+import forge_opaque_provenance_rejection_observability_gate as r0
+
+from deerflow.compile.evidence import EvidenceError
+
+OBSERVATION_EVENT = r0.OBSERVATION_EVENT
+RejectionObservationRegistry = r0.RejectionObservationRegistry
+ObservableRuntimeParityGateError = r0.ObservableRuntimeParityGateError
+
+_MAKE_REJECTIONS = {
+    "repair build must be a direct make or gmake invocation": (
+        "repair_build_invocation_invalid",
+        "repair_build",
+    ),
+    "repair build directory drifted from the frozen identity": (
+        "repair_build_directory_drift",
+        "repair_build",
+    ),
+    "repair build target drifted from the frozen identity": (
+        "repair_build_target_drift",
+        "repair_build",
+    ),
+    "repair build jobs drifted from the frozen identity": (
+        "repair_build_arguments_invalid",
+        "repair_build",
+    ),
+    "repair build contains non-preregistered arguments": (
+        "repair_build_arguments_invalid",
+        "repair_build",
+    ),
+}
+
+
+def _observable_error(
+    exc: make_parity.RuntimeParityGateError,
+    *,
+    action_hint: str,
+) -> ObservableRuntimeParityGateError:
+    metadata = _MAKE_REJECTIONS.get(str(exc))
+    if metadata is not None:
+        return ObservableRuntimeParityGateError(
+            str(exc),
+            classification=metadata[0],
+            action_kind=metadata[1],
+        )
+    return r0._observable_gate_error(exc, action_hint=action_hint)
+
+
+class ObservableRuntimeParityToolAdapter(make_parity.RuntimeParityToolAdapter):
+    """在不修改 #194 的前提下翻译 Make gate 拒绝。"""
+
+    def run(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 300,
+        workdir: str | None = None,
+        command_role: str = "other",
+    ) -> Any:
+        try:
+            return super().run(
+                command,
+                timeout_seconds=timeout_seconds,
+                workdir=workdir,
+                command_role=command_role,
+            )
+        except make_parity.RuntimeParityGateError as exc:
+            raise _observable_error(
+                exc,
+                action_hint=r0._action_hint(command_role),
+            ) from exc
+        except EvidenceError as exc:
+            if str(exc).startswith("Unsupported compile command role:"):
+                raise ObservableRuntimeParityGateError(
+                    "unsupported compile command role",
+                    classification="invalid_command_role",
+                    action_kind="command",
+                ) from exc
+            raise
+
+    def submit(self, supporting_command_id: str | None = None) -> Any:
+        try:
+            return super().submit(supporting_command_id)
+        except make_parity.RuntimeParityGateError as exc:
+            raise _observable_error(exc, action_hint="submit") from exc

--- a/scripts/forge_opaque_provenance_make_runtime_parity_gate.py
+++ b/scripts/forge_opaque_provenance_make_runtime_parity_gate.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Issue #208 R2 Make runtime-parity 零 provider 动作门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+import forge_opaque_provenance_make_lifecycle_gate as make_lifecycle
+import forge_opaque_provenance_runtime_parity_gate as base
+
+SCHEMA_VERSION = "forge-opaque-provenance-make-runtime-parity-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/208"
+ACTION_LIMITS = base.ACTION_LIMITS
+AtomicActionBudget = base.AtomicActionBudget
+RuntimeParityGateError = base.RuntimeParityGateError
+SerialToolCallMiddleware = base.SerialToolCallMiddleware
+
+_FORBIDDEN_ROLES = frozenset({"clone", "configure", "dependency_setup", "housekeeping", "replay_delay"})
+
+
+@dataclass(frozen=True)
+class FrozenActionPolicy:
+    workdir: str = make_lifecycle.WORKDIR
+    build_directory: str = make_lifecycle.WORKDIR
+    target: str = make_lifecycle.TARGET
+    build_output: str = f"{make_lifecycle.WORKDIR}/{make_lifecycle.BUILD_OUTPUT}"
+    staged_artifact: str = f"/artifacts/{make_lifecycle.STAGED_ARTIFACT}"
+    jobs: str = "2"
+
+
+def validate_repair_build(
+    command: str,
+    *,
+    workdir: str,
+    policy: FrozenActionPolicy,
+) -> None:
+    tokens = base._tokens(command)
+    leaf = PurePosixPath(tokens[0]).name
+    if leaf not in {"make", "gmake"}:
+        raise RuntimeParityGateError("repair build must be a direct make or gmake invocation")
+    try:
+        invocation = make_lifecycle.reference.parse_make_invocation(
+            leaf,
+            tuple(tokens[1:]),
+            workdir=workdir,
+        )
+    except make_lifecycle.reference.MakeReferenceError as exc:
+        raise RuntimeParityGateError("repair build contains non-preregistered arguments") from exc
+    if invocation.effective_directory != policy.build_directory:
+        raise RuntimeParityGateError("repair build directory drifted from the frozen identity")
+    if invocation.target != policy.target:
+        raise RuntimeParityGateError("repair build target drifted from the frozen identity")
+    if invocation.jobs != policy.jobs:
+        raise RuntimeParityGateError("repair build jobs drifted from the frozen identity")
+
+
+def validate_artifact_stage(
+    command: str,
+    *,
+    workdir: str,
+    policy: FrozenActionPolicy,
+) -> None:
+    base.validate_artifact_stage(command, workdir=workdir, policy=policy)
+
+
+def classify_action(
+    command: str,
+    *,
+    workdir: str,
+    command_role: str,
+    policy: FrozenActionPolicy,
+) -> str:
+    from deerflow.compile.evidence import allowed_command_role
+    from deerflow.compile.operations import infer_command_roles, resolve_command_role
+
+    declared = allowed_command_role(command_role)
+    effective, _inferred = resolve_command_role(command, declared)
+    roles = infer_command_roles(command) | {effective}
+    if roles & _FORBIDDEN_ROLES:
+        raise RuntimeParityGateError("command uses a forbidden post-checkpoint role")
+    if "build" in roles:
+        if "artifact_stage" in roles:
+            raise RuntimeParityGateError("repair build and artifact stage must be separate actions")
+        validate_repair_build(command, workdir=workdir, policy=policy)
+        return "repair_build"
+    if "artifact_stage" in roles:
+        validate_artifact_stage(command, workdir=workdir, policy=policy)
+        return "artifact_stage"
+    if effective not in {"other", "smoke"}:
+        raise RuntimeParityGateError("command role is outside the runtime-parity action set")
+    base._tokens(command)
+    return "inspection"
+
+
+@dataclass
+class RuntimeParityToolAdapter:
+    run_tool: Any
+    submit_tool: Any
+    budget: AtomicActionBudget = field(default_factory=AtomicActionBudget)
+    policy: FrozenActionPolicy = field(default_factory=FrozenActionPolicy)
+    staged_artifacts_present: Callable[[], bool] = field(default=lambda: False)
+
+    def run(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 300,
+        workdir: str | None = None,
+        command_role: str = "other",
+    ) -> Any:
+        effective_workdir = workdir or self.policy.workdir
+        action = classify_action(
+            command,
+            workdir=effective_workdir,
+            command_role=command_role,
+            policy=self.policy,
+        )
+        automatic_submit_expected = action == "artifact_stage" or (action == "repair_build" and self.staged_artifacts_present())
+        claims: Iterable[str] = (action, "submit") if automatic_submit_expected else (action,)
+        self.budget.claim(*claims)
+        return base._invoke(
+            self.run_tool,
+            {
+                "command": command,
+                "timeout_seconds": min(300, max(1, timeout_seconds)),
+                "workdir": effective_workdir,
+                "command_role": command_role,
+            },
+        )
+
+    def submit(self, supporting_command_id: str | None = None) -> Any:
+        self.budget.claim("submit")
+        return base._invoke(
+            self.submit_tool,
+            {"supporting_command_id": supporting_command_id},
+        )
+
+
+def validate_gate_contract() -> dict[str, Any]:
+    policy = FrozenActionPolicy()
+    validate_repair_build(
+        make_lifecycle.TREATMENT_BUILD_COMMAND,
+        workdir=policy.workdir,
+        policy=policy,
+    )
+    validate_artifact_stage(
+        make_lifecycle.TREATMENT_STAGE_COMMAND,
+        workdir=policy.workdir,
+        policy=policy,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "action_limits": dict(ACTION_LIMITS),
+        "build_system": "make",
+        "effective_directory": policy.build_directory,
+        "target": policy.target,
+        "jobs": policy.jobs,
+        "parallel_tool_calls": False,
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "docker_executed": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(
+        json.dumps(
+            validate_gate_contract(),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_r2_make_execution_protocol.py
+++ b/scripts/forge_opaque_provenance_r2_make_execution_protocol.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Issue #208 R2 Make opaque provenance 一次性 execution amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-r2-make-candidate.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_r2_make_execution_runner.py"
+ACTION_GATE_PATH = "scripts/forge_opaque_provenance_make_runtime_parity_gate.py"
+OBSERVABILITY_GATE_PATH = "scripts/forge_opaque_provenance_make_rejection_observability_gate.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-r2-make-execution-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_r2_make_execution_amendment"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/208"
+AUTHORIZATION_BASELINE_COMMIT = "6f1118db689bbc3329962fb341eb765b16a28ee7"
+PARENT_MANIFEST_SHA256 = "b5b44ed5bd27250932854e0a13beffbbc665f284164147d16521d9bc7766b514"
+PARENT_EVIDENCE_IDENTITY_SHA256 = "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+
+FROZEN_PARENT_PATHS = {
+    PARENT_MANIFEST_PATH,
+    "benchmarks/preregistrations/cpp-opaque-provenance-r2-make-candidate.md",
+    "benchmarks/schemas/forge-opaque-provenance-r2-make-candidate.schema.json",
+    "scripts/forge_opaque_provenance_make_candidate_protocol.py",
+    "scripts/forge_opaque_provenance_make_candidate_runner.py",
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+    "scripts/forge_opaque_provenance_make_reference_gate.py",
+    "backend/tests/test_forge_opaque_provenance_make_candidate.py",
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py",
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py",
+    "backend/tests/test_forge_opaque_provenance_make_reference_gate.py",
+}
+
+
+class ProtocolError(RuntimeError):
+    """R2 Make execution 身份、父组件、预算或授权发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_make_candidate_protocol.py"
+    name = "forge_opaque_provenance_r2_make_execution_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load R2 Make candidate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    manifest = parent.load_manifest(repo_root / PARENT_MANIFEST_PATH, repo_root)
+    if parent.canonical_sha256(manifest) != PARENT_MANIFEST_SHA256:
+        raise ProtocolError("R2 Make candidate manifest identity drifted")
+    if manifest["evidence"]["identity_sha256"] != PARENT_EVIDENCE_IDENTITY_SHA256:
+        raise ProtocolError("R2 Make candidate evidence identity drifted")
+    return manifest, parent
+
+
+def _hash_paths(repo_root: Path, paths: set[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for relative_path in sorted(paths):
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise ProtocolError(f"frozen component missing: {relative_path}")
+        result[relative_path] = file_sha256(path)
+    return result
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent_manifest, parent = _parent_manifest(repo_root)
+    required = {
+        "runtime_adapter": repo_root / RUNTIME_ADAPTER_PATH,
+        "action_gate": repo_root / ACTION_GATE_PATH,
+        "observability_gate": repo_root / OBSERVABILITY_GATE_PATH,
+        "preregistration": repo_root / PREREGISTRATION_PATH,
+    }
+    if any(not path.is_file() for path in required.values()):
+        raise ProtocolError("runtime, gate or preregistration component missing")
+
+    provider = copy.deepcopy(parent_manifest["provider"])
+    provider["status"] = "active_authorized"
+    runtime_parity = copy.deepcopy(parent_manifest["runtime_parity"])
+    runtime_parity.update(
+        repair_build_jobs="2",
+        forbidden_actions=[
+            "clone",
+            "configure",
+            "dependency",
+            "housekeeping",
+            "manual_replay",
+            "compound_build_stage",
+        ],
+        parent_submit_uses_bound_wrapper=True,
+        fence_released_before_capture=True,
+        action_validator="Make RuntimeParityToolAdapter",
+        observable_adapter="Make ObservableRuntimeParityToolAdapter",
+        rejection_registry="RejectionObservationRegistry",
+    )
+    evidence = copy.deepcopy(parent_manifest["evidence"])
+    evidence["status"] = "authorized_not_created"
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-r2-make-execution.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "checkpoint_creation_authorized": True,
+            "reachability_request_authorized": True,
+            "provider_calls_authorized": True,
+            "formal_attempts_authorized": True,
+            "pair_collection_authorized": True,
+            "credential_read_authorized": True,
+            "model_creation_authorized": True,
+            "docker_execution_authorized": True,
+            "evidence_write_authorized": True,
+            "model_tokens_authorized": 245_000,
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent_manifest["schema_version"],
+            "canonical_sha256": parent.canonical_sha256(parent_manifest),
+            "file_sha256": file_sha256(repo_root / PARENT_MANIFEST_PATH),
+            "evidence_identity_sha256": parent_manifest["evidence"]["identity_sha256"],
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "case": copy.deepcopy(parent_manifest["case"]),
+        "independence": {
+            "historical_pairs": [
+                "opaque-provenance-cppitertools-runtime-parity-pair-01",
+                "opaque-provenance-r1-yyjson-pair-01",
+            ],
+            "historical_build_system": "cmake",
+            "current_build_system": "make",
+            "cross_build_system_replication": True,
+            "historical_pairs_pooled": False,
+            "retry_replacement_backfill_or_extension": False,
+        },
+        "checkpoint": {
+            "source_gate": "issue-204-real-make-lifecycle-zero-provider",
+            "creation_timing": "after_reachability_before_arm_continuation",
+            "capture_point": "after-neutral-tool-message-before-continuation",
+            "identity_materialized_during_pair": True,
+            "arm_state_matching": ["message", "environment", "budget"],
+            "preexisting_checkpoint_reuse_forbidden": True,
+        },
+        "provider": provider,
+        "continuation": {
+            key: parent_manifest["budget"][key]
+            for key in (
+                "maximum_requests_per_arm",
+                "maximum_model_turns_per_arm",
+                "maximum_graph_steps_per_arm",
+                "work_wall_clock_seconds_per_arm",
+                "cleanup_reserve_seconds_per_arm",
+                "maximum_recorded_tokens_per_arm",
+            )
+        },
+        "schedule": copy.deepcopy(parent_manifest["schedule"]),
+        "schedule_sha256": parent_manifest["schedule_sha256"],
+        "repair_packet": copy.deepcopy(parent_manifest["repair_packet"]),
+        "budget": {
+            "maximum_reachability_requests": 1,
+            "reachability_maximum_recorded_tokens": 5_000,
+            "recorded_tokens_per_arm": 120_000,
+            "recorded_tokens_per_pair": 240_000,
+            "stage_maximum_recorded_tokens": 245_000,
+            "enforcement": "after_reachability_and_each_arm_before_continuation",
+        },
+        "stopping": {
+            **copy.deepcopy(parent_manifest["stopping"]),
+            "classified_arm_outcome_continues_other_arm": True,
+            "endpoint_timeout_censors_arm_and_continues": True,
+        },
+        "analysis": copy.deepcopy(parent_manifest["analysis"]),
+        "runtime_parity": runtime_parity,
+        "r0_observability": copy.deepcopy(parent_manifest["r0_observability"]),
+        "evidence": evidence,
+        "opportunities": {
+            "maximum_reachability_requests": 1,
+            "maximum_pairs": 1,
+            "required_order": [
+                "reachability",
+                parent_manifest["schedule"][0]["pair_id"],
+            ],
+            "marker_consumed_on_start": True,
+            "retry_replacement_backfill_forbidden": True,
+            "schedule_extension_forbidden": True,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "require_authorization_baseline_ancestor": True,
+            "docker_provider": "ubuntu-native",
+            "docker_context": "default",
+            "docker_endpoint": "/var/run/docker.sock",
+            "control_plane": "compose-dood-on-ubuntu-native-engine",
+            "allowed_network_media": ["wired", "wifi", "mobile_hotspot"],
+            "require_empty_evidence_directory": True,
+            "managed_container_prefixes": [
+                "deerflow-compile-",
+                "deerflow-replay-",
+            ],
+            "require_zero_managed_orphans": True,
+        },
+        "execution": {
+            "release_branch": "main",
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+            "reachability_expected_response": "CANARY_OK",
+            "reachability_report": "reports/reachability.json",
+            "pair_marker": evidence["pair_marker"],
+            "parent_ledger": evidence["parent_ledger"],
+            "arm_ledger_directory": evidence["arm_ledger_directory"],
+            "report_schema_version": "forge-opaque-provenance-r2-make-report-1.0.0",
+            "report_document_type": "forge_opaque_provenance_r2_make_report",
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(required["preregistration"]),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(required["runtime_adapter"]),
+            "commands": ["validate", "preflight", "reachability", "pair"],
+            "credential_read_supported": True,
+            "provider_model_creation_supported": True,
+            "checkpoint_execute_supported": True,
+            "reachability_execute_supported": True,
+            "pair_execute_supported": True,
+            "r0_companion_evidence_supported": True,
+        },
+        "make_runtime_components": {
+            ACTION_GATE_PATH: file_sha256(required["action_gate"]),
+            OBSERVABILITY_GATE_PATH: file_sha256(required["observability_gate"]),
+        },
+        "frozen_parent_components": _hash_paths(repo_root, FROZEN_PARENT_PATHS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ProtocolError("manifest must be an object")
+    if value != generate_manifest(repo_root):
+        raise ProtocolError("R2 Make execution amendment manifest drifted")
+    budget = value["budget"]
+    if budget["recorded_tokens_per_pair"] + budget["reachability_maximum_recorded_tokens"] != budget["stage_maximum_recorded_tokens"]:
+        raise ProtocolError("stage token budget is not closed")
+    if value["runtime_parity"]["parallel_tool_calls"] is not False:
+        raise ProtocolError("parallel tool calls must remain disabled")
+    if value["runtime_parity"]["repair_build_jobs"] != "2":
+        raise ProtocolError("Make jobs identity drifted")
+    if value["r0_observability"]["companion_required_for_classified_rejection"] is not True:
+        raise ProtocolError("classified rejection companion evidence is required")
+    return value
+
+
+def load_manifest(
+    path: Path = DEFAULT_MANIFEST,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("cannot read R2 Make execution manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPO_ROOT,
+) -> None:
+    validate_manifest(manifest, repo_root)
+    if manifest["frozen_parent_components"] != _hash_paths(
+        repo_root,
+        FROZEN_PARENT_PATHS,
+    ):
+        raise ProtocolError("frozen parent components drifted")
+    for section in ("runtime_adapter", "preregistration"):
+        path = repo_root / manifest[section]["path"]
+        if file_sha256(path) != manifest[section]["file_sha256"]:
+            raise ProtocolError(f"{section} drifted")
+    expected_runtime = {
+        ACTION_GATE_PATH: file_sha256(repo_root / ACTION_GATE_PATH),
+        OBSERVABILITY_GATE_PATH: file_sha256(repo_root / OBSERVABILITY_GATE_PATH),
+    }
+    if manifest["make_runtime_components"] != expected_runtime:
+        raise ProtocolError("Make runtime components drifted")
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json",
+        "title": "Forge opaque provenance R2 Make execution amendment",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        verify_frozen_components(manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "provider_calls": 0,
+                "formal_attempts": 0,
+                "model_tokens": 0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_r2_make_execution_runner.py
+++ b/scripts/forge_opaque_provenance_r2_make_execution_runner.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""执行 Issue #208 授权的 R2 Make reachability 与单 pair。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shlex
+import sys
+import uuid
+from dataclasses import asdict, replace
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_make_lifecycle_gate as make_lifecycle  # noqa: E402
+import forge_opaque_provenance_make_rejection_observability_gate as make_observability  # noqa: E402
+import forge_opaque_provenance_make_runtime_parity_gate as make_parity  # noqa: E402
+import forge_opaque_provenance_minimal_canary_execution_runner as legacy  # noqa: E402
+import forge_opaque_provenance_r1_execution_runner as r1  # noqa: E402
+import forge_opaque_provenance_r2_make_execution_protocol as protocol  # noqa: E402
+
+primary = legacy.primary
+v2_runner = legacy.v2_runner
+v3_runner = legacy.v3_runner
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1")
+ARMS = ("baseline", "treatment")
+
+
+class ExecutionGateError(RuntimeError):
+    """R2 Make execution identity、R0 evidence、预算或 cleanup 无效。"""
+
+
+def _output_dir(manifest: dict[str, Any], output_dir: Path) -> Path:
+    expected = Path(manifest["evidence"]["directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise ExecutionGateError("evidence 必须写入 #206 冻结的 R2 Make 目录")
+    return output_dir
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _output_dir(manifest, output_dir)
+    release = legacy._release_identity(manifest, repo_root)
+    medium = legacy._network_medium(manifest)
+    primary.require_compose_dood()
+    try:
+        v3_runner.require_zero_managed_containers()
+    except v3_runner.AuthorizedPilotError as exc:
+        raise ExecutionGateError(str(exc)) from exc
+    legacy._provider_preflight(manifest)
+    entries = sorted(str(path.relative_to(output_dir)).replace("\\", "/") for path in output_dir.rglob("*") if path.is_file()) if output_dir.exists() else []
+    if require_empty and entries:
+        raise ExecutionGateError("reachability 前要求 R2 Make evidence 目录为空")
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": medium,
+        "evidence_files": entries,
+        "zero_managed_containers": True,
+        "docker_provider": manifest["preflight"]["docker_provider"],
+        "docker_endpoint": manifest["preflight"]["docker_endpoint"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _policy(manifest: dict[str, Any], *, arm: str, image_id: str) -> Any:
+    case = manifest["case"]
+    provider = manifest["provider"]
+    continuation = manifest["continuation"]
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-r2-make-hoextdown",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=case["case_id"],
+        condition=arm,
+        repetition=1,
+        expected_repo_url=case["repository_url"],
+        expected_commit_sha=case["commit_sha"],
+        expected_build_system=case["build_system"],
+        compile_image=case["compile_image"],
+        image_id=image_id,
+        model_name=provider["model"],
+        endpoint=provider["endpoint"],
+        credential_env=provider["credential_env"],
+        request_timeout_seconds=provider["request_timeout_seconds"],
+        model_max_retries=provider["max_retries"],
+        compiler_max_turns=continuation["maximum_model_turns_per_arm"],
+        subagent_timeout_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        compiler_model_turn_limit=continuation["maximum_model_turns_per_arm"],
+        compiler_graph_recursion_limit=continuation["maximum_graph_steps_per_arm"],
+        compiler_wall_clock_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        compiler_post_build_reserve_seconds=continuation["cleanup_reserve_seconds_per_arm"],
+        source_subdir=case["source_subdir"],
+        build_targets=(case["target"],),
+        artifact_instructions=(
+            (
+                case["staged_artifact"],
+                case["build_output"],
+                case["artifact_type"],
+            ),
+        ),
+    )
+
+
+def _parent_policy(manifest: dict[str, Any], *, image_id: str) -> Any:
+    return replace(
+        _policy(manifest, arm="controlled-parent", image_id=image_id),
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        compiler_max_turns=1,
+    )
+
+
+async def run_arm_continuation(
+    manifest: dict[str, Any],
+    *,
+    arm: str,
+    lifecycle_arm: Any,
+    message_state: dict[str, Any],
+    ledger: Any,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    """复用已验证的 R1 agent 骨架，但替换为 Make policy/adapter。"""
+
+    checkpoint_proxy = SimpleNamespace(
+        WORKDIR=make_lifecycle.WORKDIR,
+        BUILD_DIRECTORY=make_lifecycle.WORKDIR,
+        TARGET=make_lifecycle.TARGET,
+        BUILD_OUTPUT=make_lifecycle.BUILD_OUTPUT,
+        STAGED_ARTIFACT=make_lifecycle.STAGED_ARTIFACT,
+    )
+    original_policy = r1._policy
+    original_parity = r1.parity
+    original_checkpoint = r1.checkpoint_gate
+    original_observability = r1.observability
+    r1._policy = _policy
+    r1.parity = make_parity
+    r1.checkpoint_gate = checkpoint_proxy
+    r1.observability = make_observability
+    try:
+        return await r1.run_arm_continuation(
+            manifest,
+            arm=arm,
+            lifecycle_arm=lifecycle_arm,
+            message_state=message_state,
+            ledger=ledger,
+            model_factory=model_factory,
+            budget_sink={},
+        )
+    finally:
+        r1._policy = original_policy
+        r1.parity = original_parity
+        r1.checkpoint_gate = original_checkpoint
+        r1.observability = original_observability
+
+
+def _command_tokens(command: str) -> tuple[str, tuple[str, ...]]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ExecutionGateError("trusted command 无法规范化") from exc
+    if not tokens:
+        raise ExecutionGateError("trusted command 为空")
+    return PurePosixPath(tokens[0]).name, tuple(tokens[1:])
+
+
+def _evaluate_arm_p2(
+    session: Any,
+    frozen: Any,
+    parent_command_id: str,
+) -> tuple[Any, tuple[Any, ...]]:
+    artifact = Path(session.leadagent_repo_dir) / make_lifecycle.BUILD_OUTPUT
+    if not artifact.is_file():
+        raise ExecutionGateError("arm 丢失冻结 Make workspace artifact")
+    if artifact.stat().st_size != frozen.artifact_size or primary.lifecycle.sha256_file(artifact) != frozen.artifact_sha256:
+        raise ExecutionGateError("arm Make workspace artifact identity 漂移")
+
+    parent = make_lifecycle._parent_invocation(frozen, parent_command_id)
+    invocations = [parent]
+    previous_hash = parent.ledger_hash
+    producer_id = session.post_build_supporting_command_id or parent_command_id
+    seen_parent = False
+    for record in session.commands:
+        if record.command_id == parent_command_id:
+            seen_parent = True
+            continue
+        if not seen_parent or record.stage != "bash":
+            continue
+        executable, argv = _command_tokens(record.command)
+        output_paths = (make_lifecycle.BUILD_OUTPUT,) if record.command_id == producer_id else ()
+        invocation = make_lifecycle.provenance.record_invocation(
+            command_id=record.command_id,
+            physical_attempt_id=frozen.physical_attempt_id,
+            sequence=len(invocations) + 1,
+            repository_url=frozen.repository_url,
+            commit_sha=frozen.commit_sha,
+            image_id=frozen.image_id,
+            executable=executable,
+            argv=argv,
+            workdir=record.workdir or make_lifecycle.WORKDIR,
+            previous_hash=previous_hash,
+            exit_code=record.exit_code if record.exit_code is not None else 1,
+            timed_out=record.timed_out,
+            output_paths=output_paths,
+            model_declared_role=record.role,
+        )
+        invocations.append(invocation)
+        previous_hash = invocation.ledger_hash
+    commands = {item.command_id: item for item in invocations}
+    if producer_id not in commands:
+        producer_id = parent_command_id
+    identity = make_lifecycle.provenance.ArtifactIdentity(
+        schema_version=make_lifecycle.provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=len(invocations) + 1,
+    )
+    return (
+        make_lifecycle.reference.evaluate_make_p2(
+            frozen,
+            tuple(invocations),
+            identity,
+        ),
+        tuple(invocations),
+    )
+
+
+def _run_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+    repo_root: Path,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    from langgraph.checkpoint.sqlite import SqliteSaver
+
+    from deerflow.compile import operations
+    from deerflow.compile.paths import (
+        get_host_artifacts_dir,
+        get_host_logs_dir,
+        get_host_repro_dir,
+        get_host_workspace_dir,
+    )
+    from deerflow.compile.schemas import utc_now_iso
+    from deerflow.tools import bound_compile_tools
+
+    preflight = collect_preflight(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        require_empty=False,
+    )
+    reachability = legacy._passed_reachability(
+        manifest,
+        output_dir,
+        preflight["release_revision"],
+    )
+    digest = protocol.canonical_sha256(manifest)
+    marker = output_dir / manifest["execution"]["pair_marker"]
+    v3_runner._claim_marker(
+        marker,
+        kind="forge_opaque_provenance_r2_make_pair_attempt",
+        manifest_sha256=digest,
+        revision=preflight["release_revision"],
+    )
+
+    capture_id = f"opaque-make-{uuid.uuid4().hex[:12]}"
+    services = operations.get_compile_services()
+    manager = services.manager
+    runtime = services.runtime
+    docker = primary.lifecycle.environment_checkpoint.DockerCLI()
+    snapshot = output_dir / "checkpoint" / capture_id
+    parent = manager.create_session(
+        thread_id=f"parent-{uuid.uuid4().hex[:12]}",
+        session_id=f"parent-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=make_lifecycle.REPOSITORY_URL,
+        image=make_lifecycle.COMPILE_IMAGE,
+    )
+    parent_ledger = primary.ExperimentLedger.create(
+        output_dir / manifest["execution"]["parent_ledger"],
+        experiment_id=primary.new_evidence_id("experiment"),
+        physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+        context={
+            "scope": "opaque-provenance-r2-make-controlled-parent",
+            "manifest_sha256": digest,
+            "case_id": make_lifecycle.CASE_ID,
+        },
+    )
+    gate = None
+    parent_active = False
+    cleanup_succeeded = False
+    arm_results: list[dict[str, Any]] = []
+    try:
+        Path(parent.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(parent)
+        manager.save_session(parent)
+        clone = runtime.exec(
+            parent,
+            (f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {make_lifecycle.REPOSITORY_URL} && git fetch --depth 1 origin {make_lifecycle.COMMIT_SHA} && git checkout --detach FETCH_HEAD"),
+            workdir=make_lifecycle.WORKDIR,
+            timeout_seconds=180,
+        )
+        if clone.exit_code != 0:
+            raise ExecutionGateError("parent 无法检出冻结 Make commit")
+        parent.commit_sha = make_lifecycle.COMMIT_SHA
+        parent.build_system = "make"
+        parent.build_system_capabilities = ["make"]
+        parent.selected_build_system = "make"
+        parent.status = "inspected"
+        manager.save_session(parent)
+        supporting = primary._record_command(
+            manager=manager,
+            runtime=runtime,
+            session=parent,
+            command=make_lifecycle.PARENT_COMMAND,
+            role="build",
+        )
+        parent.post_build_supporting_command_id = supporting.command_id
+        parent.post_build_started_at = utc_now_iso()
+        parent.post_build_commands_remaining = 2
+        manager.save_session(parent)
+
+        workspace_artifact = Path(parent.leadagent_repo_dir) / make_lifecycle.BUILD_OUTPUT
+        frozen_values = {
+            "artifact_size": workspace_artifact.stat().st_size,
+            "artifact_sha256": primary.lifecycle.sha256_file(workspace_artifact),
+        }
+        parent_frozen = make_lifecycle.build_frozen_identity(
+            image_id=parent.image_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            **frozen_values,
+        )
+        parent_p2, parent_history = make_lifecycle.evaluate_parent(
+            parent_frozen,
+            parent_command_id=supporting.command_id,
+        )
+        primary.activate_experiment(
+            thread_id=parent.thread_id,
+            experiment_id=parent_ledger.experiment_id,
+            physical_attempt_id=parent_ledger.physical_attempt_id,
+            ledger=parent_ledger,
+            policy=_parent_policy(manifest, image_id=parent.image_id),
+        )
+        parent_active = True
+        submit_result: str | None = None
+
+        def submit_parent() -> str:
+            nonlocal submit_result
+            if submit_result is not None:
+                raise ExecutionGateError("parent submit 不得重复执行")
+            submit_result = bound_compile_tools._submit_with_post_build_phase(
+                parent,
+                supporting_command_id=supporting.command_id,
+            )
+            return submit_result
+
+        def capture_evidence() -> dict[str, Any]:
+            failure = legacy._failure_event(parent_ledger)["payload"]
+            payload = json.loads(submit_result or "{}")
+            if (
+                payload.get("status") != "failed"
+                or payload.get("replay_status") != "not_run"
+                or failure.get("classification") != "build_system_unproven"
+                or failure.get("secondary_classifications") != []
+                or legacy._constraint_failures(parent) != ["build_system_unproven"]
+                or parent.replay_attempts
+            ):
+                raise ExecutionGateError("parent 未形成单一 Make opaque provenance failure")
+            return {
+                "classification": failure["classification"],
+                "failure_id": failure["failure_id"],
+                "submit_attempt_id": failure["submit_attempt_id"],
+                "session_sha256": primary.lifecycle.sha256_file(Path(parent.metadata_path)),
+                "parent_p2": asdict(parent_p2),
+                "parent_command_history_sha256": (make_lifecycle.provenance.command_history_sha256(parent_history)),
+            }
+
+        coordinator = primary.lifecycle.CaptureCoordinator(output_dir / "checkpoint/coordinator.sqlite")
+        with SqliteSaver.from_conn_string(str(output_dir / "checkpoint/messages.sqlite")) as saver:
+            saver.setup()
+            message_runtime = primary.lifecycle.LifecycleMessageRuntime(
+                saver,
+                submit_parent,
+                repair_packet=make_lifecycle.build_repair_packet(),
+            )
+            environment = primary.lifecycle.LifecycleEnvironmentAdapter(
+                docker,
+                local_snapshot_root=snapshot,
+                host_snapshot_root=primary.host_snapshot_root(snapshot),
+            )
+            gate = primary.lifecycle.RealLifecycleCheckpointGate(
+                coordinator=coordinator,
+                message_runtime=message_runtime,
+                environment=environment,
+                budget_capture=primary._budget_manifest,
+                manager=manager,
+                compile_runtime=runtime,
+                owner="opaque-provenance-r2-make-execution",
+            )
+            gate.capture(
+                capture_id=capture_id,
+                session=parent,
+                instruction=("Continue from the failed submit and satisfy the verifier without changing the frozen repository or target."),
+                arm_plan=primary._arm_plan(capture_id),
+                bind_sources={
+                    "workspace": get_host_workspace_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        manager.paths,
+                    ),
+                    "artifacts": get_host_artifacts_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        manager.paths,
+                    ),
+                    "logs": get_host_logs_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        manager.paths,
+                    ),
+                    "repro": get_host_repro_dir(
+                        parent.session_id,
+                        parent.thread_id,
+                        manager.paths,
+                    ),
+                },
+                evidence=capture_evidence,
+            )
+            primary.deactivate_experiment(parent.thread_id)
+            parent_active = False
+            parent_ledger.append("experiment.completed", {"status": "passed"})
+            provisioned = {arm: gate.provision_arm(capture_id, arm, parent_session=parent) for arm in ARMS}
+            if gate.canonical_arm_environment("baseline") != gate.canonical_arm_environment("treatment"):
+                raise ExecutionGateError("baseline/treatment 初始环境不同源")
+
+            with asyncio.Runner() as async_runner:
+                for arm in manifest["schedule"][0]["arm_order"]:
+                    legacy.require_arm_budget(
+                        manifest,
+                        reachability_tokens=reachability["recorded_tokens"],
+                        completed_arm_tokens=[result["recorded_tokens"] for result in arm_results],
+                    )
+                    current = provisioned[arm]
+                    ledger = primary.ExperimentLedger.create(
+                        output_dir / manifest["execution"]["arm_ledger_directory"] / f"{arm}.jsonl",
+                        experiment_id=primary.new_evidence_id("experiment"),
+                        physical_attempt_id=primary.new_evidence_id("mechanism_attempt"),
+                        context={
+                            "scope": "opaque-provenance-r2-make-arm",
+                            "manifest_sha256": digest,
+                            "arm": arm,
+                            "capture_id": capture_id,
+                        },
+                    )
+                    message_state = primary._message_state(gate, current)
+                    try:
+                        result = async_runner.run(
+                            run_arm_continuation(
+                                manifest,
+                                arm=arm,
+                                lifecycle_arm=current,
+                                message_state=message_state,
+                                ledger=ledger,
+                                model_factory=model_factory,
+                            )
+                        )
+                    except Exception as exc:
+                        result = v2_runner.classify_arm_terminal(
+                            manifest,
+                            arm=arm,
+                            ledger=ledger,
+                            error=exc,
+                        )
+                    else:
+                        result = v2_runner._passed_arm(result, ledger)
+                    authoritative = manager.load_session(
+                        current.session.session_id,
+                        current.session.thread_id,
+                    )
+                    arm_frozen = make_lifecycle.build_frozen_identity(
+                        image_id=authoritative.image_id,
+                        physical_attempt_id=ledger.physical_attempt_id,
+                        **frozen_values,
+                    )
+                    p2, history = _evaluate_arm_p2(
+                        authoritative,
+                        arm_frozen,
+                        supporting.command_id,
+                    )
+                    result["p2"] = asdict(p2)
+                    result["command_history_sha256"] = make_lifecycle.provenance.command_history_sha256(history)
+                    result["post_checkpoint_provenance_conversion"] = p2.status == "proven"
+                    if result["verification_outcome"]["status"] == "passed" and p2.status != "proven":
+                        raise ExecutionGateError(f"{arm} production verification 通过但 Make P2 未证明")
+                    arm_results.append(result)
+            cleaned = gate.cleanup(capture_id, parent_session=parent)
+            cleanup_succeeded = cleaned.phase == "cleaned"
+            if not cleanup_succeeded:
+                raise ExecutionGateError("pair cleanup 未闭合")
+            try:
+                v3_runner.require_zero_managed_containers()
+            except v3_runner.AuthorizedPilotError as exc:
+                raise ExecutionGateError("pair cleanup 后仍存在 managed container") from exc
+
+        total_tokens = reachability["recorded_tokens"] + sum(item["recorded_tokens"] for item in arm_results)
+        if total_tokens > manifest["budget"]["stage_maximum_recorded_tokens"]:
+            raise ExecutionGateError("阶段 recorded-token 超过机械上限")
+        report = {
+            "schema_version": manifest["execution"]["report_schema_version"],
+            "document_type": manifest["execution"]["report_document_type"],
+            "manifest_sha256": digest,
+            "release_revision": preflight["release_revision"],
+            "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+            "case_id": make_lifecycle.CASE_ID,
+            "pair_id": manifest["schedule"][0]["pair_id"],
+            "arm_order": manifest["schedule"][0]["arm_order"],
+            "provider": manifest["provider"]["id"],
+            "network_access_medium": preflight["network_access_medium"],
+            "reachability_recorded_tokens": reachability["recorded_tokens"],
+            "arms": arm_results,
+            "runtime_parity": manifest["runtime_parity"],
+            "runtime_parity_action_budgets": {item["arm"]: item.get("runtime_parity_action_budget") for item in arm_results},
+            "r0_rejection_observability": {item["arm"]: item.get("r0_rejection_observability") for item in arm_results},
+            "recorded_tokens": total_tokens,
+            "maximum_recorded_tokens": manifest["budget"]["stage_maximum_recorded_tokens"],
+            "complete_pair": len(arm_results) == 2,
+            "cleanup_succeeded": cleanup_succeeded,
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "p_value_computed": False,
+            "model_ranking_performed": False,
+            "historical_pairs_pooled": False,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        v3_runner._write_once(
+            output_dir / manifest["evidence"]["canary_report"],
+            report,
+        )
+    except BaseException as exc:
+        if parent_active:
+            primary.deactivate_experiment(parent.thread_id)
+        if gate is not None and not cleanup_succeeded:
+            try:
+                record = gate.coordinator.get(capture_id)
+                if record.phase not in {
+                    "committed",
+                    "aborted",
+                    "cleanup_pending",
+                    "cleaned",
+                }:
+                    record = gate.reconcile(capture_id)
+                cleanup_succeeded = (
+                    record.phase == "cleaned"
+                    or gate.cleanup(
+                        capture_id,
+                        parent_session=parent,
+                    ).phase
+                    == "cleaned"
+                )
+            except Exception:
+                cleanup_succeeded = False
+        else:
+            runtime.stop_and_remove_container(parent)
+        v3_runner._finish_marker(
+            marker,
+            status="failed",
+            error_class=type(exc).__name__,
+        )
+        raise
+    v3_runner._finish_marker(marker, status="passed")
+    return report
+
+
+def execute_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    original_protocol = legacy.protocol
+    original_collect = legacy.collect_preflight
+    legacy.protocol = protocol
+    legacy.collect_preflight = collect_preflight
+    try:
+        return legacy.execute_reachability(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        )
+    finally:
+        legacy.protocol = original_protocol
+        legacy.collect_preflight = original_collect
+
+
+def execute_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    return _run_pair(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        model_factory=model_factory,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("validate", "preflight", "reachability", "pair"),
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        result: Any = {
+            "status": "valid",
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    elif args.command == "preflight":
+        result = collect_preflight(
+            manifest,
+            output_dir=args.output_dir,
+            require_empty=True,
+        )
+    elif args.command == "reachability":
+        result = execute_reachability(manifest, output_dir=args.output_dir)
+    else:
+        result = execute_pair(manifest, output_dir=args.output_dir)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 Make 专用 runtime-parity action validator，direct `make/gmake` 必须绑定 `/workspace/repo`、`libhoedown.a` 与 jobs `2`，并保持 4/2/2/2 原子动作预算。
- 新增 #194 R0 observable 版本层，继续使用 `agent.tool_failed` + `agent.tool_rejection_observed`，不记录原始命令、模型正文或凭据。
- 派生 R2 Make 一次性 execution protocol、manifest、完整 const Schema、中文预注册和独立 pair runner；不调用旧 CMake `_run_pair`，不修改 production Compiler/Oracle 或历史 evidence。
- 冻结唯一 reachability、唯一 `baseline -> treatment` pair 与 245,000 recorded-token 阶段上限；禁止 retry、replacement、backfill 和 schedule extension。

## 验证

- 聚焦测试：`19 passed`
- Make reference/lifecycle/candidate、CMake runtime-parity、R0 与 R1 execution 相邻回归：`95 passed`
- Ruff check/format、compileall、CLI validate、确定性再生成、diff 与敏感信息审计通过
- 当前阶段：0 provider、0 Docker、0 formal attempt、0 model token、0 evidence write

Closes #208