### PR TITLE
研究：完成六 case lifecycle 零 provider 门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 完成 Issue #232/#233 六 case 确认性 lifecycle 零 provider 门禁
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py`, `scripts/forge_opaque_provenance_confirmatory_candidate_v2_protocol.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate_docker.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_candidate_v2.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-lifecycle-zero-provider-gate.md`
+  - 根因: `sql-parser-shared` 的 v1 空 bootstrap 会因 checkout 文件 mtime 决定 `make library` 是消费已跟踪生成文件还是重新运行 Bison；四次 lifecycle 为 2 次通过、2 次 `sha256_mismatch`，路径、类型和大小一致但 SHA-256/build-id 不同。
+  - 修复: v2 只显式冻结 `cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose`；parent 在独立 subshell 执行 bootstrap，避免改变后续 Make 工作目录。v1 protocol 保持逐字不变，12-pair schedule identity 保持 `3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134`。
+  - 验证: 固定镜像 `sha256:900d7ce4b902b79df5c64ffab88631b251538f1bde578c4dd2bf91558e9d1554`；`sql-parser-shared` 稳定性门禁连续两次通过，最终六 case lifecycle `6 passed in 453.74s`，相邻回归 `115 passed, 6 skipped`，最终聚焦 `25 passed, 6 skipped`；Ruff、pycompile、确定性再生成、diff 与后置 0 orphan 均通过。
+  - 边界: 0 provider、0 credential read、0 checkpoint、0 formal attempt、0 model token、0 正式 evidence write；Issue #232 已记录 v1 失败和停止决策，Issue #233 跟踪唯一修正，尚未授权 provider runner 或 12-pair 采集。
+
 - 2026-08-31 — 冻结 Issue #230 opaque provenance 六 case 确认性 pilot 候选协议
   - 文件: `scripts/forge_opaque_provenance_confirmatory_candidate_protocol.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate.md`
   - 实现: result-blind 冻结 CMake `pupnp/ada-url/args` 与 Make `gpac/fio/sql-parser-shared`，每 case 两个 replicate 且项目内对调 arm order；`sql-parser` 使用独立 shared-library oracle，不修改旧 formal protocol。
@@ -643,6 +650,8 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- 上游仓库已跟踪 parser generator 产物时，空 bootstrap 不保证重放确定性：Git checkout 的 mtime 可能让 Make 在“复用生成文件”和“重新运行 Bison/Flex”之间切换，最终 artifact 路径、类型、大小相同但 build-id/SHA-256 不同。冻结协议应显式运行已审计的 generator 命令，并在 parent wrapper 中用 subshell 隔离 `cd`；不得通过放宽 clean replay SHA-256 verifier 掩盖非确定性。
+- 一次性诊断容器若在容器内执行 GitHub fetch，当前网络可能长期阻塞；诊断必须有独立短时限和精确 container ID，超时后按 ID 终止并删除，再核对 compile/replay orphan 为 0。不能把 fetch 阻塞记为 case lifecycle 失败，也不能因此启动 Docker Desktop。
 - 真实 Docker gate 不应在测试体内用 `apt-get update` 临时准备单个依赖：本次 OpenH264 gate 在 `mirrors.aliyun.com` 下载完整 index 时耗尽 600 秒，但尚未 clone、build 或进入 lifecycle，不能记为 case 失败。若依赖是单一、架构固定的小包，应在预注册中冻结版本、URL 与 SHA-256，以短 timeout 下载并校验后派生临时 image；parent/arms/replay 共用该 image ID，结束后按 label 和精确 identity 删除。DooD 测试还必须把仓库挂载到与 WSL 宿主相同的 `/mnt/c/...` 绝对路径，并把 `tmp_path` 放在该路径下，不能把测试容器内部 `/tmp` 交给 daemon 当 bind source。
 
 - 版本化 runner 不能把一个候选 runtime 模块同时伪装成 R1 的 `parity` 与 `observability` 接口；静态 adapter 有 `R3ActionPolicy/ObservableRuntimeParityToolAdapter` 不代表它也导出 `FrozenActionPolicy/SerialToolCallMiddleware/RejectionObservationRegistry`。真实执行前必须以零 provider contract test 构造完整 agent 骨架，并把 registry 等可能失败的初始化放入能解除 active experiment 的 `try/finally`；0 model request 的异常必须分类为 mechanism invalid，不能归为 `no_submit`。

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_candidate_v2.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_candidate_v2.py
@@ -1,0 +1,97 @@
+"""Issue #233 confirmatory candidate v2 的 pre-result amendment 合同。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_opaque_provenance_confirmatory_candidate_v2_protocol.py"
+
+
+def _load_protocol():
+    spec = importlib.util.spec_from_file_location(
+        "forge_opaque_provenance_confirmatory_candidate_v2_test",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_protocol()
+
+
+def test_v2_preserves_parent_and_allows_only_sql_parser_bootstrap_delta() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    delta = protocol.validate_allowed_delta(manifest, REPO_ROOT)
+    assert delta == {
+        "status": "passed",
+        "parent_manifest_sha256": protocol.PARENT_MANIFEST_SHA256,
+        "case_id": "sql-parser-shared",
+        "bootstrap_before": [],
+        "bootstrap_after": [protocol.SQL_PARSER_BOOTSTRAP],
+        "schedule_identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134",
+        "schedule_modified": False,
+        "artifact_oracle_modified": False,
+        "verifier_relaxation": False,
+    }
+
+
+def test_manifest_schema_and_authorization_are_frozen() -> None:
+    manifest = json.loads(protocol.DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+    assert protocol.validate_manifest(manifest, REPO_ROOT) == manifest
+    assert json.loads(protocol.DEFAULT_SCHEMA.read_text(encoding="utf-8")) == protocol.schema_document(manifest)
+    assert manifest["authorization"] == protocol.parent.generate_manifest(REPO_ROOT)["authorization"]
+    assert all(value is False for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["authorization"]["model_tokens_authorized"] == 0
+
+
+def test_unrelated_case_or_schedule_drift_fails_closed() -> None:
+    for mutation in ("case", "schedule", "oracle"):
+        drifted = protocol.generate_manifest(REPO_ROOT)
+        if mutation == "case":
+            drifted["cases"][0]["direct_target"] = "wrong"
+        elif mutation == "schedule":
+            drifted["schedule"]["pairs"][0]["arm_order"].reverse()
+        else:
+            drifted["cases"][-1]["artifact"]["artifact_type"] = "static_library"
+        with pytest.raises(protocol.ConfirmatoryCandidateV2Error):
+            protocol.validate_allowed_delta(drifted, REPO_ROOT)
+
+
+def test_authorization_or_bootstrap_drift_fails_closed() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    authorized = copy.deepcopy(manifest)
+    authorized["authorization"]["docker_execution_authorized"] = True
+    with pytest.raises(protocol.ConfirmatoryCandidateV2Error):
+        protocol.validate_manifest(authorized, REPO_ROOT)
+    bootstrap_drift = copy.deepcopy(manifest)
+    bootstrap_drift["cases"][-1]["bootstrap_commands"] = ["touch src/parser/bison_parser.y"]
+    with pytest.raises(protocol.ConfirmatoryCandidateV2Error):
+        protocol.validate_allowed_delta(bootstrap_drift, REPO_ROOT)
+
+
+def test_static_gate_has_no_external_effects() -> None:
+    report = protocol.validate_static_gate(REPO_ROOT)
+    assert report["status"] == "passed"
+    assert report["case_count"] == 6
+    assert report["pair_count"] == 12
+    assert report["provider_calls"] == report["formal_attempts"] == report["model_tokens"] == 0
+    assert report["credential_read"] is False
+    assert report["docker_executed"] is False
+    assert report["checkpoint_created"] is False
+    assert report["evidence_writes"] == 0
+
+
+def test_new_sources_do_not_contain_provider_or_credential_entrypoints() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in ("openai_ak", "deepseek_api_key", "api_key=", "chatopenai(", "execute-pair", "reachability"):
+        assert forbidden not in source

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate.py
@@ -1,0 +1,106 @@
+"""Issue #232 六 case confirmatory lifecycle adapter 的静态合同。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_opaque_provenance_confirmatory_lifecycle_gate.py"
+
+
+def _load_gate():
+    scripts = str(REPO_ROOT / "scripts")
+    sys.path.insert(0, scripts)
+    try:
+        spec = importlib.util.spec_from_file_location("forge_opaque_provenance_confirmatory_lifecycle_test", SCRIPT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(scripts)
+
+
+gate = _load_gate()
+
+
+def test_six_case_adapters_are_derived_from_frozen_candidate() -> None:
+    adapters = gate.build_case_adapters(REPO_ROOT)
+    assert [adapter.case_id for adapter in adapters] == ["pupnp", "ada-url", "args", "gpac", "fio", "sql-parser-shared"]
+    assert [adapter.build_system for adapter in adapters] == ["cmake", "cmake", "cmake", "make", "make", "make"]
+    assert [adapter.artifact_type for adapter in adapters] == ["static_library", "static_library", "executable", "static_library", "executable", "shared_library"]
+    assert all(adapter.parent_command.startswith("sh -c ") for adapter in adapters)
+    assert all(adapter.treatment_stage_command == f"cp {adapter.stage_source} {adapter.stage_destination}" for adapter in adapters)
+
+
+@pytest.mark.parametrize("case_id", gate.candidate.CASE_ORDER)
+def test_parent_is_single_fault_and_direct_treatment_is_append_only(case_id: str) -> None:
+    adapter = gate.build_case_adapter(case_id, REPO_ROOT)
+    frozen = gate.build_frozen_identity(
+        adapter,
+        image_id="sha256:" + "7" * 64,
+        physical_attempt_id=f"attempt-static-{case_id}",
+        build_tree_sha256="8" * 64 if adapter.build_system == "cmake" else None,
+        artifact_size=2048,
+        artifact_sha256="9" * 64,
+    )
+    parent, parent_history = gate.evaluate_parent(adapter, frozen, parent_command_id="parent-wrapper")
+    treatment, treatment_history = gate.evaluate_treatment(
+        adapter,
+        frozen,
+        parent_command_id="parent-wrapper",
+        treatment_build_command_id="treatment-build",
+        treatment_stage_command_id="treatment-stage",
+    )
+    assert (parent.status, parent.classification, parent.reason) == ("unproven", "opaque_build_provenance", "opaque_wrapper")
+    assert (treatment.status, treatment.proof_mode) == ("proven", adapter.expected_proof_mode)
+    assert treatment_history[: len(parent_history)] == parent_history
+
+
+def test_static_gate_closes_external_authorization_and_freezes_image_inputs() -> None:
+    report = gate.validate_gate_contract(REPO_ROOT)
+    assert len(report["cases"]) == 6
+    assert report["candidate_manifest_sha256"] == gate.CANDIDATE_MANIFEST_SHA256
+    assert report["candidate_manifest_file_sha256"] == gate.CANDIDATE_MANIFEST_FILE_SHA256
+    assert report["compile_dockerfile_sha256"] == gate.COMPILE_DOCKERFILE_SHA256
+    assert report["compile_image"] == "autocompiler:gcc13"
+    assert report["provider_calls"] == 0
+    assert report["credential_read"] is False
+    assert report["checkpoint_created"] is False
+    assert report["formal_attempts"] == 0
+    assert report["model_tokens"] == 0
+    assert report["formal_evidence_writes"] == 0
+
+
+def test_unknown_case_and_invalid_build_tree_identity_fail_closed() -> None:
+    with pytest.raises(gate.ConfirmatoryLifecycleGateError):
+        gate.build_case_adapter("unknown", REPO_ROOT)
+    make_adapter = gate.build_case_adapter("fio", REPO_ROOT)
+    with pytest.raises(gate.ConfirmatoryLifecycleGateError):
+        gate.build_frozen_identity(
+            make_adapter,
+            image_id="sha256:" + "1" * 64,
+            physical_attempt_id="attempt-invalid-make-tree",
+            build_tree_sha256="2" * 64,
+            artifact_size=1,
+            artifact_sha256="3" * 64,
+        )
+
+
+def test_cli_reports_static_zero_provider_contract(capsys: pytest.CaptureFixture[str]) -> None:
+    assert gate.main(["validate"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert len(report["cases"]) == 6
+    assert report["provider_calls"] == report["model_tokens"] == 0
+
+
+def test_new_sources_do_not_contain_provider_or_credential_entrypoints() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8").lower()
+    for forbidden in ("openai_ak", "deepseek_api_key", "api_key=", "chatopenai(", "execute-pair", "reachability"):
+        assert forbidden not in source

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate_docker.py
@@ -1,0 +1,389 @@
+"""Issue #232 六 case confirmatory lifecycle 的 opt-in Ubuntu 原生 Docker 门禁。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.evidence import (
+    ExperimentLedger,
+    ExperimentPolicy,
+    activate_experiment,
+    deactivate_experiment,
+    new_evidence_id,
+)
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import (
+    CompileOperationsServices,
+    cleanup_and_finalize_compile_session_impl,
+    submit_build_result_impl,
+)
+from deerflow.compile.schemas import BuildCommandRecord, utc_now_iso
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "forge_opaque_provenance_confirmatory_lifecycle_gate.py"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_PROVENANCE_CONFIRMATORY_LIFECYCLE_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_PROVENANCE_CONFIRMATORY_LIFECYCLE_DOCKER=1 in WSL Ubuntu",
+)
+
+
+def _load_gate():
+    scripts = str(REPO_ROOT / "scripts")
+    sys.path.insert(0, scripts)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "forge_opaque_provenance_confirmatory_lifecycle_docker_test",
+            SCRIPT_PATH,
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(scripts)
+
+
+gate = _load_gate()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_ubuntu_native_docker():
+    if not DOCKER_ENABLED:
+        yield
+        return
+    native_gate = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "require-ubuntu-native-docker.sh")],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if native_gate.returncode != 0:
+        pytest.fail(native_gate.stderr.strip() or native_gate.stdout.strip())
+    image = subprocess.run(
+        ["docker", "image", "inspect", gate.COMPILE_IMAGE],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if image.returncode != 0:
+        pytest.fail(f"Required image {gate.COMPILE_IMAGE!r} is unavailable")
+    yield
+
+
+def _record_command(
+    *,
+    manager: CompileSessionManager,
+    runtime: CompileDockerRuntime,
+    session: Any,
+    command: str,
+    role: str,
+) -> BuildCommandRecord:
+    started_at = utc_now_iso()
+    started = time.monotonic()
+    result = runtime.exec(
+        session,
+        command,
+        workdir=gate.WORKDIR,
+        timeout_seconds=600,
+    )
+    record = BuildCommandRecord(
+        stage="bash",
+        command=command,
+        workdir=gate.WORKDIR,
+        role=role,
+        exit_code=result.exit_code,
+        started_at=started_at,
+        completed_at=utc_now_iso(),
+        timeout_seconds=600,
+        duration_seconds=round(time.monotonic() - started, 6),
+        timed_out=result.exit_code == 124,
+        termination=("timeout" if result.exit_code == 124 else ("failed" if result.exit_code != 0 else "completed")),
+    )
+    manager.record_command(session, record)
+    manager.save_session(session)
+    assert result.exit_code == 0, result.combined_output
+    return record
+
+
+def _policy(adapter: Any, *, image_id: str) -> ExperimentPolicy:
+    return ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-confirmatory-lifecycle-gate",
+        manifest_sha256=gate.CANDIDATE_MANIFEST_SHA256,
+        case_id=adapter.case_id,
+        condition="confirmatory-lifecycle-zero-provider",
+        repetition=1,
+        expected_repo_url=adapter.repository_url,
+        expected_commit_sha=adapter.commit_sha,
+        expected_build_system=adapter.build_system,
+        compile_image=gate.COMPILE_IMAGE,
+        image_id=image_id,
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_ZERO_PROVIDER_CREDENTIAL",
+        request_timeout_seconds=300,
+        model_max_retries=0,
+        compiler_max_turns=8,
+        subagent_timeout_seconds=600,
+        memory_enabled=False,
+        skills_enabled=False,
+        # 依赖已由固定 Dockerfile 烘焙；本门禁不把镜像构建伪装成 agent dependency action。
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        source_subdir=".",
+        bootstrap_commands=adapter.bootstrap_commands,
+        build_targets=(adapter.target,),
+        artifact_instructions=(
+            (
+                adapter.staged_artifact,
+                adapter.build_output,
+                adapter.artifact_type,
+            ),
+        ),
+    )
+
+
+def _failure_events(ledger: ExperimentLedger) -> list[dict[str, Any]]:
+    return [event for event in ledger.read() if event["event"] == "failure.recorded"]
+
+
+def _constraint_failures(session: Any) -> list[str]:
+    assert session.verification is not None
+    checks = [check for check in session.verification.checks if check.name == "benchmark_constraints"]
+    return [] if not checks else list(checks[0].actual)
+
+
+def _compile_container_names() -> set[str]:
+    result = subprocess.run(
+        ["docker", "ps", "-a", "--format", "{{.Names}}"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return {name for name in result.stdout.splitlines() if name.startswith(("deerflow-compile-", "deerflow-replay-"))}
+
+
+@pytest.mark.parametrize("case_id", gate.candidate.CASE_ORDER)
+def test_confirmatory_case_parent_treatment_replay_and_cleanup(
+    case_id: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate.validate_gate_contract(REPO_ROOT)
+    adapter = gate.build_case_adapter(case_id, REPO_ROOT)
+    names_before = _compile_container_names()
+    workspace = tmp_path / "workspace"
+    paths = Paths(
+        base_dir=tmp_path / ".deer-flow",
+        workspace_root=workspace,
+        host_workspace_root=str(workspace),
+    )
+    manager = CompileSessionManager(paths=paths, default_image=gate.COMPILE_IMAGE)
+    runtime = CompileDockerRuntime(manager=manager)
+    session = manager.create_session(
+        thread_id=f"issue232-{case_id}-{uuid.uuid4().hex[:10]}",
+        session_id=f"session-{uuid.uuid4().hex[:12]}",
+        run_id=f"run-{uuid.uuid4().hex[:12]}",
+        repo_url=adapter.repository_url,
+        image=gate.COMPILE_IMAGE,
+    )
+    ledger = ExperimentLedger.create(
+        tmp_path / "ledger.jsonl",
+        experiment_id=new_evidence_id("experiment"),
+        physical_attempt_id=new_evidence_id("physical_attempt"),
+        context={"scope": "issue-232-confirmatory-lifecycle", "case_id": case_id},
+    )
+    known_container_ids: set[str] = set()
+    active = False
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    try:
+        Path(session.leadagent_repo_dir).mkdir(parents=True, exist_ok=True)
+        runtime.create_container(session)
+        manager.save_session(session)
+        assert session.image_id is not None and session.container_id is not None
+        known_container_ids.add(session.container_id)
+
+        clone_command = (
+            f"git config --global --add safe.directory /workspace/repo && git init . && git remote add origin {shlex.quote(adapter.repository_url)} && git fetch --depth 1 origin {adapter.commit_sha} && git checkout --detach FETCH_HEAD"
+        )
+        clone = runtime.exec(
+            session,
+            clone_command,
+            workdir=gate.WORKDIR,
+            timeout_seconds=180,
+        )
+        assert clone.exit_code == 0, clone.combined_output
+        package_check = runtime.exec(
+            session,
+            shlex.join(("dpkg-query", "-W", *adapter.required_system_packages)),
+            workdir=gate.WORKDIR,
+            timeout_seconds=30,
+        )
+        assert package_check.exit_code == 0, package_check.combined_output
+        session.commit_sha = adapter.commit_sha
+        session.build_system = adapter.build_system
+        session.build_system_capabilities = [adapter.build_system]
+        session.selected_build_system = adapter.build_system
+        session.status = "inspected"
+        manager.save_session(session)
+
+        activate_experiment(
+            thread_id=session.thread_id,
+            experiment_id=ledger.experiment_id,
+            physical_attempt_id=ledger.physical_attempt_id,
+            ledger=ledger,
+            policy=_policy(adapter, image_id=session.image_id),
+        )
+        active = True
+        parent_record = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command=adapter.parent_command,
+            role="build",
+        )
+        workspace_artifact = Path(session.leadagent_repo_dir) / adapter.build_output
+        assert workspace_artifact.is_file() and workspace_artifact.stat().st_size > 0
+        build_tree_sha256 = None
+        if adapter.build_tree_relative_path is not None:
+            build_tree = Path(session.leadagent_repo_dir) / adapter.build_tree_relative_path
+            assert build_tree.is_file()
+            build_tree_sha256 = gate.file_sha256(build_tree)
+        frozen = gate.build_frozen_identity(
+            adapter,
+            image_id=session.image_id,
+            physical_attempt_id=f"issue232-{case_id}-lifecycle",
+            build_tree_sha256=build_tree_sha256,
+            artifact_size=workspace_artifact.stat().st_size,
+            artifact_sha256=gate.file_sha256(workspace_artifact),
+        )
+        parent_p2, parent_history = gate.evaluate_parent(
+            adapter,
+            frozen,
+            parent_command_id=parent_record.command_id,
+        )
+        assert (parent_p2.status, parent_p2.reason) == ("unproven", "opaque_wrapper")
+
+        parent_payload = json.loads(
+            submit_build_result_impl(
+                session=session,
+                supporting_command_id=parent_record.command_id,
+            )
+        )
+        assert parent_payload["status"] == "failed"
+        assert parent_payload["candidate_status"] == "failed"
+        assert parent_payload["replay_status"] == "not_run"
+        assert session.replay_attempts == []
+        assert _constraint_failures(session) == ["build_system_unproven"]
+        assert len(session.artifacts) == 1
+        assert session.artifacts[0].artifact_type == adapter.artifact_type
+        parent_failures = _failure_events(ledger)
+        assert len(parent_failures) == 1
+        assert parent_failures[0]["payload"]["classification"] == "build_system_unproven"
+
+        treatment_build = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command=adapter.treatment_build_command,
+            role="build",
+        )
+        treatment_stage = _record_command(
+            manager=manager,
+            runtime=runtime,
+            session=session,
+            command=adapter.treatment_stage_command,
+            role="artifact_stage",
+        )
+        treatment_p2, treatment_history = gate.evaluate_treatment(
+            adapter,
+            frozen,
+            parent_command_id=parent_record.command_id,
+            treatment_build_command_id=treatment_build.command_id,
+            treatment_stage_command_id=treatment_stage.command_id,
+        )
+        assert (treatment_p2.status, treatment_p2.proof_mode) == (
+            "proven",
+            adapter.expected_proof_mode,
+        )
+        assert treatment_history[: len(parent_history)] == parent_history
+
+        treatment_payload = json.loads(
+            submit_build_result_impl(
+                session=session,
+                supporting_command_id=treatment_build.command_id,
+            )
+        )
+        if treatment_payload["status"] != "passed":
+            pytest.fail(
+                json.dumps(
+                    {
+                        "submit": treatment_payload,
+                        "replay_attempts": [asdict(replay) for replay in session.replay_attempts],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        assert treatment_payload["candidate_status"] == "passed"
+        assert treatment_payload["replay_status"] == "passed"
+        assert len(treatment_payload["artifacts"]) == 1
+        assert treatment_payload["artifacts"][0]["artifact_type"] == adapter.artifact_type
+        assert len(session.replay_attempts) == 1
+        replay = session.replay_attempts[0]
+        assert replay.status == "passed" and replay.cleanup_succeeded is True
+        if replay.container_id is not None:
+            known_container_ids.add(replay.container_id)
+
+        deactivate_experiment(session.thread_id)
+        active = False
+        finalized, cleanup = cleanup_and_finalize_compile_session_impl(session=session)
+        assert cleanup.succeeded and cleanup.removed
+        assert finalized.status == "completed"
+        assert finalized.finalized_at is not None
+        assert finalized.verification is not None
+        finalization_checks = [check for check in finalized.verification.checks if check.name == "accepted_artifacts_unchanged_after_cleanup"]
+        assert len(finalization_checks) == 1 and finalization_checks[0].passed
+    finally:
+        if active:
+            deactivate_experiment(session.thread_id)
+        runtime.stop_and_remove_container(session)
+
+    for container_id in known_container_ids:
+        inspect = subprocess.run(
+            ["docker", "container", "inspect", container_id],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert inspect.returncode != 0
+    assert _compile_container_names() == names_before

--- a/benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json",
+  "schema_version": "forge-opaque-provenance-confirmatory-candidate-2.0.0",
+  "document_type": "forge_opaque_provenance_confirmatory_candidate_v2",
+  "authorization": {
+    "provider_calls_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "checkpoint_creation_authorized": false,
+    "pair_collection_authorized": false,
+    "formal_attempts_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "selection": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+    "mode": "result_blind_exact_commit_source_audit",
+    "frozen_sources": {
+      "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+      "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+    },
+    "case_count": 6,
+    "build_system_counts": {
+      "cmake": 3,
+      "make": 3
+    },
+    "artifact_type_counts": {
+      "executable": 2,
+      "static_library": 3,
+      "shared_library": 1
+    },
+    "exclusions": {
+      "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+      "janet": "local model-result evidence already exists, so the case is not result-blind",
+      "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+      "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+    }
+  },
+  "cases": [
+    {
+      "case_id": "pupnp",
+      "source_case_id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "language": "C",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DUPNP_ENABLE_TESTING=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "upnp_static",
+      "artifact": {
+        "build_output_path": "build/upnp/libupnp.a",
+        "staged_relative_path": "libupnp.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+        "stage_destination": "/artifacts/libupnp.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "ada-url",
+      "source_case_id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DADA_TESTING=OFF",
+        "-DADA_BENCHMARKS=OFF",
+        "-DADA_TOOLS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "ada",
+      "artifact": {
+        "build_output_path": "build/src/libada.a",
+        "staged_relative_path": "libada.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/src/libada.a",
+        "stage_destination": "/artifacts/libada.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "args",
+      "source_case_id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DARGS_BUILD_EXAMPLE=ON",
+        "-DARGS_BUILD_UNITTESTS=OFF",
+        "-DBUILD_FUZZERS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "gitlike",
+      "artifact": {
+        "build_output_path": "build/gitlike",
+        "staged_relative_path": "gitlike",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/build/gitlike",
+        "stage_destination": "/artifacts/gitlike"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "gpac",
+      "source_case_id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "language": "C",
+      "build_system": "make",
+      "size_stratum": "large",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --static-bin"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "pkg-config",
+        "zlib1g-dev"
+      ],
+      "direct_target": "lib",
+      "artifact": {
+        "build_output_path": "bin/gcc/libgpac_static.a",
+        "staged_relative_path": "libgpac_static.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+        "stage_destination": "/artifacts/libgpac_static.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [
+          "testsuite"
+        ],
+        "submodules_on_target_dependency_path": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "fio",
+      "source_case_id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --disable-native"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "zlib1g-dev"
+      ],
+      "direct_target": "fio",
+      "artifact": {
+        "build_output_path": "fio",
+        "staged_relative_path": "fio",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/fio",
+        "stage_destination": "/artifacts/fio"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "sql-parser-shared",
+      "source_case_id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "bison",
+        "build-essential",
+        "flex"
+      ],
+      "direct_target": "library",
+      "artifact": {
+        "build_output_path": "libsqlparser.so",
+        "staged_relative_path": "libsqlparser.so",
+        "artifact_type": "shared_library",
+        "stage_source": "/workspace/repo/libsqlparser.so",
+        "stage_destination": "/artifacts/libsqlparser.so"
+      },
+      "oracle_correction": {
+        "mode": "pre_result_exact_commit_source_correction",
+        "old_artifact": {
+          "staged_relative_path": "libsqlparser.a",
+          "build_output_path": "libsqlparser.a",
+          "artifact_type": "static_library",
+          "producing_target": "library"
+        },
+        "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+        "source_protocol_modified": false
+      },
+      "source_audit": {
+        "submodules": [],
+        "generated_parser_sources_tracked": true,
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    }
+  ],
+  "schedule": {
+    "pair_count": 12,
+    "arm_count": 24,
+    "replicates_per_case": 2,
+    "project_internal_order_reversal_required": true,
+    "baseline_first_pairs": 6,
+    "treatment_first_pairs": 6,
+    "pairs": [
+      {
+        "pair_id": "pupnp-rep-01",
+        "case_id": "pupnp",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-01",
+        "case_id": "ada-url",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "args-rep-01",
+        "case_id": "args",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-01",
+        "case_id": "gpac",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-01",
+        "case_id": "fio",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-01",
+        "case_id": "sql-parser-shared",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-02",
+        "case_id": "sql-parser-shared",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-02",
+        "case_id": "fio",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-02",
+        "case_id": "gpac",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "args-rep-02",
+        "case_id": "args",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-02",
+        "case_id": "ada-url",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pupnp-rep-02",
+        "case_id": "pupnp",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+  },
+  "runtime_contract": {
+    "provider_and_model_single_for_batch": true,
+    "provider_identity_status": "pending_execution_amendment",
+    "request_timeout_seconds": 300,
+    "request_retries": 0,
+    "fallback_forbidden": true,
+    "parallel_tool_calls": false,
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "request_limit_per_arm": 8,
+    "turn_limit_per_arm": 8,
+    "graph_step_limit_per_arm": 24,
+    "work_timeout_seconds_per_arm": 600,
+    "cleanup_timeout_seconds_per_arm": 120,
+    "per_arm_recorded_token_ceiling": 120000,
+    "batch_recorded_token_ceiling": 2940000,
+    "shared_tool_contract_identical_between_arms": true,
+    "treatment_exposure_only": "repair_packet"
+  },
+  "measurement_contract": {
+    "parent_fault": "opaque_build_provenance",
+    "parent_proof_status": "unproven/opaque_wrapper",
+    "treatment_required_proof_modes": {
+      "cmake": "direct_cmake",
+      "make": "direct_make"
+    },
+    "r0_companion_required": true,
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_and_zero_orphan_required": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "batch_protocol_mutation_after_start_forbidden": true
+  },
+  "analysis": {
+    "independent_unit": "project_block",
+    "project_block_count": 6,
+    "project_score": "mean of two replicate paired conversion differences",
+    "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+    "primary_test_requires_all_project_blocks_estimable": true,
+    "infrastructure_censoring_reported_separately": true,
+    "mechanism_invalid_reported_separately": true,
+    "intervention_delivery_invalid_reported_separately": true,
+    "historical_exploratory_pairs_pooled": false,
+    "model_ranking_performed": false
+  },
+  "future_state": {
+    "checkpoint_status": "not_created",
+    "evidence_status": "not_created",
+    "execution_runner_status": "not_implemented",
+    "execution_requires_new_amendment": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md",
+    "file_sha256": "5084b6dd89d279981342ac51ceadbde56d1843a3be62c634dc61184affeff273"
+  },
+  "amendment": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+    "mode": "pre_result_lifecycle_reproducibility_amendment",
+    "parent_manifest": {
+      "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+      "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+      "modified": false
+    },
+    "trigger": {
+      "case_id": "sql-parser-shared",
+      "classification": "clean_replay_sha256_mismatch",
+      "provider_results_observed": false,
+      "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+    },
+    "allowed_semantic_delta": {
+      "path": "cases[sql-parser-shared].bootstrap_commands",
+      "before": [],
+      "after": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ]
+    },
+    "verifier_relaxation": false,
+    "schedule_modified": false,
+    "artifact_oracle_modified": false
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md
@@ -1,0 +1,33 @@
+# Forge opaque provenance 六 case confirmatory candidate v2 amendment
+
+- GitHub Issue：[Issue #233](https://github.com/WWFXL/Forge-AutoCompiler/issues/233)
+- 父协议：Issue #230 candidate v1
+- 状态：pre-result、未授权、零 provider
+
+## 触发原因
+
+Issue #232 的 Ubuntu-native Docker lifecycle gate 发现 `sql-parser-shared` 在相同 exact commit 和 image 下间歇性 clean replay SHA-256 mismatch。失败产物与接受产物的相对路径、ELF shared-library 类型和字节大小一致，只有内容哈希与 GNU build-id 不同。
+
+隔离双 checkout 显示 `make library` 会受 checkout mtime 顺序影响：一条路径重新运行 Bison 生成 `bison_parser.cpp/.h`，另一条路径直接消费仓库内已跟踪生成文件。空 bootstrap 因而没有冻结真实源码生成路径。发现与诊断均发生在任何新 case provider 结果之前。
+
+## 唯一语义修正
+
+v1 manifest、schema 和 preregistration 保持逐字不变。v2 机械继承六 case、12-pair schedule、analysis、runtime、measurement 与全部关闭的 authorization，只把 `sql-parser-shared.bootstrap_commands` 从空数组改为：
+
+```bash
+cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose
+```
+
+该命令与上游 Makefile 的生成命令一致，并在每次 build 前无条件选择同一源码生成路径。Lifecycle adapter 在 self-contained parent wrapper 中用独立 subshell 执行 bootstrap，避免 `cd` 改变后续 Make workdir。
+
+## 不变项
+
+- Repository、exact commit、Make target `library`、artifact `libsqlparser.so` 与 shared-library oracle 不变。
+- 其余五个 case 逐字不变。
+- 12-pair 顺序与 schedule identity 不变。
+- Production artifact type/size/SHA、clean replay 和 cleanup 语义不变；不放宽 verifier。
+- Provider、credential、Docker、checkpoint、pair collection、formal attempt、evidence write 与 model token 授权仍全部关闭。
+
+## 停止规则
+
+只有 v2 相对 v1 的允许差异合同、`sql-parser-shared` 连续 lifecycle 稳定性门禁和完整六 case lifecycle 门禁都通过后，v2 才可成为未来 execution amendment 的父候选。若仍出现 SHA mismatch，必须排除该 case 并重新选择 Make project block；不得继续叠加 touch、strip 或 verifier 例外。

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-lifecycle-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-lifecycle-zero-provider-gate.md
@@ -1,0 +1,37 @@
+# Forge opaque provenance 六 case lifecycle 零 provider 门禁
+
+- GitHub Issue：[Issue #232](https://github.com/WWFXL/Forge-AutoCompiler/issues/232)
+- 状态：opt-in、零 provider、非正式实验
+- 父协议：Issue #233 六 case confirmatory candidate v2 amendment
+- Docker：仅允许 Ubuntu WSL2 原生 `docker.service`
+
+## 目的
+
+在实现 provider runner 或创建正式 checkpoint 前，验证六个 result-blind case 均能复用同一条生产 Compile Session 验收链。门禁只回答 case bootstrap、P2 构造、artifact oracle、clean replay 和 cleanup 是否在真实容器中可达，不估计模型效应。
+
+## 最薄生命周期
+
+每个 case 使用一个临时 Compile Session：
+
+1. 在 `autocompiler:gcc13` 中检出冻结 exact commit，并确认 Dockerfile 已包含冻结系统依赖。
+2. 执行一个 self-contained opaque wrapper，包含 bootstrap、冻结 target build 与 artifact stage。
+3. 首次 submit 必须识别正确 artifact，但只因 `build_system_unproven` 拒绝；P2 reference 必须为 `unproven/opaque_wrapper`，且不启动 replay。
+4. 在相同 append-only command history 上追加一次 direct CMake/Make build 和独立 stage；P2 必须转为 `proven/direct_cmake` 或 `proven/direct_make`。
+5. 第二次 submit 必须通过 production artifact classification 与唯一 clean replay。
+6. production finalize 必须在删除 compile container 后复核 accepted artifact，并以 `completed` 终结；本次创建的 compile/replay container 不得残留。
+
+这不是正式 baseline/treatment pair，也不创建 checkpoint。单 Session 的目的只是验证共同生命周期接线，不能进入确认性效应估计。
+
+## 冻结边界
+
+- Case identity、bootstrap、configure 参数、target 和 artifact oracle 直接读取并严格校验 #233 candidate v2 manifest；#230 v1 保持不变。
+- Compile image 固定为 `autocompiler:gcc13`，并固定 `docker/compile/Dockerfile` 的文件 SHA-256。
+- CMake 使用 `Ninja` 与 `/workspace/repo/build`；Make 使用冻结 target；两者 direct build 均固定有界 `-j2`。
+- Parent wrapper 只能在顶层暴露 `sh`，treatment 必须由可信 runtime 记录 direct build executable。
+- 直接复用生产 `submit_build_result_impl`、clean replay 和 `cleanup_and_finalize_compile_session_impl`，不修改生产 Compiler 或 evaluator。
+
+## 授权与停止规则
+
+本门禁授权六个 opt-in Docker case，但固定 0 provider、0 credential read、0 checkpoint、0 formal attempt、0 model token 与 0 正式 evidence write。临时 session、ledger、replay 目录只存在于 pytest 临时目录并在结束时清理。
+
+如果六个 case 无法共享同一 adapter，必须复制历史 checkpoint orchestration，或必须修改生产 Compiler 才能通过，则停止实现并重新评审；不得以 provider 调用、正式 evidence 或放宽 oracle 绕过失败。

--- a/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json
@@ -1,0 +1,487 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json",
+  "title": "Forge opaque provenance confirmatory candidate v2",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json",
+    "schema_version": "forge-opaque-provenance-confirmatory-candidate-2.0.0",
+    "document_type": "forge_opaque_provenance_confirmatory_candidate_v2",
+    "authorization": {
+      "provider_calls_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "checkpoint_creation_authorized": false,
+      "pair_collection_authorized": false,
+      "formal_attempts_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "selection": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+      "mode": "result_blind_exact_commit_source_audit",
+      "frozen_sources": {
+        "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+        "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+        "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+      },
+      "case_count": 6,
+      "build_system_counts": {
+        "cmake": 3,
+        "make": 3
+      },
+      "artifact_type_counts": {
+        "executable": 2,
+        "static_library": 3,
+        "shared_library": 1
+      },
+      "exclusions": {
+        "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+        "janet": "local model-result evidence already exists, so the case is not result-blind",
+        "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+        "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+      }
+    },
+    "cases": [
+      {
+        "case_id": "pupnp",
+        "source_case_id": "pupnp",
+        "repository_url": "https://github.com/pupnp/pupnp",
+        "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+        "language": "C",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "upnp_static",
+        "artifact": {
+          "build_output_path": "build/upnp/libupnp.a",
+          "staged_relative_path": "libupnp.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+          "stage_destination": "/artifacts/libupnp.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "ada-url",
+        "source_case_id": "ada-url",
+        "repository_url": "https://github.com/ada-url/ada",
+        "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "ada",
+        "artifact": {
+          "build_output_path": "build/src/libada.a",
+          "staged_relative_path": "libada.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/src/libada.a",
+          "stage_destination": "/artifacts/libada.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "args",
+        "source_case_id": "args",
+        "repository_url": "https://github.com/Taywee/args",
+        "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "gitlike",
+        "artifact": {
+          "build_output_path": "build/gitlike",
+          "staged_relative_path": "gitlike",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/build/gitlike",
+          "stage_destination": "/artifacts/gitlike"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "gpac",
+        "source_case_id": "gpac",
+        "repository_url": "https://github.com/gpac/gpac",
+        "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+        "language": "C",
+        "build_system": "make",
+        "size_stratum": "large",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "direct_target": "lib",
+        "artifact": {
+          "build_output_path": "bin/gcc/libgpac_static.a",
+          "staged_relative_path": "libgpac_static.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+          "stage_destination": "/artifacts/libgpac_static.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [
+            "testsuite"
+          ],
+          "submodules_on_target_dependency_path": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "fio",
+        "source_case_id": "fio",
+        "repository_url": "https://github.com/axboe/fio",
+        "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "direct_target": "fio",
+        "artifact": {
+          "build_output_path": "fio",
+          "staged_relative_path": "fio",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/fio",
+          "stage_destination": "/artifacts/fio"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "sql-parser-shared",
+        "source_case_id": "sql-parser",
+        "repository_url": "https://github.com/hyrise/sql-parser",
+        "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "direct_target": "library",
+        "artifact": {
+          "build_output_path": "libsqlparser.so",
+          "staged_relative_path": "libsqlparser.so",
+          "artifact_type": "shared_library",
+          "stage_source": "/workspace/repo/libsqlparser.so",
+          "stage_destination": "/artifacts/libsqlparser.so"
+        },
+        "oracle_correction": {
+          "mode": "pre_result_exact_commit_source_correction",
+          "old_artifact": {
+            "staged_relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          },
+          "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+          "source_protocol_modified": false
+        },
+        "source_audit": {
+          "submodules": [],
+          "generated_parser_sources_tracked": true,
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      }
+    ],
+    "schedule": {
+      "pair_count": 12,
+      "arm_count": 24,
+      "replicates_per_case": 2,
+      "project_internal_order_reversal_required": true,
+      "baseline_first_pairs": 6,
+      "treatment_first_pairs": 6,
+      "pairs": [
+        {
+          "pair_id": "pupnp-rep-01",
+          "case_id": "pupnp",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-01",
+          "case_id": "ada-url",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "args-rep-01",
+          "case_id": "args",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-01",
+          "case_id": "gpac",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-01",
+          "case_id": "fio",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-01",
+          "case_id": "sql-parser-shared",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-02",
+          "case_id": "sql-parser-shared",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-02",
+          "case_id": "fio",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-02",
+          "case_id": "gpac",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "args-rep-02",
+          "case_id": "args",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-02",
+          "case_id": "ada-url",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "pupnp-rep-02",
+          "case_id": "pupnp",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        }
+      ],
+      "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    },
+    "runtime_contract": {
+      "provider_and_model_single_for_batch": true,
+      "provider_identity_status": "pending_execution_amendment",
+      "request_timeout_seconds": 300,
+      "request_retries": 0,
+      "fallback_forbidden": true,
+      "parallel_tool_calls": false,
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "request_limit_per_arm": 8,
+      "turn_limit_per_arm": 8,
+      "graph_step_limit_per_arm": 24,
+      "work_timeout_seconds_per_arm": 600,
+      "cleanup_timeout_seconds_per_arm": 120,
+      "per_arm_recorded_token_ceiling": 120000,
+      "batch_recorded_token_ceiling": 2940000,
+      "shared_tool_contract_identical_between_arms": true,
+      "treatment_exposure_only": "repair_packet"
+    },
+    "measurement_contract": {
+      "parent_fault": "opaque_build_provenance",
+      "parent_proof_status": "unproven/opaque_wrapper",
+      "treatment_required_proof_modes": {
+        "cmake": "direct_cmake",
+        "make": "direct_make"
+      },
+      "r0_companion_required": true,
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_and_zero_orphan_required": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "batch_protocol_mutation_after_start_forbidden": true
+    },
+    "analysis": {
+      "independent_unit": "project_block",
+      "project_block_count": 6,
+      "project_score": "mean of two replicate paired conversion differences",
+      "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+      "primary_test_requires_all_project_blocks_estimable": true,
+      "infrastructure_censoring_reported_separately": true,
+      "mechanism_invalid_reported_separately": true,
+      "intervention_delivery_invalid_reported_separately": true,
+      "historical_exploratory_pairs_pooled": false,
+      "model_ranking_performed": false
+    },
+    "future_state": {
+      "checkpoint_status": "not_created",
+      "evidence_status": "not_created",
+      "execution_runner_status": "not_implemented",
+      "execution_requires_new_amendment": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md",
+      "file_sha256": "5084b6dd89d279981342ac51ceadbde56d1843a3be62c634dc61184affeff273"
+    },
+    "amendment": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+      "mode": "pre_result_lifecycle_reproducibility_amendment",
+      "parent_manifest": {
+        "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+        "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+        "modified": false
+      },
+      "trigger": {
+        "case_id": "sql-parser-shared",
+        "classification": "clean_replay_sha256_mismatch",
+        "provider_results_observed": false,
+        "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+      },
+      "allowed_semantic_delta": {
+        "path": "cases[sql-parser-shared].bootstrap_commands",
+        "before": [],
+        "after": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ]
+      },
+      "verifier_relaxation": false,
+      "schedule_modified": false,
+      "artifact_oracle_modified": false
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_confirmatory_candidate_v2_protocol.py
+++ b/scripts/forge_opaque_provenance_confirmatory_candidate_v2_protocol.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Issue #233 六 case confirmatory candidate 的 pre-result bootstrap amendment。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/233"
+SCHEMA_VERSION = "forge-opaque-provenance-confirmatory-candidate-2.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_confirmatory_candidate_v2"
+
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json"
+PARENT_MANIFEST_SHA256 = "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json"
+
+SQL_PARSER_CASE_ID = "sql-parser-shared"
+SQL_PARSER_BOOTSTRAP = "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+
+
+class ConfirmatoryCandidateV2Error(RuntimeError):
+    """v2 amendment 超出允许差异或授权边界。"""
+
+
+def _load_parent_module():
+    path = SCRIPT_ROOT / "forge_opaque_provenance_confirmatory_candidate_protocol.py"
+    spec = importlib.util.spec_from_file_location(
+        "forge_opaque_provenance_confirmatory_candidate_v2_parent",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise ConfirmatoryCandidateV2Error("无法加载 #230 parent protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+parent = _load_parent_module()
+CASE_ORDER = parent.CASE_ORDER
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    path = repo_root / PARENT_MANIFEST_PATH
+    if file_sha256(path) != PARENT_MANIFEST_SHA256:
+        raise ConfirmatoryCandidateV2Error("#230 parent manifest 发生漂移")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    return parent.validate_manifest(value, repo_root)
+
+
+def _amendment() -> dict[str, Any]:
+    return {
+        "issue_url": ISSUE_URL,
+        "mode": "pre_result_lifecycle_reproducibility_amendment",
+        "parent_manifest": {
+            "path": PARENT_MANIFEST_PATH,
+            "canonical_sha256": PARENT_MANIFEST_SHA256,
+            "modified": False,
+        },
+        "trigger": {
+            "case_id": SQL_PARSER_CASE_ID,
+            "classification": "clean_replay_sha256_mismatch",
+            "provider_results_observed": False,
+            "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources",
+        },
+        "allowed_semantic_delta": {
+            "path": "cases[sql-parser-shared].bootstrap_commands",
+            "before": [],
+            "after": [SQL_PARSER_BOOTSTRAP],
+        },
+        "verifier_relaxation": False,
+        "schedule_modified": False,
+        "artifact_oracle_modified": False,
+    }
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    preregistration = repo_root / PREREGISTRATION_PATH
+    if not preregistration.is_file():
+        raise ConfirmatoryCandidateV2Error("v2 preregistration 不存在")
+    value = copy.deepcopy(_parent_manifest(repo_root))
+    value["$schema"] = "../schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json"
+    value["schema_version"] = SCHEMA_VERSION
+    value["document_type"] = DOCUMENT_TYPE
+    value["amendment"] = _amendment()
+    matches = [case for case in value["cases"] if case["case_id"] == SQL_PARSER_CASE_ID]
+    if len(matches) != 1 or matches[0]["bootstrap_commands"] != []:
+        raise ConfirmatoryCandidateV2Error("sql-parser-shared parent bootstrap 发生漂移")
+    matches[0]["bootstrap_commands"] = [SQL_PARSER_BOOTSTRAP]
+    value["preregistration"] = {
+        "path": PREREGISTRATION_PATH,
+        "file_sha256": file_sha256(preregistration),
+    }
+    return value
+
+
+def validate_allowed_delta(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    normalized = copy.deepcopy(value)
+    if normalized.pop("amendment", None) != _amendment():
+        raise ConfirmatoryCandidateV2Error("amendment metadata 发生漂移")
+    normalized["$schema"] = "../schemas/forge-opaque-provenance-confirmatory-candidate.schema.json"
+    normalized["schema_version"] = parent.SCHEMA_VERSION
+    normalized["document_type"] = parent.DOCUMENT_TYPE
+    matches = [case for case in normalized["cases"] if case["case_id"] == SQL_PARSER_CASE_ID]
+    if len(matches) != 1 or matches[0]["bootstrap_commands"] != [SQL_PARSER_BOOTSTRAP]:
+        raise ConfirmatoryCandidateV2Error("v2 bootstrap delta 发生漂移")
+    matches[0]["bootstrap_commands"] = []
+    parent_value = _parent_manifest(repo_root)
+    normalized["preregistration"] = copy.deepcopy(parent_value["preregistration"])
+    if normalized != parent_value:
+        raise ConfirmatoryCandidateV2Error("v2 包含未授权的额外语义差异")
+    return {
+        "status": "passed",
+        "parent_manifest_sha256": PARENT_MANIFEST_SHA256,
+        "case_id": SQL_PARSER_CASE_ID,
+        "bootstrap_before": [],
+        "bootstrap_after": [SQL_PARSER_BOOTSTRAP],
+        "schedule_identity_sha256": value["schedule"]["identity_sha256"],
+        "schedule_modified": False,
+        "artifact_oracle_modified": False,
+        "verifier_relaxation": False,
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    expected = generate_manifest(repo_root)
+    if not isinstance(value, dict) or value != expected:
+        raise ConfirmatoryCandidateV2Error("confirmatory candidate v2 manifest 发生漂移")
+    validate_allowed_delta(value, repo_root)
+    authorization = value["authorization"]
+    if any(item for key, item in authorization.items() if key.endswith("_authorized")):
+        raise ConfirmatoryCandidateV2Error("v2 意外授权了外部执行")
+    if authorization["model_tokens_authorized"] != 0:
+        raise ConfirmatoryCandidateV2Error("v2 意外授权了 model token")
+    return value
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json",
+        "title": "Forge opaque provenance confirmatory candidate v2",
+        "const": frozen,
+    }
+
+
+def validate_static_gate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest = generate_manifest(repo_root)
+    delta = validate_allowed_delta(manifest, repo_root)
+    return {
+        "status": "passed",
+        "manifest_sha256": canonical_sha256(manifest),
+        "allowed_delta": delta,
+        "case_count": len(manifest["cases"]),
+        "pair_count": len(manifest["schedule"]["pairs"]),
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="确定性写入 v2 manifest 与 const schema")
+    args = parser.parse_args(argv)
+    manifest = generate_manifest()
+    schema = schema_document(manifest)
+    if args.write:
+        _write_json(DEFAULT_MANIFEST, manifest)
+        _write_json(DEFAULT_SCHEMA, schema)
+    else:
+        validate_manifest(json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8")))
+        if json.loads(DEFAULT_SCHEMA.read_text(encoding="utf-8")) != schema:
+            raise ConfirmatoryCandidateV2Error("confirmatory candidate v2 schema 发生漂移")
+    print(json.dumps(validate_static_gate(), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py
+++ b/scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Issue #232 六 case opaque provenance 的零 provider lifecycle adapter。"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import shlex
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from deerflow.compile import operations
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/232"
+SCHEMA_VERSION = "forge-opaque-provenance-confirmatory-lifecycle-gate-1.0.0"
+COMPILE_IMAGE = "autocompiler:gcc13"
+WORKDIR = "/workspace/repo"
+BUILD_DIRECTORY = f"{WORKDIR}/build"
+GENERATOR = "Ninja"
+PROOF_STATUS = "opaque_wrapper"
+
+CANDIDATE_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json"
+CANDIDATE_MANIFEST_FILE_SHA256 = "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133"
+CANDIDATE_MANIFEST_SHA256 = "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812"
+COMPILE_DOCKERFILE_PATH = "docker/compile/Dockerfile"
+COMPILE_DOCKERFILE_SHA256 = "19c20e59fd8e98f44d08acdc0cce7c6c938df5a77d9f18176ba965d701b74628"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-lifecycle-zero-provider-gate.md"
+
+
+class ConfirmatoryLifecycleGateError(RuntimeError):
+    """六 case identity、P2 合同或生命周期边界发生漂移。"""
+
+
+def _load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_ROOT / filename)
+    if spec is None or spec.loader is None:
+        raise ConfirmatoryLifecycleGateError(f"无法加载冻结模块: {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+candidate = _load_module(
+    "forge_opaque_provenance_confirmatory_lifecycle_candidate",
+    "forge_opaque_provenance_confirmatory_candidate_v2_protocol.py",
+)
+cmake_reference = _load_module(
+    "forge_opaque_provenance_confirmatory_lifecycle_cmake_reference",
+    "forge_opaque_build_provenance_gate.py",
+)
+make_reference = _load_module(
+    "forge_opaque_provenance_confirmatory_lifecycle_make_reference",
+    "forge_opaque_provenance_make_reference_gate.py",
+)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class LifecycleCaseAdapter:
+    case_id: str
+    repository_url: str
+    commit_sha: str
+    build_system: str
+    bootstrap_commands: tuple[str, ...]
+    configure_arguments: tuple[str, ...]
+    required_system_packages: tuple[str, ...]
+    target: str
+    build_output: str
+    staged_artifact: str
+    artifact_type: str
+    parent_inner_command: str
+    parent_command: str
+    treatment_build_command: str
+    treatment_stage_command: str
+    expected_proof_mode: str
+    build_tree_relative_path: str | None
+
+    @property
+    def stage_source(self) -> str:
+        return f"{WORKDIR}/{self.build_output}"
+
+    @property
+    def stage_destination(self) -> str:
+        return f"/artifacts/{self.staged_artifact}"
+
+
+def _candidate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    path = repo_root / CANDIDATE_MANIFEST_PATH
+    if file_sha256(path) != CANDIDATE_MANIFEST_FILE_SHA256:
+        raise ConfirmatoryLifecycleGateError("#233 candidate v2 manifest 发生漂移")
+    return candidate.validate_manifest(json.loads(path.read_text(encoding="utf-8")), repo_root)
+
+
+def _cmake_commands(case: dict[str, Any]) -> tuple[str, str, str | None]:
+    configure = shlex.join(
+        (
+            "cmake",
+            "-S",
+            ".",
+            "-B",
+            "build",
+            "-G",
+            GENERATOR,
+            *case["configure_arguments"],
+        )
+    )
+    build = shlex.join(
+        (
+            "cmake",
+            "--build",
+            BUILD_DIRECTORY,
+            "--target",
+            case["direct_target"],
+            "-j2",
+        )
+    )
+    return configure, build, "build/build.ninja"
+
+
+def _make_commands(case: dict[str, Any]) -> tuple[list[str], str, None]:
+    build = shlex.join(("make", case["direct_target"], "-j2"))
+    bootstrap = [f"({command})" for command in case["bootstrap_commands"]]
+    return bootstrap, build, None
+
+
+def build_case_adapter(case_id: str, repo_root: Path = REPO_ROOT) -> LifecycleCaseAdapter:
+    manifest = _candidate_manifest(repo_root)
+    matches = [item for item in manifest["cases"] if item["case_id"] == case_id]
+    if len(matches) != 1:
+        raise ConfirmatoryLifecycleGateError(f"未知或重复的 case identity: {case_id}")
+    case = matches[0]
+    artifact = case["artifact"]
+    if case["build_system"] == "cmake":
+        configure, build, build_tree = _cmake_commands(case)
+        parent_steps = ["rm -rf build", configure, build]
+        proof_mode = "direct_cmake"
+    elif case["build_system"] == "make":
+        bootstrap, build, build_tree = _make_commands(case)
+        parent_steps = [*bootstrap, build]
+        proof_mode = "direct_make"
+    else:
+        raise ConfirmatoryLifecycleGateError(f"不支持的构建系统: {case['build_system']}")
+    stage = shlex.join(("cp", artifact["stage_source"], artifact["stage_destination"]))
+    parent_inner = " && ".join((*parent_steps, stage))
+    return LifecycleCaseAdapter(
+        case_id=case["case_id"],
+        repository_url=case["repository_url"],
+        commit_sha=case["commit_sha"],
+        build_system=case["build_system"],
+        bootstrap_commands=tuple(case["bootstrap_commands"]),
+        configure_arguments=tuple(case["configure_arguments"]),
+        required_system_packages=tuple(case["required_system_packages"]),
+        target=case["direct_target"],
+        build_output=artifact["build_output_path"],
+        staged_artifact=artifact["staged_relative_path"],
+        artifact_type=artifact["artifact_type"],
+        parent_inner_command=parent_inner,
+        parent_command=f"sh -c {shlex.quote(parent_inner)}",
+        treatment_build_command=build,
+        treatment_stage_command=stage,
+        expected_proof_mode=proof_mode,
+        build_tree_relative_path=build_tree,
+    )
+
+
+def build_case_adapters(
+    repo_root: Path = REPO_ROOT,
+) -> tuple[LifecycleCaseAdapter, ...]:
+    return tuple(build_case_adapter(case_id, repo_root) for case_id in candidate.CASE_ORDER)
+
+
+def build_frozen_identity(
+    adapter: LifecycleCaseAdapter,
+    *,
+    image_id: str,
+    physical_attempt_id: str,
+    artifact_size: int,
+    artifact_sha256: str,
+    build_tree_sha256: str | None = None,
+):
+    if adapter.build_system == "cmake":
+        if build_tree_sha256 is None:
+            raise ConfirmatoryLifecycleGateError("CMake identity 缺少 build tree SHA-256")
+        return cmake_reference.FrozenIdentity(
+            schema_version=cmake_reference.SCHEMA_VERSION,
+            case_id=adapter.case_id,
+            repository_url=adapter.repository_url,
+            commit_sha=adapter.commit_sha,
+            image_id=image_id,
+            physical_attempt_id=physical_attempt_id,
+            workdir=WORKDIR,
+            build_directory=BUILD_DIRECTORY,
+            generator=GENERATOR,
+            build_tree_sha256=build_tree_sha256,
+            target=adapter.target,
+            artifact_relative_path=adapter.build_output,
+            artifact_type=adapter.artifact_type,
+            artifact_size=artifact_size,
+            artifact_sha256=artifact_sha256,
+        ).validate()
+    if build_tree_sha256 is not None:
+        raise ConfirmatoryLifecycleGateError("Make identity 不应包含 build tree SHA-256")
+    return make_reference.MakeFrozenIdentity(
+        schema_version=make_reference.SCHEMA_VERSION,
+        case_id=adapter.case_id,
+        repository_url=adapter.repository_url,
+        commit_sha=adapter.commit_sha,
+        image_id=image_id,
+        physical_attempt_id=physical_attempt_id,
+        workdir=WORKDIR,
+        target=adapter.target,
+        artifact_relative_path=adapter.build_output,
+        artifact_type=adapter.artifact_type,
+        artifact_size=artifact_size,
+        artifact_sha256=artifact_sha256,
+    ).validate()
+
+
+def _artifact(frozen: Any, producer_command_id: str, *, observed_after_sequence: int):
+    return cmake_reference.ArtifactIdentity(
+        schema_version=cmake_reference.SCHEMA_VERSION,
+        physical_attempt_id=frozen.physical_attempt_id,
+        producer_command_id=producer_command_id,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        relative_path=frozen.artifact_relative_path,
+        artifact_type=frozen.artifact_type,
+        size=frozen.artifact_size,
+        sha256=frozen.artifact_sha256,
+        observed_after_sequence=observed_after_sequence,
+    )
+
+
+def _parent_invocation(adapter: LifecycleCaseAdapter, frozen: Any, command_id: str):
+    return cmake_reference.record_invocation(
+        command_id=command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=1,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="sh",
+        argv=("-c", adapter.parent_inner_command),
+        workdir=frozen.workdir,
+        previous_hash=cmake_reference.ZERO_HASH,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+
+
+def evaluate_parent(adapter: LifecycleCaseAdapter, frozen: Any, *, parent_command_id: str):
+    parent = _parent_invocation(adapter, frozen, parent_command_id)
+    artifact = _artifact(frozen, parent.command_id, observed_after_sequence=2)
+    if adapter.build_system == "cmake":
+        decision = cmake_reference.evaluate_p2(frozen, (parent,), artifact)
+    else:
+        decision = make_reference.evaluate_make_p2(frozen, (parent,), artifact)
+    if decision.status != "unproven" or decision.classification != "opaque_build_provenance" or decision.reason != PROOF_STATUS:
+        raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} parent 未形成单一 opaque-wrapper fault")
+    return decision, (parent,)
+
+
+def evaluate_treatment(
+    adapter: LifecycleCaseAdapter,
+    frozen: Any,
+    *,
+    parent_command_id: str,
+    treatment_build_command_id: str,
+    treatment_stage_command_id: str,
+):
+    parent = _parent_invocation(adapter, frozen, parent_command_id)
+    tokens = shlex.split(adapter.treatment_build_command)
+    build = cmake_reference.record_invocation(
+        command_id=treatment_build_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=2,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable=tokens[0],
+        argv=tuple(tokens[1:]),
+        workdir=frozen.workdir,
+        previous_hash=parent.ledger_hash,
+        output_paths=(frozen.artifact_relative_path,),
+        model_declared_role="build",
+    )
+    stage = cmake_reference.record_invocation(
+        command_id=treatment_stage_command_id,
+        physical_attempt_id=frozen.physical_attempt_id,
+        sequence=3,
+        repository_url=frozen.repository_url,
+        commit_sha=frozen.commit_sha,
+        image_id=frozen.image_id,
+        executable="cp",
+        argv=(adapter.stage_source, adapter.stage_destination),
+        workdir=frozen.workdir,
+        previous_hash=build.ledger_hash,
+        model_declared_role="artifact_stage",
+    )
+    invocations = (parent, build, stage)
+    artifact = _artifact(frozen, build.command_id, observed_after_sequence=4)
+    if adapter.build_system == "cmake":
+        decision = cmake_reference.evaluate_p2(frozen, invocations, artifact)
+    else:
+        decision = make_reference.evaluate_make_p2(frozen, invocations, artifact)
+    if decision.status != "proven" or decision.proof_mode != adapter.expected_proof_mode:
+        raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} treatment 未转换 P2")
+    return decision, invocations
+
+
+def validate_gate_contract(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    if file_sha256(repo_root / COMPILE_DOCKERFILE_PATH) != COMPILE_DOCKERFILE_SHA256:
+        raise ConfirmatoryLifecycleGateError("compile Dockerfile 发生漂移")
+    dockerfile = (repo_root / COMPILE_DOCKERFILE_PATH).read_text(encoding="utf-8")
+    installed_packages = {line.strip().removesuffix("\\").strip().removesuffix(";").strip() for line in dockerfile.splitlines()}
+    reports: list[dict[str, Any]] = []
+    for index, adapter in enumerate(build_case_adapters(repo_root), start=1):
+        missing_packages = [package for package in adapter.required_system_packages if package not in installed_packages]
+        if missing_packages:
+            raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} 依赖未冻结进 compile image: {missing_packages}")
+        roles = operations.infer_command_roles(adapter.parent_command)
+        if not {"build", "artifact_stage"}.issubset(roles):
+            raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} parent command role 发生漂移")
+        if operations._command_invokes(adapter.parent_command, adapter.build_system):
+            raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} parent 意外暴露 direct build identity")
+        if not operations._command_invokes(adapter.treatment_build_command, adapter.build_system):
+            raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} treatment 缺少 direct build identity")
+        fake_sha = str(index + 1) * 64
+        frozen = build_frozen_identity(
+            adapter,
+            image_id="sha256:" + str(index) * 64,
+            physical_attempt_id=f"attempt-confirmatory-lifecycle-{adapter.case_id}",
+            build_tree_sha256=fake_sha if adapter.build_system == "cmake" else None,
+            artifact_size=4096,
+            artifact_sha256=str(index + 2) * 64,
+        )
+        parent, parent_history = evaluate_parent(adapter, frozen, parent_command_id="parent-wrapper")
+        treatment, treatment_history = evaluate_treatment(
+            adapter,
+            frozen,
+            parent_command_id="parent-wrapper",
+            treatment_build_command_id="treatment-build",
+            treatment_stage_command_id="treatment-stage",
+        )
+        if treatment_history[: len(parent_history)] != parent_history:
+            raise ConfirmatoryLifecycleGateError(f"{adapter.case_id} treatment 改写 parent history")
+        reports.append(
+            {
+                "case": asdict(adapter),
+                "parent_roles": sorted(roles),
+                "parent": asdict(parent),
+                "treatment": asdict(treatment),
+                "parent_history_prefix_preserved": True,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue_url": ISSUE_URL,
+        "candidate_manifest_sha256": CANDIDATE_MANIFEST_SHA256,
+        "candidate_manifest_file_sha256": CANDIDATE_MANIFEST_FILE_SHA256,
+        "compile_dockerfile_sha256": COMPILE_DOCKERFILE_SHA256,
+        "compile_image": COMPILE_IMAGE,
+        "cases": reports,
+        "lifecycle_assertions": [
+            "exact_commit_bootstrap",
+            "parent_single_fault",
+            "direct_treatment_conversion",
+            "production_artifact_classification",
+            "production_clean_replay",
+            "production_finalize_and_cleanup",
+        ],
+        "provider_calls": 0,
+        "credential_read": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "formal_evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(json.dumps(validate_gate_contract(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增薄的、opt-in、零 provider 六 case lifecycle gate，复用生产 Compile Session、P2 evaluator、candidate verification、clean replay 与 cleanup
- 记录并停止 v1 `sql-parser-shared` 的 checkout mtime/Bison 非确定性，不放宽 artifact SHA-256 verifier
- 新增 v2 pre-result amendment，只显式冻结 Bison bootstrap，并保持旧协议、artifact oracle 与 12-pair schedule identity 不变
- 增加静态合同、真实 Ubuntu Docker lifecycle 测试、Schema 与预注册

## 验证

- v2 `sql-parser-shared` 稳定性门禁连续两次通过：39.62 秒、38.58 秒
- 六 case lifecycle：`6 passed in 453.74s`
- 相邻回归：`115 passed, 6 skipped`
- 最终聚焦：`25 passed, 6 skipped`
- Ruff check/format、pycompile、确定性再生成、`git diff --check` 全部通过
- 后置 compile/replay orphan 为 0

## 研究边界

- 0 provider、0 credential read、0 checkpoint、0 formal attempt、0 model token、0 正式 evidence write
- 不实现 provider runner，不授权或启动 12-pair/24-arm 采集
- 不修改生产 Compiler，不放宽 clean replay verifier

Closes #232
Closes #233
