### PR TITLE
研究：冻结六 case opaque provenance 确认性 pilot 候选协议

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,10 +64,16 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 冻结 Issue #230 opaque provenance 六 case 确认性 pilot 候选协议
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_candidate_protocol.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md`
+  - 实现: result-blind 冻结 CMake `pupnp/ada-url/args` 与 Make `gpac/fio/sql-parser-shared`，每 case 两个 replicate 且项目内对调 arm order；`sql-parser` 使用独立 shared-library oracle，不修改旧 formal protocol。
+  - 排除: `mruby` 的 Rake/submodule 混杂、已有模型 evidence 的 `janet`、smoke 无判别力的 `lodepng` 与错误的 `sql-parser-static` identity 均由静态合同拒绝。
+  - 验证: schedule identity 为 `3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134`；聚焦与相邻回归 `60 passed`，Ruff check/format、pycompile、确定性再生成、diff 与敏感信息扫描通过。全阶段 0 provider、0 credential read、0 Docker、0 formal attempt、0 model token、0 evidence write。
+
 - 2026-08-31 — 实现 Issue #228 OpenH264 单配对只读结果审计
   - 文件: `scripts/forge_opaque_provenance_openh264_result_audit.py`, `backend/tests/test_forge_opaque_provenance_openh264_result_audit.py`
   - 实现: 固定现有 12 个 source evidence SHA-256，验证 reachability、dependency fixture、pair marker 与 parent/baseline/treatment 三条 ledger hash chain；从 ledger 恢复两臂 request/token、R0 companion 和动作预算，并区分 treatment report-time head 与 terminal head。
-  - 验证: 真实 evidence 只读 audit 通过，恢复 baseline `4/0/0/0` 与 7 个 R0、treatment `4/1/0/1` 与 3 个 R0；聚焦及 #210/#220/#226 相邻回归 `28 passed`，Ruff、format 和 pycompile 通过。全阶段 0 provider、0 credential read、0 Docker、0 formal attempt、0 model token，原 evidence 尚未写 sidecar。
+  - 验证: 真实 evidence 只读 audit 通过，恢复 baseline `4/0/0/0` 与 7 个 R0、treatment `4/1/0/1` 与 3 个 R0；聚焦及 #210/#220/#226 相邻回归 `28 passed`，Ruff、format 和 pycompile 通过。合并后 create-once 写入 `reports/audit-v1.json`，SHA-256 为 `0671efefbea9744e44ee8bd64dc02b2feb827d6eee1696f78e527cb46638c7e2`，原 12 个 source evidence 哈希不变；审计阶段 0 provider、0 credential read、0 Docker、0 formal attempt、0 model token。
 
 - 2026-08-31 — 发布并执行 Issue #226 OpenH264 provenance 单配对 amendment
   - 文件: `scripts/forge_opaque_provenance_openh264_execution_protocol.py`, `scripts/forge_opaque_provenance_openh264_execution_runner.py`, `backend/tests/test_forge_opaque_provenance_openh264_execution.py`, `benchmarks/manifests/cpp-opaque-provenance-openh264-execution.json`, `benchmarks/schemas/forge-opaque-provenance-openh264-execution.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-openh264-execution.md`

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_candidate.py
@@ -1,0 +1,155 @@
+"""Issue #230 六 case opaque provenance 确认性 pilot 的静态合同测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS_DIR / "forge_opaque_provenance_confirmatory_candidate_protocol.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json"
+
+
+def _load_protocol():
+    name = "forge_opaque_provenance_confirmatory_candidate_protocol_test"
+    spec = importlib.util.spec_from_file_location(name, PROTOCOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_and_frozen_sources_are_deterministic() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_sources(REPO_ROOT)
+    assert manifest["selection"]["case_count"] == 6
+    assert manifest["selection"]["build_system_counts"] == {"cmake": 3, "make": 3}
+
+
+def test_candidate_has_no_external_execution_authority() -> None:
+    manifest = protocol.validate_manifest(_load(MANIFEST_PATH), REPO_ROOT)
+    assert all(value is False for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["authorization"]["model_tokens_authorized"] == 0
+    assert manifest["future_state"] == {
+        "checkpoint_status": "not_created",
+        "evidence_status": "not_created",
+        "execution_runner_status": "not_implemented",
+        "execution_requires_new_amendment": True,
+    }
+
+
+def test_case_identity_artifacts_and_result_blind_audit_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    cases = {case["case_id"]: case for case in manifest["cases"]}
+    assert set(cases) == set(protocol.CASE_ORDER)
+    assert all(case["historical_result_evidence_case_id_matches"] == 0 for case in cases.values())
+    assert cases["args"]["source_audit"]["smoke"] == {"flag": "--help", "expected_exit_code": 0}
+    assert cases["fio"]["source_audit"]["smoke"] == {"flag": "--help", "expected_exit_code": 0}
+    assert cases["gpac"]["source_audit"]["submodules_on_target_dependency_path"] == []
+    sql_parser = cases["sql-parser-shared"]
+    assert sql_parser["artifact"] == {
+        "build_output_path": "libsqlparser.so",
+        "staged_relative_path": "libsqlparser.so",
+        "artifact_type": "shared_library",
+        "stage_source": "/workspace/repo/libsqlparser.so",
+        "stage_destination": "/artifacts/libsqlparser.so",
+    }
+    assert sql_parser["oracle_correction"]["old_artifact"]["artifact_type"] == "static_library"
+    assert sql_parser["oracle_correction"]["source_protocol_modified"] is False
+
+
+def test_schedule_has_two_replicates_and_reverses_order_inside_every_project() -> None:
+    result = protocol.validate_static_gate(REPO_ROOT)
+    assert result["status"] == "passed"
+    assert (result["case_count"], result["pair_count"], result["arm_count"]) == (6, 12, 24)
+    assert (
+        result["provider_calls"],
+        result["credential_read"],
+        result["docker_executed"],
+        result["formal_attempts"],
+        result["model_tokens"],
+        result["evidence_writes"],
+    ) == (0, False, False, 0, 0, 0)
+
+
+def test_exclusions_and_inference_boundary_are_explicit() -> None:
+    manifest = _load(MANIFEST_PATH)
+    assert set(manifest["selection"]["exclusions"]) == {"mruby", "janet", "lodepng", "sql-parser-static"}
+    assert manifest["analysis"]["independent_unit"] == "project_block"
+    assert manifest["analysis"]["project_block_count"] == 6
+    assert manifest["analysis"]["primary_test_requires_all_project_blocks_estimable"] is True
+    assert manifest["analysis"]["historical_exploratory_pairs_pooled"] is False
+    assert manifest["analysis"]["model_ranking_performed"] is False
+
+
+def test_schema_and_semantic_validator_reject_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    mutations = (
+        ("authorization", "provider_calls_authorized", True),
+        ("authorization", "model_tokens_authorized", 1),
+        ("schedule", "pair_count", 11),
+        ("runtime_contract", "request_retries", 1),
+    )
+    for section, field, value in mutations:
+        drifted = copy.deepcopy(manifest)
+        drifted[section][field] = value
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ConfirmatoryCandidateError, match="manifest"):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_old_static_oracle_and_excluded_case_replacements_are_rejected() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+
+    old_static = copy.deepcopy(manifest)
+    sql_parser = old_static["cases"][-1]
+    sql_parser["case_id"] = "sql-parser-static"
+    sql_parser["artifact"]["artifact_type"] = "static_library"
+    sql_parser["artifact"]["build_output_path"] = "libsqlparser.a"
+    sql_parser["artifact"]["staged_relative_path"] = "libsqlparser.a"
+
+    excluded = []
+    for case_id in ("mruby", "janet", "lodepng"):
+        drifted = copy.deepcopy(manifest)
+        drifted["cases"][-1]["case_id"] = case_id
+        excluded.append(drifted)
+
+    for drifted in (old_static, *excluded):
+        with pytest.raises(ValidationError):
+            Draft202012Validator(schema).validate(drifted)
+        with pytest.raises(protocol.ConfirmatoryCandidateError, match="manifest"):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_new_protocol_does_not_embed_credentials_or_provider_execution() -> None:
+    combined = PROTOCOL_PATH.read_text(encoding="utf-8")
+    for forbidden in ("sk-", "api_key=", "OPENAI_AK", "DEEPSEEK_API_KEY", "os.environ["):
+        assert forbidden not in combined
+    for forbidden in ("import docker", "from docker", "subprocess.run", "subprocess.Popen"):
+        assert forbidden not in combined

--- a/benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-confirmatory-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-confirmatory-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_confirmatory_candidate",
+  "authorization": {
+    "provider_calls_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "checkpoint_creation_authorized": false,
+    "pair_collection_authorized": false,
+    "formal_attempts_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "selection": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+    "mode": "result_blind_exact_commit_source_audit",
+    "frozen_sources": {
+      "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+      "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+    },
+    "case_count": 6,
+    "build_system_counts": {
+      "cmake": 3,
+      "make": 3
+    },
+    "artifact_type_counts": {
+      "executable": 2,
+      "static_library": 3,
+      "shared_library": 1
+    },
+    "exclusions": {
+      "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+      "janet": "local model-result evidence already exists, so the case is not result-blind",
+      "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+      "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+    }
+  },
+  "cases": [
+    {
+      "case_id": "pupnp",
+      "source_case_id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "language": "C",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DUPNP_ENABLE_TESTING=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "upnp_static",
+      "artifact": {
+        "build_output_path": "build/upnp/libupnp.a",
+        "staged_relative_path": "libupnp.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+        "stage_destination": "/artifacts/libupnp.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "ada-url",
+      "source_case_id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DADA_TESTING=OFF",
+        "-DADA_BENCHMARKS=OFF",
+        "-DADA_TOOLS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "ada",
+      "artifact": {
+        "build_output_path": "build/src/libada.a",
+        "staged_relative_path": "libada.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/src/libada.a",
+        "stage_destination": "/artifacts/libada.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "args",
+      "source_case_id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DARGS_BUILD_EXAMPLE=ON",
+        "-DARGS_BUILD_UNITTESTS=OFF",
+        "-DBUILD_FUZZERS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "gitlike",
+      "artifact": {
+        "build_output_path": "build/gitlike",
+        "staged_relative_path": "gitlike",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/build/gitlike",
+        "stage_destination": "/artifacts/gitlike"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "gpac",
+      "source_case_id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "language": "C",
+      "build_system": "make",
+      "size_stratum": "large",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --static-bin"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "pkg-config",
+        "zlib1g-dev"
+      ],
+      "direct_target": "lib",
+      "artifact": {
+        "build_output_path": "bin/gcc/libgpac_static.a",
+        "staged_relative_path": "libgpac_static.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+        "stage_destination": "/artifacts/libgpac_static.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [
+          "testsuite"
+        ],
+        "submodules_on_target_dependency_path": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "fio",
+      "source_case_id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --disable-native"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "zlib1g-dev"
+      ],
+      "direct_target": "fio",
+      "artifact": {
+        "build_output_path": "fio",
+        "staged_relative_path": "fio",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/fio",
+        "stage_destination": "/artifacts/fio"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "sql-parser-shared",
+      "source_case_id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "bison",
+        "build-essential",
+        "flex"
+      ],
+      "direct_target": "library",
+      "artifact": {
+        "build_output_path": "libsqlparser.so",
+        "staged_relative_path": "libsqlparser.so",
+        "artifact_type": "shared_library",
+        "stage_source": "/workspace/repo/libsqlparser.so",
+        "stage_destination": "/artifacts/libsqlparser.so"
+      },
+      "oracle_correction": {
+        "mode": "pre_result_exact_commit_source_correction",
+        "old_artifact": {
+          "staged_relative_path": "libsqlparser.a",
+          "build_output_path": "libsqlparser.a",
+          "artifact_type": "static_library",
+          "producing_target": "library"
+        },
+        "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+        "source_protocol_modified": false
+      },
+      "source_audit": {
+        "submodules": [],
+        "generated_parser_sources_tracked": true,
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    }
+  ],
+  "schedule": {
+    "pair_count": 12,
+    "arm_count": 24,
+    "replicates_per_case": 2,
+    "project_internal_order_reversal_required": true,
+    "baseline_first_pairs": 6,
+    "treatment_first_pairs": 6,
+    "pairs": [
+      {
+        "pair_id": "pupnp-rep-01",
+        "case_id": "pupnp",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-01",
+        "case_id": "ada-url",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "args-rep-01",
+        "case_id": "args",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-01",
+        "case_id": "gpac",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-01",
+        "case_id": "fio",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-01",
+        "case_id": "sql-parser-shared",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-02",
+        "case_id": "sql-parser-shared",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-02",
+        "case_id": "fio",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-02",
+        "case_id": "gpac",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "args-rep-02",
+        "case_id": "args",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-02",
+        "case_id": "ada-url",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pupnp-rep-02",
+        "case_id": "pupnp",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+  },
+  "runtime_contract": {
+    "provider_and_model_single_for_batch": true,
+    "provider_identity_status": "pending_execution_amendment",
+    "request_timeout_seconds": 300,
+    "request_retries": 0,
+    "fallback_forbidden": true,
+    "parallel_tool_calls": false,
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "request_limit_per_arm": 8,
+    "turn_limit_per_arm": 8,
+    "graph_step_limit_per_arm": 24,
+    "work_timeout_seconds_per_arm": 600,
+    "cleanup_timeout_seconds_per_arm": 120,
+    "per_arm_recorded_token_ceiling": 120000,
+    "batch_recorded_token_ceiling": 2940000,
+    "shared_tool_contract_identical_between_arms": true,
+    "treatment_exposure_only": "repair_packet"
+  },
+  "measurement_contract": {
+    "parent_fault": "opaque_build_provenance",
+    "parent_proof_status": "unproven/opaque_wrapper",
+    "treatment_required_proof_modes": {
+      "cmake": "direct_cmake",
+      "make": "direct_make"
+    },
+    "r0_companion_required": true,
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_and_zero_orphan_required": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "batch_protocol_mutation_after_start_forbidden": true
+  },
+  "analysis": {
+    "independent_unit": "project_block",
+    "project_block_count": 6,
+    "project_score": "mean of two replicate paired conversion differences",
+    "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+    "primary_test_requires_all_project_blocks_estimable": true,
+    "infrastructure_censoring_reported_separately": true,
+    "mechanism_invalid_reported_separately": true,
+    "intervention_delivery_invalid_reported_separately": true,
+    "historical_exploratory_pairs_pooled": false,
+    "model_ranking_performed": false
+  },
+  "future_state": {
+    "checkpoint_status": "not_created",
+    "evidence_status": "not_created",
+    "execution_runner_status": "not_implemented",
+    "execution_requires_new_amendment": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md",
+    "file_sha256": "ba360ddf5061cd6d01677ed00ce257fe00221d972ffdf83c1d1b052aa507f14b"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md
@@ -1,0 +1,64 @@
+# Forge opaque provenance 六 case 确认性 pilot 候选协议
+
+- GitHub Issue：[Issue #230](https://github.com/WWFXL/Forge-AutoCompiler/issues/230)
+- 状态：未授权、零 provider、零 Docker的静态候选
+- 语言范围：C/C++
+- 构建系统：CMake 与 Make
+
+## 研究动机
+
+现有 `cppitertools`、`yyjson` 与 `OpenH264` 三个有效 pair 只构成方向一致的探索性证据。协议在这些 case 之间持续演化、每个 case 只有一次模型 realization，且历史 arm order 固定为 baseline-first，因此不能池化为总体效应。
+
+本候选在查看任何新 case 模型结果前，冻结六个全新 project block。每个 project 有两个独立 physical attempt/checkpoint replicate；一个 pair 为 `baseline -> treatment`，另一个为 `treatment -> baseline`。批次启动后不允许修改 packet、action validator、P2/R0、artifact oracle 或 schedule。
+
+## 冻结来源
+
+| 路径 | SHA-256 |
+| --- | --- |
+| `benchmarks/preregistrations/cpp-formal-v1-cases.json` | `55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee` |
+| `benchmarks/preregistrations/cpp-formal-v1.json` | `3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc` |
+| `benchmarks/manifests/cpp-formal-v1.json` | `cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a` |
+
+候选审计只读取冻结协议、本地历史 result evidence 的 `case_id` 和 GitHub exact-commit 源码。未运行构建、Docker 或模型。
+
+## 六个 project block
+
+| Case | Build | Direct target | Artifact |
+| --- | --- | --- | --- |
+| `pupnp@4c4285d6` | CMake | `upnp_static` | `build/upnp/libupnp.a`，static library |
+| `ada-url@30f3f302` | CMake | `ada` | `build/src/libada.a`，static library |
+| `args@fe4450bd` | CMake | `gitlike` | `build/gitlike`，executable；`--help` 返回 0 |
+| `gpac@2aa431ea` | Make | `lib` | `bin/gcc/libgpac_static.a`，static library |
+| `fio@c76c61b0` | Make | `fio` | `fio`，executable；`--help` 返回 0 |
+| `sql-parser-shared@ccd3f68b` | Make | `library` | `libsqlparser.so`，shared library |
+
+`sql-parser-shared` 是独立的新 identity。旧 formal source protocol 把默认 `make library` 的 artifact 写成 `libsqlparser.a`，但 exact-commit Makefile 定义 `static ?= no`，默认实际生成 `libsqlparser.so`。旧协议保持逐字不变；本候选只在新 identity 中修正 oracle，并以负例测试拒绝旧 static identity。
+
+## 排除项
+
+- `mruby`：`make all` 委派给 Rake，并会隐式初始化 Prism submodule；外部网络和二级构建工具混入 fault。
+- `janet`：本地已有 formal v3 与 multi-checkpoint 模型结果，不再 result-blind。
+- `lodepng`：`unittest` 捕获任意测试异常后仍返回 0，Forge 固定 smoke 无法区分测试成功与失败。
+- `sql-parser-static`：旧 static artifact 与默认 direct target 输出不一致。
+
+## 冻结 schedule
+
+第一轮按 `pupnp, ada-url, args, gpac, fio, sql-parser-shared`；第二轮逆序。第一轮三个 baseline-first、三个 treatment-first；每个项目第二轮使用相反顺序。总计 12 pairs / 24 arms，pair 与 replicate 不得 replacement 或 backfill。
+
+## Runtime 与测量合同
+
+- 批次只使用一个预先冻结的 provider/model；具体 identity 必须在独立 execution amendment 中、首个请求前冻结。
+- 每请求 timeout 300 秒、0 retry、禁止 fallback、禁止 parallel tool calls。
+- 每 arm action limits 为 inspection/build/stage/submit `4/2/2/2`；最多 8 requests、8 turns、24 graph steps、600 秒 work 和 120 秒 cleanup。
+- 每 arm recorded-token ceiling 120,000；24 arms 加独立 reachability 预留后的机械批次上限为 2,940,000。
+- 双臂共享 tool contract，repair packet 是唯一 treatment exposure。
+- Parent 必须只形成 `unproven/opaque_wrapper`；treatment 只有受信任 direct CMake/Make invocation 才能转为 proven。
+- R0 companion、candidate verification、clean replay、cleanup 与 0 orphan 都是有效 measurement 的必要条件。
+
+## Analysis
+
+每个 replicate 的 paired conversion difference 为 `treatment - baseline`。每个 project score 是两个 replicate difference 的平均值，六个 project block 是独立分析单位。只有六个 project block 均可估计时才运行双侧 exact sign-flip；否则 primary test 标记为不可估计，并单独报告 endpoint censoring、mechanism invalid 与 intervention-delivery invalid。历史探索 pair 不进入新检验，不计算跨 provider 排名。
+
+## 当前授权边界
+
+本 Issue 只允许生成和验证 candidate manifest/schema。Provider、credential、model creation、reachability、checkpoint、pair collection、formal attempt、Docker、evidence write 与 model token 全部为 0/false；执行 runner 尚未实现，任何真实 lifecycle 或模型采集都需要新的版本化 amendment。

--- a/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json
@@ -1,0 +1,460 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json",
+  "title": "Forge opaque provenance confirmatory candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-confirmatory-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-confirmatory-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_confirmatory_candidate",
+    "authorization": {
+      "provider_calls_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "checkpoint_creation_authorized": false,
+      "pair_collection_authorized": false,
+      "formal_attempts_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "selection": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+      "mode": "result_blind_exact_commit_source_audit",
+      "frozen_sources": {
+        "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+        "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+        "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+      },
+      "case_count": 6,
+      "build_system_counts": {
+        "cmake": 3,
+        "make": 3
+      },
+      "artifact_type_counts": {
+        "executable": 2,
+        "static_library": 3,
+        "shared_library": 1
+      },
+      "exclusions": {
+        "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+        "janet": "local model-result evidence already exists, so the case is not result-blind",
+        "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+        "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+      }
+    },
+    "cases": [
+      {
+        "case_id": "pupnp",
+        "source_case_id": "pupnp",
+        "repository_url": "https://github.com/pupnp/pupnp",
+        "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+        "language": "C",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "upnp_static",
+        "artifact": {
+          "build_output_path": "build/upnp/libupnp.a",
+          "staged_relative_path": "libupnp.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+          "stage_destination": "/artifacts/libupnp.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "ada-url",
+        "source_case_id": "ada-url",
+        "repository_url": "https://github.com/ada-url/ada",
+        "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "ada",
+        "artifact": {
+          "build_output_path": "build/src/libada.a",
+          "staged_relative_path": "libada.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/src/libada.a",
+          "stage_destination": "/artifacts/libada.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "args",
+        "source_case_id": "args",
+        "repository_url": "https://github.com/Taywee/args",
+        "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "gitlike",
+        "artifact": {
+          "build_output_path": "build/gitlike",
+          "staged_relative_path": "gitlike",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/build/gitlike",
+          "stage_destination": "/artifacts/gitlike"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "gpac",
+        "source_case_id": "gpac",
+        "repository_url": "https://github.com/gpac/gpac",
+        "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+        "language": "C",
+        "build_system": "make",
+        "size_stratum": "large",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "direct_target": "lib",
+        "artifact": {
+          "build_output_path": "bin/gcc/libgpac_static.a",
+          "staged_relative_path": "libgpac_static.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+          "stage_destination": "/artifacts/libgpac_static.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [
+            "testsuite"
+          ],
+          "submodules_on_target_dependency_path": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "fio",
+        "source_case_id": "fio",
+        "repository_url": "https://github.com/axboe/fio",
+        "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "direct_target": "fio",
+        "artifact": {
+          "build_output_path": "fio",
+          "staged_relative_path": "fio",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/fio",
+          "stage_destination": "/artifacts/fio"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "sql-parser-shared",
+        "source_case_id": "sql-parser",
+        "repository_url": "https://github.com/hyrise/sql-parser",
+        "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "direct_target": "library",
+        "artifact": {
+          "build_output_path": "libsqlparser.so",
+          "staged_relative_path": "libsqlparser.so",
+          "artifact_type": "shared_library",
+          "stage_source": "/workspace/repo/libsqlparser.so",
+          "stage_destination": "/artifacts/libsqlparser.so"
+        },
+        "oracle_correction": {
+          "mode": "pre_result_exact_commit_source_correction",
+          "old_artifact": {
+            "staged_relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          },
+          "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+          "source_protocol_modified": false
+        },
+        "source_audit": {
+          "submodules": [],
+          "generated_parser_sources_tracked": true,
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      }
+    ],
+    "schedule": {
+      "pair_count": 12,
+      "arm_count": 24,
+      "replicates_per_case": 2,
+      "project_internal_order_reversal_required": true,
+      "baseline_first_pairs": 6,
+      "treatment_first_pairs": 6,
+      "pairs": [
+        {
+          "pair_id": "pupnp-rep-01",
+          "case_id": "pupnp",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-01",
+          "case_id": "ada-url",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "args-rep-01",
+          "case_id": "args",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-01",
+          "case_id": "gpac",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-01",
+          "case_id": "fio",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-01",
+          "case_id": "sql-parser-shared",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-02",
+          "case_id": "sql-parser-shared",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-02",
+          "case_id": "fio",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-02",
+          "case_id": "gpac",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "args-rep-02",
+          "case_id": "args",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-02",
+          "case_id": "ada-url",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "pupnp-rep-02",
+          "case_id": "pupnp",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        }
+      ],
+      "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    },
+    "runtime_contract": {
+      "provider_and_model_single_for_batch": true,
+      "provider_identity_status": "pending_execution_amendment",
+      "request_timeout_seconds": 300,
+      "request_retries": 0,
+      "fallback_forbidden": true,
+      "parallel_tool_calls": false,
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "request_limit_per_arm": 8,
+      "turn_limit_per_arm": 8,
+      "graph_step_limit_per_arm": 24,
+      "work_timeout_seconds_per_arm": 600,
+      "cleanup_timeout_seconds_per_arm": 120,
+      "per_arm_recorded_token_ceiling": 120000,
+      "batch_recorded_token_ceiling": 2940000,
+      "shared_tool_contract_identical_between_arms": true,
+      "treatment_exposure_only": "repair_packet"
+    },
+    "measurement_contract": {
+      "parent_fault": "opaque_build_provenance",
+      "parent_proof_status": "unproven/opaque_wrapper",
+      "treatment_required_proof_modes": {
+        "cmake": "direct_cmake",
+        "make": "direct_make"
+      },
+      "r0_companion_required": true,
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_and_zero_orphan_required": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "batch_protocol_mutation_after_start_forbidden": true
+    },
+    "analysis": {
+      "independent_unit": "project_block",
+      "project_block_count": 6,
+      "project_score": "mean of two replicate paired conversion differences",
+      "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+      "primary_test_requires_all_project_blocks_estimable": true,
+      "infrastructure_censoring_reported_separately": true,
+      "mechanism_invalid_reported_separately": true,
+      "intervention_delivery_invalid_reported_separately": true,
+      "historical_exploratory_pairs_pooled": false,
+      "model_ranking_performed": false
+    },
+    "future_state": {
+      "checkpoint_status": "not_created",
+      "evidence_status": "not_created",
+      "execution_runner_status": "not_implemented",
+      "execution_requires_new_amendment": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md",
+      "file_sha256": "ba360ddf5061cd6d01677ed00ce257fe00221d972ffdf83c1d1b052aa507f14b"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_confirmatory_candidate_protocol.py
+++ b/scripts/forge_opaque_provenance_confirmatory_candidate_protocol.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Issue #230 六 case opaque provenance 确认性 pilot 的未授权静态协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/230"
+SCHEMA_VERSION = "forge-opaque-provenance-confirmatory-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_confirmatory_candidate"
+
+SOURCE_CASES_PATH = "benchmarks/preregistrations/cpp-formal-v1-cases.json"
+SOURCE_CASES_SHA256 = "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee"
+SOURCE_SELECTION_PATH = "benchmarks/preregistrations/cpp-formal-v1.json"
+SOURCE_SELECTION_SHA256 = "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc"
+SOURCE_MANIFEST_PATH = "benchmarks/manifests/cpp-formal-v1.json"
+SOURCE_MANIFEST_SHA256 = "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json"
+
+WORKDIR = "/workspace/repo"
+ARTIFACTS_DIR = "/artifacts"
+PAIR_COUNT = 12
+ARM_COUNT = 24
+PER_ARM_TOKEN_CEILING = 120_000
+BATCH_TOKEN_CEILING = 2_940_000
+
+CASE_ORDER = ("pupnp", "ada-url", "args", "gpac", "fio", "sql-parser-shared")
+SOURCE_CASE_IDS = {
+    "pupnp": "pupnp",
+    "ada-url": "ada-url",
+    "args": "args",
+    "gpac": "gpac",
+    "fio": "fio",
+    "sql-parser-shared": "sql-parser",
+}
+
+EXPECTED_SOURCE_IDENTITIES = {
+    "pupnp": {
+        "repository_url": "https://github.com/pupnp/pupnp",
+        "commit": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+        "build_system": "cmake",
+        "language": "C",
+    },
+    "ada-url": {
+        "repository_url": "https://github.com/ada-url/ada",
+        "commit": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+        "build_system": "cmake",
+        "language": "C++",
+    },
+    "args": {
+        "repository_url": "https://github.com/Taywee/args",
+        "commit": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+        "build_system": "cmake",
+        "language": "C++",
+    },
+    "gpac": {
+        "repository_url": "https://github.com/gpac/gpac",
+        "commit": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+        "build_system": "make",
+        "language": "C",
+    },
+    "fio": {
+        "repository_url": "https://github.com/axboe/fio",
+        "commit": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+        "build_system": "make",
+        "language": "C++",
+    },
+    "sql-parser": {
+        "repository_url": "https://github.com/hyrise/sql-parser",
+        "commit": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+        "build_system": "make",
+        "language": "C++",
+    },
+}
+
+CASE_ARTIFACTS = {
+    "pupnp": ("upnp_static", "build/upnp/libupnp.a", "libupnp.a", "static_library"),
+    "ada-url": ("ada", "build/src/libada.a", "libada.a", "static_library"),
+    "args": ("gitlike", "build/gitlike", "gitlike", "executable"),
+    "gpac": ("lib", "bin/gcc/libgpac_static.a", "libgpac_static.a", "static_library"),
+    "fio": ("fio", "fio", "fio", "executable"),
+    "sql-parser-shared": ("library", "libsqlparser.so", "libsqlparser.so", "shared_library"),
+}
+
+SOURCE_AUDIT = {
+    "pupnp": {
+        "submodules": [],
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": None,
+    },
+    "ada-url": {
+        "submodules": [],
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": None,
+    },
+    "args": {
+        "submodules": [],
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": {"flag": "--help", "expected_exit_code": 0},
+    },
+    "gpac": {
+        "submodules": ["testsuite"],
+        "submodules_on_target_dependency_path": [],
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": None,
+    },
+    "fio": {
+        "submodules": [],
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": {"flag": "--help", "expected_exit_code": 0},
+    },
+    "sql-parser-shared": {
+        "submodules": [],
+        "generated_parser_sources_tracked": True,
+        "direct_target_verified": True,
+        "external_fetch_on_frozen_path": False,
+        "smoke": None,
+    },
+}
+
+EXCLUSIONS = {
+    "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+    "janet": "local model-result evidence already exists, so the case is not result-blind",
+    "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+    "sql-parser-static": "the frozen static oracle contradicts the default make library output",
+}
+
+
+class ConfirmatoryCandidateError(RuntimeError):
+    """候选身份、顺序、授权或分析合同发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode()
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_frozen_sources(repo_root: Path = REPO_ROOT) -> None:
+    expected = {
+        SOURCE_CASES_PATH: SOURCE_CASES_SHA256,
+        SOURCE_SELECTION_PATH: SOURCE_SELECTION_SHA256,
+        SOURCE_MANIFEST_PATH: SOURCE_MANIFEST_SHA256,
+    }
+    for relative_path, expected_sha256 in expected.items():
+        if file_sha256(repo_root / relative_path) != expected_sha256:
+            raise ConfirmatoryCandidateError(f"冻结来源发生漂移: {relative_path}")
+
+
+def _load_source_documents(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    verify_frozen_sources(repo_root)
+    cases = json.loads((repo_root / SOURCE_CASES_PATH).read_text(encoding="utf-8"))
+    selection = json.loads((repo_root / SOURCE_SELECTION_PATH).read_text(encoding="utf-8"))
+    return cases, selection
+
+
+def _source_maps(repo_root: Path) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    cases_document, selection_document = _load_source_documents(repo_root)
+    cases = {item["id"]: item for item in cases_document["cases"]}
+    selections = {item["id"]: item for item in selection_document["cases"]}
+    required = set(SOURCE_CASE_IDS.values())
+    if not required.issubset(cases) or not required.issubset(selections):
+        raise ConfirmatoryCandidateError("冻结来源缺少候选 case")
+    return cases, selections
+
+
+def _validate_source_identity(source_id: str, case: dict[str, Any], selection: dict[str, Any]) -> None:
+    expected = EXPECTED_SOURCE_IDENTITIES[source_id]
+    actual = {
+        "repository_url": case.get("repository_url"),
+        "commit": case.get("commit"),
+        "build_system": case.get("build_system"),
+        "language": selection.get("language"),
+    }
+    if actual != expected or case.get("review_state") != "reviewed" or case.get("result_data_consulted") is not False:
+        raise ConfirmatoryCandidateError(f"source identity 发生漂移: {source_id}")
+
+
+def _build_case(case_id: str, source: dict[str, Any], selection: dict[str, Any]) -> dict[str, Any]:
+    source_id = SOURCE_CASE_IDS[case_id]
+    _validate_source_identity(source_id, source, selection)
+    target, output, staged, artifact_type = CASE_ARTIFACTS[case_id]
+    source_target = source["recipe"]["build_targets"]
+    if source_target != [target]:
+        raise ConfirmatoryCandidateError(f"direct target 发生漂移: {case_id}")
+
+    source_artifacts = source["artifact_oracle"]["required_artifacts"]
+    correction: dict[str, Any] | None = None
+    if case_id == "sql-parser-shared":
+        expected_old = [
+            {
+                "staged_relative_path": "libsqlparser.a",
+                "build_output_path": "libsqlparser.a",
+                "artifact_type": "static_library",
+                "producing_target": "library",
+            }
+        ]
+        if source_artifacts != expected_old:
+            raise ConfirmatoryCandidateError("sql-parser 旧 static oracle 发生漂移")
+        correction = {
+            "mode": "pre_result_exact_commit_source_correction",
+            "old_artifact": copy.deepcopy(expected_old[0]),
+            "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+            "source_protocol_modified": False,
+        }
+    else:
+        expected_artifact = [
+            {
+                "staged_relative_path": staged,
+                "build_output_path": output,
+                "artifact_type": artifact_type,
+                "producing_target": target,
+            }
+        ]
+        if source_artifacts != expected_artifact:
+            raise ConfirmatoryCandidateError(f"artifact oracle 发生漂移: {case_id}")
+
+    return {
+        "case_id": case_id,
+        "source_case_id": source_id,
+        "repository_url": source["repository_url"],
+        "commit_sha": source["commit"],
+        "language": selection["language"],
+        "build_system": source["build_system"],
+        "size_stratum": selection["size_stratum"],
+        "build_directory": WORKDIR,
+        "bootstrap_commands": copy.deepcopy(source["recipe"]["bootstrap_commands"]),
+        "configure_arguments": copy.deepcopy(source["recipe"]["configure_arguments"]),
+        "required_system_packages": copy.deepcopy(source["recipe"]["required_system_packages"]),
+        "direct_target": target,
+        "artifact": {
+            "build_output_path": output,
+            "staged_relative_path": staged,
+            "artifact_type": artifact_type,
+            "stage_source": f"{WORKDIR}/{output}",
+            "stage_destination": f"{ARTIFACTS_DIR}/{staged}",
+        },
+        "oracle_correction": correction,
+        "source_audit": copy.deepcopy(SOURCE_AUDIT[case_id]),
+        "historical_result_evidence_case_id_matches": 0,
+    }
+
+
+def _schedule() -> list[dict[str, Any]]:
+    first_orders = {
+        "pupnp": ("baseline", "treatment"),
+        "ada-url": ("treatment", "baseline"),
+        "args": ("baseline", "treatment"),
+        "gpac": ("treatment", "baseline"),
+        "fio": ("baseline", "treatment"),
+        "sql-parser-shared": ("treatment", "baseline"),
+    }
+    pairs: list[dict[str, Any]] = []
+    for case_id in CASE_ORDER:
+        pairs.append({"pair_id": f"{case_id}-rep-01", "case_id": case_id, "replicate": 1, "arm_order": list(first_orders[case_id])})
+    for case_id in reversed(CASE_ORDER):
+        reverse_order = tuple(reversed(first_orders[case_id]))
+        pairs.append({"pair_id": f"{case_id}-rep-02", "case_id": case_id, "replicate": 2, "arm_order": list(reverse_order)})
+    return pairs
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    sources, selections = _source_maps(repo_root)
+    preregistration = repo_root / PREREGISTRATION_PATH
+    if not preregistration.is_file():
+        raise ConfirmatoryCandidateError("候选预注册不存在")
+    cases = [_build_case(case_id, sources[SOURCE_CASE_IDS[case_id]], selections[SOURCE_CASE_IDS[case_id]]) for case_id in CASE_ORDER]
+    pairs = _schedule()
+    schedule_identity = canonical_sha256(pairs)
+    return {
+        "$schema": "../schemas/forge-opaque-provenance-confirmatory-candidate.schema.json",
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "authorization": {
+            "provider_calls_authorized": False,
+            "credential_read_authorized": False,
+            "model_creation_authorized": False,
+            "reachability_request_authorized": False,
+            "checkpoint_creation_authorized": False,
+            "pair_collection_authorized": False,
+            "formal_attempts_authorized": False,
+            "docker_execution_authorized": False,
+            "evidence_write_authorized": False,
+            "model_tokens_authorized": 0,
+        },
+        "selection": {
+            "issue_url": ISSUE_URL,
+            "mode": "result_blind_exact_commit_source_audit",
+            "frozen_sources": {
+                SOURCE_CASES_PATH: SOURCE_CASES_SHA256,
+                SOURCE_SELECTION_PATH: SOURCE_SELECTION_SHA256,
+                SOURCE_MANIFEST_PATH: SOURCE_MANIFEST_SHA256,
+            },
+            "case_count": len(cases),
+            "build_system_counts": {"cmake": 3, "make": 3},
+            "artifact_type_counts": {"executable": 2, "static_library": 3, "shared_library": 1},
+            "exclusions": copy.deepcopy(EXCLUSIONS),
+        },
+        "cases": cases,
+        "schedule": {
+            "pair_count": PAIR_COUNT,
+            "arm_count": ARM_COUNT,
+            "replicates_per_case": 2,
+            "project_internal_order_reversal_required": True,
+            "baseline_first_pairs": 6,
+            "treatment_first_pairs": 6,
+            "pairs": pairs,
+            "identity_sha256": schedule_identity,
+        },
+        "runtime_contract": {
+            "provider_and_model_single_for_batch": True,
+            "provider_identity_status": "pending_execution_amendment",
+            "request_timeout_seconds": 300,
+            "request_retries": 0,
+            "fallback_forbidden": True,
+            "parallel_tool_calls": False,
+            "action_limits": {"inspection": 4, "repair_build": 2, "artifact_stage": 2, "submit": 2},
+            "request_limit_per_arm": 8,
+            "turn_limit_per_arm": 8,
+            "graph_step_limit_per_arm": 24,
+            "work_timeout_seconds_per_arm": 600,
+            "cleanup_timeout_seconds_per_arm": 120,
+            "per_arm_recorded_token_ceiling": PER_ARM_TOKEN_CEILING,
+            "batch_recorded_token_ceiling": BATCH_TOKEN_CEILING,
+            "shared_tool_contract_identical_between_arms": True,
+            "treatment_exposure_only": "repair_packet",
+        },
+        "measurement_contract": {
+            "parent_fault": "opaque_build_provenance",
+            "parent_proof_status": "unproven/opaque_wrapper",
+            "treatment_required_proof_modes": {"cmake": "direct_cmake", "make": "direct_make"},
+            "r0_companion_required": True,
+            "candidate_verification_required": True,
+            "clean_replay_required": True,
+            "cleanup_and_zero_orphan_required": True,
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+            "batch_protocol_mutation_after_start_forbidden": True,
+        },
+        "analysis": {
+            "independent_unit": "project_block",
+            "project_block_count": 6,
+            "project_score": "mean of two replicate paired conversion differences",
+            "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+            "primary_test_requires_all_project_blocks_estimable": True,
+            "infrastructure_censoring_reported_separately": True,
+            "mechanism_invalid_reported_separately": True,
+            "intervention_delivery_invalid_reported_separately": True,
+            "historical_exploratory_pairs_pooled": False,
+            "model_ranking_performed": False,
+        },
+        "future_state": {
+            "checkpoint_status": "not_created",
+            "evidence_status": "not_created",
+            "execution_runner_status": "not_implemented",
+            "execution_requires_new_amendment": True,
+        },
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration),
+        },
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    expected = generate_manifest(repo_root)
+    if not isinstance(value, dict) or value != expected:
+        raise ConfirmatoryCandidateError("confirmatory candidate manifest 发生漂移")
+    authorization = value["authorization"]
+    if any(item for key, item in authorization.items() if key.endswith("_authorized")):
+        raise ConfirmatoryCandidateError("candidate 意外授权了外部执行")
+    if authorization["model_tokens_authorized"] != 0:
+        raise ConfirmatoryCandidateError("candidate 意外授权了 model token")
+    return value
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json",
+        "title": "Forge opaque provenance confirmatory candidate",
+        "const": frozen,
+    }
+
+
+def validate_static_gate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest = generate_manifest(repo_root)
+    cases = manifest["cases"]
+    pairs = manifest["schedule"]["pairs"]
+    if len(cases) != 6 or len({case["case_id"] for case in cases}) != 6:
+        raise ConfirmatoryCandidateError("case 数量或唯一性无效")
+    if len(pairs) != PAIR_COUNT or len({pair["pair_id"] for pair in pairs}) != PAIR_COUNT:
+        raise ConfirmatoryCandidateError("pair 数量或唯一性无效")
+    for case_id in CASE_ORDER:
+        project_pairs = [pair for pair in pairs if pair["case_id"] == case_id]
+        if [pair["replicate"] for pair in sorted(project_pairs, key=lambda item: item["replicate"])] != [1, 2]:
+            raise ConfirmatoryCandidateError(f"replicate identity 无效: {case_id}")
+        orders = {tuple(pair["arm_order"]) for pair in project_pairs}
+        if orders != {("baseline", "treatment"), ("treatment", "baseline")}:
+            raise ConfirmatoryCandidateError(f"arm order 未在项目内对调: {case_id}")
+    if manifest["schedule"]["identity_sha256"] != canonical_sha256(pairs):
+        raise ConfirmatoryCandidateError("schedule identity 发生漂移")
+    return {
+        "status": "passed",
+        "case_count": len(cases),
+        "pair_count": len(pairs),
+        "arm_count": sum(len(pair["arm_order"]) for pair in pairs),
+        "schedule_identity_sha256": manifest["schedule"]["identity_sha256"],
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="确定性写入 manifest 与 const schema")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = generate_manifest()
+    schema = schema_document(manifest)
+    if args.write:
+        _write_json(DEFAULT_MANIFEST, manifest)
+        _write_json(DEFAULT_SCHEMA, schema)
+    else:
+        validate_manifest(json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8")))
+        if json.loads(DEFAULT_SCHEMA.read_text(encoding="utf-8")) != schema:
+            raise ConfirmatoryCandidateError("confirmatory candidate schema 发生漂移")
+    print(json.dumps(validate_static_gate(), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 冻结 6 个 result-blind project block：CMake `pupnp/ada-url/args` 与 Make `gpac/fio/sql-parser-shared`
- 为每个 project 固定两个 replicate，并在项目内对调 baseline/treatment 顺序，总计 12 pairs / 24 arms
- 新增 deterministic candidate manifest、const schema、预注册和静态合同测试
- 以独立 identity 把 `sql-parser` 的默认 artifact 修正为 `libsqlparser.so`，不修改旧 formal protocol
- 机械拒绝 `mruby`、已有结果的 `janet`、弱 smoke 的 `lodepng` 与旧 `sql-parser-static` oracle

## 验证

- 聚焦及相邻回归：`60 passed`
- Ruff check / format：通过
- `py_compile`、确定性再生成、Schema、`git diff --check`：通过
- 敏感信息扫描：无命中

## 边界

本 PR 不实现 provider runner，不运行 Docker，不调用模型，不读取 credential，不创建 checkpoint/formal attempt，不写实验 evidence。全部授权开关保持关闭，model token 为 0；任何真实 lifecycle 或采集都需要新的版本化 amendment。

Closes #230