### PR TITLE
研究：审计 R2 Make 终态汇总缺失

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 发布并执行 Issue #208 R2 Make runtime-parity 一次性修订
-  - GitHub: 中文 Issue #208 已创建并回读；分支为 `research/208-make-runtime-amendment`，授权基线为 `main@6f1118db`。
-  - 实现: 新增 Make direct-action validator、#194 R0 observable 版本层、execution protocol/runner、manifest、Draft 2020-12 const Schema、中文预注册与测试；旧 CMake `_run_pair`、production Compiler/Oracle、#202/#204/#206 与历史 evidence 均未修改。
-  - 身份: `hoextdown@1ef9a719`、target/artifact `libhoedown.a`；direct `make/gmake` 必须绑定 effective directory `/workspace/repo`、唯一 target 与 jobs `2`。Manifest canonical SHA-256 为 `113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e`。
-  - 授权边界: execution amendment 只允许一次 reachability 与一个 `baseline -> treatment` pair，阶段上限 245,000 recorded tokens；当前尚未调用 provider、未启动 Docker、未创建 evidence 或 marker。
-  - 验证: 聚焦 `19 passed`，Make reference/lifecycle/candidate、CMake runtime-parity、R0 与 R1 execution 相邻回归 `95 passed`；Ruff、format、compileall、CLI validate 与 diff 检查通过。全程 0 provider、0 Docker、0 formal attempt、0 model token、0 evidence write。
-  - 下一步: 完成敏感信息审计、中文提交、WSL helper 推送、中文 PR/CI/合并；合并后从干净主干记录实际网络介质并运行唯一 reachability 与唯一 pair，禁止 retry/replacement/backfill。
-  - 文件: `scripts/forge_opaque_provenance_make_runtime_parity_gate.py`, `scripts/forge_opaque_provenance_make_rejection_observability_gate.py`, `scripts/forge_opaque_provenance_r2_make_execution_protocol.py`, `scripts/forge_opaque_provenance_r2_make_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_make_runtime_parity_gate.py`, `backend/tests/test_forge_opaque_provenance_r2_make_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r2-make-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r2-make-execution.md`
+- 2026-08-30 — 发布 Issue #210 R2 Make 结果审计 sidecar
+  - GitHub: 中文 Issue #210 已创建并回读；分支为 `research/210-r2-make-result-audit`，基线为 `main@00726aef`。
+  - 缺口: #208 原 canary report 在 endpoint timeout / graph-step limit 终态丢失 action-budget 与 R0 汇总，但 parent/baseline/treatment ledger hash chain 完整且原文件不可修改。
+  - 实现: 新增 result-specific 只读 audit，冻结 canary、marker 和三条 ledger SHA-256；恢复 baseline action 全 0、treatment inspection=4 及 R0 5/5 companion，并用 create-once 写入独立 `reports/audit-v1.json`。
+  - 结论: paired primary estimand 固定为 `not_estimable / baseline_endpoint_censored`；treatment 只描述为 `observed_no_conversion`，禁止池化、p 值、模型排名或重跑。
+  - 验证: 聚焦 `5 passed`，#208/#210/R0 相邻回归 `33 passed`；真实 evidence 的只读 audit、Ruff、format 和 compileall 通过，0 provider、0 Docker、0 formal attempt、0 model token。
+  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；合并后只执行一次 `write-sidecar` 并回读哈希，不修改原 canary/marker/ledger。
+  - 文件: `scripts/forge_opaque_provenance_r2_make_result_audit.py`, `backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -72,6 +72,14 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #208 R2 Make runtime-parity 一次性执行
+  - 文件: `scripts/forge_opaque_provenance_make_runtime_parity_gate.py`, `scripts/forge_opaque_provenance_make_rejection_observability_gate.py`, `scripts/forge_opaque_provenance_r2_make_execution_protocol.py`, `scripts/forge_opaque_provenance_r2_make_execution_runner.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json`
+  - 发布: 中文 Issue #208 / PR #209 已完成，三项 CI 全绿后 squash 合并为 `main@00726aef99e331a1d2719cb26986fa15e90fe547`；manifest canonical SHA-256 为 `113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e`。
+  - Reachability: Wi-Fi、DeepSeek `deepseek-v4-flash`，1 request / 17 tokens / 1.481 秒通过，实际模型匹配，0 retry、无 fallback。
+  - Pair: baseline 首次请求在 300 秒后 endpoint-censored，0 tokens/submit/replay、P2 unproven；treatment 8 requests / 38,780 tokens 后达到 graph-step limit，0 submit/replay、P2 仍 `unproven/opaque_wrapper`。总计 38,797 tokens。
+  - 完整性: pair marker passed、结构上双臂完整、cleanup 成功，0 compile/replay orphan；parent/baseline/treatment ledger 为 7/7/44 events 且 hash chain 通过。Treatment 有 5 个 classified rejection 与 5 个 R0 companion。
+  - 边界: baseline censoring 使 paired primary estimand 不可估计；treatment 是有效的 no-conversion 描述结果。禁止 retry、replacement、backfill、历史池化、p 值或模型排名。原 report 汇总 null 缺口由 Issue #210 只读 sidecar 跟踪。
 
 - 2026-08-30 — 完成 Issue #204 R2 Make provenance 真实 lifecycle 零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-make-lifecycle-zero-provider-gate.md`

--- a/backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py
+++ b/backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py
@@ -1,0 +1,232 @@
+"""Issue #210 R2 Make result audit 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r2_make_result_audit.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "forge_opaque_provenance_r2_make_result_audit_test",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load_module()
+
+
+def _event(name: str, payload: dict) -> dict:
+    return {"event": name, "payload": payload}
+
+
+def _treatment_events() -> list[dict]:
+    events: list[dict] = []
+    for index in range(4):
+        command_id = f"command-{index}"
+        events.extend(
+            [
+                _event(
+                    "command.role_resolved",
+                    {
+                        "command_id": command_id,
+                        "effective_role": "other",
+                    },
+                ),
+                _event(
+                    "command.completed",
+                    {
+                        "command_id": command_id,
+                        "stage": "bash",
+                        "exit_code": 0,
+                        "termination": "completed",
+                        "timed_out": False,
+                    },
+                ),
+            ]
+        )
+    for index, classification in enumerate(
+        [
+            "compound_shell_forbidden",
+            "inspection_budget_exhausted",
+            "repair_build_arguments_invalid",
+            "repair_build_arguments_invalid",
+            "repair_build_arguments_invalid",
+        ]
+    ):
+        failure_id = f"failure-{index}"
+        events.extend(
+            [
+                _event(
+                    "agent.tool_failed",
+                    {
+                        "failure_id": failure_id,
+                        "exception_class": "ObservableRuntimeParityGateError",
+                    },
+                ),
+                _event(
+                    "agent.tool_rejection_observed",
+                    {
+                        "failure_id": failure_id,
+                        "rejection_classification": classification,
+                    },
+                ),
+            ]
+        )
+    return events
+
+
+def _report() -> dict:
+    return {
+        "manifest_sha256": audit.EXPECTED_MANIFEST_SHA256,
+        "evidence_identity_sha256": audit.EXPECTED_EVIDENCE_IDENTITY_SHA256,
+        "complete_pair": True,
+        "cleanup_succeeded": True,
+        "runtime_parity_action_budgets": {
+            "baseline": None,
+            "treatment": None,
+        },
+        "r0_rejection_observability": {
+            "baseline": None,
+            "treatment": None,
+        },
+        "arms": [
+            {
+                "arm": "baseline",
+                "infrastructure": {"status": "endpoint_censored"},
+                "model_behavior": {"status": "not_observed"},
+                "model_requests": 1,
+                "recorded_tokens": 0,
+                "metrics": {
+                    "submit_attempts": 0,
+                    "clean_replay_attempts": 0,
+                },
+                "p2": {"status": "unproven", "reason": "opaque_wrapper"},
+                "post_checkpoint_provenance_conversion": False,
+            },
+            {
+                "arm": "treatment",
+                "infrastructure": {"status": "valid"},
+                "model_behavior": {"status": "graph_step_limit"},
+                "model_requests": 8,
+                "recorded_tokens": 38_780,
+                "metrics": {
+                    "submit_attempts": 0,
+                    "clean_replay_attempts": 0,
+                },
+                "p2": {"status": "unproven", "reason": "opaque_wrapper"},
+                "post_checkpoint_provenance_conversion": False,
+            },
+        ],
+    }
+
+
+def test_r0_summary_requires_one_to_one_companions() -> None:
+    summary = audit.summarize_r0(_treatment_events())
+    assert summary == {
+        "classified_rejections": 5,
+        "companion_events": 5,
+        "companion_complete": True,
+        "rejection_classifications": [
+            "compound_shell_forbidden",
+            "inspection_budget_exhausted",
+            "repair_build_arguments_invalid",
+        ],
+        "raw_command_persisted": False,
+    }
+    missing = _treatment_events()[:-1]
+    with pytest.raises(audit.ResultAuditError, match="linkage is incomplete"):
+        audit.summarize_r0(missing)
+
+
+def test_action_budget_reconstruction_is_result_specific_and_closed() -> None:
+    baseline = audit.reconstruct_action_budget(
+        "baseline",
+        [],
+        submit_attempts=0,
+    )
+    treatment = audit.reconstruct_action_budget(
+        "treatment",
+        _treatment_events(),
+        submit_attempts=0,
+    )
+    assert baseline["consumed"] == audit.EXPECTED_ACTION_CONSUMED["baseline"]
+    assert treatment["consumed"] == audit.EXPECTED_ACTION_CONSUMED["treatment"]
+    assert treatment["remaining"] == {
+        "inspection": 0,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2,
+    }
+    with pytest.raises(audit.ResultAuditError, match="drifted"):
+        audit.reconstruct_action_budget(
+            "treatment",
+            _treatment_events()[:-12],
+            submit_attempts=0,
+        )
+
+
+def test_audit_document_restores_summary_but_censors_paired_estimand() -> None:
+    manifest = json.loads((REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json").read_text(encoding="utf-8"))
+    result = audit.build_audit_document(
+        manifest=manifest,
+        report=_report(),
+        pair_marker={"status": "passed"},
+        events_by_arm={
+            "baseline": [],
+            "treatment": _treatment_events(),
+        },
+        source_sha256=dict(audit.EXPECTED_INPUT_SHA256),
+    )
+    assert result["paired_primary_estimand"] == {
+        "status": "not_estimable",
+        "reason": "baseline_endpoint_censored",
+    }
+    assert result["treatment_descriptive_outcome"] == {
+        "status": "observed_no_conversion",
+        "submit_attempts": 0,
+        "p2_status": "unproven",
+    }
+    assert result["arms"]["treatment"]["r0_rejection_observability"]["companion_complete"] is True
+    assert result["source_evidence_modified"] is False
+    assert (
+        result["provider_calls"],
+        result["docker_executed"],
+        result["formal_attempts"],
+        result["model_tokens"],
+    ) == (0, False, 0, 0)
+
+
+def test_sidecar_is_create_once_and_does_not_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "reports/audit-v1.json"
+    audit.write_sidecar_once(path, {"status": "audited"})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"status": "audited"}
+    with pytest.raises(audit.ResultAuditError, match="already exists"):
+        audit.write_sidecar_once(path, {"status": "drifted"})
+
+
+def test_source_has_no_provider_docker_or_original_evidence_write_path() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "ExperimentLedger.open" in source
+    assert 'path.open("x"' in source
+    for forbidden in (
+        "create_chat_model",
+        "DEEPSEEK_API_KEY",
+        "os.environ",
+        "docker.from_env",
+        "write_text(",
+        "reports/canary.json).write",
+    ):
+        assert forbidden not in source

--- a/scripts/forge_opaque_provenance_r2_make_result_audit.py
+++ b/scripts/forge_opaque_provenance_r2_make_result_audit.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Issue #210 R2 Make 冻结 evidence 的只读结果审计与 sidecar。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from deerflow.compile.evidence import ExperimentLedger
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_EVIDENCE_ROOT = Path("/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r2-hoextdown-v1")
+DEFAULT_SIDECAR = "reports/audit-v1.json"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/210"
+SCHEMA_VERSION = "forge-opaque-provenance-r2-make-result-audit-1.0.0"
+EXPECTED_MANIFEST_SHA256 = "113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e"
+EXPECTED_EVIDENCE_IDENTITY_SHA256 = "c88f74282424de834be1523c9fd93fa18171c262a05b93f09aebca9359a424a4"
+EXPECTED_INPUT_SHA256 = {
+    "reports/canary.json": ("27a1bb39d693db535aa8a34e9d538dc8ee2b9def3b83262293110e0791543a1b"),
+    "markers/pair.json": ("46bf6eff450e1e11a3091296c076730e2a509520b7cddf4b35ad37157d4a5ee9"),
+    "checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl": ("077538789c0931edfc7aa276480ad9f841e81c9187348584c872b8da2453c4d2"),
+    "pairs/opaque-provenance-r2-hoextdown-pair-01/arms/baseline.jsonl": ("3a218887cd741e535f75483abce5660ca17356b39393e338aa84437f9d948bb0"),
+    "pairs/opaque-provenance-r2-hoextdown-pair-01/arms/treatment.jsonl": ("07a9ae876a8fd7ca7a6ccedb3b6050614045e065453f5977ac213f57fc3ceceb"),
+}
+ARM_LEDGER_PATHS = {
+    "baseline": ("pairs/opaque-provenance-r2-hoextdown-pair-01/arms/baseline.jsonl"),
+    "treatment": ("pairs/opaque-provenance-r2-hoextdown-pair-01/arms/treatment.jsonl"),
+}
+ACTION_LIMITS = {
+    "inspection": 4,
+    "repair_build": 2,
+    "artifact_stage": 2,
+    "submit": 2,
+}
+EXPECTED_ACTION_CONSUMED = {
+    "baseline": {
+        "inspection": 0,
+        "repair_build": 0,
+        "artifact_stage": 0,
+        "submit": 0,
+    },
+    "treatment": {
+        "inspection": 4,
+        "repair_build": 0,
+        "artifact_stage": 0,
+        "submit": 0,
+    },
+}
+
+
+class ResultAuditError(RuntimeError):
+    """冻结结果、ledger 或可恢复汇总不完整。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ResultAuditError(f"cannot read {label}") from exc
+    if not isinstance(value, dict):
+        raise ResultAuditError(f"{label} must be an object")
+    return value
+
+
+def summarize_r0(events: list[dict[str, Any]]) -> dict[str, Any]:
+    failures = [event for event in events if event.get("event") == "agent.tool_failed" and event.get("payload", {}).get("exception_class") == "ObservableRuntimeParityGateError"]
+    observations = [event for event in events if event.get("event") == "agent.tool_rejection_observed"]
+    failure_ids = [event["payload"].get("failure_id") for event in failures]
+    observation_ids = [event["payload"].get("failure_id") for event in observations]
+    if (
+        any(not isinstance(value, str) or not value for value in failure_ids)
+        or any(not isinstance(value, str) or not value for value in observation_ids)
+        or len(failure_ids) != len(set(failure_ids))
+        or len(observation_ids) != len(set(observation_ids))
+        or set(failure_ids) != set(observation_ids)
+    ):
+        raise ResultAuditError("classified rejection and R0 companion linkage is incomplete")
+    return {
+        "classified_rejections": len(failures),
+        "companion_events": len(observations),
+        "companion_complete": True,
+        "rejection_classifications": sorted({event["payload"]["rejection_classification"] for event in observations}),
+        "raw_command_persisted": False,
+    }
+
+
+def reconstruct_action_budget(
+    arm: str,
+    events: list[dict[str, Any]],
+    *,
+    submit_attempts: int,
+) -> dict[str, Any]:
+    if arm not in EXPECTED_ACTION_CONSUMED:
+        raise ResultAuditError("unknown arm")
+    role_by_command: dict[str, str] = {}
+    for event in events:
+        if event.get("event") != "command.role_resolved":
+            continue
+        payload = event.get("payload", {})
+        command_id = payload.get("command_id")
+        role = payload.get("effective_role")
+        if not isinstance(command_id, str) or command_id in role_by_command or role not in {"other", "smoke", "build", "artifact_stage"}:
+            raise ResultAuditError("command role evidence is ambiguous")
+        role_by_command[command_id] = role
+
+    completed_ids: list[str] = []
+    for event in events:
+        if event.get("event") != "command.completed":
+            continue
+        payload = event.get("payload", {})
+        if payload.get("stage") == "bash" and payload.get("exit_code") == 0 and payload.get("termination") == "completed" and payload.get("timed_out") is False:
+            command_id = payload.get("command_id")
+            if not isinstance(command_id, str) or command_id in completed_ids:
+                raise ResultAuditError("completed command evidence is ambiguous")
+            completed_ids.append(command_id)
+    if set(completed_ids) != set(role_by_command):
+        raise ResultAuditError("command completion and role evidence differ")
+    if type(submit_attempts) is not int or submit_attempts != 0:
+        raise ResultAuditError("submit action budget is not recoverable for this result")
+
+    consumed = {action: 0 for action in ACTION_LIMITS}
+    for command_id in completed_ids:
+        role = role_by_command[command_id]
+        action = {
+            "other": "inspection",
+            "smoke": "inspection",
+            "build": "repair_build",
+            "artifact_stage": "artifact_stage",
+        }[role]
+        consumed[action] += 1
+    consumed["submit"] = submit_attempts
+    if consumed != EXPECTED_ACTION_CONSUMED[arm]:
+        raise ResultAuditError("reconstructed action budget drifted")
+    return {
+        "limits": dict(ACTION_LIMITS),
+        "consumed": consumed,
+        "remaining": {action: ACTION_LIMITS[action] - consumed[action] for action in ACTION_LIMITS},
+        "recovered_from_frozen_ledger": True,
+    }
+
+
+def build_audit_document(
+    *,
+    manifest: dict[str, Any],
+    report: dict[str, Any],
+    pair_marker: dict[str, Any],
+    events_by_arm: dict[str, list[dict[str, Any]]],
+    source_sha256: dict[str, str],
+) -> dict[str, Any]:
+    if canonical_sha256(manifest) != EXPECTED_MANIFEST_SHA256:
+        raise ResultAuditError("manifest canonical identity drifted")
+    if report.get("manifest_sha256") != EXPECTED_MANIFEST_SHA256:
+        raise ResultAuditError("canary manifest identity drifted")
+    if report.get("evidence_identity_sha256") != EXPECTED_EVIDENCE_IDENTITY_SHA256:
+        raise ResultAuditError("canary evidence identity drifted")
+    if (
+        pair_marker.get("status") != "passed"
+        or report.get("complete_pair") is not True
+        or report.get("cleanup_succeeded") is not True
+        or report.get("runtime_parity_action_budgets") != {"baseline": None, "treatment": None}
+        or report.get("r0_rejection_observability") != {"baseline": None, "treatment": None}
+    ):
+        raise ResultAuditError("source report no longer matches the audit defect")
+    arms = report.get("arms")
+    if not isinstance(arms, list) or [item.get("arm") for item in arms] != [
+        "baseline",
+        "treatment",
+    ]:
+        raise ResultAuditError("source arm order drifted")
+
+    audited_arms: dict[str, Any] = {}
+    for arm_report in arms:
+        arm = arm_report["arm"]
+        events = events_by_arm.get(arm)
+        if not isinstance(events, list):
+            raise ResultAuditError("arm ledger is missing")
+        metrics = arm_report.get("metrics", {})
+        audited_arms[arm] = {
+            "infrastructure_status": arm_report.get("infrastructure", {}).get("status"),
+            "model_behavior_status": arm_report.get("model_behavior", {}).get("status"),
+            "model_requests": arm_report.get("model_requests"),
+            "recorded_tokens": arm_report.get("recorded_tokens"),
+            "submit_attempts": metrics.get("submit_attempts"),
+            "clean_replay_attempts": metrics.get("clean_replay_attempts"),
+            "p2_status": arm_report.get("p2", {}).get("status"),
+            "p2_reason": arm_report.get("p2", {}).get("reason"),
+            "post_checkpoint_provenance_conversion": arm_report.get("post_checkpoint_provenance_conversion"),
+            "r0_rejection_observability": summarize_r0(events),
+            "runtime_parity_action_budget": reconstruct_action_budget(
+                arm,
+                events,
+                submit_attempts=metrics.get("submit_attempts"),
+            ),
+        }
+    baseline = audited_arms["baseline"]
+    treatment = audited_arms["treatment"]
+    if (
+        baseline["infrastructure_status"] != "endpoint_censored"
+        or baseline["p2_status"] != "unproven"
+        or treatment["infrastructure_status"] != "valid"
+        or treatment["p2_status"] != "unproven"
+        or treatment["post_checkpoint_provenance_conversion"] is not False
+    ):
+        raise ResultAuditError("arm outcome drifted from the frozen result")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "document_type": "forge_opaque_provenance_r2_make_result_audit",
+        "issue_url": ISSUE_URL,
+        "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+        "evidence_identity_sha256": EXPECTED_EVIDENCE_IDENTITY_SHA256,
+        "source_sha256": source_sha256,
+        "source_report_summary_fields_missing": [
+            "runtime_parity_action_budgets",
+            "r0_rejection_observability",
+        ],
+        "arms": audited_arms,
+        "paired_primary_estimand": {
+            "status": "not_estimable",
+            "reason": "baseline_endpoint_censored",
+        },
+        "treatment_descriptive_outcome": {
+            "status": "observed_no_conversion",
+            "submit_attempts": treatment["submit_attempts"],
+            "p2_status": treatment["p2_status"],
+        },
+        "complete_pair_is_structural_only": True,
+        "historical_pairs_pooled": False,
+        "treatment_effect_estimated": False,
+        "p_value_computed": False,
+        "model_ranking_performed": False,
+        "provider_calls": 0,
+        "docker_executed": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "source_evidence_modified": False,
+    }
+
+
+def audit_evidence(
+    evidence_root: Path = DEFAULT_EVIDENCE_ROOT,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    manifest = _load_object(
+        repo_root / "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json",
+        "manifest",
+    )
+    for relative_path, expected in EXPECTED_INPUT_SHA256.items():
+        path = evidence_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise ResultAuditError(f"frozen input drifted: {relative_path}")
+    report = _load_object(evidence_root / "reports/canary.json", "canary report")
+    pair_marker = _load_object(evidence_root / "markers/pair.json", "pair marker")
+    parent_path = evidence_root / ("checkpoints/opaque-provenance-r2-hoextdown-pair-01/parent/events.jsonl")
+    ExperimentLedger.open(parent_path).read()
+    events_by_arm = {arm: ExperimentLedger.open(evidence_root / relative_path).read() for arm, relative_path in ARM_LEDGER_PATHS.items()}
+    return build_audit_document(
+        manifest=manifest,
+        report=report,
+        pair_marker=pair_marker,
+        events_by_arm=events_by_arm,
+        source_sha256=dict(EXPECTED_INPUT_SHA256),
+    )
+
+
+def write_sidecar_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+    except FileExistsError as exc:
+        raise ResultAuditError("audit sidecar already exists") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("audit", "write-sidecar"))
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+    result = audit_evidence(args.evidence_root, repo_root=args.repo_root)
+    if args.command == "write-sidecar":
+        write_sidecar_once(args.evidence_root / DEFAULT_SIDECAR, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 result-specific、只读的 R2 Make evidence audit，冻结原 canary、pair marker 与三条 ledger SHA-256，并通过 `ExperimentLedger.open()` 验证 hash chain。
- 从冻结 ledger 恢复 R0 汇总：baseline 0/0，treatment 5 个 classified rejection 与 5 个 companion 一一对应。
- 只在结构化 command role/completion 足以自证时恢复动作预算：baseline 全 0；treatment inspection=4、其余=0。
- sidecar 使用 create-once `reports/audit-v1.json`，不覆盖原 canary、marker 或 ledger。
- 明确分析口径：baseline endpoint-censored，因此 paired primary estimand 不可估计；treatment 仅为 observed no-conversion 描述结果。

## 验证

- 聚焦测试：`5 passed`
- #208/#210/R0 相邻回归：`33 passed`
- 真实 evidence 的只读 audit、Ruff、format、compileall、diff 与敏感值扫描通过
- 0 provider、0 Docker、0 formal attempt、0 model token；未写 sidecar

Closes #210