### PR TITLE
研究：验证 R3 Make jobs 真实生命周期

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 完成 Issue #214 R3 Make jobs 真实 lifecycle 本地门禁
+  - 文件: `scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md`
+  - 实现: 新版本 adapter 复用并固定 #204 Docker orchestration 哈希，分别暴露 `make libhoedown.a` 与 `make -j1 libhoedown.a`；不修改 #202/#204/#208/#210/#212 或冻结 evidence。
+  - 结论: 两个 profile 均在 Ubuntu WSL2 原生 Docker production Compile Session 中把 Make P2 从 `unproven/opaque_wrapper` 转为 `proven/direct_make`，且 candidate verification、唯一 clean replay、R0 分类与 cleanup 全部通过；后置 compile/replay/capture orphan 均为 0。
+  - 验证: 真实 Docker `2 passed in 156.30s`，相邻回归 `86 passed`，静态聚焦 `4 passed`，Ruff check/format、`py_compile`、`git diff --check` 与敏感信息扫描通过。
+  - 边界: 0 provider、0 credential read、0 formal physical attempt、0 model token、0正式 evidence write；本地 SQLite checkpointer 仅用于 #204 双臂同源恢复。中文 Issue #214 已创建并回读，待提交、PR/CI 与合并。
+
 - 2026-08-30 — 完成 Issue #212 R3 Make 构造对齐零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md`
   - 发布: 中文 Issue #212 / PR #213 已创建并回读；提交 `6e0ff544`，CI backend tests（3 分 58 秒）、backend lint（14 秒）与 frontend lint（1 分 37 秒）全绿。
@@ -582,6 +589,8 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- PowerShell 可能误解析传给 WSL Docker CLI 的 Go template（例如 `{{.Server.Version}}`），导致只读 gate 在接触 daemon 后被错误参数拒绝。跨 PowerShell/WSL gate 使用固定 argv 且不传 template；版本检查直接运行 `docker version`，列表检查使用不需要 format 的 `docker ps -aq` / `docker images -q`。
 
 - 历史 manifest 会按字节冻结 `scripts/forge_opaque_provenance_runtime_parity_gate.py`、共享 `evidence.py` 和 LLM/tool-error middleware 等父组件；即使行为兼容，原地增加异常元数据、Schema 或仅运行 Ruff 格式化也会让旧协议 current-tree gate 报 runtime drift。新增 instrumentation 必须放入新的版本化 adapter/companion event，并用完整 backend CI 确认所有冻结文件零差异。
 - 真实 lifecycle capture 的 evidence Schema 强制要求 `submit_attempt_id`；只记录 classification/failure ID 会在 environment freeze 前 fail closed。新 gate 应直接从同一 `failure.recorded` payload 复制该 ID，并先做 Schema 级静态断言。

--- a/backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py
@@ -1,0 +1,61 @@
+"""Issue #214 R3 Make jobs lifecycle 静态合同。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_gate():
+    module_name = "forge_opaque_provenance_r3_make_lifecycle_gate_contract"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS_DIR / "forge_opaque_provenance_r3_make_lifecycle_gate.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+    return module
+
+
+gate = _load_gate()
+
+
+def test_r3_make_lifecycle_contract_accepts_both_jobs_profiles() -> None:
+    result = gate.validate_gate_contract()
+
+    assert result["schema_version"] == gate.SCHEMA_VERSION
+    assert [item["profile"]["profile_id"] for item in result["profiles"]] == ["jobs-omitted", "jobs-1"]
+    assert all(item["parent"]["status"] == "unproven" for item in result["profiles"])
+    assert all(item["treatment"]["status"] == "proven" for item in result["profiles"])
+    assert all(item["treatment"]["proof_mode"] == "direct_make" for item in result["profiles"])
+    assert all(item["parent_history_prefix_preserved"] is True for item in result["profiles"])
+    assert result["provider_calls"] == 0
+    assert result["credential_read"] is False
+    assert result["formal_attempts"] == 0
+    assert result["model_tokens"] == 0
+    assert result["evidence_writes"] == 0
+
+
+@pytest.mark.parametrize(
+    ("profile_id", "command"),
+    (("jobs-omitted", "make libhoedown.a"), ("jobs-1", "make -j1 libhoedown.a")),
+)
+def test_docker_adapter_exposes_only_the_selected_build_profile(profile_id: str, command: str) -> None:
+    adapter = gate.build_docker_adapter(profile_id)
+    assert adapter.TREATMENT_BUILD_COMMAND == command
+    assert adapter.TREATMENT_STAGE_COMMAND == "cp libhoedown.a /artifacts/libhoedown.a"
+    assert adapter.build_repair_packet() == gate.lifecycle.build_repair_packet()
+
+
+def test_unknown_jobs_profile_is_rejected() -> None:
+    with pytest.raises(gate.R3MakeLifecycleGateError, match="未知 R3 Make jobs profile"):
+        gate.build_docker_adapter("jobs-unbounded")

--- a/backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py
@@ -1,0 +1,54 @@
+"""Issue #214 R3 Make jobs profile 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_R3_MAKE_LIFECYCLE_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_R3_MAKE_LIFECYCLE_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+    return module
+
+
+gate = _load_module(
+    "forge_opaque_provenance_r3_make_lifecycle_gate_docker_adapter",
+    SCRIPTS_DIR / "forge_opaque_provenance_r3_make_lifecycle_gate.py",
+)
+legacy = _load_module(
+    "forge_opaque_provenance_make_lifecycle_gate_docker_orchestration",
+    REPO_ROOT / gate.LEGACY_DOCKER_TEST_PATH,
+)
+
+
+@pytest.mark.parametrize("profile_id", tuple(gate.PROFILES))
+def test_r3_make_jobs_profile_real_lifecycle(
+    profile_id: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate.validate_gate_contract()
+    monkeypatch.setattr(legacy, "adapter", gate.build_docker_adapter(profile_id))
+
+    legacy.test_real_make_parent_treatment_replay_and_cleanup(tmp_path, monkeypatch)

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md
@@ -1,0 +1,30 @@
+# R3 Make jobs 真实 lifecycle 零 provider 门禁
+
+- Issue：[#214](https://github.com/WWFXL/Forge-AutoCompiler/issues/214)
+- 性质：运行前冻结的工程与构造效度门禁，不是模型实验，也不写正式 evidence。
+- 上游：#202 Make P2 reference、#204 真实 lifecycle、#212 R3 Make 动作可达性。
+
+## 研究问题
+
+在同一 hoextdown commit、镜像、目录、target、stage 与 repair packet 下，R3 公开动作面允许的两种 direct Make 命令，是否都能在 production Compile Session 中把 opaque parent 的 P2 从 `unproven/opaque_wrapper` 转为 `proven/direct_make`，并通过 candidate verification 与 clean replay？
+
+## 冻结 profile
+
+1. `jobs-omitted`：`make libhoedown.a`
+2. `jobs-1`：`make -j1 libhoedown.a`
+
+二者都必须在 `/workspace/repo` 执行；stage 独立固定为 `cp libhoedown.a /artifacts/libhoedown.a`。禁止复用 #204 的 `-j2` 作为 R3 结果。
+
+## 验收标准
+
+- parent：`build_system_unproven`，不启动 replay；
+- baseline：保持同一失败分类；
+- treatment：P2 为 `proven/direct_make`；
+- candidate 与唯一 clean replay 均通过；
+- R0 分类、产物 identity 与双臂前缀历史完整；
+- cleanup 后无 `deerflow-compile-*`、`deerflow-replay-*` 或 capture label orphan；
+- 两个 profile 独立通过，不能以其中一个替代另一个。
+
+## 外部影响边界
+
+固定为 0 provider call、0 credential read、0 formal physical attempt、0 model token、0正式 evidence write。双臂同源恢复沿用 #204 的本地 SQLite checkpointer，仅作为零 provider lifecycle 测试设施。只使用 Ubuntu WSL2 原生 `docker.service`，不得启动 Docker Desktop。

--- a/scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py
+++ b/scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Issue #214 R3 Make jobs 动作的真实 lifecycle 适配器。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import forge_opaque_provenance_make_lifecycle_gate as lifecycle
+import forge_opaque_provenance_r3_make_construct_alignment_gate as alignment
+
+SCHEMA_VERSION = "forge-opaque-provenance-r3-make-lifecycle-gate-1.0.0"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/214"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md"
+LEGACY_DOCKER_TEST_PATH = "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py"
+LEGACY_DOCKER_TEST_SHA256 = "5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652"
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+
+
+class R3MakeLifecycleGateError(RuntimeError):
+    """R3 lifecycle profile、冻结边界或 P2 结果无效。"""
+
+
+@dataclass(frozen=True)
+class MakeJobsProfile:
+    profile_id: str
+    build_command: str
+    expected_jobs: str | None
+
+
+PROFILES = {
+    profile.profile_id: profile
+    for profile in (
+        MakeJobsProfile("jobs-omitted", "make libhoedown.a", None),
+        MakeJobsProfile("jobs-1", "make -j1 libhoedown.a", "1"),
+    )
+}
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def get_profile(profile_id: str) -> MakeJobsProfile:
+    try:
+        return PROFILES[profile_id]
+    except KeyError as exc:
+        raise R3MakeLifecycleGateError(f"未知 R3 Make jobs profile: {profile_id}") from exc
+
+
+def evaluate_treatment(
+    frozen: Any,
+    *,
+    profile_id: str,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    """使用公开 jobs profile 建立 direct Make provenance，不改写 parent 历史。"""
+
+    profile = get_profile(profile_id)
+    invocation = alignment.validate_repair_build(profile.build_command, workdir=frozen.workdir)
+    if invocation.jobs != profile.expected_jobs:
+        raise R3MakeLifecycleGateError("R3 Make jobs 解析结果偏离 profile")
+    tokens = shlex.split(profile.build_command)
+    lifecycle._validate_case_identity(frozen)
+    parent = lifecycle._parent_invocation(frozen, parent_command_id)
+    build = lifecycle.provenance.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable=tokens[0],
+        argv=tuple(tokens[1:]),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = lifecycle.provenance.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(frozen.artifact_relative_path, f"/artifacts/{lifecycle.STAGED_ARTIFACT}"),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    invocations = (parent, build, stage)
+    decision = lifecycle.reference.evaluate_make_p2(
+        frozen,
+        invocations,
+        lifecycle._artifact(frozen, build.command_id, observed_after_sequence=4),
+    )
+    if decision.status != "proven" or decision.proof_mode != "direct_make":
+        raise R3MakeLifecycleGateError("R3 treatment 未转换 Make P2 结果")
+    return decision, invocations
+
+
+def build_docker_adapter(profile_id: str) -> SimpleNamespace:
+    """向冻结 #204 Docker 编排提供相同窄接口。"""
+
+    profile = get_profile(profile_id)
+
+    def evaluate_profile_treatment(frozen: Any, **kwargs: str):
+        return evaluate_treatment(frozen, profile_id=profile.profile_id, **kwargs)
+
+    return SimpleNamespace(
+        COMPILE_IMAGE=lifecycle.COMPILE_IMAGE,
+        WORKDIR=lifecycle.WORKDIR,
+        REPOSITORY_URL=lifecycle.REPOSITORY_URL,
+        COMMIT_SHA=lifecycle.COMMIT_SHA,
+        TARGET=lifecycle.TARGET,
+        STAGED_ARTIFACT=lifecycle.STAGED_ARTIFACT,
+        BUILD_OUTPUT=lifecycle.BUILD_OUTPUT,
+        ARTIFACT_TYPE=lifecycle.ARTIFACT_TYPE,
+        PARENT_COMMAND=lifecycle.PARENT_COMMAND,
+        TREATMENT_BUILD_COMMAND=profile.build_command,
+        TREATMENT_STAGE_COMMAND=lifecycle.TREATMENT_STAGE_COMMAND,
+        CASE_ID=lifecycle.CASE_ID,
+        provenance=lifecycle.provenance,
+        validate_gate_contract=lambda: validate_gate_contract(),
+        build_frozen_identity=lifecycle.build_frozen_identity,
+        evaluate_parent=lifecycle.evaluate_parent,
+        evaluate_treatment=evaluate_profile_treatment,
+        build_repair_packet=lifecycle.build_repair_packet,
+        validate_repair_packet=lifecycle.validate_repair_packet,
+    )
+
+
+def validate_gate_contract(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    alignment.validate_gate_contract(repo_root)
+    lifecycle.validate_gate_contract(repo_root)
+    if file_sha256(repo_root / LEGACY_DOCKER_TEST_PATH) != LEGACY_DOCKER_TEST_SHA256:
+        raise R3MakeLifecycleGateError("冻结 #204 Docker orchestration 发生漂移")
+
+    profile_results = []
+    for index, profile in enumerate(PROFILES.values(), start=1):
+        frozen = lifecycle.build_frozen_identity(
+            image_id="sha256:" + str(index) * 64,
+            physical_attempt_id=f"attempt-r3-make-lifecycle-{profile.profile_id}",
+            artifact_size=4096,
+            artifact_sha256=str(index + 2) * 64,
+        )
+        parent, parent_history = lifecycle.evaluate_parent(frozen, parent_command_id="parent-wrapper")
+        treatment, treatment_history = evaluate_treatment(
+            frozen,
+            profile_id=profile.profile_id,
+            parent_command_id="parent-wrapper",
+            treatment_build_command_id=f"{profile.profile_id}-make-build",
+            treatment_stage_command_id=f"{profile.profile_id}-artifact-stage",
+        )
+        if treatment_history[: len(parent_history)] != parent_history:
+            raise R3MakeLifecycleGateError("R3 treatment 改写了 parent provenance 历史")
+        profile_results.append(
+            {
+                "profile": asdict(profile),
+                "parent": asdict(parent),
+                "treatment": asdict(treatment),
+                "parent_history_prefix_preserved": True,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "preregistration_sha256": file_sha256(repo_root / PREREGISTRATION_PATH),
+        "legacy_docker_orchestration_sha256": LEGACY_DOCKER_TEST_SHA256,
+        "profiles": profile_results,
+        "lifecycle_assertions": [
+            "production_compile_session",
+            "candidate_verification",
+            "clean_replay",
+            "r0_classification",
+            "zero_orphan_cleanup",
+        ],
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(json.dumps(validate_gate_contract(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 研究问题

#212 已确认 R2 runtime 固定 `-j2` 与公开动作面不一致。本 PR 建立新的 R3 Make 真实 Docker lifecycle identity，验证省略 jobs 和 `-j1` 是否都能在 production Compile Session 中满足 Make P2、candidate verification 与 clean replay。

## 实现

- 新增版本化 R3 lifecycle adapter，profile 固定为 `make libhoedown.a` 与 `make -j1 libhoedown.a`；
- 复用 #204 已验证的真实 Docker orchestration，并固定旧测试文件 SHA-256，避免复制约 300 行编排；
- 新增静态合同、opt-in Ubuntu 原生 Docker 门禁和运行前协议；
- 不修改 #202 reference gate、#204 lifecycle gate/Docker 测试、#208 runtime/runner/manifest、#210 audit、#212 alignment gate 或任何冻结 evidence。

## 结果

- 两个 profile 均从 `unproven/opaque_wrapper` 转为 `proven/direct_make`；
- 两个 profile 的 candidate verification 与唯一 clean replay 均通过；
- Docker：`2 passed in 156.30s`；
- 相邻回归：`86 passed`；静态聚焦：`4 passed`；
- 后置 compile/replay/capture orphan 均为 0；
- Ruff check/format、py_compile、diff check 与敏感信息扫描通过。

## 外部影响

0 provider call、0 credential read、0 formal physical attempt、0 model token、0正式 evidence write。本地 SQLite checkpointer 仅复用 #204 的双臂同源恢复测试设施。

Closes #214