### PR TITLE
研究：增加 OpenH264 provenance 候选与生命周期门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 完成 Issue #224 OpenH264 独立 Make candidate 与真实 lifecycle 门禁
+  - 文件: `scripts/forge_opaque_provenance_openh264_candidate_gate.py`, `backend/tests/test_forge_opaque_provenance_openh264_candidate.py`, `backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py`, `benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md`
+  - 选择: result-blind 审计从冻结 source protocol 选定 `openh264@4a2615fac570c6ca1ed4f157b9fdab9466edfd80`；历史真实 ledger/report 匹配均为 0，固定提交无 submodule，根 `Makefile` 与 OSS-Fuzz 都直接构建 `libopenh264.a`。`sql-parser` 因 `.a` 还需 `static=yes`、`lodepng` 因 OSS-Fuzz 绕过 Make 暂不使用。
+  - 实现: 新 candidate 复用 R3 action parser、#220 组合 bindings 与 #222 完整 agent construction；OpenH264 policy 精确允许 direct Make、jobs 省略或 `1..2`、独立 stage，并拒绝无界/超限/target drift。Manifest canonical SHA-256 为 `ab29737969549ddf3d309fb2868a0254b8a346842cc1e168d7e475d123f4e0d6`，全部 provider/checkpoint/pair/evidence write 授权关闭。
+  - lifecycle: 基础 `autocompiler:gcc13` 缺少 `nasm`，opt-in gate 以固定 URL/SHA-256 的 `nasm 2.16.01-1build1` 小包临时派生 image；parent `unproven/opaque_wrapper`、baseline 同源失败、treatment `proven/direct_make`、candidate verification 与 clean replay 全部通过，真实 Docker 为 `1 passed in 412.14s`，后置 compile/replay/continuation/Issue #224 image orphan 均为 0。
+  - 验证: 聚焦 `6 passed`、Make/R3/#220/#222 相邻回归 `88 passed`，Ruff check/format、pycompile、CLI、Schema、diff 与敏感信息扫描通过。全阶段 0 provider、0 credential read、0 formal evidence write、0 model token；未创建 checkpoint 或 behavioral pair。
+
 - 2026-08-30 — 完成 Issue #222 R3 Make 完整 agent construction 零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py`, `backend/tests/test_forge_opaque_provenance_r3_make_agent_construction_gate.py`
   - 实现: 直接消费 #220 组合 bindings，用项目既有 `BaseChatModel.bind_tools()` fake model 真实构造 `create_agent + ThreadState + InMemorySaver`，接入 R3 adapter、R0 registry、`SerialToolCallMiddleware` 与真实 LLM/tool-error middleware；checkpoint 状态固定为 Human/AI submit/Tool failure 三消息。
@@ -618,6 +625,8 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- 真实 Docker gate 不应在测试体内用 `apt-get update` 临时准备单个依赖：本次 OpenH264 gate 在 `mirrors.aliyun.com` 下载完整 index 时耗尽 600 秒，但尚未 clone、build 或进入 lifecycle，不能记为 case 失败。若依赖是单一、架构固定的小包，应在预注册中冻结版本、URL 与 SHA-256，以短 timeout 下载并校验后派生临时 image；parent/arms/replay 共用该 image ID，结束后按 label 和精确 identity 删除。DooD 测试还必须把仓库挂载到与 WSL 宿主相同的 `/mnt/c/...` 绝对路径，并把 `tmp_path` 放在该路径下，不能把测试容器内部 `/tmp` 交给 daemon 当 bind source。
 
 - 版本化 runner 不能把一个候选 runtime 模块同时伪装成 R1 的 `parity` 与 `observability` 接口；静态 adapter 有 `R3ActionPolicy/ObservableRuntimeParityToolAdapter` 不代表它也导出 `FrozenActionPolicy/SerialToolCallMiddleware/RejectionObservationRegistry`。真实执行前必须以零 provider contract test 构造完整 agent 骨架，并把 registry 等可能失败的初始化放入能解除 active experiment 的 `try/finally`；0 model request 的异常必须分类为 mechanism invalid，不能归为 `no_submit`。
 - PowerShell 可能误解析传给 WSL Docker CLI 的 Go template（例如 `{{.Server.Version}}`）或混合单双引号的复杂正则，导致只读 gate 在业务逻辑前被拒绝。跨 PowerShell/WSL gate 使用固定 argv 且不传 template；版本检查直接运行 `docker version`，列表检查使用不需要 format 的 `docker ps -aq` / `docker images -q`；敏感扫描拆成简单单引号模式。

--- a/backend/tests/test_forge_opaque_provenance_openh264_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_openh264_candidate.py
@@ -1,0 +1,135 @@
+"""Issue #224 OpenH264 独立 Make checkpoint 的零 provider 门禁。"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+GATE_PATH = SCRIPTS_DIR / "forge_opaque_provenance_openh264_candidate_gate.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json"
+
+
+def _load_gate():
+    name = "forge_opaque_provenance_openh264_candidate_gate_test"
+    spec = importlib.util.spec_from_file_location(name, GATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+    return module
+
+
+gate = _load_gate()
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_and_result_blind_selection_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == gate.generate_manifest(REPO_ROOT)
+    assert schema == gate.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    gate.verify_frozen_components(REPO_ROOT)
+    assert manifest["selection"]["source_case"]["id"] == "openh264"
+    assert manifest["selection"]["historical_physical_evidence_matches"] == 0
+    assert manifest["selection"]["published_report_matches"] == 0
+    assert manifest["reference_sources"]["submodules_at_exact_commit"] == []
+
+
+def test_authorization_and_future_evidence_are_closed() -> None:
+    manifest = gate.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert all(value is False for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["authorization"]["model_tokens_authorized"] == 0
+    assert manifest["checkpoint"]["status"] == "not_created"
+    assert manifest["evidence"]["status"] == "not_created"
+    assert manifest["runtime_parity"]["treatment_exposure_only"] == "repair_packet"
+
+
+def test_static_p2_lifecycle_and_action_surface_close() -> None:
+    result = gate.validate_static_gate(REPO_ROOT)
+    assert result["parent"]["status"] == "unproven"
+    assert result["parent"]["reason"] == "opaque_wrapper"
+    assert result["treatment"]["status"] == "proven"
+    assert result["treatment"]["proof_mode"] == "direct_make"
+    assert result["parent_history_prefix_preserved"] is True
+    assert set(result["accepted"].values()) == {"repair_build"}
+    assert result["rejected"] == {
+        "make -j libopenh264.a": "repair_build_jobs_unbounded",
+        "make -j0 libopenh264.a": "repair_build_jobs_out_of_bounds",
+        "make -j3 libopenh264.a": "repair_build_jobs_out_of_bounds",
+        "make libhoedown.a": "repair_build_target_drift",
+    }
+    assert (
+        result["provider_calls"],
+        result["credential_read"],
+        result["docker_executed"],
+        result["formal_evidence_writes"],
+        result["model_tokens"],
+    ) == (0, False, False, 0, 0)
+
+
+def test_candidate_policy_reaches_full_agent_construction_gate() -> None:
+    result = asyncio.run(gate.validate_agent_construction())
+    assert result["status"] == "passed"
+    assert result["candidate_policy"]["target"] == "libopenh264.a"
+    assert result["success_probe"]["request_evidence"] == {
+        "model.request_started": 1,
+        "model.request_completed": 1,
+        "model.request_failed": 0,
+        "model.request_cancelled": 0,
+    }
+    assert result["failure_probe"]["classification"] == "pre_model_execution_error"
+    assert result["cleanup_probe"]["status"] == "passed"
+    assert (
+        result["provider_calls"],
+        result["credential_read"],
+        result["docker_executed"],
+        result["formal_evidence_writes"],
+        result["model_tokens"],
+    ) == (0, False, False, 0, 0)
+
+
+def test_schema_and_protocol_reject_identity_or_authorization_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    mutations = (
+        ("authorization", "provider_calls_authorized", True),
+        ("authorization", "model_tokens_authorized", 1),
+        ("case", "target", "all"),
+        ("runtime_parity", "parallel_tool_calls", True),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(gate.OpenH264CandidateGateError, match="manifest"):
+            gate.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_new_sources_do_not_embed_credentials_or_provider_execution() -> None:
+    combined = GATE_PATH.read_text(encoding="utf-8")
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "DEEPSEEK_API_KEY", "os.environ["):
+        assert forbidden not in combined
+    assert 'provider_calls_authorized": False' in combined
+    assert gate.validate_repair_packet(gate.build_repair_packet()) == gate.build_repair_packet()

--- a/backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py
@@ -1,0 +1,110 @@
+"""Issue #224 OpenH264 candidate 的 opt-in Ubuntu 原生 Docker lifecycle 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_OPENH264_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_OPENH264_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    try:
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(SCRIPTS_DIR))
+    return module
+
+
+gate = _load_module(
+    "forge_opaque_provenance_openh264_candidate_gate_docker",
+    SCRIPTS_DIR / "forge_opaque_provenance_openh264_candidate_gate.py",
+)
+legacy = _load_module(
+    "forge_opaque_provenance_openh264_legacy_docker_orchestration",
+    REPO_ROOT / "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py",
+)
+
+
+def _docker(
+    *args: str,
+    check: bool = True,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_openh264_real_parent_treatment_replay_and_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate.validate_static_gate(REPO_ROOT)
+    tag = f"forge-issue224-openh264-{uuid.uuid4().hex[:12]}"
+    label = f"forge.issue224.image={tag}"
+    context = tmp_path / "image"
+    context.mkdir()
+    (context / "Dockerfile").write_text(
+        "FROM autocompiler:gcc13\n"
+        "RUN curl --location --fail --show-error --connect-timeout 15 "
+        "--max-time 60 --output /tmp/nasm.deb "
+        f"{gate.NASM_DEB_URL} "
+        f"&& echo '{gate.NASM_DEB_SHA256}  /tmp/nasm.deb' | sha256sum --check - "
+        "&& dpkg --install /tmp/nasm.deb && rm /tmp/nasm.deb\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    image_id: str | None = None
+    try:
+        built = _docker(
+            "build",
+            "--label",
+            label,
+            "--tag",
+            tag,
+            str(context),
+            timeout=180,
+        )
+        assert built.returncode == 0
+        image_id = _docker("image", "inspect", tag, "--format", "{{.Id}}").stdout.strip()
+        assert image_id.startswith("sha256:")
+        nasm = _docker("run", "--rm", image_id, "nasm", "-v")
+        assert nasm.returncode == 0
+
+        monkeypatch.setattr(legacy, "adapter", gate.build_docker_adapter(image_id))
+        legacy.test_real_make_parent_treatment_replay_and_cleanup(tmp_path, monkeypatch)
+    finally:
+        if image_id:
+            _docker("image", "rm", "--force", image_id, check=False)
+        _docker("image", "rm", "--force", tag, check=False)
+    remaining = _docker(
+        "image",
+        "ls",
+        "--quiet",
+        "--filter",
+        f"label={label}",
+    ).stdout.splitlines()
+    assert remaining == []

--- a/benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-openh264-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-openh264-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_openh264_candidate",
+  "authorization": {
+    "checkpoint_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "provider_calls_authorized": false,
+    "formal_attempts_authorized": false,
+    "pair_collection_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "selection": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/224",
+    "mode": "result_blind_source_and_evidence_audit",
+    "source_protocol": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+    "source_protocol_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+    "source_case": {
+      "id": "openh264",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "build_system": "make",
+      "review_state": "reviewed",
+      "result_data_consulted": false,
+      "recipe": {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [
+          "libopenh264.a"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "nasm"
+        ]
+      },
+      "artifact_oracle": {
+        "required_artifacts": [
+          {
+            "staged_relative_path": "libopenh264.a",
+            "build_output_path": "libopenh264.a",
+            "artifact_type": "static_library",
+            "producing_target": "libopenh264.a"
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "kind": "upstream_exact_commit",
+          "path": "Makefile",
+          "url": "https://github.com/cisco/openh264/blob/4a2615fac570c6ca1ed4f157b9fdab9466edfd80/Makefile",
+          "supports": [
+            "build_path",
+            "artifact_identity"
+          ]
+        },
+        {
+          "kind": "oss_fuzz_snapshot",
+          "path": "openh264/build.sh",
+          "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openh264/build.sh",
+          "supports": [
+            "build_path"
+          ]
+        }
+      ]
+    },
+    "historical_manifest_mentions": true,
+    "historical_physical_evidence_matches": 0,
+    "published_report_matches": 0,
+    "alternatives_rejected": {
+      "sql-parser": "static=yes is required to align target and static-library oracle",
+      "lodepng": "OSS-Fuzz bypasses Make and executable smoke adds semantics"
+    }
+  },
+  "case": {
+    "case_id": "openh264-opaque-provenance-r4-make",
+    "repository_url": "https://github.com/cisco/openh264",
+    "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+    "build_system": "make",
+    "build_directory": "/workspace/repo",
+    "target": "libopenh264.a",
+    "build_output": "libopenh264.a",
+    "staged_artifact": "libopenh264.a",
+    "artifact_type": "static_library",
+    "required_system_packages": [
+      "build-essential",
+      "nasm"
+    ],
+    "bootstrap_commands": [],
+    "configure_arguments": []
+  },
+  "reference_sources": {
+    "upstream_makefile": {
+      "url": "https://github.com/cisco/openh264/blob/4a2615fac570c6ca1ed4f157b9fdab9466edfd80/Makefile",
+      "sha256": "202daf149e44d1fd34017ce68e1ea8020187f1be50e869946446b3592456291b",
+      "direct_target": "libopenh264.a"
+    },
+    "oss_fuzz_recipe": {
+      "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openh264/build.sh",
+      "sha256": "4f53629516eb904cdd65a13ac427b99bf5d298daa4b7001327f6018f6a8a3ab4",
+      "direct_target": "libopenh264.a"
+    },
+    "submodules_at_exact_commit": []
+  },
+  "lifecycle_fixture": {
+    "base_image": "autocompiler:gcc13",
+    "derived_image_persisted": false,
+    "nasm_package": {
+      "version": "2.16.01-1build1",
+      "architecture": "amd64",
+      "url": "https://mirrors.ustc.edu.cn/ubuntu/pool/universe/n/nasm/nasm_2.16.01-1build1_amd64.deb",
+      "sha256": "22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3",
+      "download_timeout_seconds": 60
+    },
+    "apt_index_download_forbidden": true
+  },
+  "checkpoint": {
+    "status": "not_created",
+    "checkpoint_id": null,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "creation_requires_execution_amendment": true
+  },
+  "runtime_parity": {
+    "direct_executables": [
+      "make",
+      "gmake"
+    ],
+    "jobs": {
+      "omitted_allowed": true,
+      "minimum": 1,
+      "maximum": 2
+    },
+    "parallel_tool_calls": false,
+    "shared_tool_contract_identical": true,
+    "treatment_exposure_only": "repair_packet",
+    "artifact_stage": {
+      "source": "/workspace/repo/libopenh264.a",
+      "destination": "/artifacts/libopenh264.a",
+      "separate_from_build": true
+    },
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true
+  },
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "primary_classification": "build_system_unproven",
+    "mechanism_classification": "opaque_build_provenance",
+    "expected_build_system": "make",
+    "selected_build_system": "make",
+    "build_directory": "/workspace/repo",
+    "target": "libopenh264.a",
+    "proof_status": "opaque_wrapper",
+    "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+  },
+  "agent_construction": {
+    "source_issue": 222,
+    "full_create_agent_gate_required": true,
+    "candidate_policy_injected_into_published_bindings": true,
+    "expected_model_requests": 1,
+    "provider_calls": 0,
+    "model_tokens": 0
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-openh264-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r4-openh264-candidate-v1",
+    "status": "not_created",
+    "append_only": true,
+    "zero_provider_gate_writes_evidence": false,
+    "identity_sha256": "dd777763ab03ec6853c7e36299b78acff3e0383ca8b808f0c59b51744669b683"
+  },
+  "analysis": {
+    "unit_of_analysis": "future_single_state_matched_make_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "historical_pairs_pooled": false,
+    "model_ranking_performed": false
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md",
+    "file_sha256": "51c1f34f7e6a194ca8e60d95ee9f70233b9a9ddf0dbe5ff3cfa9b26511b95255"
+  },
+  "frozen_components": {
+    "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+    "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a",
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+    "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+    "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+    "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+    "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json": "2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f",
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py": "5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md
@@ -1,0 +1,36 @@
+# OpenH264 独立 Make checkpoint 零 provider candidate
+
+- Issue：[#224](https://github.com/WWFXL/Forge-AutoCompiler/issues/224)
+- 性质：result-blind、零 provider、零凭据读取、零 model token 的 candidate/lifecycle 门禁。
+- 历史边界：#218 hoextdown pair 保持机制无效终态，本候选不是 retry、replacement 或 backfill。
+
+## 候选择取
+
+从冻结的 `cpp-formal-v1-cases.json` 审计 Make cases。`openh264@4a2615fac570c6ca1ed4f157b9fdab9466edfd80` 只在历史 manifest 出现；本地 append-only physical evidence 与已发布 report 均没有该 case。固定提交只有一个根 `Makefile` 且无 submodule，`libopenh264.a` target 与单一 static-library oracle 直接对应；固定 OSS-Fuzz recipe 也调用同一 target。
+
+暂不选择：
+
+- `sql-parser`：`library` 默认产出 shared library，要得到 oracle 中的 `.a` 还需额外 `static=yes`；
+- `lodepng`：OSS-Fuzz recipe 绕过 Make，且 executable smoke 会引入额外终态语义。
+
+## 冻结构造
+
+- repository：`https://github.com/cisco/openh264`
+- commit：`4a2615fac570c6ca1ed4f157b9fdab9466edfd80`
+- build directory：`/workspace/repo`
+- direct target / output / staged artifact：`libopenh264.a`
+- system packages：`build-essential`、`nasm`
+- jobs：可省略或为 `1..2`；无界、0、超限或 target drift 均 fail-closed
+- parent：opaque shell wrapper，产物存在但 P2 为 `build_system_unproven`
+- treatment：独立 direct Make 与 artifact stage，P2 必须转换为 `direct_make`
+- repair packet：唯一 treatment exposure，不包含 command、argv、shell 或凭据
+
+## Agent construction 与 lifecycle
+
+候选把 OpenH264 action policy 注入 #220 已修复的组合 bindings，并复用 #222 的完整 `create_agent + ThreadState + InMemorySaver` fake-model 门禁。成功路径必须精确产生一个 request started/completed，异常路径和 cleanup 路径必须释放所有 active context。
+
+真实 Docker gate 是 opt-in，只使用 Ubuntu WSL2 原生 daemon。仓库基础编译镜像不含 `nasm`，因此 gate 临时派生一个只增加 `nasm 2.16.01-1build1 amd64` 的 image；固定 `.deb` 的 SHA-256 为 `22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3`，下载上限 60 秒，禁止下载 apt index。parent、baseline、treatment 与 clean replay 共用其不可变 image identity，结束后删除派生 image。该 fixture 不修改生产镜像，也不把 dependency setup 暴露给 post-checkpoint treatment。
+
+## 授权与结论边界
+
+本阶段不创建 checkpoint、provider model、reachability、behavioral pair 或 formal evidence，model-token authorization 为 0。即使门禁通过，也只能说明新 case 的构造与 lifecycle 可执行；后续 provider amendment 必须另建 Issue、manifest、evidence identity 和一次性停止规则。单 pair 只做描述性机制复制，不与历史 case 池化，不计算 p 值，不排名模型。

--- a/benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json",
+  "title": "Forge opaque provenance OpenH264 candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-openh264-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-openh264-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_openh264_candidate",
+    "authorization": {
+      "checkpoint_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "provider_calls_authorized": false,
+      "formal_attempts_authorized": false,
+      "pair_collection_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "selection": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/224",
+      "mode": "result_blind_source_and_evidence_audit",
+      "source_protocol": "benchmarks/preregistrations/cpp-formal-v1-cases.json",
+      "source_protocol_sha256": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "source_case": {
+        "id": "openh264",
+        "repository_url": "https://github.com/cisco/openh264",
+        "commit": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+        "build_system": "make",
+        "review_state": "reviewed",
+        "result_data_consulted": false,
+        "recipe": {
+          "source_subdir": ".",
+          "bootstrap_commands": [],
+          "configure_arguments": [],
+          "build_targets": [
+            "libopenh264.a"
+          ],
+          "required_system_packages": [
+            "build-essential",
+            "nasm"
+          ]
+        },
+        "artifact_oracle": {
+          "required_artifacts": [
+            {
+              "staged_relative_path": "libopenh264.a",
+              "build_output_path": "libopenh264.a",
+              "artifact_type": "static_library",
+              "producing_target": "libopenh264.a"
+            }
+          ]
+        },
+        "evidence": [
+          {
+            "kind": "upstream_exact_commit",
+            "path": "Makefile",
+            "url": "https://github.com/cisco/openh264/blob/4a2615fac570c6ca1ed4f157b9fdab9466edfd80/Makefile",
+            "supports": [
+              "build_path",
+              "artifact_identity"
+            ]
+          },
+          {
+            "kind": "oss_fuzz_snapshot",
+            "path": "openh264/build.sh",
+            "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openh264/build.sh",
+            "supports": [
+              "build_path"
+            ]
+          }
+        ]
+      },
+      "historical_manifest_mentions": true,
+      "historical_physical_evidence_matches": 0,
+      "published_report_matches": 0,
+      "alternatives_rejected": {
+        "sql-parser": "static=yes is required to align target and static-library oracle",
+        "lodepng": "OSS-Fuzz bypasses Make and executable smoke adds semantics"
+      }
+    },
+    "case": {
+      "case_id": "openh264-opaque-provenance-r4-make",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libopenh264.a",
+      "build_output": "libopenh264.a",
+      "staged_artifact": "libopenh264.a",
+      "artifact_type": "static_library",
+      "required_system_packages": [
+        "build-essential",
+        "nasm"
+      ],
+      "bootstrap_commands": [],
+      "configure_arguments": []
+    },
+    "reference_sources": {
+      "upstream_makefile": {
+        "url": "https://github.com/cisco/openh264/blob/4a2615fac570c6ca1ed4f157b9fdab9466edfd80/Makefile",
+        "sha256": "202daf149e44d1fd34017ce68e1ea8020187f1be50e869946446b3592456291b",
+        "direct_target": "libopenh264.a"
+      },
+      "oss_fuzz_recipe": {
+        "url": "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openh264/build.sh",
+        "sha256": "4f53629516eb904cdd65a13ac427b99bf5d298daa4b7001327f6018f6a8a3ab4",
+        "direct_target": "libopenh264.a"
+      },
+      "submodules_at_exact_commit": []
+    },
+    "lifecycle_fixture": {
+      "base_image": "autocompiler:gcc13",
+      "derived_image_persisted": false,
+      "nasm_package": {
+        "version": "2.16.01-1build1",
+        "architecture": "amd64",
+        "url": "https://mirrors.ustc.edu.cn/ubuntu/pool/universe/n/nasm/nasm_2.16.01-1build1_amd64.deb",
+        "sha256": "22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3",
+        "download_timeout_seconds": 60
+      },
+      "apt_index_download_forbidden": true
+    },
+    "checkpoint": {
+      "status": "not_created",
+      "checkpoint_id": null,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "creation_requires_execution_amendment": true
+    },
+    "runtime_parity": {
+      "direct_executables": [
+        "make",
+        "gmake"
+      ],
+      "jobs": {
+        "omitted_allowed": true,
+        "minimum": 1,
+        "maximum": 2
+      },
+      "parallel_tool_calls": false,
+      "shared_tool_contract_identical": true,
+      "treatment_exposure_only": "repair_packet",
+      "artifact_stage": {
+        "source": "/workspace/repo/libopenh264.a",
+        "destination": "/artifacts/libopenh264.a",
+        "separate_from_build": true
+      },
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true
+    },
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "make",
+      "selected_build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libopenh264.a",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+    },
+    "agent_construction": {
+      "source_issue": 222,
+      "full_create_agent_gate_required": true,
+      "candidate_policy_injected_into_published_bindings": true,
+      "expected_model_requests": 1,
+      "provider_calls": 0,
+      "model_tokens": 0
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-openh264-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r4-openh264-candidate-v1",
+      "status": "not_created",
+      "append_only": true,
+      "zero_provider_gate_writes_evidence": false,
+      "identity_sha256": "dd777763ab03ec6853c7e36299b78acff3e0383ca8b808f0c59b51744669b683"
+    },
+    "analysis": {
+      "unit_of_analysis": "future_single_state_matched_make_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "historical_pairs_pooled": false,
+      "model_ranking_performed": false
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md",
+      "file_sha256": "51c1f34f7e6a194ca8e60d95ee9f70233b9a9ddf0dbe5ff3cfa9b26511b95255"
+    },
+    "frozen_components": {
+      "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "scripts/forge_opaque_provenance_make_reference_gate.py": "5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a",
+      "scripts/forge_opaque_provenance_make_lifecycle_gate.py": "bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b",
+      "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+      "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+      "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+      "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json": "2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f",
+      "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py": "5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_openh264_candidate_gate.py
+++ b/scripts/forge_opaque_provenance_openh264_candidate_gate.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""Issue #224 OpenH264 独立 Make checkpoint 的零 provider candidate/lifecycle 门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import hashlib
+import json
+import shlex
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/224"
+SCHEMA_VERSION = "forge-opaque-provenance-openh264-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_openh264_candidate"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md"
+SOURCE_PROTOCOL_PATH = "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+SOURCE_PROTOCOL_SHA256 = "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+
+CASE_ID = "openh264-opaque-provenance-r4-make"
+SOURCE_CASE_ID = "openh264"
+REPOSITORY_URL = "https://github.com/cisco/openh264"
+COMMIT_SHA = "4a2615fac570c6ca1ed4f157b9fdab9466edfd80"
+COMPILE_IMAGE = "autocompiler:gcc13"
+WORKDIR = "/workspace/repo"
+TARGET = "libopenh264.a"
+BUILD_OUTPUT = "libopenh264.a"
+STAGED_ARTIFACT = "libopenh264.a"
+ARTIFACT_TYPE = "static_library"
+PARENT_COMMAND = "sh -c 'make clean && make -j2 libopenh264.a && cp libopenh264.a /artifacts/libopenh264.a'"
+_PARENT_INNER_COMMAND = "make clean && make -j2 libopenh264.a && cp libopenh264.a /artifacts/libopenh264.a"
+TREATMENT_BUILD_COMMAND = "make -j1 libopenh264.a"
+TREATMENT_STAGE_COMMAND = "cp libopenh264.a /artifacts/libopenh264.a"
+PROOF_STATUS = "opaque_wrapper"
+REPAIR_GOAL = "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-r4-openh264-candidate-v1"
+
+UPSTREAM_MAKEFILE_URL = f"https://github.com/cisco/openh264/blob/{COMMIT_SHA}/Makefile"
+UPSTREAM_MAKEFILE_SHA256 = "202daf149e44d1fd34017ce68e1ea8020187f1be50e869946446b3592456291b"
+OSS_FUZZ_RECIPE_URL = "https://github.com/google/oss-fuzz/blob/08682bfc14e31d12fcc94b52b4805d7994fb70fd/projects/openh264/build.sh"
+OSS_FUZZ_RECIPE_SHA256 = "4f53629516eb904cdd65a13ac427b99bf5d298daa4b7001327f6018f6a8a3ab4"
+NASM_DEB_URL = "https://mirrors.ustc.edu.cn/ubuntu/pool/universe/n/nasm/nasm_2.16.01-1build1_amd64.deb"
+NASM_DEB_SHA256 = "22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3"
+
+FROZEN_COMPONENTS = {
+    SOURCE_PROTOCOL_PATH: SOURCE_PROTOCOL_SHA256,
+    "scripts/forge_opaque_provenance_make_reference_gate.py": ("5df722d6115aa879a9dbe43fb5f98278ff72df6958ae99f22fe4cb2f6d16c14a"),
+    "scripts/forge_opaque_provenance_make_lifecycle_gate.py": ("bb9fc467df0476cc1e7fdcca06bf64d020cb39f0efd48502289d814b3152230b"),
+    "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": ("b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0"),
+    "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": ("cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06"),
+    "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": ("f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a"),
+    "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json": ("2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f"),
+    "backend/tests/test_forge_opaque_provenance_make_lifecycle_gate_docker.py": ("5d4dead7f121433e6b82dca150ba7375e79c76b569c1172f36532f30c51ad652"),
+}
+
+
+class OpenH264CandidateGateError(RuntimeError):
+    """候选身份、动作面、P2 lifecycle 或 construction 组合无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_frozen_components(repo_root: Path = REPO_ROOT) -> None:
+    for relative_path, expected in FROZEN_COMPONENTS.items():
+        if file_sha256(repo_root / relative_path) != expected:
+            raise OpenH264CandidateGateError(f"冻结组件发生漂移: {relative_path}")
+
+
+def load_source_case(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    source_path = repo_root / SOURCE_PROTOCOL_PATH
+    if file_sha256(source_path) != SOURCE_PROTOCOL_SHA256:
+        raise OpenH264CandidateGateError("formal v1 source protocol 发生漂移")
+    document = json.loads(source_path.read_text(encoding="utf-8"))
+    matches = [item for item in document.get("cases", []) if isinstance(item, dict) and item.get("id") == SOURCE_CASE_ID]
+    if len(matches) != 1:
+        raise OpenH264CandidateGateError("OpenH264 source case 不唯一")
+    source_case = matches[0]
+    expected_identity = (
+        source_case.get("repository_url"),
+        source_case.get("commit"),
+        source_case.get("build_system"),
+        source_case.get("review_state"),
+        source_case.get("result_data_consulted"),
+    )
+    if expected_identity != (
+        REPOSITORY_URL,
+        COMMIT_SHA,
+        "make",
+        "reviewed",
+        False,
+    ):
+        raise OpenH264CandidateGateError("OpenH264 source identity 发生漂移")
+    if source_case.get("recipe") != {
+        "source_subdir": ".",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "build_targets": [TARGET],
+        "required_system_packages": ["build-essential", "nasm"],
+    }:
+        raise OpenH264CandidateGateError("OpenH264 source recipe 发生漂移")
+    required = source_case.get("artifact_oracle", {}).get("required_artifacts")
+    if required != [
+        {
+            "staged_relative_path": STAGED_ARTIFACT,
+            "build_output_path": BUILD_OUTPUT,
+            "artifact_type": ARTIFACT_TYPE,
+            "producing_target": TARGET,
+        }
+    ]:
+        raise OpenH264CandidateGateError("OpenH264 artifact oracle 发生漂移")
+    return copy.deepcopy(source_case)
+
+
+def build_repair_packet() -> dict[str, str]:
+    return {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": WORKDIR,
+        "target": TARGET,
+        "proof_status": PROOF_STATUS,
+        "repair_goal": REPAIR_GOAL,
+    }
+
+
+def validate_repair_packet(value: dict[str, Any]) -> dict[str, str]:
+    expected = build_repair_packet()
+    if value != expected:
+        raise OpenH264CandidateGateError("repair packet identity 发生漂移")
+    serialized = canonical_bytes(value).decode("utf-8").lower()
+    for forbidden in (
+        "make libopenh264.a",
+        "bash -lc",
+        "sh -c",
+        "argv",
+        "command_line",
+        "shell",
+        "secret",
+        "api_key",
+    ):
+        if forbidden in serialized:
+            raise OpenH264CandidateGateError("repair packet 泄漏了解法或敏感字段")
+    return expected
+
+
+def _evidence_identity(source_case: dict[str, Any]) -> str:
+    return canonical_sha256(
+        {
+            "schema_version": "forge-opaque-provenance-openh264-evidence-1.0.0",
+            "case": source_case,
+            "action_surface": {
+                "build_directory": WORKDIR,
+                "target": TARGET,
+                "jobs": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+                "artifact": STAGED_ARTIFACT,
+            },
+            "repair_packet": build_repair_packet(),
+            "parent_agent_construction_gate": FROZEN_COMPONENTS["scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py"],
+        }
+    )
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    verify_frozen_components(repo_root)
+    source_case = load_source_case(repo_root)
+    preregistration = repo_root / PREREGISTRATION_PATH
+    if not preregistration.is_file():
+        raise OpenH264CandidateGateError("候选预注册不存在")
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-openh264-candidate.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "checkpoint_creation_authorized": False,
+            "reachability_request_authorized": False,
+            "provider_calls_authorized": False,
+            "formal_attempts_authorized": False,
+            "pair_collection_authorized": False,
+            "credential_read_authorized": False,
+            "model_creation_authorized": False,
+            "evidence_write_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "selection": {
+            "issue_url": ISSUE_URL,
+            "mode": "result_blind_source_and_evidence_audit",
+            "source_protocol": SOURCE_PROTOCOL_PATH,
+            "source_protocol_sha256": SOURCE_PROTOCOL_SHA256,
+            "source_case": source_case,
+            "historical_manifest_mentions": True,
+            "historical_physical_evidence_matches": 0,
+            "published_report_matches": 0,
+            "alternatives_rejected": {
+                "sql-parser": "static=yes is required to align target and static-library oracle",
+                "lodepng": "OSS-Fuzz bypasses Make and executable smoke adds semantics",
+            },
+        },
+        "case": {
+            "case_id": CASE_ID,
+            "repository_url": REPOSITORY_URL,
+            "commit_sha": COMMIT_SHA,
+            "build_system": "make",
+            "build_directory": WORKDIR,
+            "target": TARGET,
+            "build_output": BUILD_OUTPUT,
+            "staged_artifact": STAGED_ARTIFACT,
+            "artifact_type": ARTIFACT_TYPE,
+            "required_system_packages": ["build-essential", "nasm"],
+            "bootstrap_commands": [],
+            "configure_arguments": [],
+        },
+        "reference_sources": {
+            "upstream_makefile": {
+                "url": UPSTREAM_MAKEFILE_URL,
+                "sha256": UPSTREAM_MAKEFILE_SHA256,
+                "direct_target": TARGET,
+            },
+            "oss_fuzz_recipe": {
+                "url": OSS_FUZZ_RECIPE_URL,
+                "sha256": OSS_FUZZ_RECIPE_SHA256,
+                "direct_target": TARGET,
+            },
+            "submodules_at_exact_commit": [],
+        },
+        "lifecycle_fixture": {
+            "base_image": COMPILE_IMAGE,
+            "derived_image_persisted": False,
+            "nasm_package": {
+                "version": "2.16.01-1build1",
+                "architecture": "amd64",
+                "url": NASM_DEB_URL,
+                "sha256": NASM_DEB_SHA256,
+                "download_timeout_seconds": 60,
+            },
+            "apt_index_download_forbidden": True,
+        },
+        "checkpoint": {
+            "status": "not_created",
+            "checkpoint_id": None,
+            "arm_state_matching": ["message", "environment", "budget"],
+            "creation_requires_execution_amendment": True,
+        },
+        "runtime_parity": {
+            "direct_executables": ["make", "gmake"],
+            "jobs": {"omitted_allowed": True, "minimum": 1, "maximum": 2},
+            "parallel_tool_calls": False,
+            "shared_tool_contract_identical": True,
+            "treatment_exposure_only": "repair_packet",
+            "artifact_stage": {
+                "source": f"{WORKDIR}/{BUILD_OUTPUT}",
+                "destination": f"/artifacts/{STAGED_ARTIFACT}",
+                "separate_from_build": True,
+            },
+            "candidate_verification_required": True,
+            "clean_replay_required": True,
+            "cleanup_required": True,
+        },
+        "repair_packet": build_repair_packet(),
+        "agent_construction": {
+            "source_issue": 222,
+            "full_create_agent_gate_required": True,
+            "candidate_policy_injected_into_published_bindings": True,
+            "expected_model_requests": 1,
+            "provider_calls": 0,
+            "model_tokens": 0,
+        },
+        "evidence": {
+            "schema_version": "forge-opaque-provenance-openh264-evidence-1.0.0",
+            "directory": EVIDENCE_DIRECTORY,
+            "status": "not_created",
+            "append_only": True,
+            "zero_provider_gate_writes_evidence": False,
+            "identity_sha256": _evidence_identity(source_case),
+        },
+        "analysis": {
+            "unit_of_analysis": "future_single_state_matched_make_pair",
+            "primary_outcome": ("paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay"),
+            "descriptive_only": True,
+            "treatment_effect_estimated": False,
+            "historical_pairs_pooled": False,
+            "model_ranking_performed": False,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration),
+        },
+        "frozen_components": copy.deepcopy(FROZEN_COMPONENTS),
+    }
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": ("https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json"),
+        "title": "Forge opaque provenance OpenH264 candidate",
+        "const": frozen,
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise OpenH264CandidateGateError("OpenH264 candidate manifest 发生漂移")
+    if any(value for key, value in value["authorization"].items() if key.endswith("_authorized")):
+        raise OpenH264CandidateGateError("candidate 意外授权了外部执行")
+    if value["authorization"]["model_tokens_authorized"] != 0:
+        raise OpenH264CandidateGateError("candidate 意外授权了 model token")
+    return value
+
+
+def load_manifest(
+    path: Path = DEFAULT_MANIFEST,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    return validate_manifest(json.loads(path.read_text(encoding="utf-8")), repo_root)
+
+
+def _runtime_modules():
+    if str(SCRIPT_ROOT) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_ROOT))
+    import forge_opaque_provenance_make_lifecycle_gate as base_lifecycle
+    import forge_opaque_provenance_r3_make_agent_construction_gate as construction
+    import forge_opaque_provenance_r3_make_candidate_runner as r3_runtime
+    import forge_opaque_provenance_r3_make_execution_failure_gate as failure_gate
+
+    return base_lifecycle, construction, r3_runtime, failure_gate
+
+
+def build_frozen_identity(
+    *,
+    image_id: str,
+    physical_attempt_id: str,
+    artifact_size: int,
+    artifact_sha256: str,
+):
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    return base_lifecycle.reference.MakeFrozenIdentity(
+        schema_version=base_lifecycle.reference.SCHEMA_VERSION,
+        case_id=CASE_ID,
+        repository_url=REPOSITORY_URL,
+        commit_sha=COMMIT_SHA,
+        image_id=image_id,
+        physical_attempt_id=physical_attempt_id,
+        workdir=WORKDIR,
+        target=TARGET,
+        artifact_relative_path=BUILD_OUTPUT,
+        artifact_type=ARTIFACT_TYPE,
+        artifact_size=artifact_size,
+        artifact_sha256=artifact_sha256,
+    ).validate()
+
+
+def _validate_case_identity(frozen: Any) -> None:
+    actual = (
+        frozen.case_id,
+        frozen.repository_url,
+        frozen.commit_sha,
+        frozen.workdir,
+        frozen.target,
+        frozen.artifact_relative_path,
+        frozen.artifact_type,
+    )
+    expected = (
+        CASE_ID,
+        REPOSITORY_URL,
+        COMMIT_SHA,
+        WORKDIR,
+        TARGET,
+        BUILD_OUTPUT,
+        ARTIFACT_TYPE,
+    )
+    if actual != expected:
+        raise OpenH264CandidateGateError("OpenH264 lifecycle identity 发生漂移")
+
+
+def _parent_invocation(frozen: Any, command_id: str):
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    return base_lifecycle.provenance.record_invocation(
+        command_id=command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", _PARENT_INNER_COMMAND),
+        workdir=frozen.workdir,
+        previous_hash=base_lifecycle.provenance.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def _artifact(frozen: Any, producer_command_id: str, *, observed_after_sequence: int):
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    return base_lifecycle.provenance.ArtifactIdentity(
+        schema_version=base_lifecycle.provenance.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=observed_after_sequence,
+    )
+
+
+def evaluate_parent(frozen: Any, *, parent_command_id: str):
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    decision = base_lifecycle.reference.evaluate_make_p2(
+        frozen,
+        (parent,),
+        _artifact(frozen, parent.command_id, observed_after_sequence=2),
+    )
+    if decision.status != "unproven" or decision.classification != "opaque_build_provenance" or decision.reason != PROOF_STATUS:
+        raise OpenH264CandidateGateError("parent 未形成单一 opaque-wrapper fault")
+    return decision, (parent,)
+
+
+def evaluate_treatment(
+    frozen: Any,
+    *,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    _validate_case_identity(frozen)
+    parent = _parent_invocation(frozen, parent_command_id)
+    tokens = shlex.split(TREATMENT_BUILD_COMMAND)
+    build = base_lifecycle.provenance.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable=tokens[0],
+        argv=tuple(tokens[1:]),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = base_lifecycle.provenance.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(frozen.artifact_relative_path, f"/artifacts/{STAGED_ARTIFACT}"),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    invocations = (parent, build, stage)
+    decision = base_lifecycle.reference.evaluate_make_p2(
+        frozen,
+        invocations,
+        _artifact(frozen, build.command_id, observed_after_sequence=4),
+    )
+    if decision.status != "proven" or decision.proof_mode != "direct_make":
+        raise OpenH264CandidateGateError("treatment 未转换 Make P2")
+    return decision, invocations
+
+
+def _candidate_policy():
+    _base_lifecycle, _construction, r3_runtime, _failure_gate = _runtime_modules()
+    return r3_runtime.R3ActionPolicy(
+        workdir=WORKDIR,
+        build_directory=WORKDIR,
+        target=TARGET,
+        build_output=f"{WORKDIR}/{BUILD_OUTPUT}",
+        staged_artifact=f"/artifacts/{STAGED_ARTIFACT}",
+        maximum_jobs=2,
+    )
+
+
+def validate_static_gate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    base_lifecycle, _construction, r3_runtime, _failure_gate = _runtime_modules()
+    manifest = load_manifest(DEFAULT_MANIFEST, repo_root)
+    operations = base_lifecycle.operations
+    roles = operations.infer_command_roles(PARENT_COMMAND)
+    if roles != {"artifact_stage", "build", "housekeeping"}:
+        raise OpenH264CandidateGateError("parent wrapper role 发生漂移")
+    if operations._command_invokes(PARENT_COMMAND, "make"):
+        raise OpenH264CandidateGateError("parent wrapper 意外暴露 direct Make identity")
+
+    policy = _candidate_policy()
+    accepted = {
+        command: r3_runtime.classify_action(
+            command,
+            workdir=WORKDIR,
+            command_role="build",
+            policy=policy,
+        )
+        for command in (
+            "make libopenh264.a",
+            "make -j1 libopenh264.a",
+            "gmake --jobs=2 libopenh264.a",
+        )
+    }
+    rejected: dict[str, str] = {}
+    for command in (
+        "make -j libopenh264.a",
+        "make -j0 libopenh264.a",
+        "make -j3 libopenh264.a",
+        "make libhoedown.a",
+    ):
+        try:
+            r3_runtime.classify_action(
+                command,
+                workdir=WORKDIR,
+                command_role="build",
+                policy=policy,
+            )
+        except r3_runtime.R3RuntimeParityGateError as exc:
+            rejected[command] = exc.evidence_rejection_classification
+        else:
+            raise OpenH264CandidateGateError("非法 build action 未被拒绝")
+
+    frozen = build_frozen_identity(
+        image_id="sha256:" + "4" * 64,
+        physical_attempt_id="attempt-openh264-candidate-static",
+        artifact_size=4096,
+        artifact_sha256="5" * 64,
+    )
+    parent, parent_history = evaluate_parent(frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = evaluate_treatment(
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-build",
+        treatment_stage_command_id="treatment-stage",
+    )
+    if treatment_history[: len(parent_history)] != parent_history:
+        raise OpenH264CandidateGateError("treatment 改写了 parent history")
+    return {
+        "manifest_sha256": canonical_sha256(manifest),
+        "source_case": load_source_case(repo_root),
+        "parent": asdict(parent),
+        "treatment": asdict(treatment),
+        "parent_history_prefix_preserved": True,
+        "accepted": accepted,
+        "rejected": rejected,
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "formal_evidence_writes": 0,
+        "model_tokens": 0,
+    }
+
+
+async def validate_agent_construction() -> dict[str, Any]:
+    _base_lifecycle, construction, _r3_runtime, failure_gate = _runtime_modules()
+    original = construction.failure_gate.build_runtime_bindings
+    if original is not failure_gate.build_runtime_bindings:
+        raise OpenH264CandidateGateError("#222 construction binding identity 发生漂移")
+
+    def candidate_bindings():
+        parity, observability = original()
+        parity.FrozenActionPolicy = _candidate_policy
+        return parity, observability
+
+    construction.failure_gate.build_runtime_bindings = candidate_bindings
+    try:
+        parent_manifest = construction.protocol.load_manifest()
+        result = await construction.validate_gate(parent_manifest)
+    finally:
+        construction.failure_gate.build_runtime_bindings = original
+    success = result["success_probe"]
+    if (
+        success["request_evidence"].get("model.request_started") != 1
+        or success["request_evidence"].get("model.request_completed") != 1
+        or result["provider_calls"] != 0
+        or result["model_tokens"] != 0
+        or result["formal_evidence_writes"] != 0
+    ):
+        raise OpenH264CandidateGateError("OpenH264 construction probe 未闭合")
+    return {
+        "status": "passed",
+        "parent_gate_schema_version": result["schema_version"],
+        "candidate_policy": asdict(_candidate_policy()),
+        "success_probe": success,
+        "failure_probe": result["failure_probe"],
+        "cleanup_probe": result["cleanup_probe"],
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "formal_evidence_writes": 0,
+        "model_tokens": 0,
+    }
+
+
+def build_docker_adapter(compile_image: str = COMPILE_IMAGE) -> SimpleNamespace:
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = _runtime_modules()
+    return SimpleNamespace(
+        COMPILE_IMAGE=compile_image,
+        WORKDIR=WORKDIR,
+        REPOSITORY_URL=REPOSITORY_URL,
+        COMMIT_SHA=COMMIT_SHA,
+        TARGET=TARGET,
+        STAGED_ARTIFACT=STAGED_ARTIFACT,
+        BUILD_OUTPUT=BUILD_OUTPUT,
+        ARTIFACT_TYPE=ARTIFACT_TYPE,
+        PARENT_COMMAND=PARENT_COMMAND,
+        TREATMENT_BUILD_COMMAND=TREATMENT_BUILD_COMMAND,
+        TREATMENT_STAGE_COMMAND=TREATMENT_STAGE_COMMAND,
+        CASE_ID=CASE_ID,
+        provenance=base_lifecycle.provenance,
+        validate_gate_contract=validate_static_gate,
+        build_frozen_identity=build_frozen_identity,
+        evaluate_parent=evaluate_parent,
+        evaluate_treatment=evaluate_treatment,
+        build_repair_packet=build_repair_packet,
+        validate_repair_packet=validate_repair_packet,
+    )
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate", "plan"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+        result: Any = {"manifest_sha256": canonical_sha256(manifest)}
+    elif args.command == "plan":
+        manifest = load_manifest(args.manifest)
+        result = {
+            "manifest_sha256": canonical_sha256(manifest),
+            "execution_authorized": False,
+            "provider_calls": 0,
+            "model_tokens": 0,
+            "next_gate": "opt_in_ubuntu_native_docker_lifecycle",
+        }
+    else:
+        manifest = load_manifest(args.manifest)
+        result = {
+            "manifest_sha256": canonical_sha256(manifest),
+            "static_gate": validate_static_gate(),
+            "agent_construction": asyncio.run(validate_agent_construction()),
+        }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 从冻结 source protocol result-blind 选择 `openh264@4a2615fac570c6ca1ed4f157b9fdab9466edfd80`，冻结 direct Make target、static-library oracle、上游 Makefile/OSS-Fuzz 哈希与全新 evidence identity；
- 新增 OpenH264 candidate manifest、const Schema、预注册和零 provider gate；
- 把 OpenH264 action policy 注入 #220 组合 bindings 与 #222 完整 agent construction，验证 direct Make/jobs/stage、pre-model failure 和 cleanup 顺序；
- 增加 opt-in Ubuntu-native Docker lifecycle：parent `unproven/opaque_wrapper`，treatment `proven/direct_make`，candidate verification 与 clean replay 通过；
- 基础编译镜像缺少 `nasm`，fixture 使用固定版本、URL、SHA-256 和 60 秒下载上限派生临时 image，结束后按精确 identity 删除，不修改生产镜像。

## 验证

- 聚焦：`6 passed`
- 相邻 Make/R3/#220/#222 回归：`88 passed`
- 真实 Ubuntu-native Docker：`1 passed in 412.14s`
- Ruff check/format、pycompile、CLI、Schema、`git diff --check` 与敏感信息扫描通过
- 后置 compile/replay/continuation/Issue #224 image orphan 均为 0

## 研究边界

本阶段 0 provider、0 credential read、0 formal evidence write、0 model token；没有创建 checkpoint、reachability 或 behavioral pair。#218 hoextdown 失败 evidence 保持不变，本 PR 不是 retry、replacement 或 backfill。

Closes #224