### PR TITLE
研究：审计 R3 Make 执行失败并补安全门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,12 +64,20 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
-- 2026-08-30 — 完成 Issue #218 R3 Make 单配对 execution amendment 本地门禁
+- 2026-08-30 — 审计 R3 Make 机制无效终态并实现 Issue #220 执行安全门禁
+  - 文件: `scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_execution_failure_gate.py`
+  - 终态: #218 唯一 reachability 以 1 request / 17 recorded tokens / 1.475 秒通过；唯一 pair 在模型请求前因 R3 runtime binding 缺少 `RejectionObservationRegistry`、`FrozenActionPolicy` 与 `SerialToolCallMiddleware` 失败，两臂均为 0 request / 0 submit / 0 replay，pair marker 为 `failed/EvidenceError`，不能形成 paired estimand。
+  - 根因链: registry 在受保护 `try/finally` 前构造，`AttributeError` 泄漏 active experiment；旧 classifier 把零请求异常误记为 `no_submit`；cleanup 随后向 completed ledger 追加 `before_cleanup` event，被 immutability gate 阻断。三个退出容器与本 capture continuation image 已按精确 identity 人工删除，0 compile/replay orphan。
+  - 修复: 新版本化门禁正确组合 R3 action adapter 与 R0 registry/middleware，零请求异常 fail-closed 为 `pre_model_execution_error / mechanism_invalid` 并持久化 error class，cleanup 前机械解除 parent/baseline/treatment experiment context；不修改 #216/#218 冻结组件或 evidence。
+  - Evidence: `reports/failure-audit-v1.json` create-once sidecar SHA-256 为 `2cf698346b0a1a319c274e220fca6c2fd798a78cdcf1dbbdb5393298af681010`；8 个输入哈希、3 个冻结组件哈希和三条 ledger hash chain 通过。聚焦/相邻回归 `25 passed`，Ruff check/format 与敏感信息扫描通过。
+  - 边界: 中文 Issue #220 已创建并回读；禁止重跑、retry、replacement、backfill、历史池化或模型排名。本修复阶段 0 provider、0 credential read、0 Docker execution、0 model token。
+
+- 2026-08-30 — 发布并执行 Issue #218 R3 Make 单配对 execution amendment
   - 文件: `scripts/forge_opaque_provenance_r3_make_execution_protocol.py`, `scripts/forge_opaque_provenance_r3_make_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_r3_make_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json`, `benchmarks/schemas/forge-opaque-provenance-r3-make-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-execution.md`
   - 协议: 授权 DeepSeek `deepseek-v4-flash` 一次 reachability 与成功后的一个 baseline→treatment pair；300 秒、0 retry、每臂最多 8 requests/8 turns/24 graph steps/120,000 recorded tokens，阶段上限 245,000，禁止 replacement/backfill/extension。
   - Runner: 从冻结 #208 runner 做版本化机械派生，只替换 protocol、R3 action/R0 adapter、输出目录、marker/ledger/checkpoint/report identity，并同时记录 R3 experiment case ID 与底层 P2 reference case ID；差异归一化后与父 runner 字节相等。
   - 验证: canonical manifest SHA-256 为 `e2335b9e180ff539752dbb6b9d049da561980b0af7a64a193b49ab423913e86f`；聚焦 `8 passed`、Make/R0/R3 相邻 `117 passed, 3 skipped`，Ruff check/format、pycompile、CLI、Schema、diff、冻结哈希与敏感信息扫描通过。
-  - 边界: 当前仍为 0 provider、0 formal attempt、0 model token、0 evidence write，正式与 candidate evidence 目录均不存在；中文 Issue #218 已创建并回读。待提交/PR/CI/合并后运行零 provider preflight，再按 marker 顺序执行唯一 reachability 与 pair。
+  - 发布: 中文 PR #219 三项 CI 全绿后 squash 合并为 `main@7ab7791f1445070e455cded76c080ccf2b972cd6`。真实 preflight 确认 Ubuntu-native Docker、Wi-Fi、发布身份、空 evidence、0 orphan 与凭据仅存在性后运行唯一 reachability/pair；pair 的机制无效终态由 Issue #220 跟踪，禁止直接重跑。
 
 - 2026-08-30 — 完成 Issue #216 R3 Make 单配对未执行候选与零 provider runtime 门禁
   - 文件: `scripts/forge_opaque_provenance_r3_make_candidate_protocol.py`, `scripts/forge_opaque_provenance_r3_make_candidate_runner.py`, `backend/tests/test_forge_opaque_provenance_r3_make_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-r3-make-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-r3-make-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-r3-make-candidate.md`
@@ -604,6 +612,7 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 版本化 runner 不能把一个候选 runtime 模块同时伪装成 R1 的 `parity` 与 `observability` 接口；静态 adapter 有 `R3ActionPolicy/ObservableRuntimeParityToolAdapter` 不代表它也导出 `FrozenActionPolicy/SerialToolCallMiddleware/RejectionObservationRegistry`。真实执行前必须以零 provider contract test 构造完整 agent 骨架，并把 registry 等可能失败的初始化放入能解除 active experiment 的 `try/finally`；0 model request 的异常必须分类为 mechanism invalid，不能归为 `no_submit`。
 - PowerShell 可能误解析传给 WSL Docker CLI 的 Go template（例如 `{{.Server.Version}}`）或混合单双引号的复杂正则，导致只读 gate 在业务逻辑前被拒绝。跨 PowerShell/WSL gate 使用固定 argv 且不传 template；版本检查直接运行 `docker version`，列表检查使用不需要 format 的 `docker ps -aq` / `docker images -q`；敏感扫描拆成简单单引号模式。
 
 - 历史 manifest 会按字节冻结 `scripts/forge_opaque_provenance_runtime_parity_gate.py`、共享 `evidence.py` 和 LLM/tool-error middleware 等父组件；即使行为兼容，原地增加异常元数据、Schema 或仅运行 Ruff 格式化也会让旧协议 current-tree gate 报 runtime drift。新增 instrumentation 必须放入新的版本化 adapter/companion event，并用完整 backend CI 确认所有冻结文件零差异。

--- a/backend/tests/test_forge_opaque_provenance_r3_make_execution_failure_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_r3_make_execution_failure_gate.py
@@ -1,0 +1,150 @@
+"""Issue #220 R3 Make 失败审计与安全门禁的零 provider 测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from deerflow.compile.evidence import ExperimentLedger
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py"
+
+
+def _load_module():
+    scripts = str(SCRIPT_PATH.parent)
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    spec = importlib.util.spec_from_file_location(
+        "forge_opaque_provenance_r3_make_execution_failure_gate_test",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+def test_runtime_bindings_combine_r3_adapter_with_r0_registry() -> None:
+    parity, observability = gate.build_runtime_bindings()
+    assert parity.FrozenActionPolicy is gate.r3_candidate.R3ActionPolicy
+    assert parity.SerialToolCallMiddleware is gate.make_parity.SerialToolCallMiddleware
+    assert observability.ObservableRuntimeParityToolAdapter is gate.r3_candidate.ObservableRuntimeParityToolAdapter
+    assert observability.RejectionObservationRegistry is gate.make_observability.RejectionObservationRegistry
+    assert observability.OBSERVATION_EVENT == "agent.tool_rejection_observed"
+
+
+def test_zero_request_error_is_mechanism_invalid_not_no_submit(
+    tmp_path: Path,
+) -> None:
+    ledger = ExperimentLedger.create(
+        tmp_path / "arm.jsonl",
+        experiment_id="experiment_11111111111111111111111111111111",
+        physical_attempt_id="mechanism_attempt_11111111111111111111111111111111",
+        context={"arm": "baseline"},
+    )
+    result = gate.classify_pre_model_failure(
+        arm="baseline",
+        ledger=ledger,
+        error=AttributeError("missing runtime binding"),
+    )
+    assert result is not None
+    assert result["status"] == "invalid"
+    assert result["valid_behavioral_observation"] is False
+    assert result["model_behavior"] == {
+        "status": "not_observed",
+        "terminal_error_class": "AttributeError",
+    }
+    assert result["model_requests"] == result["recorded_tokens"] == 0
+    terminal = ledger.read()[-1]
+    assert terminal["payload"] == {
+        "status": "invalid_mechanism_attempt",
+        "classification": "pre_model_execution_error",
+        "terminal_error_class": "AttributeError",
+    }
+
+
+def test_request_evidence_defers_to_existing_behavioral_classifier(
+    tmp_path: Path,
+) -> None:
+    ledger = ExperimentLedger.create(
+        tmp_path / "arm.jsonl",
+        experiment_id="experiment_22222222222222222222222222222222",
+        physical_attempt_id="mechanism_attempt_22222222222222222222222222222222",
+        context={"arm": "treatment"},
+    )
+    ledger.append("model.request_started", {"request": 1})
+    before = ledger.read()
+    assert (
+        gate.classify_pre_model_failure(
+            arm="treatment",
+            ledger=ledger,
+            error=TimeoutError(),
+        )
+        is None
+    )
+    assert ledger.read() == before
+
+
+def test_cleanup_deactivates_all_contexts_before_gate_cleanup() -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    class FakeGate:
+        def cleanup(self, capture_id: str, *, parent_session):
+            calls.append(("cleanup", parent_session.session_id))
+            return SimpleNamespace(phase="cleaned")
+
+    result = gate.cleanup_after_deactivation(
+        FakeGate(),
+        "capture-1",
+        parent_session=SimpleNamespace(session_id="parent-1"),
+        experiment_thread_ids=["parent", "baseline", "treatment", "baseline"],
+        deactivate=lambda thread_id: calls.append(("deactivate", thread_id)),
+    )
+    assert result.phase == "cleaned"
+    assert calls == [
+        ("deactivate", "parent"),
+        ("deactivate", "baseline"),
+        ("deactivate", "treatment"),
+        ("cleanup", "parent-1"),
+    ]
+    with pytest.raises(gate.FailureGateError, match="explicit experiment"):
+        gate.cleanup_after_deactivation(
+            FakeGate(),
+            "capture-1",
+            parent_session=SimpleNamespace(session_id="parent-1"),
+            experiment_thread_ids=[],
+        )
+
+
+def test_sidecar_is_create_once(tmp_path: Path) -> None:
+    path = tmp_path / "reports/failure-audit-v1.json"
+    gate.write_sidecar_once(path, {"status": "audited"})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"status": "audited"}
+    with pytest.raises(gate.FailureGateError, match="already exists"):
+        gate.write_sidecar_once(path, {"status": "drifted"})
+
+
+def test_source_has_no_provider_credential_or_docker_execution() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "ExperimentLedger.open" in source
+    assert 'path.open("x"' in source
+    for forbidden in (
+        "create_chat_model",
+        "DEEPSEEK_API_KEY",
+        "os.environ",
+        "docker.from_env",
+        "subprocess.run",
+        "requests.",
+        "httpx.",
+    ):
+        assert forbidden not in source

--- a/scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py
+++ b/scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Issue #220 R3 Make 失败 evidence 审计与未来执行安全门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import forge_opaque_provenance_make_rejection_observability_gate as make_observability
+import forge_opaque_provenance_make_runtime_parity_gate as make_parity
+import forge_opaque_provenance_r3_make_candidate_runner as r3_candidate
+
+from deerflow.compile.evidence import ExperimentLedger, deactivate_experiment
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_EVIDENCE_ROOT = Path(
+    "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r3-hoextdown-v1"
+)
+DEFAULT_SIDECAR = "reports/failure-audit-v1.json"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/220"
+SCHEMA_VERSION = "forge-opaque-provenance-r3-make-execution-failure-audit-1.0.0"
+EXPECTED_MANIFEST_SHA256 = (
+    "e2335b9e180ff539752dbb6b9d049da561980b0af7a64a193b49ab423913e86f"
+)
+EXPECTED_EVIDENCE_IDENTITY_SHA256 = (
+    "17bf1a758d953f4e0c579039c97c8a3e669caf92ca720f93b3edfe29116c9890"
+)
+CAPTURE_ID = "opaque-r3-make-33f2bf48e0d5"
+PAIR_ID = "opaque-provenance-r3-hoextdown-pair-01"
+EXPECTED_INPUT_SHA256 = {
+    "reports/reachability.json": (
+        "ab3faa1e3a7341f86858020d1a2d7446e2ae035156a211354a39776d22567313"
+    ),
+    "markers/reachability.json": (
+        "9518d926646f97523e8aeb9b720cd834ffef851a58a2b595e36c0e0f71c38b9f"
+    ),
+    "markers/pair.json": (
+        "8c9510134806e73bec2d847ba8402663340b889a6f5382c91104c47404744c5a"
+    ),
+    f"checkpoints/{PAIR_ID}/parent/events.jsonl": (
+        "1c293e8070781742d5251d7992fd7c32a8a01b25b17995762372882db9ea3686"
+    ),
+    f"pairs/{PAIR_ID}/arms/baseline.jsonl": (
+        "bfb99d21828b59537117f41dc1b01aa282d8ec315348fe73418a28bd79d344ff"
+    ),
+    f"pairs/{PAIR_ID}/arms/treatment.jsonl": (
+        "b8ec8569fa09339700e2fbe70898da43692f5e2b623a7f4d666e1e05f53e1305"
+    ),
+    "checkpoint/coordinator.sqlite": (
+        "4e4951f099dd6fe0c20bb3a2d7d9031a7360c9913e1ab873a8be1c2f0a75054b"
+    ),
+    "checkpoint/messages.sqlite": (
+        "5c10a000bc68e7a09053396e298b8e8b52256c6084a51b3e8b9a71dedb970117"
+    ),
+}
+EXPECTED_COMPONENT_SHA256 = {
+    "scripts/forge_opaque_provenance_r3_make_execution_runner.py": (
+        "5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955"
+    ),
+    "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": (
+        "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0"
+    ),
+    "scripts/forge_opaque_provenance_r1_execution_runner.py": (
+        "eb782230560a6e8ca20a973c7a8e89c0dc20e57cf22a5294d2fd8030a7fdcd49"
+    ),
+}
+SESSION_INPUTS = {
+    "baseline": (
+        "baseline-opaque-r3-make-33f2bf48e0d5-thread/"
+        "baseline-opaque-r3-make-33f2bf48e0d5-session/session.json",
+        "f874ace0be0299a2699a8cf4a9042deb7ee1f64e14ef1ad501ec82429d430753",
+    ),
+    "treatment": (
+        "treatment-opaque-r3-make-33f2bf48e0d5-thread/"
+        "treatment-opaque-r3-make-33f2bf48e0d5-session/session.json",
+        "9ce10cb9ad2def594bb0f6ab2c3719972f7c5b2e859447c116bcddff36f99e11",
+    ),
+}
+MODEL_REQUEST_EVENTS = frozenset(
+    {
+        "model.request_started",
+        "model.request_completed",
+        "model.request_failed",
+        "model.request_cancelled",
+    }
+)
+
+
+class FailureGateError(RuntimeError):
+    """冻结输入、失败分类或安全门禁不完整。"""
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FailureGateError(f"cannot read {label}") from exc
+    if not isinstance(value, dict):
+        raise FailureGateError(f"{label} must be an object")
+    return value
+
+
+def build_runtime_bindings() -> tuple[SimpleNamespace, SimpleNamespace]:
+    """为下一版 runner 合并 R3 action adapter 与冻结 R0 companion。"""
+
+    parity = SimpleNamespace(
+        FrozenActionPolicy=r3_candidate.R3ActionPolicy,
+        SerialToolCallMiddleware=make_parity.SerialToolCallMiddleware,
+    )
+    observability = SimpleNamespace(
+        OBSERVATION_EVENT=make_observability.OBSERVATION_EVENT,
+        RejectionObservationRegistry=make_observability.RejectionObservationRegistry,
+        ObservableRuntimeParityToolAdapter=(
+            r3_candidate.ObservableRuntimeParityToolAdapter
+        ),
+    )
+    return parity, observability
+
+
+def classify_pre_model_failure(
+    *,
+    arm: str,
+    ledger: ExperimentLedger,
+    error: Exception,
+) -> dict[str, Any] | None:
+    """零模型请求异常必须作为机制执行失败，而不是模型 no-submit。"""
+
+    events = ledger.read()
+    if any(event["event"] in MODEL_REQUEST_EVENTS for event in events):
+        return None
+    terminal_error_class = type(error).__name__
+    ledger.append(
+        "experiment.completed",
+        {
+            "status": "invalid_mechanism_attempt",
+            "classification": "pre_model_execution_error",
+            "terminal_error_class": terminal_error_class,
+        },
+    )
+    return {
+        "arm": arm,
+        "status": "invalid",
+        "valid_behavioral_observation": False,
+        "infrastructure": {"status": "mechanism_invalid"},
+        "model_behavior": {
+            "status": "not_observed",
+            "terminal_error_class": terminal_error_class,
+        },
+        "model_requests": 0,
+        "recorded_tokens": 0,
+        "verification_outcome": {
+            "status": "not_attempted",
+            "submit_attempts": 0,
+            "clean_replay_attempts": 0,
+        },
+        "physical_attempt_id": ledger.physical_attempt_id,
+        "ledger_head_sha256": ledger.read()[-1]["event_sha256"],
+    }
+
+
+def cleanup_after_deactivation(
+    gate: Any,
+    capture_id: str,
+    *,
+    parent_session: Any,
+    experiment_thread_ids: list[str],
+    deactivate: Callable[[str], Any] = deactivate_experiment,
+) -> Any:
+    """先解除所有 experiment context，再进入 production cleanup。"""
+
+    safe_ids = tuple(dict.fromkeys(experiment_thread_ids))
+    if not safe_ids or any(
+        not isinstance(value, str) or not value for value in safe_ids
+    ):
+        raise FailureGateError("cleanup requires explicit experiment thread ids")
+    for thread_id in safe_ids:
+        deactivate(thread_id)
+    return gate.cleanup(capture_id, parent_session=parent_session)
+
+
+def _arm_summary(arm: str, events: list[dict[str, Any]]) -> dict[str, Any]:
+    event_names = [event["event"] for event in events]
+    if event_names != ["experiment.started", "experiment.completed"]:
+        raise FailureGateError(f"{arm} ledger no longer matches zero-request failure")
+    terminal = events[-1]["payload"]
+    if (
+        terminal.get("status") != "model_behavior_outcome"
+        or terminal.get("model_behavior") != "no_submit"
+        or terminal.get("verification_outcome") != "not_attempted"
+    ):
+        raise FailureGateError(f"{arm} terminal taxonomy drifted")
+    return {
+        "ledger_events": len(events),
+        "model_requests": 0,
+        "recorded_tokens": 0,
+        "submit_attempts": 0,
+        "clean_replay_attempts": 0,
+        "persisted_terminal_taxonomy": "no_submit",
+        "valid_behavioral_observation": False,
+        "corrected_failure_classification": "pre_model_execution_error",
+        "original_terminal_error_class": "not_recoverable_from_frozen_evidence",
+    }
+
+
+def _coordinator_summary(path: Path) -> dict[str, Any]:
+    uri = f"file:{path.as_posix()}?mode=ro&immutable=1"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            row = connection.execute(
+                "SELECT capture_id, phase, payload_json FROM checkpoint_capture"
+            ).fetchone()
+    except sqlite3.Error as exc:
+        raise FailureGateError("cannot read coordinator evidence") from exc
+    if row is None or row[0] != CAPTURE_ID or row[1] != "cleanup_pending":
+        raise FailureGateError("coordinator failure phase drifted")
+    payload = json.loads(row[2])
+    arm_states = {
+        arm: payload.get("arms", {}).get(arm, {}).get("status")
+        for arm in ("baseline", "treatment")
+    }
+    if arm_states != {"baseline": "ready", "treatment": "ready"}:
+        raise FailureGateError("coordinator arm states drifted")
+    return {
+        "capture_id": row[0],
+        "phase": row[1],
+        "arm_states": arm_states,
+        "cleanup_recorded": payload.get("cleanup") is not None,
+    }
+
+
+def audit_evidence(
+    evidence_root: Path = DEFAULT_EVIDENCE_ROOT,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    manifest = _load_object(
+        repo_root / "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json",
+        "manifest",
+    )
+    if canonical_sha256(manifest) != EXPECTED_MANIFEST_SHA256:
+        raise FailureGateError("manifest canonical identity drifted")
+    for relative_path, expected in EXPECTED_COMPONENT_SHA256.items():
+        if file_sha256(repo_root / relative_path) != expected:
+            raise FailureGateError(f"frozen component drifted: {relative_path}")
+    for relative_path, expected in EXPECTED_INPUT_SHA256.items():
+        path = evidence_root / relative_path
+        if not path.is_file() or file_sha256(path) != expected:
+            raise FailureGateError(f"frozen input drifted: {relative_path}")
+
+    reachability = _load_object(
+        evidence_root / "reports/reachability.json", "reachability report"
+    )
+    reachability_marker = _load_object(
+        evidence_root / "markers/reachability.json", "reachability marker"
+    )
+    pair_marker = _load_object(evidence_root / "markers/pair.json", "pair marker")
+    if (
+        reachability_marker.get("status") != "passed"
+        or reachability.get("passed") is not True
+        or reachability.get("request_count") != 1
+        or reachability.get("recorded_tokens") != 17
+        or pair_marker.get("status") != "failed"
+        or pair_marker.get("error_class") != "EvidenceError"
+        or (evidence_root / "reports/canary.json").exists()
+    ):
+        raise FailureGateError("execution terminal state drifted")
+
+    parent_path = evidence_root / f"checkpoints/{PAIR_ID}/parent/events.jsonl"
+    parent_events = ExperimentLedger.open(parent_path).read()
+    if (
+        len(parent_events) != 7
+        or parent_events[-1]["event"] != "experiment.completed"
+        or parent_events[-1]["payload"] != {"status": "passed"}
+    ):
+        raise FailureGateError("parent ledger drifted")
+    arms = {
+        arm: _arm_summary(
+            arm,
+            ExperimentLedger.open(
+                evidence_root / f"pairs/{PAIR_ID}/arms/{arm}.jsonl"
+            ).read(),
+        )
+        for arm in ("baseline", "treatment")
+    }
+
+    sessions: dict[str, Any] = {}
+    for arm, (relative_path, expected_sha256) in SESSION_INPUTS.items():
+        path = evidence_root.parent / relative_path
+        if file_sha256(path) != expected_sha256:
+            raise FailureGateError(f"{arm} session evidence drifted")
+        session = _load_object(path, f"{arm} session")
+        if (
+            session.get("status") != "verification_failed"
+            or len(session.get("commands", [])) != 1
+            or session.get("replay_attempts") != []
+            or session.get("finalized_at") is not None
+        ):
+            raise FailureGateError(f"{arm} session terminal state drifted")
+        sessions[arm] = {
+            "status": session["status"],
+            "post_checkpoint_commands": 0,
+            "replay_attempts": 0,
+            "finalized": False,
+        }
+
+    parity, observability = build_runtime_bindings()
+    if (
+        hasattr(r3_candidate, "RejectionObservationRegistry")
+        or hasattr(r3_candidate, "FrozenActionPolicy")
+        or hasattr(r3_candidate, "SerialToolCallMiddleware")
+        or parity.FrozenActionPolicy is not r3_candidate.R3ActionPolicy
+        or observability.RejectionObservationRegistry
+        is not make_observability.RejectionObservationRegistry
+    ):
+        raise FailureGateError("runtime binding root cause drifted")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "document_type": "forge_opaque_provenance_r3_make_execution_failure_audit",
+        "issue_url": ISSUE_URL,
+        "manifest_sha256": EXPECTED_MANIFEST_SHA256,
+        "evidence_identity_sha256": EXPECTED_EVIDENCE_IDENTITY_SHA256,
+        "source_sha256": dict(EXPECTED_INPUT_SHA256),
+        "reachability": {
+            "status": "passed",
+            "actual_model": reachability["actual_model"],
+            "request_count": 1,
+            "recorded_tokens": 17,
+            "duration_ms": reachability["duration_ms"],
+            "fallback_used": reachability["fallback_used"],
+        },
+        "pair": {
+            "status": "failed",
+            "marker_error_class": "EvidenceError",
+            "complete_pair": False,
+            "valid_behavioral_pair": False,
+            "canary_report_created": False,
+            "arms": arms,
+            "sessions": sessions,
+        },
+        "coordinator": _coordinator_summary(
+            evidence_root / "checkpoint/coordinator.sqlite"
+        ),
+        "root_cause": {
+            "classification": "r3_runtime_binding_missing_symbols",
+            "missing_candidate_symbols": [
+                "RejectionObservationRegistry",
+                "FrozenActionPolicy",
+                "SerialToolCallMiddleware",
+            ],
+            "exception_before_guarded_finally": True,
+            "active_experiment_leaked": True,
+            "zero_request_misclassified_as_no_submit": True,
+            "cleanup_blocked_by_completed_ledger": True,
+        },
+        "future_execution_guards": {
+            "composed_runtime_bindings": True,
+            "zero_request_failure_is_mechanism_invalid": True,
+            "terminal_error_class_persisted": True,
+            "deactivate_before_cleanup": True,
+        },
+        "paired_primary_estimand": {
+            "status": "not_estimable",
+            "reason": "invalid_mechanism_attempt_before_model_request",
+        },
+        "retry_performed": False,
+        "replacement_performed": False,
+        "backfill_performed": False,
+        "historical_pairs_pooled": False,
+        "model_ranking_performed": False,
+        "provider_calls_during_audit": 0,
+        "credential_read_during_audit": False,
+        "docker_executed_during_audit": False,
+        "model_tokens_during_audit": 0,
+        "source_evidence_modified": False,
+    }
+
+
+def write_sidecar_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+    except FileExistsError as exc:
+        raise FailureGateError("failure audit sidecar already exists") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("audit", "write-sidecar"))
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+    result = audit_evidence(args.evidence_root, repo_root=args.repo_root)
+    if args.command == "write-sidecar":
+        write_sidecar_once(args.evidence_root / DEFAULT_SIDECAR, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 对 #218 冻结失败 evidence 做只读审计，验证 reachability、pair marker、parent/baseline/treatment ledger hash chain、Compile Session 与 coordinator 终态
- 定位 R3 runner 把 candidate runtime 同时绑定为 parity/observability 接口导致的三个缺失 symbol，并将两臂 0 请求终态纠正为 `pre_model_execution_error / mechanism_invalid`
- 提供下一版 runner 可复用的组合 runtime bindings、零请求 fail-closed 分类和 cleanup 前 experiment 去激活门禁
- 为真实 evidence 创建 create-once `failure-audit-v1.json` sidecar；不修改 #216/#218 冻结组件或原始 evidence

## 真实终态

- reachability：`deepseek-v4-flash`，1 request / 17 recorded tokens / 1.475 秒，无 fallback
- pair：`failed/EvidenceError`，baseline/treatment 均为 0 request / 0 submit / 0 replay，不构成有效 behavioral pair
- sidecar SHA-256：`2cf698346b0a1a319c274e220fca6c2fd798a78cdcf1dbbdb5393298af681010`
- 退出的三个 Compile Session 容器和本 capture continuation image 已按精确 identity 清理；0 compile/replay orphan

## 验证

- `25 passed`：新门禁、R3 execution/candidate 与 R2 result audit 相邻回归
- Ruff check / format、`py_compile`、`git diff --check` 通过
- 敏感信息扫描无命中
- 审计阶段 0 provider、0 credential read、0 Docker execution、0 model token

## 研究边界

- 不重跑 #218 pair，不执行 retry、replacement、backfill 或 schedule extension
- 不估计 paired treatment effect，不池化历史 pair，不排名模型
- 新 provider execution 必须另建版本化 amendment 与独立 evidence identity

Closes #220
