### PR TITLE
研究：冻结 R3 Make 单配对 candidate 与 runtime gate

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,12 +64,19 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-30 — 完成 Issue #216 R3 Make 单配对未执行候选与零 provider runtime 门禁
+  - 文件: `scripts/forge_opaque_provenance_r3_make_candidate_protocol.py`, `scripts/forge_opaque_provenance_r3_make_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_r3_make_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md`
+  - 实现: 从冻结 #208 R2 identity 派生全新 R3 candidate，保持 hoextdown case、九字段 repair packet、baseline→treatment、state matching 与 245,000 token ceiling，但关闭 checkpoint/provider/credential/Docker/pair/evidence 等全部执行授权；repair packet 仍是唯一 treatment exposure。
+  - Runtime: 同一 adapter 接受 jobs 省略、`-j1` 与 `--jobs=2`，拒绝无界、0 和超过 2 并保留独立 R0 分类；只提供 validate/plan/只读 Git preflight，三个 execute 入口均 fail-closed。
+  - 验证: canonical manifest SHA-256 为 `e45c9a5cfbba70d30ee2c82a68631a3430ea3e66748d808888660cae5c105d7b`，evidence identity 为 `17bf1a758d953f4e0c579039c97c8a3e669caf92ca720f93b3edfe29116c9890`；聚焦 `6 passed`、Make/R0/R3 相邻 `109 passed, 3 skipped`，Ruff check/format、py_compile、CLI 与敏感信息扫描通过。
+  - 边界: 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write；中文 Issue #216 已创建并回读，待提交、PR/CI 与合并。合并后才运行 release preflight，另建 amendment 前仍不授权模型。
+
 - 2026-08-30 — 完成 Issue #214 R3 Make jobs 真实 lifecycle 本地门禁
   - 文件: `scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md`
   - 实现: 新版本 adapter 复用并固定 #204 Docker orchestration 哈希，分别暴露 `make libhoedown.a` 与 `make -j1 libhoedown.a`；不修改 #202/#204/#208/#210/#212 或冻结 evidence。
   - 结论: 两个 profile 均在 Ubuntu WSL2 原生 Docker production Compile Session 中把 Make P2 从 `unproven/opaque_wrapper` 转为 `proven/direct_make`，且 candidate verification、唯一 clean replay、R0 分类与 cleanup 全部通过；后置 compile/replay/capture orphan 均为 0。
   - 验证: 真实 Docker `2 passed in 156.30s`，相邻回归 `86 passed`，静态聚焦 `4 passed`，Ruff check/format、`py_compile`、`git diff --check` 与敏感信息扫描通过。
-  - 边界: 0 provider、0 credential read、0 formal physical attempt、0 model token、0正式 evidence write；本地 SQLite checkpointer 仅用于 #204 双臂同源恢复。中文 Issue #214 已创建并回读，待提交、PR/CI 与合并。
+  - 边界: 0 provider、0 credential read、0 formal physical attempt、0 model token、0正式 evidence write；本地 SQLite checkpointer 仅用于 #204 双臂同源恢复。中文 Issue #214 / PR #215 已合并为 `main@e58ef0f0e7d5968667dc0c0ce586834251daeac1`。
 
 - 2026-08-30 — 完成 Issue #212 R3 Make 构造对齐零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_construct_alignment_gate.py`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md`
@@ -590,7 +597,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
-- PowerShell 可能误解析传给 WSL Docker CLI 的 Go template（例如 `{{.Server.Version}}`），导致只读 gate 在接触 daemon 后被错误参数拒绝。跨 PowerShell/WSL gate 使用固定 argv 且不传 template；版本检查直接运行 `docker version`，列表检查使用不需要 format 的 `docker ps -aq` / `docker images -q`。
+- PowerShell 可能误解析传给 WSL Docker CLI 的 Go template（例如 `{{.Server.Version}}`）或混合单双引号的复杂正则，导致只读 gate 在业务逻辑前被拒绝。跨 PowerShell/WSL gate 使用固定 argv 且不传 template；版本检查直接运行 `docker version`，列表检查使用不需要 format 的 `docker ps -aq` / `docker images -q`；敏感扫描拆成简单单引号模式。
 
 - 历史 manifest 会按字节冻结 `scripts/forge_opaque_provenance_runtime_parity_gate.py`、共享 `evidence.py` 和 LLM/tool-error middleware 等父组件；即使行为兼容，原地增加异常元数据、Schema 或仅运行 Ruff 格式化也会让旧协议 current-tree gate 报 runtime drift。新增 instrumentation 必须放入新的版本化 adapter/companion event，并用完整 backend CI 确认所有冻结文件零差异。
 - 真实 lifecycle capture 的 evidence Schema 强制要求 `submit_attempt_id`；只记录 classification/failure ID 会在 environment freeze 前 fail closed。新 gate 应直接从同一 `failure.recorded` payload 复制该 ID，并先做 Schema 级静态断言。

--- a/backend/tests/test_forge_opaque_provenance_r3_make_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_r3_make_candidate.py
@@ -1,0 +1,149 @@
+"""Issue #216 R3 Make 单配对 candidate 的零 provider 门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS_DIR / "forge_opaque_provenance_r3_make_candidate_protocol.py"
+RUNNER_PATH = SCRIPTS_DIR / "forge_opaque_provenance_r3_make_candidate_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module("forge_opaque_provenance_r3_make_candidate_protocol_test", PROTOCOL_PATH)
+runner = _load_module("forge_opaque_provenance_r3_make_candidate_runner_test", RUNNER_PATH)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_and_frozen_parent_components_are_deterministic() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(REPO_ROOT)
+    assert manifest["parent"]["canonical_sha256"] == protocol.PARENT_MANIFEST_CANONICAL_SHA256
+
+
+def test_candidate_authorization_and_action_surface_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert all(value is False for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["authorization"]["model_tokens_authorized"] == 0
+    assert manifest["checkpoint"]["status"] == "not_created"
+    assert manifest["evidence"]["status"] == "not_created"
+    assert manifest["schedule"][0]["arm_order"] == ["baseline", "treatment"]
+    assert manifest["schedule"][0]["treatment_exposure_only"] == "repair_packet"
+    assert manifest["runtime_parity"]["action_surface"]["jobs"] == {
+        "omitted_allowed": True,
+        "minimum": 1,
+        "maximum": 2,
+    }
+
+
+def test_runtime_wiring_accepts_bounded_jobs_and_preserves_r0_classifications() -> None:
+    result = runner.validate_runtime_gate_contract()
+    assert set(result["accepted"].values()) == {"repair_build"}
+    assert result["rejected"] == {
+        "make -j libhoedown.a": "repair_build_jobs_unbounded",
+        "make -j0 libhoedown.a": "repair_build_jobs_out_of_bounds",
+        "make -j3 libhoedown.a": "repair_build_jobs_out_of_bounds",
+    }
+    assert result["r0_companion_event"] == "agent.tool_rejection_observed"
+    assert (
+        result["provider_calls"],
+        result["credential_read"],
+        result["docker_executed"],
+        result["checkpoint_created"],
+        result["formal_attempts"],
+        result["model_tokens"],
+        result["evidence_writes"],
+    ) == (0, False, False, False, 0, 0, 0)
+
+    adapter = runner.ObservableRuntimeParityToolAdapter(run_tool=lambda **kwargs: kwargs, submit_tool=lambda **kwargs: kwargs)
+    with pytest.raises(runner.make_observability.ObservableRuntimeParityGateError) as captured:
+        adapter.run("make -j libhoedown.a", command_role="build")
+    assert captured.value.evidence_rejection_classification == "repair_build_jobs_unbounded"
+    assert captured.value.evidence_action_kind == "repair_build"
+
+
+def test_plan_and_preflight_are_read_only_and_execute_paths_fail_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    plan = runner.build_plan(manifest)
+    assert plan["execution_authorized"] is False
+    assert plan["treatment_exposure_only"] == "repair_packet"
+
+    values = {
+        ("git", "branch", "--show-current"): "main",
+        ("git", "rev-parse", "HEAD"): protocol.AUTHORIZATION_BASELINE_COMMIT,
+        ("git", "rev-parse", "origin/main"): protocol.AUTHORIZATION_BASELINE_COMMIT,
+        ("git", "status", "--porcelain"): "",
+        ("git", "merge-base", "--is-ancestor", protocol.AUTHORIZATION_BASELINE_COMMIT, "HEAD"): "",
+    }
+    candidate = REPO_ROOT / ".compile-sessions" / Path(manifest["evidence"]["directory"]).name
+    snapshot = runner.collect_preflight_snapshot(
+        manifest,
+        repo_root=REPO_ROOT,
+        host_candidate_evidence_directory=candidate,
+        command_runner=lambda command, _cwd: values[tuple(command)],
+    )
+    assert snapshot["provider_calls"] == 0
+    assert snapshot["credential_read"] is False
+    assert snapshot["docker_executed"] is False
+    assert snapshot["evidence_writes"] == 0
+    assert not candidate.exists()
+
+    for execute in (runner.execute_checkpoint, runner.execute_reachability, runner.execute_pair):
+        with pytest.raises(runner.RuntimeGateError, match="not authorized"):
+            execute(manifest)
+
+
+def test_schema_and_protocol_reject_authorization_jobs_or_schedule_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    mutations = (
+        ("authorization", "provider_calls_authorized", True),
+        ("authorization", "model_tokens_authorized", 1),
+        ("runtime_parity", "parallel_tool_calls", True),
+        ("schedule", 0, []),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_new_sources_do_not_embed_credentials_or_provider_execution() -> None:
+    combined = PROTOCOL_PATH.read_text(encoding="utf-8") + RUNNER_PATH.read_text(encoding="utf-8")
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "os.environ["):
+        assert forbidden not in combined
+    assert "execute_reachability" in combined
+    assert "not authorized by Issue #216" in combined

--- a/benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-r3-make-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-r3-make-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_r3_make_candidate",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/216",
+    "checkpoint_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "pair_collection_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json",
+    "schema_version": "forge-opaque-provenance-r2-make-execution-1.0.0",
+    "canonical_sha256": "113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e",
+    "file_sha256": "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d",
+    "historical_result_reused": false,
+    "authorization_baseline_commit": "e58ef0f0e7d5968667dc0c0ce586834251daeac1"
+  },
+  "case": {
+    "case_id": "hoextdown-opaque-provenance-r3-make",
+    "repository_url": "https://github.com/kjdev/hoextdown",
+    "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+    "build_system": "make",
+    "source_subdir": ".",
+    "target": "libhoedown.a",
+    "build_output": "libhoedown.a",
+    "staged_artifact": "libhoedown.a",
+    "artifact_type": "static_library",
+    "compile_image": "autocompiler:gcc13",
+    "build_directory": "/workspace/repo",
+    "required_system_packages": [
+      "build-essential"
+    ],
+    "parent_proof_status": "opaque_wrapper",
+    "parent_expected_failure": "build_system_unproven"
+  },
+  "checkpoint": {
+    "status": "not_created",
+    "checkpoint_id": null,
+    "source_gate": "issue-214-r3-make-lifecycle-zero-provider",
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "creation_requires_execution_amendment": true
+  },
+  "provider": {
+    "status": "candidate_not_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-r3-hoextdown-pair-01",
+      "order": 1,
+      "case_id": "hoextdown-opaque-provenance-r3-make",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "r3_bounded_jobs_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "2b6e9f52b8299febab2f13d12cd01b41c1ba4a18b33dc4deba989a8317f8eeb2",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "fields": [
+      "schema_version",
+      "primary_classification",
+      "mechanism_classification",
+      "expected_build_system",
+      "selected_build_system",
+      "build_directory",
+      "target",
+      "proof_status",
+      "repair_goal"
+    ],
+    "template": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "make",
+      "selected_build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libhoedown.a",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+    },
+    "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+    "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "forbidden_solution_fields": [
+      "command",
+      "argv",
+      "command_line",
+      "shell",
+      "credential",
+      "secret"
+    ]
+  },
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "shared_tool_contract_identical": true,
+    "treatment_exposure_only": "repair_packet",
+    "action_surface": {
+      "direct_executables": [
+        "make",
+        "gmake"
+      ],
+      "build_directory": "/workspace/repo",
+      "target": "libhoedown.a",
+      "jobs": {
+        "omitted_allowed": true,
+        "minimum": 1,
+        "maximum": 2
+      },
+      "artifact_stage": {
+        "source": "/workspace/repo/libhoedown.a",
+        "destination": "/artifacts/libhoedown.a",
+        "separate_from_build": true
+      }
+    },
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true,
+    "forbidden_actions": [
+      "clone",
+      "configure",
+      "dependency",
+      "housekeeping",
+      "manual_replay",
+      "compound_build_stage"
+    ]
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+    }
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-r3-make-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r3-hoextdown-candidate-v1",
+    "status": "not_created",
+    "append_only": true,
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "17bf1a758d953f4e0c579039c97c8a3e669caf92ca720f93b3edfe29116c9890"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_replacement_backfill_or_extension_forbidden": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true
+  },
+  "analysis": {
+    "purpose": "r3_make_action_surface_aligned_conversion_replication_candidate",
+    "unit_of_analysis": "single_state_matched_make_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "p_value_computed": false,
+    "model_ranking_performed": false,
+    "historical_pairs_pooled": false
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "authorization_baseline_commit": "e58ef0f0e7d5968667dc0c0ce586834251daeac1",
+    "require_authorization_baseline_ancestor": true,
+    "require_frozen_component_hashes": true,
+    "require_empty_candidate_evidence_directory": true,
+    "require_checkpoint_not_created": true,
+    "docker_check_forbidden": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md",
+    "file_sha256": "57d56d685ed76d3ad2957906a4fe46b23dd3e8eb17302542706bac10b476e9a9"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+    "file_sha256": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+    "commands": [
+      "validate",
+      "plan",
+      "preflight"
+    ],
+    "credential_read_supported": false,
+    "provider_model_creation_supported": false,
+    "checkpoint_execute_supported": false,
+    "reachability_execute_supported": false,
+    "pair_execute_supported": false,
+    "docker_execute_supported": false,
+    "evidence_write_supported": false,
+    "r0_companion_contract_supported": true
+  },
+  "frozen_parent_components": {
+    "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json": "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d",
+    "scripts/forge_opaque_provenance_r2_make_execution_protocol.py": "9cf49a76284c6f80feb439c4112e438336ca0f5276300cf0e403100d9569d4dd",
+    "scripts/forge_opaque_provenance_r2_make_execution_runner.py": "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0",
+    "scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py": "152e945707d18682101d80d525416c079945d934336da373e994e4338bce19d6",
+    "scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py": "132fc6248af4690c9823060657b490626031e44f55a5232de09a79a3426b3b4e",
+    "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py": "54d1c6f7c1137783b83c8208bbaa213e9cbf23b12fdda73de961b96e8f704347",
+    "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py": "af7219ab296804cb21a519a28d2aeec15e8d09f4076d88054ff4b9efdd668a77",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md": "c88f4750ed75c9360dcae7220541fc597e7a5422e87ac384fa591374a309346b",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md": "2205f3f40b1dd71e3a86327dc3696826b793f3969507598fc5893f686509b1af"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md
@@ -1,0 +1,20 @@
+# R3 Make 单配对未执行 candidate
+
+- Issue：[#216](https://github.com/WWFXL/Forge-AutoCompiler/issues/216)
+- 性质：零 provider、零 Docker、未执行候选；不是 #208 retry、replacement、backfill 或 extension。
+- 父证据：#208 R2 execution 只读结果；#212 action alignment；#214 真实 lifecycle。
+
+## 候选问题
+
+在 hoextdown case、九字段 repair packet、`baseline -> treatment`、state matching 和预算不变时，公开且双臂共享的 R3 action surface 能否支持未来的单配对 conversion replication？本阶段只验证 runner 接线，不估计 treatment effect，也不产生模型行为结果。
+
+## 冻结动作面
+
+- build 只能 direct `make/gmake`，目录 `/workspace/repo`，target `libhoedown.a`；
+- jobs 可省略或为 `1..2`，拒绝无界、0、超限和非法值；
+- stage 必须独立执行，只允许 `libhoedown.a -> /artifacts/libhoedown.a`；
+- repair packet 仍是唯一 treatment exposure；双臂共享相同工具描述、validator、预算和 R0 companion 合同。
+
+## 授权与停止规则
+
+Checkpoint、reachability、provider、credential、Docker、pair 和 evidence write 全部未授权，model-token authorization 为 0。Runtime adapter 只提供 `validate`、`plan` 与只读 Git `preflight`；任何 execute 入口必须 fail-closed。只有本候选合并且 release preflight 通过后，才能另建 execution amendment，并再次明确是否授权 provider 调用。

--- a/benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json",
+  "title": "Forge opaque provenance R3 Make candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-r3-make-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-r3-make-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_r3_make_candidate",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/216",
+      "checkpoint_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "pair_collection_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json",
+      "schema_version": "forge-opaque-provenance-r2-make-execution-1.0.0",
+      "canonical_sha256": "113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e",
+      "file_sha256": "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d",
+      "historical_result_reused": false,
+      "authorization_baseline_commit": "e58ef0f0e7d5968667dc0c0ce586834251daeac1"
+    },
+    "case": {
+      "case_id": "hoextdown-opaque-provenance-r3-make",
+      "repository_url": "https://github.com/kjdev/hoextdown",
+      "commit_sha": "1ef9a71957570c2a65b7daa1b2f693ad87daf385",
+      "build_system": "make",
+      "source_subdir": ".",
+      "target": "libhoedown.a",
+      "build_output": "libhoedown.a",
+      "staged_artifact": "libhoedown.a",
+      "artifact_type": "static_library",
+      "compile_image": "autocompiler:gcc13",
+      "build_directory": "/workspace/repo",
+      "required_system_packages": [
+        "build-essential"
+      ],
+      "parent_proof_status": "opaque_wrapper",
+      "parent_expected_failure": "build_system_unproven"
+    },
+    "checkpoint": {
+      "status": "not_created",
+      "checkpoint_id": null,
+      "source_gate": "issue-214-r3-make-lifecycle-zero-provider",
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "creation_requires_execution_amendment": true
+    },
+    "provider": {
+      "status": "candidate_not_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-r3-hoextdown-pair-01",
+        "order": 1,
+        "case_id": "hoextdown-opaque-provenance-r3-make",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "r3_bounded_jobs_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "2b6e9f52b8299febab2f13d12cd01b41c1ba4a18b33dc4deba989a8317f8eeb2",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "fields": [
+        "schema_version",
+        "primary_classification",
+        "mechanism_classification",
+        "expected_build_system",
+        "selected_build_system",
+        "build_directory",
+        "target",
+        "proof_status",
+        "repair_goal"
+      ],
+      "template": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "libhoedown.a",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+      },
+      "origin_path": "scripts/forge_opaque_provenance_make_lifecycle_gate.py",
+      "origin_file_sha256": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "forbidden_solution_fields": [
+        "command",
+        "argv",
+        "command_line",
+        "shell",
+        "credential",
+        "secret"
+      ]
+    },
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "shared_tool_contract_identical": true,
+      "treatment_exposure_only": "repair_packet",
+      "action_surface": {
+        "direct_executables": [
+          "make",
+          "gmake"
+        ],
+        "build_directory": "/workspace/repo",
+        "target": "libhoedown.a",
+        "jobs": {
+          "omitted_allowed": true,
+          "minimum": 1,
+          "maximum": 2
+        },
+        "artifact_stage": {
+          "source": "/workspace/repo/libhoedown.a",
+          "destination": "/artifacts/libhoedown.a",
+          "separate_from_build": true
+        }
+      },
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true,
+      "forbidden_actions": [
+        "clone",
+        "configure",
+        "dependency",
+        "housekeeping",
+        "manual_replay",
+        "compound_build_stage"
+      ]
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+      }
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-r3-make-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r3-hoextdown-candidate-v1",
+      "status": "not_created",
+      "append_only": true,
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "17bf1a758d953f4e0c579039c97c8a3e669caf92ca720f93b3edfe29116c9890"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_replacement_backfill_or_extension_forbidden": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true
+    },
+    "analysis": {
+      "purpose": "r3_make_action_surface_aligned_conversion_replication_candidate",
+      "unit_of_analysis": "single_state_matched_make_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "p_value_computed": false,
+      "model_ranking_performed": false,
+      "historical_pairs_pooled": false
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "authorization_baseline_commit": "e58ef0f0e7d5968667dc0c0ce586834251daeac1",
+      "require_authorization_baseline_ancestor": true,
+      "require_frozen_component_hashes": true,
+      "require_empty_candidate_evidence_directory": true,
+      "require_checkpoint_not_created": true,
+      "docker_check_forbidden": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md",
+      "file_sha256": "57d56d685ed76d3ad2957906a4fe46b23dd3e8eb17302542706bac10b476e9a9"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+      "file_sha256": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+      "commands": [
+        "validate",
+        "plan",
+        "preflight"
+      ],
+      "credential_read_supported": false,
+      "provider_model_creation_supported": false,
+      "checkpoint_execute_supported": false,
+      "reachability_execute_supported": false,
+      "pair_execute_supported": false,
+      "docker_execute_supported": false,
+      "evidence_write_supported": false,
+      "r0_companion_contract_supported": true
+    },
+    "frozen_parent_components": {
+      "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json": "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d",
+      "scripts/forge_opaque_provenance_r2_make_execution_protocol.py": "9cf49a76284c6f80feb439c4112e438336ca0f5276300cf0e403100d9569d4dd",
+      "scripts/forge_opaque_provenance_r2_make_execution_runner.py": "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0",
+      "scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py": "152e945707d18682101d80d525416c079945d934336da373e994e4338bce19d6",
+      "scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py": "132fc6248af4690c9823060657b490626031e44f55a5232de09a79a3426b3b4e",
+      "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py": "54d1c6f7c1137783b83c8208bbaa213e9cbf23b12fdda73de961b96e8f704347",
+      "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py": "af7219ab296804cb21a519a28d2aeec15e8d09f4076d88054ff4b9efdd668a77",
+      "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md": "c88f4750ed75c9360dcae7220541fc597e7a5422e87ac384fa591374a309346b",
+      "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md": "2205f3f40b1dd71e3a86327dc3696826b793f3969507598fc5893f686509b1af"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_r3_make_candidate_protocol.py
+++ b/scripts/forge_opaque_provenance_r3_make_candidate_protocol.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Issue #216 R3 Make 单配对未执行候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-r2-make-execution.json"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_r3_make_candidate_runner.py"
+
+SCHEMA_VERSION = "forge-opaque-provenance-r3-make-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_r3_make_candidate"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/216"
+AUTHORIZATION_BASELINE_COMMIT = "e58ef0f0e7d5968667dc0c0ce586834251daeac1"
+PARENT_MANIFEST_CANONICAL_SHA256 = "113192d509b3c15762f8055cb32fc9364a4a4be6bede1eeed838e540a025224e"
+
+FROZEN_PARENT_COMPONENTS = {
+    PARENT_MANIFEST_PATH: "c25a9eca30b58e686c21a03497a0c5a163dda45ab06eaf922442a83780d7b17d",
+    "scripts/forge_opaque_provenance_r2_make_execution_protocol.py": "9cf49a76284c6f80feb439c4112e438336ca0f5276300cf0e403100d9569d4dd",
+    "scripts/forge_opaque_provenance_r2_make_execution_runner.py": "0854a836f347d371974594eadb32f72d0cff4361bcb06bd5e1ad2a9effef78c0",
+    "scripts/forge_opaque_provenance_r3_make_construct_alignment_gate.py": "152e945707d18682101d80d525416c079945d934336da373e994e4338bce19d6",
+    "scripts/forge_opaque_provenance_r3_make_lifecycle_gate.py": "132fc6248af4690c9823060657b490626031e44f55a5232de09a79a3426b3b4e",
+    "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate.py": "54d1c6f7c1137783b83c8208bbaa213e9cbf23b12fdda73de961b96e8f704347",
+    "backend/tests/test_forge_opaque_provenance_r3_make_lifecycle_gate_docker.py": "af7219ab296804cb21a519a28d2aeec15e8d09f4076d88054ff4b9efdd668a77",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-construct-alignment-gate.md": "c88f4750ed75c9360dcae7220541fc597e7a5422e87ac384fa591374a309346b",
+    "benchmarks/preregistrations/cpp-opaque-provenance-r3-make-lifecycle-zero-provider-gate.md": "2205f3f40b1dd71e3a86327dc3696826b793f3969507598fc5893f686509b1af",
+}
+
+
+class ProtocolError(RuntimeError):
+    """R3 candidate 身份、授权或冻结组件无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot load {label}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"{label} must be an object")
+    return value
+
+
+def verify_frozen_components(repo_root: Path = REPO_ROOT) -> None:
+    for relative_path, expected_sha256 in FROZEN_PARENT_COMPONENTS.items():
+        if file_sha256(repo_root / relative_path) != expected_sha256:
+            raise ProtocolError(f"frozen parent component drifted: {relative_path}")
+
+
+def _parent_manifest(repo_root: Path) -> dict[str, Any]:
+    verify_frozen_components(repo_root)
+    parent = _load_object(repo_root / PARENT_MANIFEST_PATH, "R2 Make execution manifest")
+    if canonical_sha256(parent) != PARENT_MANIFEST_CANONICAL_SHA256:
+        raise ProtocolError("R2 Make execution manifest canonical identity drifted")
+    return parent
+
+
+def _evidence_identity(case: dict[str, Any], schedule: list[dict[str, Any]], repair_packet: dict[str, Any]) -> str:
+    return canonical_sha256(
+        {
+            "schema_version": "forge-opaque-provenance-r3-make-evidence-1.0.0",
+            "case": case,
+            "schedule": schedule,
+            "repair_packet": repair_packet,
+            "jobs_policy": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+            "parent_manifest_canonical_sha256": PARENT_MANIFEST_CANONICAL_SHA256,
+        }
+    )
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent = _parent_manifest(repo_root)
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("R3 candidate runtime or preregistration is missing")
+
+    case = copy.deepcopy(parent["case"])
+    case["case_id"] = "hoextdown-opaque-provenance-r3-make"
+    schedule = [
+        {
+            "pair_id": "opaque-provenance-r3-hoextdown-pair-01",
+            "order": 1,
+            "case_id": case["case_id"],
+            "arm_order": ["baseline", "treatment"],
+            "state_matched": True,
+            "treatment_exposure_only": "repair_packet",
+            "shared_measurement_policy": "r3_bounded_jobs_with_r0_observability_v1",
+        }
+    ]
+    repair_packet = copy.deepcopy(parent["repair_packet"])
+    provider = copy.deepcopy(parent["provider"])
+    provider["status"] = "candidate_not_authorized"
+    action_surface = {
+        "direct_executables": ["make", "gmake"],
+        "build_directory": case["build_directory"],
+        "target": case["target"],
+        "jobs": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+        "artifact_stage": {
+            "source": f"{case['build_directory']}/{case['build_output']}",
+            "destination": f"/artifacts/{case['staged_artifact']}",
+            "separate_from_build": True,
+        },
+    }
+    evidence_identity = _evidence_identity(case, schedule, repair_packet)
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-r3-make-candidate.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "checkpoint_creation_authorized": False,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "pair_collection_authorized": False,
+            "credential_read_authorized": False,
+            "model_creation_authorized": False,
+            "docker_execution_authorized": False,
+            "evidence_write_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent["schema_version"],
+            "canonical_sha256": PARENT_MANIFEST_CANONICAL_SHA256,
+            "file_sha256": FROZEN_PARENT_COMPONENTS[PARENT_MANIFEST_PATH],
+            "historical_result_reused": False,
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+        },
+        "case": case,
+        "checkpoint": {
+            "status": "not_created",
+            "checkpoint_id": None,
+            "source_gate": "issue-214-r3-make-lifecycle-zero-provider",
+            "arm_state_matching": ["message", "environment", "budget"],
+            "creation_requires_execution_amendment": True,
+        },
+        "provider": provider,
+        "continuation": copy.deepcopy(parent["continuation"]),
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "repair_packet": repair_packet,
+        "budget": copy.deepcopy(parent["budget"]),
+        "runtime_parity": {
+            "action_limits": copy.deepcopy(parent["runtime_parity"]["action_limits"]),
+            "atomic_budget_claim": True,
+            "parallel_tool_calls": False,
+            "shared_tool_contract_identical": True,
+            "treatment_exposure_only": "repair_packet",
+            "action_surface": action_surface,
+            "candidate_verification_required": True,
+            "clean_replay_required": True,
+            "cleanup_required": True,
+            "forbidden_actions": copy.deepcopy(parent["runtime_parity"]["forbidden_actions"]),
+        },
+        "r0_observability": copy.deepcopy(parent["r0_observability"]),
+        "evidence": {
+            "schema_version": "forge-opaque-provenance-r3-make-evidence-1.0.0",
+            "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r3-hoextdown-candidate-v1",
+            "status": "not_created",
+            "append_only": True,
+            "zero_provider_preflight_writes_evidence": False,
+            "identity_sha256": evidence_identity,
+        },
+        "stopping": copy.deepcopy(parent["stopping"]),
+        "analysis": {
+            **copy.deepcopy(parent["analysis"]),
+            "purpose": "r3_make_action_surface_aligned_conversion_replication_candidate",
+            "treatment_effect_estimated": False,
+            "historical_pairs_pooled": False,
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "require_authorization_baseline_ancestor": True,
+            "require_frozen_component_hashes": True,
+            "require_empty_candidate_evidence_directory": True,
+            "require_checkpoint_not_created": True,
+            "docker_check_forbidden": True,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "plan", "preflight"],
+            "credential_read_supported": False,
+            "provider_model_creation_supported": False,
+            "checkpoint_execute_supported": False,
+            "reachability_execute_supported": False,
+            "pair_execute_supported": False,
+            "docker_execute_supported": False,
+            "evidence_write_supported": False,
+            "r0_companion_contract_supported": True,
+        },
+        "frozen_parent_components": copy.deepcopy(FROZEN_PARENT_COMPONENTS),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("R3 Make candidate manifest drifted")
+    if any(value["authorization"][key] for key in value["authorization"] if key.endswith("_authorized")):
+        raise ProtocolError("R3 Make candidate unexpectedly authorizes execution")
+    if value["authorization"]["model_tokens_authorized"] != 0:
+        raise ProtocolError("R3 Make candidate token authorization drifted")
+    if value["checkpoint"]["status"] != "not_created" or value["evidence"]["status"] != "not_created":
+        raise ProtocolError("R3 Make candidate unexpectedly materialized state")
+    return value
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return validate_manifest(_load_object(path, "R3 Make candidate manifest"), repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json",
+        "title": "Forge opaque provenance R3 Make candidate",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    print(json.dumps({"manifest_sha256": canonical_sha256(manifest), "authorization": manifest["authorization"]}, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_r3_make_candidate_runner.py
+++ b/scripts/forge_opaque_provenance_r3_make_candidate_runner.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Issue #216 R3 Make candidate 的零 provider runtime gate。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import forge_opaque_provenance_make_rejection_observability_gate as make_observability
+import forge_opaque_provenance_make_runtime_parity_gate as make_parity
+import forge_opaque_provenance_r3_make_candidate_protocol as protocol
+import forge_opaque_provenance_r3_make_construct_alignment_gate as alignment
+
+from deerflow.compile.evidence import EvidenceError, allowed_command_role
+from deerflow.compile.operations import infer_command_roles, resolve_command_role
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+ACTION_LIMITS = make_parity.ACTION_LIMITS
+AtomicActionBudget = make_parity.AtomicActionBudget
+CommandRunner = Callable[[Sequence[str], Path], str]
+_FORBIDDEN_ROLES = frozenset({"clone", "configure", "dependency_setup", "housekeeping", "replay_delay"})
+
+
+class RuntimeGateError(RuntimeError):
+    """候选 runtime、只读快照或未授权入口无效。"""
+
+
+class R3RuntimeParityGateError(make_parity.RuntimeParityGateError):
+    def __init__(self, message: str, *, classification: str, action_kind: str) -> None:
+        super().__init__(message)
+        self.evidence_rejection_classification = classification
+        self.evidence_action_kind = action_kind
+
+
+@dataclass(frozen=True)
+class R3ActionPolicy:
+    workdir: str = alignment.lifecycle.WORKDIR
+    build_directory: str = alignment.lifecycle.WORKDIR
+    target: str = alignment.lifecycle.TARGET
+    build_output: str = f"{alignment.lifecycle.WORKDIR}/{alignment.lifecycle.BUILD_OUTPUT}"
+    staged_artifact: str = f"/artifacts/{alignment.lifecycle.STAGED_ARTIFACT}"
+    maximum_jobs: int = 2
+
+
+def validate_repair_build(command: str, *, workdir: str, policy: R3ActionPolicy) -> None:
+    try:
+        alignment.validate_repair_build(
+            command,
+            workdir=workdir,
+            policy=alignment.AlignedMakePolicy(
+                build_directory=policy.build_directory,
+                target=policy.target,
+                maximum_jobs=policy.maximum_jobs,
+            ),
+        )
+    except alignment.ConstructAlignmentGateError as exc:
+        raise R3RuntimeParityGateError(
+            str(exc),
+            classification=exc.evidence_rejection_classification,
+            action_kind=exc.evidence_action_kind,
+        ) from exc
+
+
+def classify_action(command: str, *, workdir: str, command_role: str, policy: R3ActionPolicy) -> str:
+    declared = allowed_command_role(command_role)
+    effective, _inferred = resolve_command_role(command, declared)
+    roles = infer_command_roles(command) | {effective}
+    if roles & _FORBIDDEN_ROLES:
+        raise make_parity.RuntimeParityGateError("command uses a forbidden post-checkpoint role")
+    if "build" in roles:
+        if "artifact_stage" in roles:
+            raise make_parity.RuntimeParityGateError("repair build and artifact stage must be separate actions")
+        validate_repair_build(command, workdir=workdir, policy=policy)
+        return "repair_build"
+    if "artifact_stage" in roles:
+        make_parity.validate_artifact_stage(command, workdir=workdir, policy=policy)
+        return "artifact_stage"
+    if effective not in {"other", "smoke"}:
+        raise make_parity.RuntimeParityGateError("command role is outside the runtime-parity action set")
+    make_parity.base._tokens(command)
+    return "inspection"
+
+
+@dataclass
+class RuntimeParityToolAdapter:
+    run_tool: Any
+    submit_tool: Any
+    budget: AtomicActionBudget = field(default_factory=AtomicActionBudget)
+    policy: R3ActionPolicy = field(default_factory=R3ActionPolicy)
+    staged_artifacts_present: Callable[[], bool] = field(default=lambda: False)
+
+    def run(
+        self,
+        command: str,
+        *,
+        timeout_seconds: int = 300,
+        workdir: str | None = None,
+        command_role: str = "other",
+    ) -> Any:
+        effective_workdir = workdir or self.policy.workdir
+        action = classify_action(command, workdir=effective_workdir, command_role=command_role, policy=self.policy)
+        automatic_submit_expected = action == "artifact_stage" or (action == "repair_build" and self.staged_artifacts_present())
+        claims: Iterable[str] = (action, "submit") if automatic_submit_expected else (action,)
+        self.budget.claim(*claims)
+        return make_parity.base._invoke(
+            self.run_tool,
+            {
+                "command": command,
+                "timeout_seconds": min(300, max(1, timeout_seconds)),
+                "workdir": effective_workdir,
+                "command_role": command_role,
+            },
+        )
+
+    def submit(self, supporting_command_id: str | None = None) -> Any:
+        self.budget.claim("submit")
+        return make_parity.base._invoke(self.submit_tool, {"supporting_command_id": supporting_command_id})
+
+
+class ObservableRuntimeParityToolAdapter(RuntimeParityToolAdapter):
+    """将 R3 分类映射到既有 R0 companion 合同。"""
+
+    def run(self, command: str, **kwargs: Any) -> Any:
+        try:
+            return super().run(command, **kwargs)
+        except R3RuntimeParityGateError as exc:
+            raise make_observability.ObservableRuntimeParityGateError(
+                str(exc),
+                classification=exc.evidence_rejection_classification,
+                action_kind=exc.evidence_action_kind,
+            ) from exc
+        except make_parity.RuntimeParityGateError as exc:
+            raise make_observability.r0._observable_gate_error(exc, action_hint=make_observability.r0._action_hint(kwargs.get("command_role", "other"))) from exc
+        except EvidenceError as exc:
+            if str(exc).startswith("Unsupported compile command role:"):
+                raise make_observability.ObservableRuntimeParityGateError(
+                    "unsupported compile command role",
+                    classification="invalid_command_role",
+                    action_kind="command",
+                ) from exc
+            raise
+
+    def submit(self, supporting_command_id: str | None = None) -> Any:
+        try:
+            return super().submit(supporting_command_id)
+        except make_parity.RuntimeParityGateError as exc:
+            raise make_observability.r0._observable_gate_error(exc, action_hint="submit") from exc
+
+
+def _run_command(command: Sequence[str], cwd: Path) -> str:
+    if not command or command[0] != "git":
+        raise RuntimeGateError("candidate preflight only permits read-only git commands")
+    try:
+        result = subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeGateError("candidate preflight git command failed") from exc
+    return result.stdout.strip()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_runtime_gate_contract() -> dict[str, Any]:
+    alignment.validate_gate_contract()
+    policy = R3ActionPolicy()
+    accepted = {command: classify_action(command, workdir=policy.workdir, command_role="build", policy=policy) for command in ("make libhoedown.a", "make -j1 libhoedown.a", "gmake --jobs=2 libhoedown.a")}
+    rejected: dict[str, str] = {}
+    for command in ("make -j libhoedown.a", "make -j0 libhoedown.a", "make -j3 libhoedown.a"):
+        try:
+            classify_action(command, workdir=policy.workdir, command_role="build", policy=policy)
+        except R3RuntimeParityGateError as exc:
+            rejected[command] = exc.evidence_rejection_classification
+    if len(rejected) != 3:
+        raise RuntimeGateError("R3 jobs rejection contract is incomplete")
+    make_parity.validate_artifact_stage(
+        "cp libhoedown.a /artifacts/libhoedown.a",
+        workdir=policy.workdir,
+        policy=policy,
+    )
+    return {
+        "accepted": accepted,
+        "rejected": rejected,
+        "jobs_policy": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+        "r0_companion_event": make_observability.OBSERVATION_EVENT,
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def build_plan(manifest: dict[str, Any]) -> dict[str, Any]:
+    protocol.validate_manifest(manifest)
+    runtime = validate_runtime_gate_contract()
+    return {
+        "schema_version": manifest["schema_version"],
+        "case_id": manifest["case"]["case_id"],
+        "pair_id": manifest["schedule"][0]["pair_id"],
+        "arm_order": manifest["schedule"][0]["arm_order"],
+        "treatment_exposure_only": manifest["schedule"][0]["treatment_exposure_only"],
+        "action_surface": manifest["runtime_parity"]["action_surface"],
+        "phase_recorded_token_ceiling": manifest["budget"]["stage_maximum_recorded_tokens"],
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "evidence_identity_sha256": manifest["evidence"]["identity_sha256"],
+        "runtime_gate": runtime,
+        "execution_authorized": False,
+    }
+
+
+def collect_preflight_snapshot(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+    host_candidate_evidence_directory: Path,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    protocol.validate_manifest(manifest, repo_root)
+    candidate_name = PurePosixPath(manifest["evidence"]["directory"]).name
+    expected_candidate = repo_root / ".compile-sessions" / candidate_name
+    if host_candidate_evidence_directory.resolve(strict=False) != expected_candidate.resolve(strict=False):
+        raise RuntimeGateError("candidate evidence directory is not bound to the frozen identity")
+    branch = command_runner(("git", "branch", "--show-current"), repo_root)
+    head = command_runner(("git", "rev-parse", "HEAD"), repo_root)
+    origin_main = command_runner(("git", "rev-parse", "origin/main"), repo_root)
+    status = command_runner(("git", "status", "--porcelain"), repo_root)
+    ancestry = command_runner(("git", "merge-base", "--is-ancestor", manifest["preflight"]["authorization_baseline_commit"], "HEAD"), repo_root)
+    entries = len(tuple(host_candidate_evidence_directory.iterdir())) if host_candidate_evidence_directory.exists() else 0
+    snapshot = {
+        "schema_version": "forge-opaque-provenance-r3-make-candidate-preflight-1.0.0",
+        "branch": branch,
+        "head_commit": head,
+        "origin_main_commit": origin_main,
+        "worktree_clean": status == "",
+        "authorization_baseline_ancestor": ancestry == "",
+        "frozen_parent_components": {path: _file_sha256(repo_root / path) for path in sorted(manifest["frozen_parent_components"])},
+        "candidate_evidence_directory": manifest["evidence"]["directory"],
+        "candidate_evidence_entries": entries,
+        "checkpoint_status": manifest["checkpoint"]["status"],
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "evidence_writes": 0,
+    }
+    if branch != "main" or not head or head != origin_main or status != "" or ancestry != "" or snapshot["frozen_parent_components"] != manifest["frozen_parent_components"] or entries != 0 or snapshot["checkpoint_status"] != "not_created":
+        raise RuntimeGateError("R3 candidate preflight snapshot is not release-ready")
+    return snapshot
+
+
+def execute_checkpoint(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("checkpoint creation is not authorized by Issue #216")
+
+
+def execute_reachability(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("reachability request is not authorized by Issue #216")
+
+
+def execute_pair(_manifest: dict[str, Any]) -> None:
+    raise RuntimeGateError("provider pair is not authorized by Issue #216")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "plan", "preflight"))
+    parser.add_argument("--manifest", type=Path, default=protocol.DEFAULT_MANIFEST)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--host-candidate-evidence-directory", type=Path)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest, args.repo_root)
+    if args.command == "preflight":
+        if args.host_candidate_evidence_directory is None:
+            raise RuntimeGateError("preflight requires the candidate evidence directory")
+        result: Any = collect_preflight_snapshot(
+            manifest,
+            repo_root=args.repo_root,
+            host_candidate_evidence_directory=args.host_candidate_evidence_directory,
+        )
+    elif args.command == "plan":
+        result = build_plan(manifest)
+    else:
+        result = {
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "runtime_gate": validate_runtime_gate_contract(),
+            "execution_authorized": False,
+        }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 研究问题

#214/#215 证明 R3 jobs 动作在真实 lifecycle 可达，但没有证明模型会选择合法动作。本 PR 冻结一个全新的、未执行的 R3 单配对 candidate，并在零 provider 层验证 future runner 的 action surface 与 R0 接线。

## 实现

- 从冻结 #208 identity 继承 hoextdown case、九字段 repair packet、`baseline -> treatment`、state matching、预算与描述性边界；
- 双臂共享 direct `make/gmake`、目录、target、jobs 省略或 `1..2`、独立 stage 合同；repair packet 仍是唯一 treatment exposure；
- runtime adapter 接受 `make libhoedown.a`、`make -j1 ...`、`gmake --jobs=2 ...`，并对无界/0/超限 jobs 保留独立 R0 分类；
- adapter 只提供 validate/plan/只读 Git preflight，checkpoint/reachability/pair 三个入口全部 fail-closed；
- 不修改 #202/#204/#208/#210/#212/#214 或任何冻结 evidence。

## 冻结身份

- manifest canonical SHA-256：`e45c9a5cfbba70d30ee2c82a68631a3430ea3e66748d808888660cae5c105d7b`
- candidate evidence identity：`17bf1a758d953f4e0c579039c97c8a3e669caf92ca720f93b3edfe29116c9890`
- 所有 execution authorization 为 false，model-token authorization 为 0；candidate evidence 目录不存在。

## 验证

- 聚焦：`6 passed`
- Make/R0/R3 相邻：`109 passed, 3 skipped`（3 个均为未开启的 opt-in Docker gate）
- Ruff check/format、py_compile、CLI validate/plan、manifest/schema 与敏感信息扫描通过
- 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 evidence write

合并后仅运行只读 release preflight；provider execution 仍需新的 amendment。

Closes #216