### PR TITLE
研究：对齐 R3 Make 动作可达性与 P2 构造

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,14 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 发布 Issue #210 R2 Make 结果审计 sidecar
-  - GitHub: 中文 Issue #210 已创建并回读；分支为 `research/210-r2-make-result-audit`，基线为 `main@00726aef`。
-  - 缺口: #208 原 canary report 在 endpoint timeout / graph-step limit 终态丢失 action-budget 与 R0 汇总，但 parent/baseline/treatment ledger hash chain 完整且原文件不可修改。
-  - 实现: 新增 result-specific 只读 audit，冻结 canary、marker 和三条 ledger SHA-256；恢复 baseline action 全 0、treatment inspection=4 及 R0 5/5 companion，并用 create-once 写入独立 `reports/audit-v1.json`。
-  - 结论: paired primary estimand 固定为 `not_estimable / baseline_endpoint_censored`；treatment 只描述为 `observed_no_conversion`，禁止池化、p 值、模型排名或重跑。
-  - 验证: 聚焦 `5 passed`，#208/#210/R0 相邻回归 `33 passed`；真实 evidence 的只读 audit、Ruff、format 和 compileall 通过，0 provider、0 Docker、0 formal attempt、0 model token。
-  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；合并后只执行一次 `write-sidecar` 并回读哈希，不修改原 canary/marker/ledger。
-  - 文件: `scripts/forge_opaque_provenance_r2_make_result_audit.py`, `backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py`
+- 2026-08-30 — 建立 Issue #212 R3 Make 构造对齐零 provider 门禁
+  - GitHub: 中文 Issue #212 已创建并回读；分支为 `research/212-r3-make-construct-alignment`，基线为 `main@62a76d2f`。
+  - 缺口: #202 P2 不要求固定 jobs，#208 runtime 却只接受 jobs=`2`，且双臂共享工具描述未公开 jobs 与精确 stage 约束；R2 treatment no-conversion 对冻结 runtime 有效，但不足以排除 intervention under-specification。
+  - 实现: 新建 experiment-only validator，把 jobs 归为公开的有界资源策略，允许省略或 `1..2`；双臂共享 direct Make、directory、target、jobs 与 stage source/destination 契约，repair packet 保持 #208 九字段内容不变且仍是唯一 treatment exposure。
+  - 验证: 聚焦 `16 passed`，#202/#204/#208/#210 相邻回归 `73 passed`，完整有效集合 `2408 passed, 47 skipped, 1 deselected`；完整 Ruff/format、CLI、py_compile、敏感信息扫描和 #210 真实 evidence 只读 audit 通过，8 个冻结组件哈希不变。唯一 deselect 是 #184 正式采集后永久失效的 #182 空 evidence 旧断言，不删除冻结 evidence 修绿。
+  - 边界: 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；不修改或重跑 #208/#210。
+  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；门禁发布后才另建真实 Docker lifecycle identity 候选，本 Issue 不授权模型实验。
+  - 文件: `scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md`
 
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
@@ -72,6 +72,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #210 R2 Make 结果审计 sidecar
+  - 文件: `scripts/forge_opaque_provenance_r2_make_result_audit.py`, `backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py`
+  - 发布: 中文 Issue #210 / PR #211 三项 CI 全绿后 squash 合并为 `main@62a76d2f4f293730652f4722530390c026c19516`。
+  - 审计: 从 hash-chain 完整的 parent/baseline/treatment ledger 恢复 baseline action 全 0、treatment inspection=4 与 R0 5/5 companion；paired primary estimand 固定为 `not_estimable / baseline_endpoint_censored`，treatment 为 `observed_no_conversion`。
+  - Sidecar: 只 create-once 写入 `reports/audit-v1.json`，SHA-256 为 `35fb5c0c045dcd4fa61913e5089066f1ce1716ef2de50797908b6bad12824cf0`；evidence 从 9 个文件增为恰好 10 个，原 canary、marker 和 ledger 哈希全部不变。
+  - 边界: 禁止池化、p 值、模型排名、重跑、replacement 或 backfill；后续审计只读，不再修改 #208 evidence。
 
 - 2026-08-30 — 完成 Issue #208 R2 Make runtime-parity 一次性执行
   - 文件: `scripts/forge_opaque_provenance_make_runtime_parity_gate.py`, `scripts/forge_opaque_provenance_make_rejection_observability_gate.py`, `scripts/forge_opaque_provenance_r2_make_execution_protocol.py`, `scripts/forge_opaque_provenance_r2_make_execution_runner.py`, `benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json`

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,15 +5,6 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
-- 2026-08-30 — 建立 Issue #212 R3 Make 构造对齐零 provider 门禁
-  - GitHub: 中文 Issue #212 已创建并回读；分支为 `research/212-r3-make-construct-alignment`，基线为 `main@62a76d2f`。
-  - 缺口: #202 P2 不要求固定 jobs，#208 runtime 却只接受 jobs=`2`，且双臂共享工具描述未公开 jobs 与精确 stage 约束；R2 treatment no-conversion 对冻结 runtime 有效，但不足以排除 intervention under-specification。
-  - 实现: 新建 experiment-only validator，把 jobs 归为公开的有界资源策略，允许省略或 `1..2`；双臂共享 direct Make、directory、target、jobs 与 stage source/destination 契约，repair packet 保持 #208 九字段内容不变且仍是唯一 treatment exposure。
-  - 验证: 聚焦 `16 passed`，#202/#204/#208/#210 相邻回归 `73 passed`，完整有效集合 `2408 passed, 47 skipped, 1 deselected`；完整 Ruff/format、CLI、py_compile、敏感信息扫描和 #210 真实 evidence 只读 audit 通过，8 个冻结组件哈希不变。唯一 deselect 是 #184 正式采集后永久失效的 #182 空 evidence 旧断言，不删除冻结 evidence 修绿。
-  - 边界: 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；不修改或重跑 #208/#210。
-  - 下一步: 中文提交、WSL helper 推送、中文 PR/CI/合并；门禁发布后才另建真实 Docker lifecycle identity 候选，本 Issue 不授权模型实验。
-  - 文件: `scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md`
-
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
   - 实现: 新增实验专用 `forge-combined-checkpoint-1.0.0` manifest，把 message、environment、budget 绑定到同一 `capture_id` 与 message state SHA-256；三层全部校验后才发布父 manifest。
@@ -72,6 +63,13 @@
 
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
+
+- 2026-08-30 — 完成 Issue #212 R3 Make 构造对齐零 provider 门禁
+  - 文件: `scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md`
+  - 发布: 中文 Issue #212 / PR #213 已创建并回读；提交 `6e0ff544`，CI backend tests（3 分 58 秒）、backend lint（14 秒）与 frontend lint（1 分 37 秒）全绿。
+  - 结论: #202 P2 不要求固定 jobs；#208 runtime 的 jobs=`2` 与未公开 stage 约束构成 intervention under-specification 风险。新 experiment-only gate 把 jobs 归为公开的有界资源策略，允许省略或 `1..2`，并让双臂共享 direct Make、directory、target、jobs 与 stage source/destination 契约。
+  - 完整性: Repair packet 保持 #208 九字段内容不变且仍是唯一 treatment exposure；8 个冻结组件与 #210 真实 evidence 只读 audit 均无漂移。聚焦 `16 passed`、相邻 `73 passed`、完整有效集合 `2408 passed, 47 skipped, 1 deselected`。
+  - 边界: 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；不修改或重跑 #208/#210。下一阶段才另建真实 Docker lifecycle identity 候选，本 Issue 不授权模型实验。
 
 - 2026-08-30 — 完成 Issue #210 R2 Make 结果审计 sidecar
   - 文件: `scripts/forge_opaque_provenance_r2_make_result_audit.py`, `backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py`

--- a/backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py
@@ -1,0 +1,167 @@
+"""Issue #212 R3 Make 构造对齐零 provider 测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    path = SCRIPTS_DIR / "forge_opaque_provenance_r3_make_construct_alignment_gate.py"
+    spec = importlib.util.spec_from_file_location("forge_r3_make_construct_alignment_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+@pytest.mark.parametrize(
+    ("command", "jobs"),
+    [
+        ("make libhoedown.a", None),
+        ("make -j1 libhoedown.a", "1"),
+        ("make --jobs 2 libhoedown.a", "2"),
+        ("gmake -C /workspace/repo --jobs=2 libhoedown.a", "2"),
+    ],
+)
+def test_runtime_accepts_public_bounded_jobs_contract(command: str, jobs: str | None) -> None:
+    invocation = gate.validate_repair_build(command, workdir=gate.lifecycle.WORKDIR)
+    assert invocation.jobs == jobs
+    assert invocation.effective_directory == gate.lifecycle.WORKDIR
+    assert invocation.target == gate.lifecycle.TARGET
+
+
+@pytest.mark.parametrize(
+    ("command", "classification"),
+    [
+        ("make -j libhoedown.a", "repair_build_jobs_unbounded"),
+        ("make -j0 libhoedown.a", "repair_build_jobs_out_of_bounds"),
+        ("make -j3 libhoedown.a", "repair_build_jobs_out_of_bounds"),
+        ("make -jmany libhoedown.a", "repair_build_arguments_invalid"),
+        ("make -C /workspace/other libhoedown.a", "repair_build_directory_drift"),
+        ("make other", "repair_build_target_drift"),
+        ("make CFLAGS=-O3 libhoedown.a", "repair_build_arguments_invalid"),
+        ("cmake --build build", "repair_build_invocation_invalid"),
+    ],
+)
+def test_runtime_rejects_out_of_contract_actions(
+    command: str,
+    classification: str,
+) -> None:
+    with pytest.raises(gate.ConstructAlignmentGateError) as raised:
+        gate.validate_repair_build(command, workdir=gate.lifecycle.WORKDIR)
+    assert raised.value.evidence_rejection_classification == classification
+    assert raised.value.evidence_action_kind == "repair_build"
+
+
+def test_every_runtime_admissible_example_satisfies_frozen_p2_parser() -> None:
+    for command in (
+        "make libhoedown.a",
+        "make -j1 libhoedown.a",
+        "gmake --jobs=2 libhoedown.a",
+    ):
+        invocation = gate.validate_repair_build(command, workdir=gate.lifecycle.WORKDIR)
+        frozen = gate.lifecycle.reference.build_frozen_identity()
+        parent = gate.lifecycle.provenance.record_invocation(
+            command_id="parent",
+            physical_attempt_id=frozen.physical_attempt_id,
+            sequence=1,
+            repository_url=frozen.repository_url,
+            commit_sha=frozen.commit_sha,
+            image_id=frozen.image_id,
+            executable="sh",
+            argv=("-c", "opaque parent"),
+            workdir=frozen.workdir,
+            previous_hash=gate.lifecycle.provenance.ZERO_HASH,
+            output_paths=(frozen.artifact_relative_path,),
+            model_declared_role="build",
+        )
+        tokens = shlex.split(command)
+        direct = gate.lifecycle.provenance.record_invocation(
+            command_id="direct",
+            physical_attempt_id=frozen.physical_attempt_id,
+            sequence=2,
+            repository_url=frozen.repository_url,
+            commit_sha=frozen.commit_sha,
+            image_id=frozen.image_id,
+            executable=tokens[0],
+            argv=tuple(tokens[1:]),
+            workdir=frozen.workdir,
+            previous_hash=parent.ledger_hash,
+            output_paths=(frozen.artifact_relative_path,),
+            model_declared_role="build",
+        )
+        artifact = gate.lifecycle.reference._artifact(
+            frozen,
+            direct.command_id,
+            observed_after_sequence=3,
+        )
+        decision = gate.lifecycle.reference.evaluate_make_p2(
+            frozen,
+            (parent, direct),
+            artifact,
+        )
+        assert invocation.effective_directory == frozen.workdir
+        assert invocation.target == frozen.target
+        assert decision.status == "proven"
+        assert decision.proof_mode == "direct_make"
+
+
+def test_shared_tool_contract_is_identical_and_packet_is_only_exposure() -> None:
+    baseline = gate.build_arm_contract("baseline")
+    treatment = gate.build_arm_contract("treatment")
+    assert baseline["tool_description"] == treatment["tool_description"]
+    assert baseline["action_surface"] == treatment["action_surface"]
+    assert "repair_packet" not in baseline
+    assert treatment["repair_packet"] == gate.lifecycle.build_repair_packet()
+    lowered = baseline["tool_description"].lower()
+    assert "jobs" in lowered
+    assert "1 或 2" in lowered
+    assert "build 与 artifact stage" in lowered
+    assert "/workspace/repo/libhoedown.a" in lowered
+    assert "/artifacts/libhoedown.a" in lowered
+
+
+def test_compound_build_and_stage_is_not_part_of_shared_contract() -> None:
+    with pytest.raises(gate.ConstructAlignmentGateError):
+        gate.validate_repair_build(
+            "make libhoedown.a && cp libhoedown.a /artifacts/libhoedown.a",
+            workdir=gate.lifecycle.WORKDIR,
+        )
+
+
+def test_gate_is_zero_provider_and_freezes_r2_components() -> None:
+    report = gate.validate_gate_contract(REPO_ROOT)
+    assert report["frozen_components_verified"] == len(gate.FROZEN_COMPONENTS)
+    assert len(report["preregistration_sha256"]) == 64
+    assert report["shared_tool_contract_identical"] is True
+    assert report["treatment_exposure_only"] == "repair_packet"
+    assert report["repair_packet_unchanged"] is True
+    assert report["p2_identity_includes_jobs"] is False
+    assert report["jobs_policy"] == {
+        "omitted_allowed": True,
+        "minimum": 1,
+        "maximum": 2,
+    }
+    assert (
+        report["provider_calls"],
+        report["credential_read"],
+        report["docker_executed"],
+        report["checkpoint_created"],
+        report["formal_attempts"],
+        report["model_tokens"],
+        report["evidence_writes"],
+    ) == (0, False, False, False, 0, 0, 0)

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md
@@ -1,0 +1,27 @@
+# C/C++ opaque provenance R3 Make 构造对齐零 provider 门禁
+
+状态：本地候选。追踪 Issue：[#212](https://github.com/WWFXL/Forge-AutoCompiler/issues/212)。
+
+## 研究动机
+
+#208 的 treatment 在有效网络下未发生 P2 conversion，但 #202 reference criterion 不要求固定 jobs，#208 runtime 却把 jobs 恰好为 `2` 作为动作准入条件，而且双臂共享的工具描述没有公开该条件。冻结结果仍是有效的 `observed_no_conversion`，但不足以排除 intervention under-specification。
+
+本门禁不修改、重跑或补写 #208/#210 evidence。它只验证未来新 identity 的 action surface 是否与 outcome construct 对齐，不构成模型效果证据。
+
+## 构造对齐规则
+
+- P2 provenance identity：direct `make/gmake`、冻结 effective directory、单 target、exact run/artifact producer identity；jobs 不属于 P2 identity。
+- 资源策略：jobs 可以省略或取 `1..2`，禁止无界 `-j`、`0`、超过 `2` 和非数字值。
+- Runtime-admissible direct Make actions 必须是 P2-acceptable actions 的子集；资源策略比 P2 更严格的部分必须在 baseline/treatment 共用的工具契约中明示。
+- Build 与 artifact stage 必须拆成两个动作；stage source/destination 固定为 `/workspace/repo/libhoedown.a` 与 `/artifacts/libhoedown.a`，并通过双臂共享工具契约公开。继续禁止 clone、configure、dependency、housekeeping、manual replay 和 compound build/stage。
+- Repair packet 保持 #208 九字段内容不变，仍不包含 command、argv、shell 或完整解法；它是唯一 treatment exposure。
+
+## R0 可观测性
+
+未来 adapter 必须区分 `repair_build_jobs_unbounded`、`repair_build_jobs_out_of_bounds`、directory drift、target drift、invocation invalid 和 arguments invalid。Companion 仍只允许 bounded classification、action kind、model request ID、tool ordinal 与 command SHA-256，不保存原始命令、异常正文、模型正文、工具参数或凭据。
+
+## 停止规则
+
+本阶段只运行静态 validator、单元测试、冻结哈希与敏感信息审计。固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write。
+
+门禁通过只允许下一阶段另建真实 Docker lifecycle identity 候选；不授权 reachability、provider canary、single pair、replacement 或 batch。

--- a/scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py
+++ b/scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Issue #212 R3 Make 动作可达性与 P2 构造对齐门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_make_lifecycle_gate as lifecycle  # noqa: E402
+
+SCHEMA_VERSION = "forge-opaque-provenance-r3-make-construct-alignment-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/212"
+PREREGISTRATION_PATH = (
+    "benchmarks/preregistrations/"
+    "cpp-opaque-provenance-r3-make-construct-alignment-gate.md"
+)
+R2_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json"
+R2_MANIFEST_CANONICAL_SHA256 = (
+    "113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e"
+)
+
+FROZEN_COMPONENTS = {
+    "scripts/forge_opaque_provenance_make_reference_gate.py": (
+        "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a"
+    ),
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": (
+        "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b"
+    ),
+    "scripts/forge_opaque_provenance_make_runtime_parity_gate.py": (
+        "146e7b83d1a0afbe31928308d2a63ec000021a63755751df8ae59628a4071075"
+    ),
+    "scripts/forge_opaque_provenance_make_rejection_observability_gate.py": (
+        "2148b8a80ba25e95baa7e1e20c6d5209bc07bb89675026f78320f5636d1737c1"
+    ),
+    "scripts/forge_opaque_provenance_r2_make_execution_runner.py": (
+        "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0"
+    ),
+    "scripts/forge_opaque_provenance_r2_make_result_audit.py": (
+        "1deb4e47b9c85b7fc78a63e2669a4bcc2e16a22bf5c18827ba648c6671eb9ee8"
+    ),
+    "backend/tests/test_forge_opaque_provenance_r2_make_result_audit.py": (
+        "c2293d1472da48b1a323f1a4ba9787caa8f93e2f878e7949aec2c6e83ed74bae"
+    ),
+    R2_MANIFEST_PATH: (
+        "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d"
+    ),
+}
+
+SHARED_TOOL_DESCRIPTION = """在当前 R3 arm 中执行单一、非 compound 的命令。
+
+共同动作契约：
+- inspection 只能使用不改变源码、构建配置或依赖的单一命令；
+- repair build 只能直接调用 make 或 gmake，effective directory 必须是
+  /workspace/repo，并且只能构建 target libhoedown.a；
+- jobs 可以省略，也可以设为 1 或 2；禁止无界 -j 和超过 2 的并行度；
+- build 与 artifact stage 必须是两个独立动作；stage 只允许把
+  /workspace/repo/libhoedown.a 复制到 /artifacts/libhoedown.a；
+- command_role 必须与 inspection、build 或 artifact_stage 的动作一致。
+"""
+
+
+class ConstructAlignmentGateError(RuntimeError):
+    """R3 Make 动作、构造身份或冻结边界无效。"""
+
+    def __init__(self, message: str, *, classification: str) -> None:
+        super().__init__(message)
+        self.evidence_rejection_classification = classification
+        self.evidence_action_kind = "repair_build"
+
+
+@dataclass(frozen=True)
+class AlignedMakePolicy:
+    build_directory: str = lifecycle.WORKDIR
+    target: str = lifecycle.TARGET
+    maximum_jobs: int = 2
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_frozen_components(repo_root: Path = REPO_ROOT) -> None:
+    for relative_path, expected_sha256 in FROZEN_COMPONENTS.items():
+        if file_sha256(repo_root / relative_path) != expected_sha256:
+            raise ConstructAlignmentGateError(
+                f"冻结组件发生漂移: {relative_path}",
+                classification="frozen_component_drift",
+            )
+
+
+def validate_repair_build(
+    command: str,
+    *,
+    workdir: str,
+    policy: AlignedMakePolicy | None = None,
+) -> Any:
+    """验证 direct Make 身份，并将 jobs 仅作为公开的资源上限。"""
+
+    import shlex
+
+    current = policy or AlignedMakePolicy()
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ConstructAlignmentGateError(
+            "repair build 参数无法解析",
+            classification="repair_build_arguments_invalid",
+        ) from exc
+    if not tokens or PurePosixPath(tokens[0]).name not in {"make", "gmake"}:
+        raise ConstructAlignmentGateError(
+            "repair build 必须直接调用 make 或 gmake",
+            classification="repair_build_invocation_invalid",
+        )
+    try:
+        invocation = lifecycle.reference.parse_make_invocation(
+            PurePosixPath(tokens[0]).name,
+            tuple(tokens[1:]),
+            workdir=workdir,
+        )
+    except lifecycle.reference.MakeReferenceError as exc:
+        raise ConstructAlignmentGateError(
+            "repair build 包含未注册参数",
+            classification="repair_build_arguments_invalid",
+        ) from exc
+    if invocation.effective_directory != current.build_directory:
+        raise ConstructAlignmentGateError(
+            "repair build 目录偏离冻结身份",
+            classification="repair_build_directory_drift",
+        )
+    if invocation.target != current.target:
+        raise ConstructAlignmentGateError(
+            "repair build target 偏离冻结身份",
+            classification="repair_build_target_drift",
+        )
+    if invocation.jobs == "unbounded":
+        raise ConstructAlignmentGateError(
+            "repair build 禁止无界 jobs",
+            classification="repair_build_jobs_unbounded",
+        )
+    if invocation.jobs is not None and not (
+        invocation.jobs.isdigit() and 1 <= int(invocation.jobs) <= current.maximum_jobs
+    ):
+        raise ConstructAlignmentGateError(
+            "repair build jobs 超出公开资源边界",
+            classification="repair_build_jobs_out_of_bounds",
+        )
+    return invocation
+
+
+def build_arm_contract(arm: str) -> dict[str, Any]:
+    if arm not in {"baseline", "treatment"}:
+        raise ConstructAlignmentGateError(
+            "未知实验 arm",
+            classification="arm_identity_invalid",
+        )
+    contract: dict[str, Any] = {
+        "arm": arm,
+        "tool_description": SHARED_TOOL_DESCRIPTION,
+        "action_surface": {
+            "direct_executables": ["make", "gmake"],
+            "build_directory": lifecycle.WORKDIR,
+            "target": lifecycle.TARGET,
+            "jobs": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+            "artifact_stage": {
+                "source": f"{lifecycle.WORKDIR}/{lifecycle.BUILD_OUTPUT}",
+                "destination": f"/artifacts/{lifecycle.STAGED_ARTIFACT}",
+                "separate_from_build": True,
+            },
+        },
+    }
+    if arm == "treatment":
+        contract["repair_packet"] = lifecycle.build_repair_packet()
+    return contract
+
+
+def validate_gate_contract(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    validate_frozen_components(repo_root)
+    manifest = json.loads((repo_root / R2_MANIFEST_PATH).read_text(encoding="utf-8"))
+    preregistration_sha256 = file_sha256(repo_root / PREREGISTRATION_PATH)
+    if canonical_sha256(manifest) != R2_MANIFEST_CANONICAL_SHA256:
+        raise ConstructAlignmentGateError(
+            "R2 Make manifest canonical identity 漂移",
+            classification="frozen_component_drift",
+        )
+    baseline = build_arm_contract("baseline")
+    treatment = build_arm_contract("treatment")
+    treatment_without_packet = {
+        key: value
+        for key, value in treatment.items()
+        if key not in {"arm", "repair_packet"}
+    }
+    baseline_without_arm = {
+        key: value for key, value in baseline.items() if key != "arm"
+    }
+    if treatment_without_packet != baseline_without_arm:
+        raise ConstructAlignmentGateError(
+            "双臂共享工具契约不一致",
+            classification="shared_action_surface_drift",
+        )
+    packet = treatment["repair_packet"]
+    if packet != manifest["repair_packet"]["template"]:
+        raise ConstructAlignmentGateError(
+            "repair packet 偏离 R2 冻结内容",
+            classification="repair_packet_drift",
+        )
+    accepted = (
+        "make libhoedown.a",
+        "make -j1 libhoedown.a",
+        "gmake --jobs=2 libhoedown.a",
+    )
+    normalized = [
+        asdict(
+            validate_repair_build(
+                command,
+                workdir=lifecycle.WORKDIR,
+            )
+        )
+        for command in accepted
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "r2_manifest_canonical_sha256": R2_MANIFEST_CANONICAL_SHA256,
+        "preregistration_sha256": preregistration_sha256,
+        "frozen_components_verified": len(FROZEN_COMPONENTS),
+        "shared_tool_contract_identical": True,
+        "treatment_exposure_only": "repair_packet",
+        "repair_packet_unchanged": True,
+        "p2_identity_includes_jobs": False,
+        "jobs_policy": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+        "accepted_examples": normalized,
+        "next_stage": "new_real_docker_lifecycle_identity_candidate",
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(
+        json.dumps(
+            validate_gate_contract(),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 R3 Make experiment-only 构造对齐 gate，把 jobs 从 P2 provenance identity 中分离为公开的有界资源策略。
- 允许省略 jobs 或使用 1..2，拒绝无界、0、超限与非法参数；保持 direct Make、冻结目录/target、build/stage 分离。
- 为 baseline/treatment 固定相同的工具契约，公开 jobs 和 stage source/destination；repair packet 保持 #208 九字段内容不变且仍是唯一 treatment exposure。
- 冻结 #202/#204/#208/#210 的 8 个组件哈希，不修改或重跑历史 evidence。
- 更新预注册和项目快照。

## 研究边界

本 PR 固定 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write。它只允许后续另建真实 Docker lifecycle identity 候选，不授权 reachability 或模型实验。

## 验证

- 聚焦：`16 passed`
- #202/#204/#208/#210 相邻回归：`73 passed`
- 完整有效集合：`2408 passed, 47 skipped, 1 deselected`
- 完整 backend Ruff check/format：通过
- CLI、py_compile、敏感信息扫描、#210 真实 evidence 只读 audit：通过

唯一 deselect 是 #184 正式采集后永久失效的 #182 空 evidence 旧断言；没有删除或移动冻结 evidence。

Closes #212