### PR TITLE
研究：执行 OpenH264 provenance 单配对 amendment

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -5,6 +5,14 @@
 ## 进行中 (In Progress)
 <!-- 跨 session 未完成的工作。完成后挪到「最近变更」。 -->
 
+- 2026-08-31 — 发布并执行 Issue #226 OpenH264 provenance 单配对 amendment
+  - GitHub: 中文 Issue #226 已创建并回读；分支为 `research/issue-226-openh264-execution`，基线为 `main@185fcbed4e7ad01f6eae6cb247304601f480f83f`。
+  - 实现: 新 execution protocol/manifest/const Schema 与 528 行薄 wrapper 注入 #224 OpenH264 lifecycle、#220 正确 parity/observability bindings、pre-model fail-closed classifier 和独立 evidence identity，不复制冻结 #218 `_run_pair` 控制流。Manifest canonical SHA-256 为 `536f6688f8c6289e2e4bd3a46ebd95fab7dc7dbdedf728e88d937cb171bb0cfc`。
+  - Fixture: 固定 `nasm 2.16.01-1build1 amd64` URL/SHA-256，以精确命名 prep container 执行 `docker cp`、`dpkg --install` 和 Docker 29 `commit --no-pause`；禁止 apt index 与 `docker build`，pair 结束或失败后删除 container、tag 和真实 image ID，并独立记录 cleanup report。
+  - 验证: 聚焦 `9 passed`、Make/R3/OpenH264 相邻回归 `107 passed`，全量 Ruff/format、pycompile、CLI、Schema、diff 和敏感信息扫描通过。后端全量为 `2453 passed, 50 skipped, 1 failed`；唯一失败是已知 #182 空 evidence 旧断言，真实 #184 evidence 已存在，不得删除冻结 evidence 规避。
+  - 边界: 当前仍为 0 provider、0 credential read、0 Docker、0 formal evidence write、0 model token。下一步是中文提交、WSL helper 推送、中文 PR/CI/合并；合并后在干净主干执行唯一 preflight、reachability 和一个 `baseline -> treatment` pair，禁止 retry/replacement/backfill、历史池化、p 值和模型排名。
+  - 文件: `scripts/forge_opaque_provenance_openh264_execution_protocol.py`, `scripts/forge_opaque_provenance_openh264_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_openh264_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json`, `benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md`
+
 - 2026-08-15 — 验证 failure checkpoint 三层组合恢复
   - GitHub: 中文 Issue #141 已创建并回读；分支为 `research/141-combined-checkpoint-prototype`，基线为 `main@cd31d8df`。
   - 实现: 新增实验专用 `forge-combined-checkpoint-1.0.0` manifest，把 message、environment、budget 绑定到同一 `capture_id` 与 message state SHA-256；三层全部校验后才发布父 manifest。

--- a/backend/tests/test_forge_opaque_provenance_openh264_execution.py
+++ b/backend/tests/test_forge_opaque_provenance_openh264_execution.py
@@ -1,0 +1,328 @@
+"""Issue #226 OpenH264 execution amendment 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS_DIR / "forge_opaque_provenance_openh264_execution_protocol.py"
+RUNNER_PATH = SCRIPTS_DIR / "forge_opaque_provenance_openh264_execution_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_opaque_provenance_openh264_execution_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_opaque_provenance_openh264_execution_runner_test",
+    RUNNER_PATH,
+)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _completed(args: list[str], returncode: int = 0, stdout: str = ""):
+    return subprocess.CompletedProcess(args, returncode, stdout, "")
+
+
+def test_manifest_schema_and_execution_identity_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(manifest, REPO_ROOT)
+    assert manifest["case"]["target"] == "libopenh264.a"
+    assert manifest["case"]["compile_image"] == protocol.COMPILE_IMAGE
+    assert manifest["schedule"][0]["pair_id"] == protocol.PAIR_ID
+    assert manifest["opportunities"]["required_order"] == [
+        "reachability",
+        protocol.PAIR_ID,
+    ]
+
+
+def test_authorization_budget_provider_and_fixture_are_closed() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    assert manifest["authorization"]["model_tokens_authorized"] == 245_000
+    assert manifest["provider"] == {
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "model": "deepseek-v4-flash",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "streaming": False,
+        "fallback": "forbidden",
+        "status": "active_authorized",
+    }
+    assert manifest["continuation"]["maximum_requests_per_arm"] == 8
+    assert manifest["budget"]["stage_maximum_recorded_tokens"] == 245_000
+    assert manifest["dependency_fixture"]["apt_index_download_forbidden"] is True
+    assert manifest["dependency_fixture"]["prepare_once"] is True
+
+
+def test_runtime_hooks_inject_correct_bindings_and_openh264_lifecycle() -> None:
+    assert runner.REPO_ROOT == REPO_ROOT
+    originals = (
+        runner.reference.protocol,
+        runner.reference.make_lifecycle,
+        runner.reference.make_parity,
+        runner.reference.make_observability,
+        runner.reference._policy,
+        runner.reference.v2_runner.classify_arm_terminal,
+    )
+    with runner._reference_runtime_hooks():
+        assert runner.reference.protocol is runner.protocol
+        assert runner.reference.make_lifecycle.TARGET == "libopenh264.a"
+        assert runner.reference.make_lifecycle.COMPILE_IMAGE == protocol.COMPILE_IMAGE
+        assert hasattr(runner.reference.make_parity, "FrozenActionPolicy")
+        assert hasattr(runner.reference.make_parity, "SerialToolCallMiddleware")
+        assert hasattr(
+            runner.reference.make_observability,
+            "RejectionObservationRegistry",
+        )
+        assert hasattr(
+            runner.reference.make_observability,
+            "ObservableRuntimeParityToolAdapter",
+        )
+        assert runner.reference.v2_runner.classify_arm_terminal is not originals[-1]
+    assert originals == (
+        runner.reference.protocol,
+        runner.reference.make_lifecycle,
+        runner.reference.make_parity,
+        runner.reference.make_observability,
+        runner.reference._policy,
+        runner.reference.v2_runner.classify_arm_terminal,
+    )
+
+
+def test_dependency_fixture_uses_fixed_package_commit_and_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    image_id = "sha256:" + "a" * 64
+    commands: list[list[str]] = []
+
+    def command_runner(args: list[str], _timeout: int):
+        commands.append(args)
+        if args[1:3] in (["container", "inspect"], ["image", "inspect"]):
+            if "--format" in args:
+                return _completed(args, stdout=image_id + "\n")
+            return _completed(args, returncode=1)
+        if args[1:3] == ["exec", manifest["dependency_fixture"]["preparation_container_name"]] and args[-2:] == ["nasm", "-v"]:
+            return _completed(args, stdout="NASM version 2.16.01\n")
+        return _completed(args)
+
+    def downloader(package: dict, destination: Path) -> dict:
+        destination.write_bytes(b"fixed-nasm-package")
+        return {"sha256": package["sha256"], "size_bytes": 18}
+
+    marker = tmp_path / "markers/dependency-fixture.json"
+    monkeypatch.setattr(
+        runner.reference.v3_runner,
+        "_claim_marker",
+        lambda *_args, **_kwargs: marker.parent.mkdir(parents=True, exist_ok=True),
+    )
+    monkeypatch.setattr(
+        runner.reference.v3_runner,
+        "_finish_marker",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(runner, "_write_once", lambda path, value: path.parent.mkdir(parents=True, exist_ok=True) or path.write_text(json.dumps(value), encoding="utf-8"))
+    report = runner._prepare_dependency_fixture(
+        manifest,
+        output_dir=tmp_path,
+        release_revision="b" * 40,
+        command_runner=command_runner,
+        downloader=downloader,
+    )
+    assert report["image_id"] == image_id
+    assert report["apt_index_downloaded"] is False
+    assert ["docker", "commit", "--no-pause", manifest["dependency_fixture"]["preparation_container_name"], protocol.COMPILE_IMAGE] in commands
+    assert not any("apt-get" in token for command in commands for token in command)
+
+    cleanup = runner._cleanup_dependency_fixture(
+        manifest,
+        output_dir=tmp_path,
+        image_id=image_id,
+        command_runner=command_runner,
+    )
+    assert cleanup["cleanup_succeeded"] is True
+    assert ["docker", "image", "rm", "--force", protocol.COMPILE_IMAGE] in commands
+    assert ["docker", "image", "rm", "--force", image_id] in commands
+
+
+def test_preflight_remains_zero_provider_and_writes_no_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    monkeypatch.setattr(
+        runner.candidate,
+        "validate_static_gate",
+        lambda _root: {"parent_history_prefix_preserved": True},
+    )
+
+    async def construction():
+        return {"status": "passed"}
+
+    monkeypatch.setattr(runner.candidate, "validate_agent_construction", construction)
+    monkeypatch.setattr(
+        runner.reference,
+        "collect_preflight",
+        lambda *_args, **_kwargs: {
+            "ready": True,
+            "release_revision": "c" * 40,
+            "network_access_medium": "wifi",
+            "evidence_files": [],
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "_require_fixture_absent",
+        lambda *_args, **_kwargs: None,
+    )
+    output = tmp_path / "absent-evidence"
+    result = runner.collect_preflight(
+        manifest,
+        output_dir=output,
+        repo_root=tmp_path,
+        require_empty=True,
+    )
+    assert result["full_agent_construction_gate"] == "passed"
+    assert result["dependency_fixture_absent"] is True
+    assert (
+        result["provider_calls"],
+        result["formal_attempts"],
+        result["model_tokens"],
+    ) == (0, 0, 0)
+    assert not output.exists()
+
+
+def test_pair_delegates_once_and_always_cleans_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    image_id = "sha256:" + "d" * 64
+    calls: list[str] = []
+    monkeypatch.setattr(
+        runner,
+        "collect_preflight",
+        lambda *_args, **_kwargs: {"release_revision": "e" * 40},
+    )
+    monkeypatch.setattr(
+        runner.reference.legacy,
+        "_passed_reachability",
+        lambda *_args, **_kwargs: {"recorded_tokens": 17},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_prepare_dependency_fixture",
+        lambda *_args, **_kwargs: calls.append("prepare") or {"image_id": image_id},
+    )
+    monkeypatch.setattr(
+        runner.reference,
+        "execute_pair",
+        lambda *_args, **_kwargs: calls.append("pair") or {"complete_pair": True},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_cleanup_dependency_fixture",
+        lambda *_args, **_kwargs: calls.append("cleanup") or {"cleanup_succeeded": True},
+    )
+    result = runner.execute_pair(manifest, output_dir=tmp_path)
+    assert result == {"complete_pair": True}
+    assert calls == ["prepare", "pair", "cleanup"]
+
+
+def test_pair_does_not_mutate_cleanup_evidence_when_fixture_claim_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        runner,
+        "collect_preflight",
+        lambda *_args, **_kwargs: {"release_revision": "f" * 40},
+    )
+    monkeypatch.setattr(
+        runner.reference.legacy,
+        "_passed_reachability",
+        lambda *_args, **_kwargs: {"recorded_tokens": 17},
+    )
+
+    def rejected(*_args, **_kwargs):
+        raise runner.OpenH264ExecutionError("marker already exists")
+
+    monkeypatch.setattr(runner, "_prepare_dependency_fixture", rejected)
+    monkeypatch.setattr(
+        runner,
+        "_cleanup_dependency_fixture",
+        lambda *_args, **_kwargs: calls.append("cleanup"),
+    )
+    with pytest.raises(runner.OpenH264ExecutionError, match="marker already exists"):
+        runner.execute_pair(manifest, output_dir=tmp_path)
+    assert calls == []
+
+
+def test_schema_rejects_identity_authorization_or_fixture_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    mutations = (
+        ("authorization", "provider_calls_authorized", False),
+        ("case", "target", "all"),
+        ("provider", "max_retries", 1),
+        ("dependency_fixture", "apt_index_download_forbidden", False),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ProtocolError, match="manifest drifted"):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_new_sources_do_not_embed_credentials_or_duplicate_reference_runner() -> None:
+    combined = RUNNER_PATH.read_text(encoding="utf-8") + PROTOCOL_PATH.read_text(encoding="utf-8")
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert len(source.splitlines()) < 550
+    assert "def _run_pair(" not in source
+    assert source.index("sys.path.insert(0, str(REPO_SCRIPT_ROOT))") < source.index("import forge_opaque_provenance_openh264_candidate_gate")
+    assert "apt-get update" not in combined
+    assert "docker build" not in combined
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "os.environ["):
+        assert forbidden not in combined

--- a/benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-openh264-execution.schema.json",
+  "schema_version": "forge-opaque-provenance-openh264-execution-1.0.0",
+  "document_type": "forge_opaque_provenance_openh264_execution_amendment",
+  "authorization": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/226",
+    "checkpoint_creation_authorized": true,
+    "reachability_request_authorized": true,
+    "provider_calls_authorized": true,
+    "formal_attempts_authorized": true,
+    "pair_collection_authorized": true,
+    "credential_read_authorized": true,
+    "model_creation_authorized": true,
+    "docker_execution_authorized": true,
+    "evidence_write_authorized": true,
+    "model_tokens_authorized": 245000
+  },
+  "parent": {
+    "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json",
+    "schema_version": "forge-opaque-provenance-openh264-candidate-1.0.0",
+    "canonical_sha256": "ab29737969549ddf3d309fb2868a0254b8a346842cc1e168d7e475d123f4e0d6",
+    "file_sha256": "ecdf5ad13996c1f7592f421ede5deb6fea00d42f40c7aabb82e0959f6405bb08",
+    "evidence_identity_sha256": "dd777763ab03ec6853c7e36299b78acff3e0383ca8b808f0c59b51744669b683",
+    "authorization_baseline_commit": "185fcbed4e7ad01f6eae6cb247304601f480f83f",
+    "release_revision_policy": "descendant-compatible"
+  },
+  "case": {
+    "case_id": "openh264-opaque-provenance-r4-make",
+    "repository_url": "https://github.com/cisco/openh264",
+    "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+    "build_system": "make",
+    "build_directory": "/workspace/repo",
+    "target": "libopenh264.a",
+    "build_output": "libopenh264.a",
+    "staged_artifact": "libopenh264.a",
+    "artifact_type": "static_library",
+    "required_system_packages": [
+      "build-essential",
+      "nasm"
+    ],
+    "bootstrap_commands": [],
+    "configure_arguments": [],
+    "compile_image": "forge-openh264-execution:issue226-v1",
+    "source_subdir": ".",
+    "reference_case_id": "openh264-opaque-provenance-r4-make"
+  },
+  "provider": {
+    "status": "active_authorized",
+    "id": "deepseek-v4-flash",
+    "endpoint": "https://api.deepseek.com",
+    "credential_env": "DEEPSEEK_API_KEY",
+    "model": "deepseek-v4-flash",
+    "request_timeout_seconds": 300,
+    "max_retries": 0,
+    "fallback": "forbidden",
+    "streaming": false
+  },
+  "checkpoint": {
+    "source_gate": "issue-224-openh264-lifecycle-zero-provider",
+    "creation_timing": "after_reachability_before_arm_continuation",
+    "capture_point": "after-neutral-tool-message-before-continuation",
+    "identity_materialized_during_pair": true,
+    "arm_state_matching": [
+      "message",
+      "environment",
+      "budget"
+    ],
+    "preexisting_checkpoint_reuse_forbidden": true
+  },
+  "continuation": {
+    "maximum_requests_per_arm": 8,
+    "maximum_model_turns_per_arm": 8,
+    "maximum_graph_steps_per_arm": 24,
+    "work_wall_clock_seconds_per_arm": 600,
+    "cleanup_reserve_seconds_per_arm": 120,
+    "maximum_recorded_tokens_per_arm": 120000
+  },
+  "schedule": [
+    {
+      "pair_id": "opaque-provenance-openh264-pair-01",
+      "order": 1,
+      "case_id": "openh264-opaque-provenance-r4-make",
+      "arm_order": [
+        "baseline",
+        "treatment"
+      ],
+      "state_matched": true,
+      "treatment_exposure_only": "repair_packet",
+      "shared_measurement_policy": "openh264_bounded_make_with_r0_observability_v1"
+    }
+  ],
+  "schedule_sha256": "7662f3c45d9d6c73c70b1673577eb3c70ad02a09b41858819f07f879dfc2d01d",
+  "repair_packet": {
+    "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+    "primary_classification": "build_system_unproven",
+    "mechanism_classification": "opaque_build_provenance",
+    "expected_build_system": "make",
+    "selected_build_system": "make",
+    "build_directory": "/workspace/repo",
+    "target": "libopenh264.a",
+    "proof_status": "opaque_wrapper",
+    "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+  },
+  "budget": {
+    "maximum_reachability_requests": 1,
+    "reachability_maximum_recorded_tokens": 5000,
+    "recorded_tokens_per_arm": 120000,
+    "recorded_tokens_per_pair": 240000,
+    "stage_maximum_recorded_tokens": 245000,
+    "enforcement": "after_reachability_and_each_arm_before_continuation"
+  },
+  "runtime_parity": {
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "atomic_budget_claim": true,
+    "parallel_tool_calls": false,
+    "shared_tool_contract_identical": true,
+    "treatment_exposure_only": "repair_packet",
+    "action_surface": {
+      "direct_executables": [
+        "make",
+        "gmake"
+      ],
+      "build_directory": "/workspace/repo",
+      "target": "libopenh264.a",
+      "jobs": {
+        "omitted_allowed": true,
+        "minimum": 1,
+        "maximum": 2
+      },
+      "artifact_stage": {
+        "source": "/workspace/repo/libopenh264.a",
+        "destination": "/artifacts/libopenh264.a",
+        "separate_from_build": true
+      }
+    },
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_required": true,
+    "forbidden_actions": [
+      "clone",
+      "configure",
+      "dependency",
+      "housekeeping",
+      "manual_replay",
+      "compound_build_stage"
+    ]
+  },
+  "r0_observability": {
+    "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+    "legacy_failure_event": "agent.tool_failed",
+    "legacy_failure_schema_preserved": true,
+    "companion_event": "agent.tool_rejection_observed",
+    "companion_required_for_classified_rejection": true,
+    "failure_link_field": "failure_id",
+    "atomic_fields": [
+      "rejection_classification",
+      "action_kind",
+      "model_request_id",
+      "tool_ordinal",
+      "command_sha256"
+    ],
+    "raw_command_error_model_text_and_credentials_forbidden": true,
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+    }
+  },
+  "dependency_fixture": {
+    "base_image": "autocompiler:gcc13",
+    "derived_image_persisted": false,
+    "nasm_package": {
+      "version": "2.16.01-1build1",
+      "architecture": "amd64",
+      "url": "https://mirrors.ustc.edu.cn/ubuntu/pool/universe/n/nasm/nasm_2.16.01-1build1_amd64.deb",
+      "sha256": "22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3",
+      "download_timeout_seconds": 60
+    },
+    "apt_index_download_forbidden": true,
+    "compile_image": "forge-openh264-execution:issue226-v1",
+    "preparation_container_name": "forge-openh264-issue226-image-prep",
+    "docker_label": "forge.opaque_provenance.issue226",
+    "prepare_once": true,
+    "cleanup_required": true
+  },
+  "evidence": {
+    "schema_version": "forge-opaque-provenance-openh264-execution-evidence-1.0.0",
+    "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-openh264-execution-v1",
+    "checkpoint_manifest": "checkpoints/opaque-provenance-openh264-pair-01/checkpoint.json",
+    "parent_ledger": "checkpoints/opaque-provenance-openh264-pair-01/parent/events.jsonl",
+    "pair_ledger": "pairs/opaque-provenance-openh264-pair-01/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-openh264-pair-01/arms",
+    "reachability_marker": "markers/reachability.json",
+    "dependency_fixture_marker": "markers/dependency-fixture.json",
+    "pair_marker": "markers/pair.json",
+    "reachability_report": "reports/reachability.json",
+    "dependency_fixture_report": "reports/dependency-fixture.json",
+    "dependency_fixture_cleanup_report": "reports/dependency-fixture-cleanup.json",
+    "canary_report": "reports/canary.json",
+    "append_only": true,
+    "status": "authorized_not_created",
+    "zero_provider_preflight_writes_evidence": false,
+    "identity_sha256": "035d45828ebd112e4f0bd44678e654a8cddcf2c69f92d4d18f358103c1142243"
+  },
+  "execution": {
+    "release_branch": "main",
+    "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+    "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+    "reachability_expected_response": "CANARY_OK",
+    "reachability_report": "reports/reachability.json",
+    "pair_marker": "markers/pair.json",
+    "parent_ledger": "checkpoints/opaque-provenance-openh264-pair-01/parent/events.jsonl",
+    "arm_ledger_directory": "pairs/opaque-provenance-openh264-pair-01/arms",
+    "report_schema_version": "forge-opaque-provenance-openh264-report-1.0.0",
+    "report_document_type": "forge_opaque_provenance_openh264_report"
+  },
+  "stopping": {
+    "reachability_failure_stops_before_pair": true,
+    "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+    "retry_replacement_backfill_or_extension_forbidden": true,
+    "classified_arm_outcome_continues_other_arm": true,
+    "endpoint_timeout_censors_arm_and_continues": true
+  },
+  "opportunities": {
+    "maximum_reachability_requests": 1,
+    "maximum_pairs": 1,
+    "required_order": [
+      "reachability",
+      "opaque-provenance-openh264-pair-01"
+    ],
+    "marker_consumed_on_start": true,
+    "retry_replacement_backfill_forbidden": true,
+    "schedule_extension_forbidden": true
+  },
+  "analysis": {
+    "unit_of_analysis": "single_state_matched_make_pair",
+    "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+    "descriptive_only": true,
+    "treatment_effect_estimated": false,
+    "historical_pairs_pooled": false,
+    "model_ranking_performed": false,
+    "purpose": "independent_openh264_make_conversion_replication",
+    "p_value_computed": false
+  },
+  "preflight": {
+    "release_branch": "main",
+    "require_clean_worktree": true,
+    "require_head_equals_origin_main": true,
+    "require_authorization_baseline_ancestor": true,
+    "docker_provider": "ubuntu-native",
+    "docker_context": "default",
+    "docker_endpoint": "/var/run/docker.sock",
+    "control_plane": "compose-dood-on-ubuntu-native-engine",
+    "allowed_network_media": [
+      "wired",
+      "wifi",
+      "mobile_hotspot"
+    ],
+    "require_empty_evidence_directory": true,
+    "managed_container_prefixes": [
+      "deerflow-compile-",
+      "deerflow-replay-"
+    ],
+    "require_zero_managed_orphans": true,
+    "authorization_baseline_commit": "185fcbed4e7ad01f6eae6cb247304601f480f83f",
+    "require_empty_dependency_fixture": true,
+    "require_full_agent_construction_gate": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md",
+    "file_sha256": "2ef7d9a84868f7cb2eccf01eefeda35e4b0b87140168649f245e4d9947daced6"
+  },
+  "runtime_adapter": {
+    "path": "scripts/forge_opaque_provenance_openh264_execution_runner.py",
+    "file_sha256": "bce38c6ce0302a910bd5b0c1518d77b38d4a091e14fb58c975796c1d0a4223e3",
+    "derived_from_path": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+    "derived_from_sha256": "5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955",
+    "commands": [
+      "validate",
+      "preflight",
+      "reachability",
+      "pair"
+    ],
+    "corrected_runtime_bindings_required": true,
+    "dependency_fixture_cleanup_required": true
+  },
+  "frozen_parent_components": {
+    "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json": "ecdf5ad13996c1f7592f421ede5deb6fea00d42f40c7aabb82e0959f6405bb08",
+    "benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json": "65a685aa330d45df7c78dffe7fe4797dcce6c0803e34ad206fea56468208ad14",
+    "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md": "51c1f34f7e6a194ca8e60d95ee9f70233b9a9ddf0dbe5ff3cfa9b26511b95255",
+    "scripts/forge_opaque_provenance_openh264_candidate_gate.py": "5963e3af5b4630022720a889956e63af65f29f325498e99bfb2036d97f3b379c",
+    "backend/tests/test_forge_opaque_provenance_openh264_candidate.py": "6deba2741b1b3e7dba4aeb5c5694af9807734ce6674a05090d09928aad808a7f",
+    "backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py": "2afe2aa3a49c94ecb16a6ee42aeb4a49a2b87f0f3d01096d300e84f023a48f75",
+    "scripts/forge_opaque_provenance_r3_make_execution_runner.py": "5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955",
+    "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+    "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json": "2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md
@@ -1,0 +1,21 @@
+# OpenH264 provenance 单配对 execution amendment
+
+- Issue：[#226](https://github.com/WWFXL/Forge-AutoCompiler/issues/226)
+- 父候选：Issue #224 / PR #225，`main@185fcbed4e7ad01f6eae6cb247304601f480f83f`
+- 性质：全新 OpenH264 evidence identity；不是 #218 retry、replacement 或 backfill。
+
+## 执行授权
+
+Provider 固定 DeepSeek `deepseek-v4-flash`、`https://api.deepseek.com`、300 秒、0 retry、非 streaming、禁止 fallback。只允许一次 reachability；成功后只允许一个 `baseline -> treatment` state-matched pair。每臂最多 8 requests、8 turns、24 graph steps、120,000 recorded tokens；阶段总上限 245,000。
+
+## 运行时边界
+
+Runner 复用冻结 #218 lifecycle 编排，但把 OpenH264 lifecycle adapter、#220 正确 parity/observability bindings 与本 manifest protocol 注入同一受保护上下文；不得再把 candidate module 同时伪装成 parity 与 observability。合并后 preflight 必须再次通过 #224 static gate 与完整 fake-model agent construction。
+
+基础编译镜像缺少 `nasm`。Pair 前仅允许一次 dependency fixture：下载固定 `nasm 2.16.01-1build1 amd64` 包并校验 SHA-256 `22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3`，通过精确命名 prep container 安装后 `docker commit --no-pause` 为 manifest 固定 tag。失败 marker 终结后禁止再次准备；pair 完成或失败后必须删除 prep container、tag 与实际 image ID。
+
+## 证据与停止规则
+
+Reachability、dependency fixture、pair、checkpoint、parent/arm ledger 与 canary report 使用全新目录和路径。Reachability 失败即停止；identity、fixture、预算、cleanup 或未分类失败即停止。Endpoint timeout 只删失当前 arm 并继续另一 arm；分类后的 arm outcome 继续配对。禁止 retry、replacement、backfill 或 extension。
+
+结果只做单 pair 描述性机制复制。不得与 #218 无效 hoextdown pair、CMake pair 或其他 Make case 池化，不计算 p 值，不排名模型。

--- a/benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json",
+  "title": "Forge opaque provenance OpenH264 execution amendment",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-openh264-execution.schema.json",
+    "schema_version": "forge-opaque-provenance-openh264-execution-1.0.0",
+    "document_type": "forge_opaque_provenance_openh264_execution_amendment",
+    "authorization": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/226",
+      "checkpoint_creation_authorized": true,
+      "reachability_request_authorized": true,
+      "provider_calls_authorized": true,
+      "formal_attempts_authorized": true,
+      "pair_collection_authorized": true,
+      "credential_read_authorized": true,
+      "model_creation_authorized": true,
+      "docker_execution_authorized": true,
+      "evidence_write_authorized": true,
+      "model_tokens_authorized": 245000
+    },
+    "parent": {
+      "manifest_path": "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json",
+      "schema_version": "forge-opaque-provenance-openh264-candidate-1.0.0",
+      "canonical_sha256": "ab29737969549ddf3d309fb2868a0254b8a346842cc1e168d7e475d123f4e0d6",
+      "file_sha256": "ecdf5ad13996c1f7592f421ede5deb6fea00d42f40c7aabb82e0959f6405bb08",
+      "evidence_identity_sha256": "dd777763ab03ec6853c7e36299b78acff3e0383ca8b808f0c59b51744669b683",
+      "authorization_baseline_commit": "185fcbed4e7ad01f6eae6cb247304601f480f83f",
+      "release_revision_policy": "descendant-compatible"
+    },
+    "case": {
+      "case_id": "openh264-opaque-provenance-r4-make",
+      "repository_url": "https://github.com/cisco/openh264",
+      "commit_sha": "4a2615fac570c6ca1ed4f157b9fdab9466edfd80",
+      "build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libopenh264.a",
+      "build_output": "libopenh264.a",
+      "staged_artifact": "libopenh264.a",
+      "artifact_type": "static_library",
+      "required_system_packages": [
+        "build-essential",
+        "nasm"
+      ],
+      "bootstrap_commands": [],
+      "configure_arguments": [],
+      "compile_image": "forge-openh264-execution:issue226-v1",
+      "source_subdir": ".",
+      "reference_case_id": "openh264-opaque-provenance-r4-make"
+    },
+    "provider": {
+      "status": "active_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "checkpoint": {
+      "source_gate": "issue-224-openh264-lifecycle-zero-provider",
+      "creation_timing": "after_reachability_before_arm_continuation",
+      "capture_point": "after-neutral-tool-message-before-continuation",
+      "identity_materialized_during_pair": true,
+      "arm_state_matching": [
+        "message",
+        "environment",
+        "budget"
+      ],
+      "preexisting_checkpoint_reuse_forbidden": true
+    },
+    "continuation": {
+      "maximum_requests_per_arm": 8,
+      "maximum_model_turns_per_arm": 8,
+      "maximum_graph_steps_per_arm": 24,
+      "work_wall_clock_seconds_per_arm": 600,
+      "cleanup_reserve_seconds_per_arm": 120,
+      "maximum_recorded_tokens_per_arm": 120000
+    },
+    "schedule": [
+      {
+        "pair_id": "opaque-provenance-openh264-pair-01",
+        "order": 1,
+        "case_id": "openh264-opaque-provenance-r4-make",
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ],
+        "state_matched": true,
+        "treatment_exposure_only": "repair_packet",
+        "shared_measurement_policy": "openh264_bounded_make_with_r0_observability_v1"
+      }
+    ],
+    "schedule_sha256": "7662f3c45d9d6c73c70b1673577eb3c70ad02a09b41858819f07f879dfc2d01d",
+    "repair_packet": {
+      "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+      "primary_classification": "build_system_unproven",
+      "mechanism_classification": "opaque_build_provenance",
+      "expected_build_system": "make",
+      "selected_build_system": "make",
+      "build_directory": "/workspace/repo",
+      "target": "libopenh264.a",
+      "proof_status": "opaque_wrapper",
+      "repair_goal": "Execute and record a trusted build-system invocation bound to the frozen directory and target, then submit again."
+    },
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "stage_maximum_recorded_tokens": 245000,
+      "enforcement": "after_reachability_and_each_arm_before_continuation"
+    },
+    "runtime_parity": {
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "atomic_budget_claim": true,
+      "parallel_tool_calls": false,
+      "shared_tool_contract_identical": true,
+      "treatment_exposure_only": "repair_packet",
+      "action_surface": {
+        "direct_executables": [
+          "make",
+          "gmake"
+        ],
+        "build_directory": "/workspace/repo",
+        "target": "libopenh264.a",
+        "jobs": {
+          "omitted_allowed": true,
+          "minimum": 1,
+          "maximum": 2
+        },
+        "artifact_stage": {
+          "source": "/workspace/repo/libopenh264.a",
+          "destination": "/artifacts/libopenh264.a",
+          "separate_from_build": true
+        }
+      },
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_required": true,
+      "forbidden_actions": [
+        "clone",
+        "configure",
+        "dependency",
+        "housekeeping",
+        "manual_replay",
+        "compound_build_stage"
+      ]
+    },
+    "r0_observability": {
+      "schema_version": "forge-opaque-provenance-rejection-observability-gate-1.0.0",
+      "legacy_failure_event": "agent.tool_failed",
+      "legacy_failure_schema_preserved": true,
+      "companion_event": "agent.tool_rejection_observed",
+      "companion_required_for_classified_rejection": true,
+      "failure_link_field": "failure_id",
+      "atomic_fields": [
+        "rejection_classification",
+        "action_kind",
+        "model_request_id",
+        "tool_ordinal",
+        "command_sha256"
+      ],
+      "raw_command_error_model_text_and_credentials_forbidden": true,
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "backend/tests/test_forge_opaque_provenance_rejection_observability_gate.py": "436099e045138ac05d8c53e81d2a8b2a821f1e44213bbcd540e39d1d6e531f2c"
+      }
+    },
+    "dependency_fixture": {
+      "base_image": "autocompiler:gcc13",
+      "derived_image_persisted": false,
+      "nasm_package": {
+        "version": "2.16.01-1build1",
+        "architecture": "amd64",
+        "url": "https://mirrors.ustc.edu.cn/ubuntu/pool/universe/n/nasm/nasm_2.16.01-1build1_amd64.deb",
+        "sha256": "22eede0f2dd62343b0298182f62f7485704fe02f166395b02c92a8883377e0b3",
+        "download_timeout_seconds": 60
+      },
+      "apt_index_download_forbidden": true,
+      "compile_image": "forge-openh264-execution:issue226-v1",
+      "preparation_container_name": "forge-openh264-issue226-image-prep",
+      "docker_label": "forge.opaque_provenance.issue226",
+      "prepare_once": true,
+      "cleanup_required": true
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-openh264-execution-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-openh264-execution-v1",
+      "checkpoint_manifest": "checkpoints/opaque-provenance-openh264-pair-01/checkpoint.json",
+      "parent_ledger": "checkpoints/opaque-provenance-openh264-pair-01/parent/events.jsonl",
+      "pair_ledger": "pairs/opaque-provenance-openh264-pair-01/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-openh264-pair-01/arms",
+      "reachability_marker": "markers/reachability.json",
+      "dependency_fixture_marker": "markers/dependency-fixture.json",
+      "pair_marker": "markers/pair.json",
+      "reachability_report": "reports/reachability.json",
+      "dependency_fixture_report": "reports/dependency-fixture.json",
+      "dependency_fixture_cleanup_report": "reports/dependency-fixture-cleanup.json",
+      "canary_report": "reports/canary.json",
+      "append_only": true,
+      "status": "authorized_not_created",
+      "zero_provider_preflight_writes_evidence": false,
+      "identity_sha256": "035d45828ebd112e4f0bd44678e654a8cddcf2c69f92d4d18f358103c1142243"
+    },
+    "execution": {
+      "release_branch": "main",
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "reachability_expected_response": "CANARY_OK",
+      "reachability_report": "reports/reachability.json",
+      "pair_marker": "markers/pair.json",
+      "parent_ledger": "checkpoints/opaque-provenance-openh264-pair-01/parent/events.jsonl",
+      "arm_ledger_directory": "pairs/opaque-provenance-openh264-pair-01/arms",
+      "report_schema_version": "forge-opaque-provenance-openh264-report-1.0.0",
+      "report_document_type": "forge_opaque_provenance_openh264_report"
+    },
+    "stopping": {
+      "reachability_failure_stops_before_pair": true,
+      "identity_evidence_budget_cleanup_or_unclassified_failure_stops": true,
+      "retry_replacement_backfill_or_extension_forbidden": true,
+      "classified_arm_outcome_continues_other_arm": true,
+      "endpoint_timeout_censors_arm_and_continues": true
+    },
+    "opportunities": {
+      "maximum_reachability_requests": 1,
+      "maximum_pairs": 1,
+      "required_order": [
+        "reachability",
+        "opaque-provenance-openh264-pair-01"
+      ],
+      "marker_consumed_on_start": true,
+      "retry_replacement_backfill_forbidden": true,
+      "schedule_extension_forbidden": true
+    },
+    "analysis": {
+      "unit_of_analysis": "single_state_matched_make_pair",
+      "primary_outcome": "paired_post_checkpoint_p2_conversion_with_candidate_and_clean_replay",
+      "descriptive_only": true,
+      "treatment_effect_estimated": false,
+      "historical_pairs_pooled": false,
+      "model_ranking_performed": false,
+      "purpose": "independent_openh264_make_conversion_replication",
+      "p_value_computed": false
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "control_plane": "compose-dood-on-ubuntu-native-engine",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "require_empty_evidence_directory": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true,
+      "authorization_baseline_commit": "185fcbed4e7ad01f6eae6cb247304601f480f83f",
+      "require_empty_dependency_fixture": true,
+      "require_full_agent_construction_gate": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md",
+      "file_sha256": "2ef7d9a84868f7cb2eccf01eefeda35e4b0b87140168649f245e4d9947daced6"
+    },
+    "runtime_adapter": {
+      "path": "scripts/forge_opaque_provenance_openh264_execution_runner.py",
+      "file_sha256": "bce38c6ce0302a910bd5b0c1518d77b38d4a091e14fb58c975796c1d0a4223e3",
+      "derived_from_path": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+      "derived_from_sha256": "5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955",
+      "commands": [
+        "validate",
+        "preflight",
+        "reachability",
+        "pair"
+      ],
+      "corrected_runtime_bindings_required": true,
+      "dependency_fixture_cleanup_required": true
+    },
+    "frozen_parent_components": {
+      "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json": "ecdf5ad13996c1f7592f421ede5deb6fea00d42f40c7aabb82e0959f6405bb08",
+      "benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json": "65a685aa330d45df7c78dffe7fe4797dcce6c0803e34ad206fea56468208ad14",
+      "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md": "51c1f34f7e6a194ca8e60d95ee9f70233b9a9ddf0dbe5ff3cfa9b26511b95255",
+      "scripts/forge_opaque_provenance_openh264_candidate_gate.py": "5963e3af5b4630022720a889956e63af65f29f325498e99bfb2036d97f3b379c",
+      "backend/tests/test_forge_opaque_provenance_openh264_candidate.py": "6deba2741b1b3e7dba4aeb5c5694af9807734ce6674a05090d09928aad808a7f",
+      "backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py": "2afe2aa3a49c94ecb16a6ee42aeb4a49a2b87f0f3d01096d300e84f023a48f75",
+      "scripts/forge_opaque_provenance_r3_make_execution_runner.py": "5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955",
+      "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+      "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json": "2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_openh264_execution_protocol.py
+++ b/scripts/forge_opaque_provenance_openh264_execution_protocol.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Issue #226 OpenH264 provenance 单配对 execution amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-openh264-candidate.json"
+REFERENCE_EXECUTION_PATH = "benchmarks/manifests/cpp-opaque-provenance-r3-make-execution.json"
+RUNTIME_ADAPTER_PATH = "scripts/forge_opaque_provenance_openh264_execution_runner.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-openh264-execution-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_openh264_execution_amendment"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/226"
+AUTHORIZATION_BASELINE_COMMIT = "185fcbed4e7ad01f6eae6cb247304601f480f83f"
+PARENT_MANIFEST_CANONICAL_SHA256 = "ab29737969549ddf3d309fb2868a0254b8a346842cc1e168d7e475d123f4e0d6"
+PARENT_EVIDENCE_IDENTITY_SHA256 = "dd777763ab03ec6853c7e36299b78acff3e0383ca8b808f0c59b51744669b683"
+REFERENCE_EXECUTION_FILE_SHA256 = "2a435b7846d510776d4364deb92846f4e6a142fb0e8a822d0634c9fc0a3de76f"
+PAIR_ID = "opaque-provenance-openh264-pair-01"
+COMPILE_IMAGE = "forge-openh264-execution:issue226-v1"
+
+FROZEN_PARENT_SHA256 = {
+    PARENT_MANIFEST_PATH: "ecdf5ad13996c1f7592f421ede5deb6fea00d42f40c7aabb82e0959f6405bb08",
+    "benchmarks/schemas/forge-opaque-provenance-openh264-candidate.schema.json": ("65a685aa330d45df7c78dffe7fe4797dcce6c0803e34ad206fea56468208ad14"),
+    "benchmarks/preregistrations/cpp-opaque-provenance-openh264-candidate.md": ("51c1f34f7e6a194ca8e60d95ee9f70233b9a9ddf0dbe5ff3cfa9b26511b95255"),
+    "scripts/forge_opaque_provenance_openh264_candidate_gate.py": ("5963e3af5b4630022720a889956e63af65f29f325498e99bfb2036d97f3b379c"),
+    "backend/tests/test_forge_opaque_provenance_openh264_candidate.py": ("6deba2741b1b3e7dba4aeb5c5694af9807734ce6674a05090d09928aad808a7f"),
+    "backend/tests/test_forge_opaque_provenance_openh264_candidate_docker.py": ("2afe2aa3a49c94ecb16a6ee42aeb4a49a2b87f0f3d01096d300e84f023a48f75"),
+    "scripts/forge_opaque_provenance_r3_make_execution_runner.py": ("5e955e79a15b00cd97726d1254d9716f5f8f18225c2149078f51a2adba420955"),
+    "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": ("cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06"),
+    REFERENCE_EXECUTION_PATH: REFERENCE_EXECUTION_FILE_SHA256,
+}
+
+
+class ProtocolError(RuntimeError):
+    """OpenH264 execution 身份、授权、预算或冻结组件无效。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_gate(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_openh264_candidate_gate.py"
+    name = "forge_opaque_provenance_openh264_execution_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("cannot load OpenH264 candidate gate")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"cannot load {label}") from exc
+    if not isinstance(value, dict):
+        raise ProtocolError(f"{label} must be an object")
+    return value
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent_gate = _load_parent_gate(repo_root)
+    parent = parent_gate.load_manifest(repo_root / PARENT_MANIFEST_PATH, repo_root)
+    if parent_gate.canonical_sha256(parent) != PARENT_MANIFEST_CANONICAL_SHA256:
+        raise ProtocolError("OpenH264 candidate canonical identity drifted")
+    if parent["evidence"]["identity_sha256"] != PARENT_EVIDENCE_IDENTITY_SHA256:
+        raise ProtocolError("OpenH264 candidate evidence identity drifted")
+    return parent, parent_gate
+
+
+def verify_parent_components(repo_root: Path = REPO_ROOT) -> None:
+    actual = {path: file_sha256(repo_root / path) for path in sorted(FROZEN_PARENT_SHA256)}
+    if actual != FROZEN_PARENT_SHA256:
+        raise ProtocolError("OpenH264 execution parent components drifted")
+
+
+def _evidence_identity(
+    *,
+    case: dict[str, Any],
+    provider: dict[str, Any],
+    schedule: list[dict[str, Any]],
+    repair_packet: dict[str, Any],
+) -> str:
+    return canonical_sha256(
+        {
+            "schema_version": "forge-opaque-provenance-openh264-execution-evidence-1.0.0",
+            "parent_evidence_identity_sha256": PARENT_EVIDENCE_IDENTITY_SHA256,
+            "case": case,
+            "provider": provider,
+            "schedule": schedule,
+            "repair_packet": repair_packet,
+            "compile_image": COMPILE_IMAGE,
+        }
+    )
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    verify_parent_components(repo_root)
+    parent, _parent_gate = _parent_manifest(repo_root)
+    reference = _load_object(
+        repo_root / REFERENCE_EXECUTION_PATH,
+        "R3 execution reference policy",
+    )
+    runtime_path = repo_root / RUNTIME_ADAPTER_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("OpenH264 execution runtime or preregistration is missing")
+
+    case = copy.deepcopy(parent["case"])
+    case.update(
+        {
+            "compile_image": COMPILE_IMAGE,
+            "source_subdir": ".",
+            "reference_case_id": parent["case"]["case_id"],
+        }
+    )
+    provider = copy.deepcopy(reference["provider"])
+    provider["status"] = "active_authorized"
+    schedule = [
+        {
+            "pair_id": PAIR_ID,
+            "order": 1,
+            "case_id": case["case_id"],
+            "arm_order": ["baseline", "treatment"],
+            "state_matched": True,
+            "treatment_exposure_only": "repair_packet",
+            "shared_measurement_policy": "openh264_bounded_make_with_r0_observability_v1",
+        }
+    ]
+    runtime_parity = copy.deepcopy(reference["runtime_parity"])
+    runtime_parity["action_surface"] = {
+        "direct_executables": ["make", "gmake"],
+        "build_directory": case["build_directory"],
+        "target": case["target"],
+        "jobs": copy.deepcopy(parent["runtime_parity"]["jobs"]),
+        "artifact_stage": copy.deepcopy(parent["runtime_parity"]["artifact_stage"]),
+    }
+    repair_packet = copy.deepcopy(parent["repair_packet"])
+    evidence_identity = _evidence_identity(
+        case=case,
+        provider=provider,
+        schedule=schedule,
+        repair_packet=repair_packet,
+    )
+    evidence_root = "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-openh264-execution-v1"
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-openh264-execution.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "issue_url": ISSUE_URL,
+            "checkpoint_creation_authorized": True,
+            "reachability_request_authorized": True,
+            "provider_calls_authorized": True,
+            "formal_attempts_authorized": True,
+            "pair_collection_authorized": True,
+            "credential_read_authorized": True,
+            "model_creation_authorized": True,
+            "docker_execution_authorized": True,
+            "evidence_write_authorized": True,
+            "model_tokens_authorized": 245_000,
+        },
+        "parent": {
+            "manifest_path": PARENT_MANIFEST_PATH,
+            "schema_version": parent["schema_version"],
+            "canonical_sha256": PARENT_MANIFEST_CANONICAL_SHA256,
+            "file_sha256": FROZEN_PARENT_SHA256[PARENT_MANIFEST_PATH],
+            "evidence_identity_sha256": PARENT_EVIDENCE_IDENTITY_SHA256,
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "release_revision_policy": "descendant-compatible",
+        },
+        "case": case,
+        "provider": provider,
+        "checkpoint": {
+            **copy.deepcopy(reference["checkpoint"]),
+            "source_gate": "issue-224-openh264-lifecycle-zero-provider",
+        },
+        "continuation": copy.deepcopy(reference["continuation"]),
+        "schedule": schedule,
+        "schedule_sha256": canonical_sha256(schedule),
+        "repair_packet": repair_packet,
+        "budget": copy.deepcopy(reference["budget"]),
+        "runtime_parity": runtime_parity,
+        "r0_observability": copy.deepcopy(reference["r0_observability"]),
+        "dependency_fixture": {
+            **copy.deepcopy(parent["lifecycle_fixture"]),
+            "compile_image": COMPILE_IMAGE,
+            "preparation_container_name": "forge-openh264-issue226-image-prep",
+            "docker_label": "forge.opaque_provenance.issue226",
+            "prepare_once": True,
+            "cleanup_required": True,
+        },
+        "evidence": {
+            "schema_version": "forge-opaque-provenance-openh264-execution-evidence-1.0.0",
+            "directory": evidence_root,
+            "checkpoint_manifest": f"checkpoints/{PAIR_ID}/checkpoint.json",
+            "parent_ledger": f"checkpoints/{PAIR_ID}/parent/events.jsonl",
+            "pair_ledger": f"pairs/{PAIR_ID}/events.jsonl",
+            "arm_ledger_directory": f"pairs/{PAIR_ID}/arms",
+            "reachability_marker": "markers/reachability.json",
+            "dependency_fixture_marker": "markers/dependency-fixture.json",
+            "pair_marker": "markers/pair.json",
+            "reachability_report": "reports/reachability.json",
+            "dependency_fixture_report": "reports/dependency-fixture.json",
+            "dependency_fixture_cleanup_report": "reports/dependency-fixture-cleanup.json",
+            "canary_report": "reports/canary.json",
+            "append_only": True,
+            "status": "authorized_not_created",
+            "zero_provider_preflight_writes_evidence": False,
+            "identity_sha256": evidence_identity,
+        },
+        "execution": {
+            **copy.deepcopy(reference["execution"]),
+            "pair_marker": "markers/pair.json",
+            "parent_ledger": f"checkpoints/{PAIR_ID}/parent/events.jsonl",
+            "arm_ledger_directory": f"pairs/{PAIR_ID}/arms",
+            "report_schema_version": "forge-opaque-provenance-openh264-report-1.0.0",
+            "report_document_type": "forge_opaque_provenance_openh264_report",
+        },
+        "stopping": copy.deepcopy(reference["stopping"]),
+        "opportunities": {
+            **copy.deepcopy(reference["opportunities"]),
+            "required_order": ["reachability", PAIR_ID],
+        },
+        "analysis": {
+            **copy.deepcopy(parent["analysis"]),
+            "purpose": "independent_openh264_make_conversion_replication",
+            "unit_of_analysis": "single_state_matched_make_pair",
+            "p_value_computed": False,
+        },
+        "preflight": {
+            **copy.deepcopy(reference["preflight"]),
+            "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+            "require_empty_dependency_fixture": True,
+            "require_full_agent_construction_gate": True,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+        "runtime_adapter": {
+            "path": RUNTIME_ADAPTER_PATH,
+            "file_sha256": file_sha256(runtime_path),
+            "derived_from_path": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+            "derived_from_sha256": FROZEN_PARENT_SHA256["scripts/forge_opaque_provenance_r3_make_execution_runner.py"],
+            "commands": ["validate", "preflight", "reachability", "pair"],
+            "corrected_runtime_bindings_required": True,
+            "dependency_fixture_cleanup_required": True,
+        },
+        "frozen_parent_components": copy.deepcopy(FROZEN_PARENT_SHA256),
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if not isinstance(value, dict) or value != generate_manifest(repo_root):
+        raise ProtocolError("OpenH264 execution manifest drifted")
+    authorization = value["authorization"]
+    if not all(current is True for key, current in authorization.items() if key.endswith("_authorized") and key != "model_tokens_authorized"):
+        raise ProtocolError("OpenH264 execution authorization is incomplete")
+    if authorization["model_tokens_authorized"] != 245_000:
+        raise ProtocolError("OpenH264 execution token authorization drifted")
+    if value["evidence"]["status"] != "authorized_not_created":
+        raise ProtocolError("OpenH264 execution evidence status drifted")
+    return value
+
+
+def load_manifest(
+    path: Path = DEFAULT_MANIFEST,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    return validate_manifest(_load_object(path, "OpenH264 execution manifest"), repo_root)
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPO_ROOT,
+) -> None:
+    validate_manifest(manifest, repo_root)
+    verify_parent_components(repo_root)
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": ("https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json"),
+        "title": "Forge opaque provenance OpenH264 execution amendment",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "authorization": manifest["authorization"],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_openh264_execution_runner.py
+++ b/scripts/forge_opaque_provenance_openh264_execution_runner.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""执行 Issue #226 授权的 OpenH264 reachability 与单配对实验。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+REPO_SCRIPT_ROOT = REPO_ROOT / "scripts"
+if str(REPO_SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_SCRIPT_ROOT))
+
+import forge_opaque_provenance_openh264_candidate_gate as candidate  # noqa: E402
+import forge_opaque_provenance_openh264_execution_protocol as protocol  # noqa: E402
+import forge_opaque_provenance_r3_make_execution_failure_gate as failure_gate  # noqa: E402
+import forge_opaque_provenance_r3_make_execution_runner as reference  # noqa: E402
+
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = Path("/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-openh264-execution-v1")
+_IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+_MAX_PACKAGE_BYTES = 2 * 1024 * 1024
+CommandRunner = Callable[[list[str], int], subprocess.CompletedProcess[str]]
+PackageDownloader = Callable[[dict[str, Any], Path], dict[str, Any]]
+
+
+class OpenH264ExecutionError(RuntimeError):
+    """OpenH264 execution 身份、fixture、委派或清理无效。"""
+
+
+def _run_command(args: list[str], timeout_seconds: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _docker(
+    args: list[str],
+    *,
+    command_runner: CommandRunner,
+    timeout_seconds: int = 60,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = command_runner(["docker", *args], timeout_seconds)
+    if check and completed.returncode != 0:
+        operation = " ".join(args[:2])
+        raise OpenH264ExecutionError(f"dependency fixture Docker 操作失败: {operation} (exit={completed.returncode})")
+    return completed
+
+
+def _download_verified_package(
+    package: dict[str, Any],
+    destination: Path,
+) -> dict[str, Any]:
+    request = urllib.request.Request(
+        package["url"],
+        headers={"User-Agent": "Forge-AutoCompiler/issue-226"},
+    )
+    digest = hashlib.sha256()
+    size = 0
+    with (
+        urllib.request.urlopen(
+            request,
+            timeout=package["download_timeout_seconds"],
+        ) as response,
+        destination.open("xb") as stream,
+    ):
+        while chunk := response.read(64 * 1024):
+            size += len(chunk)
+            if size > _MAX_PACKAGE_BYTES:
+                raise OpenH264ExecutionError("固定 nasm 包超过预注册大小上限")
+            digest.update(chunk)
+            stream.write(chunk)
+    actual = digest.hexdigest()
+    if actual != package["sha256"]:
+        raise OpenH264ExecutionError("固定 nasm 包 SHA-256 不匹配")
+    return {"sha256": actual, "size_bytes": size}
+
+
+def _write_once(path: Path, value: dict[str, Any]) -> None:
+    reference.v3_runner._write_once(path, value)
+
+
+def _fixture_paths(
+    manifest: dict[str, Any],
+    output_dir: Path,
+) -> tuple[Path, Path, Path]:
+    evidence = manifest["evidence"]
+    return (
+        output_dir / evidence["dependency_fixture_marker"],
+        output_dir / evidence["dependency_fixture_report"],
+        output_dir / evidence["dependency_fixture_cleanup_report"],
+    )
+
+
+def _require_fixture_absent(
+    manifest: dict[str, Any],
+    *,
+    command_runner: CommandRunner,
+) -> None:
+    fixture = manifest["dependency_fixture"]
+    probes = (
+        ["container", "inspect", fixture["preparation_container_name"]],
+        ["image", "inspect", fixture["compile_image"]],
+    )
+    if any(
+        _docker(
+            args,
+            command_runner=command_runner,
+            timeout_seconds=30,
+            check=False,
+        ).returncode
+        == 0
+        for args in probes
+    ):
+        raise OpenH264ExecutionError("preflight 前存在 OpenH264 dependency fixture")
+
+
+def _prepare_dependency_fixture(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+    release_revision: str,
+    command_runner: CommandRunner = _run_command,
+    downloader: PackageDownloader = _download_verified_package,
+) -> dict[str, Any]:
+    fixture = manifest["dependency_fixture"]
+    marker, report_path, _cleanup_path = _fixture_paths(manifest, output_dir)
+    digest = protocol.canonical_sha256(manifest)
+    reference.v3_runner._claim_marker(
+        marker,
+        kind="forge_opaque_provenance_openh264_dependency_fixture",
+        manifest_sha256=digest,
+        revision=release_revision,
+    )
+    container = fixture["preparation_container_name"]
+    image_tag = fixture["compile_image"]
+    package = fixture["nasm_package"]
+    image_id: str | None = None
+    try:
+        _require_fixture_absent(manifest, command_runner=command_runner)
+        with tempfile.TemporaryDirectory(prefix="forge-openh264-issue226-") as directory:
+            package_path = Path(directory) / "nasm.deb"
+            package_evidence = downloader(package, package_path)
+            if not package_path.is_file():
+                raise OpenH264ExecutionError("dependency fixture 下载器未生成固定包")
+            _docker(
+                [
+                    "create",
+                    "--name",
+                    container,
+                    "--label",
+                    f"{fixture['docker_label']}=true",
+                    fixture["base_image"],
+                    "sleep",
+                    "infinity",
+                ],
+                command_runner=command_runner,
+            )
+            _docker(["start", container], command_runner=command_runner)
+            _docker(
+                ["cp", str(package_path), f"{container}:/tmp/nasm.deb"],
+                command_runner=command_runner,
+            )
+            _docker(
+                ["exec", container, "dpkg", "--install", "/tmp/nasm.deb"],
+                command_runner=command_runner,
+                timeout_seconds=120,
+            )
+            version = _docker(
+                ["exec", container, "nasm", "-v"],
+                command_runner=command_runner,
+            ).stdout.strip()
+            _docker(
+                ["commit", "--no-pause", container, image_tag],
+                command_runner=command_runner,
+                timeout_seconds=120,
+            )
+        image_id = _docker(
+            ["image", "inspect", image_tag, "--format", "{{.Id}}"],
+            command_runner=command_runner,
+        ).stdout.strip()
+        if _IMAGE_ID_PATTERN.fullmatch(image_id) is None:
+            raise OpenH264ExecutionError("dependency fixture image ID 无效")
+        _docker(["rm", "--force", container], command_runner=command_runner)
+        report = {
+            "schema_version": "forge-openh264-dependency-fixture-1.0.0",
+            "document_type": "forge_openh264_dependency_fixture",
+            "manifest_sha256": digest,
+            "release_revision": release_revision,
+            "base_image": fixture["base_image"],
+            "compile_image": image_tag,
+            "image_id": image_id,
+            "package_sha256": package_evidence["sha256"],
+            "package_size_bytes": package_evidence["size_bytes"],
+            "nasm_version_sha256": hashlib.sha256(version.encode("utf-8")).hexdigest(),
+            "apt_index_downloaded": False,
+            "preparation_container_removed": True,
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        _write_once(report_path, report)
+    except BaseException as exc:
+        reference.v3_runner._finish_marker(
+            marker,
+            status="failed",
+            error_class=type(exc).__name__,
+        )
+        _cleanup_dependency_fixture(
+            manifest,
+            output_dir=output_dir,
+            image_id=image_id,
+            command_runner=command_runner,
+        )
+        raise
+    reference.v3_runner._finish_marker(marker, status="passed")
+    return report
+
+
+def _cleanup_dependency_fixture(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path,
+    image_id: str | None,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    fixture = manifest["dependency_fixture"]
+    _marker, _report, cleanup_path = _fixture_paths(manifest, output_dir)
+    container = fixture["preparation_container_name"]
+    image_tag = fixture["compile_image"]
+    _docker(
+        ["rm", "--force", container],
+        command_runner=command_runner,
+        check=False,
+    )
+    _docker(
+        ["image", "rm", "--force", image_tag],
+        command_runner=command_runner,
+        check=False,
+    )
+    if image_id is not None:
+        _docker(
+            ["image", "rm", "--force", image_id],
+            command_runner=command_runner,
+            check=False,
+        )
+    container_absent = (
+        _docker(
+            ["container", "inspect", container],
+            command_runner=command_runner,
+            check=False,
+        ).returncode
+        != 0
+    )
+    tag_absent = (
+        _docker(
+            ["image", "inspect", image_tag],
+            command_runner=command_runner,
+            check=False,
+        ).returncode
+        != 0
+    )
+    image_absent = image_id is None or (
+        _docker(
+            ["image", "inspect", image_id],
+            command_runner=command_runner,
+            check=False,
+        ).returncode
+        != 0
+    )
+    cleanup = {
+        "schema_version": "forge-openh264-dependency-fixture-cleanup-1.0.0",
+        "document_type": "forge_openh264_dependency_fixture_cleanup",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "container_absent": container_absent,
+        "tag_absent": tag_absent,
+        "image_id_absent": image_absent,
+        "cleanup_succeeded": container_absent and tag_absent and image_absent,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+    _write_once(cleanup_path, cleanup)
+    if cleanup["cleanup_succeeded"] is not True:
+        raise OpenH264ExecutionError("OpenH264 dependency fixture cleanup 未闭合")
+    return cleanup
+
+
+def _lifecycle_adapter(compile_image: str) -> SimpleNamespace:
+    adapter = candidate.build_docker_adapter(compile_image)
+    base_lifecycle, _construction, _r3_runtime, _failure_gate = candidate._runtime_modules()
+    adapter._parent_invocation = candidate._parent_invocation
+    adapter.reference = base_lifecycle.reference
+    return adapter
+
+
+@contextmanager
+def _reference_runtime_hooks() -> Iterator[None]:
+    parity, observability = failure_gate.build_runtime_bindings()
+    adapter = _lifecycle_adapter(protocol.COMPILE_IMAGE)
+    originals = {
+        "protocol": reference.protocol,
+        "make_lifecycle": reference.make_lifecycle,
+        "make_parity": reference.make_parity,
+        "make_observability": reference.make_observability,
+        "policy": reference._policy,
+        "classify_arm_terminal": reference.v2_runner.classify_arm_terminal,
+    }
+
+    def openh264_policy(
+        manifest: dict[str, Any],
+        *,
+        arm: str,
+        image_id: str,
+    ) -> Any:
+        return replace(
+            originals["policy"](manifest, arm=arm, image_id=image_id),
+            benchmark_id="forge-opaque-provenance-openh264-execution",
+        )
+
+    reference.protocol = protocol
+    reference.make_lifecycle = adapter
+    reference.make_parity = parity
+    reference.make_observability = observability
+    reference._policy = openh264_policy
+
+    def classify_arm_terminal(
+        manifest: dict[str, Any],
+        *,
+        arm: str,
+        ledger: Any,
+        error: Exception,
+    ) -> dict[str, Any]:
+        invalid = failure_gate.classify_pre_model_failure(
+            arm=arm,
+            ledger=ledger,
+            error=error,
+        )
+        if invalid is not None:
+            return invalid
+        return originals["classify_arm_terminal"](
+            manifest,
+            arm=arm,
+            ledger=ledger,
+            error=error,
+        )
+
+    reference.v2_runner.classify_arm_terminal = classify_arm_terminal
+    try:
+        yield
+    finally:
+        reference.protocol = originals["protocol"]
+        reference.make_lifecycle = originals["make_lifecycle"]
+        reference.make_parity = originals["make_parity"]
+        reference.make_observability = originals["make_observability"]
+        reference._policy = originals["policy"]
+        reference.v2_runner.classify_arm_terminal = originals["classify_arm_terminal"]
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool,
+    command_runner: CommandRunner = _run_command,
+) -> dict[str, Any]:
+    static_gate = candidate.validate_static_gate(repo_root)
+    construction = asyncio.run(candidate.validate_agent_construction())
+    with _reference_runtime_hooks():
+        result = reference.collect_preflight(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            require_empty=require_empty,
+        )
+    _require_fixture_absent(manifest, command_runner=command_runner)
+    return {
+        **result,
+        "openh264_static_gate": static_gate["parent_history_prefix_preserved"],
+        "full_agent_construction_gate": construction["status"],
+        "dependency_fixture_absent": True,
+    }
+
+
+def execute_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    collect_preflight(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        require_empty=True,
+    )
+    with _reference_runtime_hooks():
+        return reference.execute_reachability(
+            manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        )
+
+
+def execute_pair(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+    command_runner: CommandRunner = _run_command,
+    downloader: PackageDownloader = _download_verified_package,
+) -> dict[str, Any]:
+    preflight = collect_preflight(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        require_empty=False,
+        command_runner=command_runner,
+    )
+    fixture: dict[str, Any] | None = None
+    operation_error: BaseException | None = None
+    with _reference_runtime_hooks():
+        reachability = reference.legacy._passed_reachability(
+            manifest,
+            output_dir,
+            preflight["release_revision"],
+        )
+        original_passed = reference.legacy._passed_reachability
+        try:
+            fixture = _prepare_dependency_fixture(
+                manifest,
+                output_dir=output_dir,
+                release_revision=preflight["release_revision"],
+                command_runner=command_runner,
+                downloader=downloader,
+            )
+            reference.legacy._passed_reachability = lambda *_args, **_kwargs: reachability
+            return reference.execute_pair(
+                manifest,
+                output_dir=output_dir,
+                repo_root=repo_root,
+                model_factory=model_factory,
+            )
+        except BaseException as exc:
+            operation_error = exc
+            raise
+        finally:
+            reference.legacy._passed_reachability = original_passed
+            if fixture is not None:
+                try:
+                    _cleanup_dependency_fixture(
+                        manifest,
+                        output_dir=output_dir,
+                        image_id=fixture["image_id"],
+                        command_runner=command_runner,
+                    )
+                except BaseException as cleanup_error:
+                    if operation_error is None:
+                        raise
+                    raise cleanup_error from operation_error
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("validate", "preflight", "reachability", "pair"),
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        parity, observability = failure_gate.build_runtime_bindings()
+        result: Any = {
+            "status": "valid",
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "corrected_runtime_bindings": all(
+                hasattr(namespace, name)
+                for namespace, name in (
+                    (parity, "FrozenActionPolicy"),
+                    (parity, "SerialToolCallMiddleware"),
+                    (observability, "RejectionObservationRegistry"),
+                    (observability, "ObservableRuntimeParityToolAdapter"),
+                )
+            ),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    elif args.command == "preflight":
+        result = collect_preflight(
+            manifest,
+            output_dir=args.output_dir,
+            require_empty=True,
+        )
+    elif args.command == "reachability":
+        result = execute_reachability(manifest, output_dir=args.output_dir)
+    else:
+        result = execute_pair(manifest, output_dir=args.output_dir)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 摘要

- 从 #224 OpenH264 candidate 派生全新一次性 execution amendment，冻结 DeepSeek `deepseek-v4-flash`、300 秒、0 retry、一次 reachability 与一个 `baseline -> treatment` pair。
- 以薄 wrapper 注入 OpenH264 lifecycle、#220 正确 runtime bindings、pre-model fail-closed classifier 和独立 evidence identity，不复制 #218 的 `_run_pair` 控制流。
- 用固定 nasm `.deb`、SHA-256、精确命名 prep container、`docker cp` / `dpkg --install` / `docker commit --no-pause` 建立一次性 dependency fixture，禁止 apt index 与 `docker build`，并在所有终态删除 container、tag 和真实 image ID。
- 支持 Compose 容器通过 `FORGE_REPO_ROOT=/repo` 在导入父 runner 前加载完整只读工作树协议链。

## 验证

- 聚焦测试：`9 passed`
- Make/R3/OpenH264 相邻回归：`107 passed`
- 后端全量：`2453 passed, 50 skipped, 1 failed`；唯一失败是 #182 旧 preflight 测试仍要求 #184 已产生的真实冻结 evidence 目录为空，与本 PR 无关，未删除 evidence 规避。
- 全量 Ruff check / format、pycompile、CLI validate、const Schema、diff check 和敏感信息扫描通过。
- Manifest canonical SHA-256：`536f6688f8c6289e2e4bd3a46ebd95fab7dc7dbdedf728e88d937cb171bb0cfc`

## 研究边界

本 PR 发布前保持 0 provider、0 credential read、0 Docker、0 formal evidence write、0 model token。合并后才允许在干净主干执行唯一 preflight、reachability 和单 pair；禁止 retry、replacement、backfill、历史池化、p 值和模型排名。

Closes #226
