### PR TITLE
研究：冻结六 case 确认性 execution candidate

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,12 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 冻结 Issue #235 六 case confirmatory execution 未授权候选
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py`, `scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md`
+  - 设计: 继承 Issue #233 六 case/12-pair identity，选择但不授权 DeepSeek `deepseek-v4-flash`；冻结独立 evidence、三层 terminal taxonomy、endpoint censoring 继续、mechanism/identity/cleanup 失败停止和 2,940,000-token 批次门禁。
+  - 复用: CMake/Make 分别复用既有 runtime-parity/R0 action policy，完整 agent construction 使用本地 fake model，批次只实现纯状态转换合同；不复制 checkpoint capture/restore 或真实 pair 主循环。
+  - 边界: 真实 pair runner 仍未实现；0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 正式 evidence write，未来真实采集必须新增 authorized amendment。
+
 - 2026-08-31 — 完成 Issue #232/#233 六 case 确认性 lifecycle 零 provider 门禁
   - 文件: `scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py`, `scripts/forge_opaque_provenance_confirmatory_candidate_v2_protocol.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_lifecycle_gate_docker.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_candidate_v2.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-candidate-v2.md`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-lifecycle-zero-provider-gate.md`
   - 根因: `sql-parser-shared` 的 v1 空 bootstrap 会因 checkout 文件 mtime 决定 `make library` 是消费已跟踪生成文件还是重新运行 Bison；四次 lifecycle 为 2 次通过、2 次 `sha256_mismatch`，路径、类型和大小一致但 SHA-256/build-id 不同。

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py
@@ -1,0 +1,117 @@
+"""Issue #235 confirmatory execution candidate 的零 provider 合同。"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def _load(name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS))
+    try:
+        spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPTS))
+
+
+protocol = _load("forge_confirmatory_execution_candidate_test", "forge_opaque_provenance_confirmatory_execution_candidate_protocol.py")
+gate = _load("forge_confirmatory_execution_composition_test", "forge_opaque_provenance_confirmatory_execution_composition_gate.py")
+
+
+def test_candidate_preserves_parent_and_closes_authorization() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    assert protocol.validate_manifest(manifest, REPO_ROOT) == manifest
+    delta = protocol.validate_allowed_delta(manifest, REPO_ROOT)
+    assert delta["parent_manifest_sha256"] == protocol.PARENT_MANIFEST_SHA256
+    assert delta["schedule_identity_sha256"] == "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    assert delta["provider_status"] == "selected_not_authorized"
+    assert delta["real_pair_runner_implemented"] is False
+    assert all(value is False for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    assert manifest["authorization"]["model_tokens_authorized"] == 0
+
+
+def test_manifest_schema_and_generation_are_deterministic() -> None:
+    manifest = json.loads(protocol.DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+    schema = json.loads(protocol.DEFAULT_SCHEMA.read_text(encoding="utf-8"))
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+
+
+def test_six_case_dispatch_accepts_only_frozen_direct_actions() -> None:
+    dispatches = gate.build_all_dispatches(REPO_ROOT)
+    assert [item.case_id for item in dispatches] == ["pupnp", "ada-url", "args", "gpac", "fio", "sql-parser-shared"]
+    assert [item.policy_family for item in dispatches] == ["cmake_runtime_parity_v1"] * 3 + ["r3_make_runtime_parity_v1"] * 3
+    assert all((item.build_action, item.stage_action) == ("repair_build", "artifact_stage") for item in dispatches)
+
+
+def test_endpoint_censoring_continues_without_replacement() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    first, second = manifest["schedule"]["pairs"][:2]
+    state = gate.next_batch_state(manifest, [{"pair_id": first["pair_id"], "terminal": "endpoint_censored", "recorded_tokens": 0}])
+    assert state == {"status": "ready", "reason": None, "recorded_tokens": 0, "next_pair_id": second["pair_id"]}
+    taxonomy = manifest["execution_candidate"]["terminal_taxonomy"]
+    assert taxonomy["replacement_forbidden"] is True
+    assert taxonomy["backfill_forbidden"] is True
+
+
+@pytest.mark.parametrize("terminal", ["mechanism_invalid", "identity_invalid", "evidence_invalid", "cleanup_failed", "orphan_detected"])
+def test_invalid_mechanism_or_cleanup_stops_batch(terminal: str) -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    pair_id = manifest["schedule"]["pairs"][0]["pair_id"]
+    state = gate.next_batch_state(manifest, [{"pair_id": pair_id, "terminal": terminal, "recorded_tokens": 100}])
+    assert state == {"status": "stopped", "reason": terminal, "recorded_tokens": 100, "next_pair_id": None}
+
+
+def test_token_ceiling_is_checked_before_next_pair() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    pair_id = manifest["schedule"]["pairs"][0]["pair_id"]
+    ceiling = manifest["runtime_contract"]["batch_recorded_token_ceiling"]
+    state = gate.next_batch_state(manifest, [{"pair_id": pair_id, "terminal": "valid", "recorded_tokens": ceiling}])
+    assert state["status"] == "stopped"
+    assert state["reason"] == "token_ceiling_reached"
+
+
+def test_unrelated_parent_or_authorization_drift_fails_closed() -> None:
+    manifest = protocol.generate_manifest(REPO_ROOT)
+    for mutation in ("case", "schedule", "authorization"):
+        drifted = copy.deepcopy(manifest)
+        if mutation == "case":
+            drifted["cases"][0]["direct_target"] = "wrong"
+        elif mutation == "schedule":
+            drifted["schedule"]["pairs"][0]["arm_order"].reverse()
+        else:
+            drifted["authorization"]["provider_calls_authorized"] = True
+        with pytest.raises(protocol.ConfirmatoryExecutionCandidateError):
+            protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_full_fake_agent_composition_gate_has_no_external_effects() -> None:
+    report = asyncio.run(gate.validate_composition_gate(REPO_ROOT))
+    assert report["status"] == "passed"
+    assert len(report["dispatches"]) == len(report["agent_construction"]) == 6
+    assert all(item["model_calls"] == 1 and item["provider_calls"] == 0 for item in report["agent_construction"])
+    assert report["provider_calls"] == report["formal_attempts"] == report["model_tokens"] == 0
+    assert report["credential_read"] is False
+    assert report["docker_executed"] is False
+    assert report["checkpoint_created"] is False
+    assert report["formal_evidence_writes"] == 0
+
+
+def test_new_sources_do_not_expose_real_execution_or_credentials() -> None:
+    sources = "\n".join((SCRIPTS / name).read_text(encoding="utf-8").lower() for name in ("forge_opaque_provenance_confirmatory_execution_candidate_protocol.py", "forge_opaque_provenance_confirmatory_execution_composition_gate.py"))
+    for forbidden in ("openai_ak", "deepseek_api_key=", "api_key=", "execute_pair(", "execute_reachability("):
+        assert forbidden not in sources

--- a/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json
@@ -1,0 +1,625 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json",
+  "schema_version": "forge-opaque-provenance-confirmatory-execution-candidate-1.0.0",
+  "document_type": "forge_opaque_provenance_confirmatory_execution_candidate",
+  "authorization": {
+    "provider_calls_authorized": false,
+    "credential_read_authorized": false,
+    "model_creation_authorized": false,
+    "reachability_request_authorized": false,
+    "checkpoint_creation_authorized": false,
+    "pair_collection_authorized": false,
+    "formal_attempts_authorized": false,
+    "docker_execution_authorized": false,
+    "evidence_write_authorized": false,
+    "model_tokens_authorized": 0
+  },
+  "selection": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+    "mode": "result_blind_exact_commit_source_audit",
+    "frozen_sources": {
+      "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+      "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+    },
+    "case_count": 6,
+    "build_system_counts": {
+      "cmake": 3,
+      "make": 3
+    },
+    "artifact_type_counts": {
+      "executable": 2,
+      "static_library": 3,
+      "shared_library": 1
+    },
+    "exclusions": {
+      "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+      "janet": "local model-result evidence already exists, so the case is not result-blind",
+      "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+      "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+    }
+  },
+  "cases": [
+    {
+      "case_id": "pupnp",
+      "source_case_id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "language": "C",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DUPNP_ENABLE_TESTING=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "upnp_static",
+      "artifact": {
+        "build_output_path": "build/upnp/libupnp.a",
+        "staged_relative_path": "libupnp.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+        "stage_destination": "/artifacts/libupnp.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "ada-url",
+      "source_case_id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DADA_TESTING=OFF",
+        "-DADA_BENCHMARKS=OFF",
+        "-DADA_TOOLS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "ada",
+      "artifact": {
+        "build_output_path": "build/src/libada.a",
+        "staged_relative_path": "libada.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/src/libada.a",
+        "stage_destination": "/artifacts/libada.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "args",
+      "source_case_id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DARGS_BUILD_EXAMPLE=ON",
+        "-DARGS_BUILD_UNITTESTS=OFF",
+        "-DBUILD_FUZZERS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "gitlike",
+      "artifact": {
+        "build_output_path": "build/gitlike",
+        "staged_relative_path": "gitlike",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/build/gitlike",
+        "stage_destination": "/artifacts/gitlike"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "gpac",
+      "source_case_id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "language": "C",
+      "build_system": "make",
+      "size_stratum": "large",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --static-bin"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "pkg-config",
+        "zlib1g-dev"
+      ],
+      "direct_target": "lib",
+      "artifact": {
+        "build_output_path": "bin/gcc/libgpac_static.a",
+        "staged_relative_path": "libgpac_static.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+        "stage_destination": "/artifacts/libgpac_static.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [
+          "testsuite"
+        ],
+        "submodules_on_target_dependency_path": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "fio",
+      "source_case_id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --disable-native"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "zlib1g-dev"
+      ],
+      "direct_target": "fio",
+      "artifact": {
+        "build_output_path": "fio",
+        "staged_relative_path": "fio",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/fio",
+        "stage_destination": "/artifacts/fio"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "sql-parser-shared",
+      "source_case_id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "bison",
+        "build-essential",
+        "flex"
+      ],
+      "direct_target": "library",
+      "artifact": {
+        "build_output_path": "libsqlparser.so",
+        "staged_relative_path": "libsqlparser.so",
+        "artifact_type": "shared_library",
+        "stage_source": "/workspace/repo/libsqlparser.so",
+        "stage_destination": "/artifacts/libsqlparser.so"
+      },
+      "oracle_correction": {
+        "mode": "pre_result_exact_commit_source_correction",
+        "old_artifact": {
+          "staged_relative_path": "libsqlparser.a",
+          "build_output_path": "libsqlparser.a",
+          "artifact_type": "static_library",
+          "producing_target": "library"
+        },
+        "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+        "source_protocol_modified": false
+      },
+      "source_audit": {
+        "submodules": [],
+        "generated_parser_sources_tracked": true,
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    }
+  ],
+  "schedule": {
+    "pair_count": 12,
+    "arm_count": 24,
+    "replicates_per_case": 2,
+    "project_internal_order_reversal_required": true,
+    "baseline_first_pairs": 6,
+    "treatment_first_pairs": 6,
+    "pairs": [
+      {
+        "pair_id": "pupnp-rep-01",
+        "case_id": "pupnp",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-01",
+        "case_id": "ada-url",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "args-rep-01",
+        "case_id": "args",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-01",
+        "case_id": "gpac",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-01",
+        "case_id": "fio",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-01",
+        "case_id": "sql-parser-shared",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-02",
+        "case_id": "sql-parser-shared",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-02",
+        "case_id": "fio",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-02",
+        "case_id": "gpac",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "args-rep-02",
+        "case_id": "args",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-02",
+        "case_id": "ada-url",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pupnp-rep-02",
+        "case_id": "pupnp",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+  },
+  "runtime_contract": {
+    "provider_and_model_single_for_batch": true,
+    "provider_identity_status": "selected_not_authorized",
+    "request_timeout_seconds": 300,
+    "request_retries": 0,
+    "fallback_forbidden": true,
+    "parallel_tool_calls": false,
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "request_limit_per_arm": 8,
+    "turn_limit_per_arm": 8,
+    "graph_step_limit_per_arm": 24,
+    "work_timeout_seconds_per_arm": 600,
+    "cleanup_timeout_seconds_per_arm": 120,
+    "per_arm_recorded_token_ceiling": 120000,
+    "batch_recorded_token_ceiling": 2940000,
+    "shared_tool_contract_identical_between_arms": true,
+    "treatment_exposure_only": "repair_packet"
+  },
+  "measurement_contract": {
+    "parent_fault": "opaque_build_provenance",
+    "parent_proof_status": "unproven/opaque_wrapper",
+    "treatment_required_proof_modes": {
+      "cmake": "direct_cmake",
+      "make": "direct_make"
+    },
+    "r0_companion_required": true,
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_and_zero_orphan_required": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "batch_protocol_mutation_after_start_forbidden": true
+  },
+  "analysis": {
+    "independent_unit": "project_block",
+    "project_block_count": 6,
+    "project_score": "mean of two replicate paired conversion differences",
+    "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+    "primary_test_requires_all_project_blocks_estimable": true,
+    "infrastructure_censoring_reported_separately": true,
+    "mechanism_invalid_reported_separately": true,
+    "intervention_delivery_invalid_reported_separately": true,
+    "historical_exploratory_pairs_pooled": false,
+    "model_ranking_performed": false
+  },
+  "future_state": {
+    "checkpoint_status": "not_created",
+    "evidence_status": "not_created",
+    "execution_runner_status": "composition_gate_only",
+    "execution_requires_new_amendment": true
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md",
+    "file_sha256": "14cbebdbba1fcab7c66902739a4eec9fb81ce8981699e3129123f71fd9e0a8c8"
+  },
+  "amendment": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+    "mode": "pre_result_lifecycle_reproducibility_amendment",
+    "parent_manifest": {
+      "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+      "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+      "modified": false
+    },
+    "trigger": {
+      "case_id": "sql-parser-shared",
+      "classification": "clean_replay_sha256_mismatch",
+      "provider_results_observed": false,
+      "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+    },
+    "allowed_semantic_delta": {
+      "path": "cases[sql-parser-shared].bootstrap_commands",
+      "before": [],
+      "after": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ]
+    },
+    "verifier_relaxation": false,
+    "schedule_modified": false,
+    "artifact_oracle_modified": false
+  },
+  "execution_candidate": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/235",
+    "status": "composition_gate_only_not_authorized",
+    "parent": {
+      "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json",
+      "file_sha256": "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133",
+      "canonical_sha256": "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812",
+      "modified": false
+    },
+    "provider": {
+      "status": "selected_not_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+      "reachability_marker": "markers/reachability.json",
+      "reachability_report": "reports/reachability.json",
+      "batch_marker": "markers/batch.json",
+      "batch_report": "reports/batch.json",
+      "pair_directory_pattern": "pairs/{pair_id}",
+      "create_once": true,
+      "historical_evidence_reused": false
+    },
+    "orchestration": {
+      "lifecycle_adapter": "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+      "cmake_action_policy": "scripts/forge_opaque_provenance_runtime_parity_gate.py",
+      "make_action_policy": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+      "r0_observability_required": true,
+      "full_agent_construction_required": true,
+      "single_asyncio_loop_for_batch": true,
+      "checkpoint_capture_restore_reimplemented": false,
+      "real_pair_runner_implemented": false
+    },
+    "repair_packets": {
+      "pupnp": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "upnp_static",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "ada-url": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "ada",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "args": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "gitlike",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "gpac": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "lib",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "fio": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "fio",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "sql-parser-shared": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "library",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      }
+    },
+    "terminal_taxonomy": {
+      "continue": [
+        "valid",
+        "endpoint_censored",
+        "model_behavior_outcome"
+      ],
+      "stop_batch": [
+        "mechanism_invalid",
+        "identity_invalid",
+        "evidence_invalid",
+        "cleanup_failed",
+        "orphan_detected",
+        "token_ceiling_reached"
+      ],
+      "replacement_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "planned_authorized_amendment": {
+      "reachability_requests": 1,
+      "scheduled_pairs": 12,
+      "scheduled_arms": 24,
+      "batch_recorded_token_ceiling": 2940000,
+      "release_commit_required": true,
+      "separate_authorization_required": true
+    },
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+      "scripts/forge_opaque_provenance_runtime_parity_gate.py": "251cc446cc508552d85cdf82238192b702bbb2e51ee428c42d47188d0f12b40b",
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+      "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+      "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+    }
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md
@@ -1,0 +1,37 @@
+# Forge opaque provenance 六 case confirmatory execution candidate
+
+- GitHub Issue：[Issue #235](https://github.com/WWFXL/Forge-AutoCompiler/issues/235)
+- 父协议：Issue #233 candidate v2
+- 状态：pre-execution、未授权、零 provider
+
+## 目的
+
+在任何模型请求前冻结确认性批次的 provider identity、evidence identity、case dispatch、终态分类与批次停止规则。本候选只证明既有 lifecycle、runtime parity、R0、agent construction 和批次状态机可以组合；不实现或暴露真实采集入口。
+
+## 冻结执行身份
+
+- Provider/model：DeepSeek `deepseek-v4-flash`，endpoint `https://api.deepseek.com`，credential 仅以环境变量名 `DEEPSEEK_API_KEY` 标识。
+- 每请求 300 秒、0 retry、非 streaming、禁止 fallback、replacement 与 backfill。
+- 六 case、12 pairs / 24 arms、项目内 arm order 对调、4/2/2/2 action limits、每 arm 120,000 与批次 2,940,000 recorded-token ceiling 全部继承父协议。
+- Evidence 使用新的只写一次目录；reachability、batch、pair、arm、checkpoint 与 cleanup identity 不复用任何历史实验。
+
+选择 DeepSeek 是为了保持三个有效 exploratory pair 的 provider/model 条件，不把模型切换混入确认性 treatment effect；这不是模型排名，也不授权调用。
+
+## 复用边界
+
+- 六 case 的 bootstrap、parent fault、P2 conversion、artifact oracle 与 replay 读取 Issue #233 lifecycle adapter。
+- CMake 使用既有 CMake runtime-parity/R0 组件；Make 使用 R3 Make action policy 与 R0 组件。
+- 完整 `create_agent`、串行 tool call、请求 evidence、pre-model failure 分类和 cleanup 顺序通过本地 fake model gate 验证。
+- 批次调度复用 behavioral pilot v2 已验证的单 asyncio loop 与三层 terminal taxonomy 模式；本阶段只实现纯状态转换合同，不复制 checkpoint capture/restore 或真实 pair 主循环。
+
+## 终态与停止规则
+
+- `endpoint_censored` 记录为 infrastructure attrition，不 replacement/backfill，并继续下一预注册 pair。
+- `model_behavior_outcome` 与 verification failed/no-submit/graph-step-limit 都作为观察结果，继续另一 arm 与后续 pair。
+- `mechanism_invalid`、identity drift、evidence write failure、cleanup failure 或 orphan 非零立即停止整个批次。
+- 启动每个 pair 前检查累计 recorded tokens；达到或超过 2,940,000 后停止，禁止启动部分 pair。
+- 每个 project block 两个 replicate 都可估计时才进入 project-level primary；否则只报告 attrition，不补跑。
+
+## 当前授权
+
+0 provider、0 credential read、0 model creation、0 reachability、0 Docker、0 checkpoint、0 pair、0 formal attempt、0 model token、0 正式 evidence write。未来真实执行必须新增 authorized amendment，绑定已合并的 release commit、一次 reachability 和同一个 12-pair schedule；本 candidate 不能直接执行。

--- a/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json
@@ -1,0 +1,630 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json",
+  "title": "Forge opaque provenance confirmatory execution candidate",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json",
+    "schema_version": "forge-opaque-provenance-confirmatory-execution-candidate-1.0.0",
+    "document_type": "forge_opaque_provenance_confirmatory_execution_candidate",
+    "authorization": {
+      "provider_calls_authorized": false,
+      "credential_read_authorized": false,
+      "model_creation_authorized": false,
+      "reachability_request_authorized": false,
+      "checkpoint_creation_authorized": false,
+      "pair_collection_authorized": false,
+      "formal_attempts_authorized": false,
+      "docker_execution_authorized": false,
+      "evidence_write_authorized": false,
+      "model_tokens_authorized": 0
+    },
+    "selection": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+      "mode": "result_blind_exact_commit_source_audit",
+      "frozen_sources": {
+        "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+        "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+        "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+      },
+      "case_count": 6,
+      "build_system_counts": {
+        "cmake": 3,
+        "make": 3
+      },
+      "artifact_type_counts": {
+        "executable": 2,
+        "static_library": 3,
+        "shared_library": 1
+      },
+      "exclusions": {
+        "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+        "janet": "local model-result evidence already exists, so the case is not result-blind",
+        "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+        "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+      }
+    },
+    "cases": [
+      {
+        "case_id": "pupnp",
+        "source_case_id": "pupnp",
+        "repository_url": "https://github.com/pupnp/pupnp",
+        "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+        "language": "C",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "upnp_static",
+        "artifact": {
+          "build_output_path": "build/upnp/libupnp.a",
+          "staged_relative_path": "libupnp.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+          "stage_destination": "/artifacts/libupnp.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "ada-url",
+        "source_case_id": "ada-url",
+        "repository_url": "https://github.com/ada-url/ada",
+        "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "ada",
+        "artifact": {
+          "build_output_path": "build/src/libada.a",
+          "staged_relative_path": "libada.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/src/libada.a",
+          "stage_destination": "/artifacts/libada.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "args",
+        "source_case_id": "args",
+        "repository_url": "https://github.com/Taywee/args",
+        "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "gitlike",
+        "artifact": {
+          "build_output_path": "build/gitlike",
+          "staged_relative_path": "gitlike",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/build/gitlike",
+          "stage_destination": "/artifacts/gitlike"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "gpac",
+        "source_case_id": "gpac",
+        "repository_url": "https://github.com/gpac/gpac",
+        "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+        "language": "C",
+        "build_system": "make",
+        "size_stratum": "large",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "direct_target": "lib",
+        "artifact": {
+          "build_output_path": "bin/gcc/libgpac_static.a",
+          "staged_relative_path": "libgpac_static.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+          "stage_destination": "/artifacts/libgpac_static.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [
+            "testsuite"
+          ],
+          "submodules_on_target_dependency_path": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "fio",
+        "source_case_id": "fio",
+        "repository_url": "https://github.com/axboe/fio",
+        "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "direct_target": "fio",
+        "artifact": {
+          "build_output_path": "fio",
+          "staged_relative_path": "fio",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/fio",
+          "stage_destination": "/artifacts/fio"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "sql-parser-shared",
+        "source_case_id": "sql-parser",
+        "repository_url": "https://github.com/hyrise/sql-parser",
+        "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "direct_target": "library",
+        "artifact": {
+          "build_output_path": "libsqlparser.so",
+          "staged_relative_path": "libsqlparser.so",
+          "artifact_type": "shared_library",
+          "stage_source": "/workspace/repo/libsqlparser.so",
+          "stage_destination": "/artifacts/libsqlparser.so"
+        },
+        "oracle_correction": {
+          "mode": "pre_result_exact_commit_source_correction",
+          "old_artifact": {
+            "staged_relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          },
+          "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+          "source_protocol_modified": false
+        },
+        "source_audit": {
+          "submodules": [],
+          "generated_parser_sources_tracked": true,
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      }
+    ],
+    "schedule": {
+      "pair_count": 12,
+      "arm_count": 24,
+      "replicates_per_case": 2,
+      "project_internal_order_reversal_required": true,
+      "baseline_first_pairs": 6,
+      "treatment_first_pairs": 6,
+      "pairs": [
+        {
+          "pair_id": "pupnp-rep-01",
+          "case_id": "pupnp",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-01",
+          "case_id": "ada-url",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "args-rep-01",
+          "case_id": "args",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-01",
+          "case_id": "gpac",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-01",
+          "case_id": "fio",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-01",
+          "case_id": "sql-parser-shared",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-02",
+          "case_id": "sql-parser-shared",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-02",
+          "case_id": "fio",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-02",
+          "case_id": "gpac",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "args-rep-02",
+          "case_id": "args",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-02",
+          "case_id": "ada-url",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "pupnp-rep-02",
+          "case_id": "pupnp",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        }
+      ],
+      "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    },
+    "runtime_contract": {
+      "provider_and_model_single_for_batch": true,
+      "provider_identity_status": "selected_not_authorized",
+      "request_timeout_seconds": 300,
+      "request_retries": 0,
+      "fallback_forbidden": true,
+      "parallel_tool_calls": false,
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "request_limit_per_arm": 8,
+      "turn_limit_per_arm": 8,
+      "graph_step_limit_per_arm": 24,
+      "work_timeout_seconds_per_arm": 600,
+      "cleanup_timeout_seconds_per_arm": 120,
+      "per_arm_recorded_token_ceiling": 120000,
+      "batch_recorded_token_ceiling": 2940000,
+      "shared_tool_contract_identical_between_arms": true,
+      "treatment_exposure_only": "repair_packet"
+    },
+    "measurement_contract": {
+      "parent_fault": "opaque_build_provenance",
+      "parent_proof_status": "unproven/opaque_wrapper",
+      "treatment_required_proof_modes": {
+        "cmake": "direct_cmake",
+        "make": "direct_make"
+      },
+      "r0_companion_required": true,
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_and_zero_orphan_required": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "batch_protocol_mutation_after_start_forbidden": true
+    },
+    "analysis": {
+      "independent_unit": "project_block",
+      "project_block_count": 6,
+      "project_score": "mean of two replicate paired conversion differences",
+      "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+      "primary_test_requires_all_project_blocks_estimable": true,
+      "infrastructure_censoring_reported_separately": true,
+      "mechanism_invalid_reported_separately": true,
+      "intervention_delivery_invalid_reported_separately": true,
+      "historical_exploratory_pairs_pooled": false,
+      "model_ranking_performed": false
+    },
+    "future_state": {
+      "checkpoint_status": "not_created",
+      "evidence_status": "not_created",
+      "execution_runner_status": "composition_gate_only",
+      "execution_requires_new_amendment": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md",
+      "file_sha256": "14cbebdbba1fcab7c66902739a4eec9fb81ce8981699e3129123f71fd9e0a8c8"
+    },
+    "amendment": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+      "mode": "pre_result_lifecycle_reproducibility_amendment",
+      "parent_manifest": {
+        "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+        "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+        "modified": false
+      },
+      "trigger": {
+        "case_id": "sql-parser-shared",
+        "classification": "clean_replay_sha256_mismatch",
+        "provider_results_observed": false,
+        "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+      },
+      "allowed_semantic_delta": {
+        "path": "cases[sql-parser-shared].bootstrap_commands",
+        "before": [],
+        "after": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ]
+      },
+      "verifier_relaxation": false,
+      "schedule_modified": false,
+      "artifact_oracle_modified": false
+    },
+    "execution_candidate": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/235",
+      "status": "composition_gate_only_not_authorized",
+      "parent": {
+        "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json",
+        "file_sha256": "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133",
+        "canonical_sha256": "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812",
+        "modified": false
+      },
+      "provider": {
+        "status": "selected_not_authorized",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": false
+      },
+      "evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+        "reachability_marker": "markers/reachability.json",
+        "reachability_report": "reports/reachability.json",
+        "batch_marker": "markers/batch.json",
+        "batch_report": "reports/batch.json",
+        "pair_directory_pattern": "pairs/{pair_id}",
+        "create_once": true,
+        "historical_evidence_reused": false
+      },
+      "orchestration": {
+        "lifecycle_adapter": "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+        "cmake_action_policy": "scripts/forge_opaque_provenance_runtime_parity_gate.py",
+        "make_action_policy": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+        "r0_observability_required": true,
+        "full_agent_construction_required": true,
+        "single_asyncio_loop_for_batch": true,
+        "checkpoint_capture_restore_reimplemented": false,
+        "real_pair_runner_implemented": false
+      },
+      "repair_packets": {
+        "pupnp": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "upnp_static",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "ada-url": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "ada",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "args": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "gitlike",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "gpac": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "lib",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "fio": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "fio",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "sql-parser-shared": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "library",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        }
+      },
+      "terminal_taxonomy": {
+        "continue": [
+          "valid",
+          "endpoint_censored",
+          "model_behavior_outcome"
+        ],
+        "stop_batch": [
+          "mechanism_invalid",
+          "identity_invalid",
+          "evidence_invalid",
+          "cleanup_failed",
+          "orphan_detected",
+          "token_ceiling_reached"
+        ],
+        "replacement_forbidden": true,
+        "backfill_forbidden": true
+      },
+      "planned_authorized_amendment": {
+        "reachability_requests": 1,
+        "scheduled_pairs": 12,
+        "scheduled_arms": 24,
+        "batch_recorded_token_ceiling": 2940000,
+        "release_commit_required": true,
+        "separate_authorization_required": true
+      },
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+        "scripts/forge_opaque_provenance_runtime_parity_gate.py": "251cc446cc508552d85cdf82238192b702bbb2e51ee428c42d47188d0f12b40b",
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+        "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+        "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+        "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+      }
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py
+++ b/scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Issue #235 六 case confirmatory execution 的未授权候选协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/235"
+SCHEMA_VERSION = "forge-opaque-provenance-confirmatory-execution-candidate-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_confirmatory_execution_candidate"
+
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json"
+PARENT_MANIFEST_FILE_SHA256 = "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133"
+PARENT_MANIFEST_SHA256 = "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md"
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json"
+
+FROZEN_COMPONENTS = {
+    "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+    "scripts/forge_opaque_provenance_runtime_parity_gate.py": "251cc446cc508552d85cdf82238192b702bbb2e51ee428c42d47188d0f12b40b",
+    "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+    "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+    "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+    "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+    "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95",
+}
+
+
+class ConfirmatoryExecutionCandidateError(RuntimeError):
+    """确认性 execution candidate 身份、授权或停止规则发生漂移。"""
+
+
+def _load_parent_module():
+    path = SCRIPT_ROOT / "forge_opaque_provenance_confirmatory_candidate_v2_protocol.py"
+    spec = importlib.util.spec_from_file_location("forge_confirmatory_execution_parent", path)
+    if spec is None or spec.loader is None:
+        raise ConfirmatoryExecutionCandidateError("无法加载 Issue #233 parent protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+parent = _load_parent_module()
+CASE_ORDER = parent.CASE_ORDER
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_frozen_components(repo_root: Path = REPO_ROOT) -> None:
+    for relative_path, expected in FROZEN_COMPONENTS.items():
+        if file_sha256(repo_root / relative_path) != expected:
+            raise ConfirmatoryExecutionCandidateError(f"冻结组件发生漂移: {relative_path}")
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    path = repo_root / PARENT_MANIFEST_PATH
+    if file_sha256(path) != PARENT_MANIFEST_FILE_SHA256:
+        raise ConfirmatoryExecutionCandidateError("Issue #233 parent manifest 文件发生漂移")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if canonical_sha256(value) != PARENT_MANIFEST_SHA256:
+        raise ConfirmatoryExecutionCandidateError("Issue #233 parent manifest identity 发生漂移")
+    return parent.validate_manifest(value, repo_root)
+
+
+def build_repair_packet(case: dict[str, Any]) -> dict[str, str]:
+    build_directory = "/workspace/repo/build" if case["build_system"] == "cmake" else "/workspace/repo"
+    return {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": case["build_system"],
+        "selected_build_system": case["build_system"],
+        "build_directory": build_directory,
+        "target": case["direct_target"],
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact",
+    }
+
+
+def _execution_candidate(parent_manifest: dict[str, Any]) -> dict[str, Any]:
+    packets = {case["case_id"]: build_repair_packet(case) for case in parent_manifest["cases"]}
+    return {
+        "issue_url": ISSUE_URL,
+        "status": "composition_gate_only_not_authorized",
+        "parent": {"path": PARENT_MANIFEST_PATH, "file_sha256": PARENT_MANIFEST_FILE_SHA256, "canonical_sha256": PARENT_MANIFEST_SHA256, "modified": False},
+        "provider": {
+            "status": "selected_not_authorized",
+            "id": "deepseek-v4-flash",
+            "endpoint": "https://api.deepseek.com",
+            "credential_env": "DEEPSEEK_API_KEY",
+            "model": "deepseek-v4-flash",
+            "request_timeout_seconds": 300,
+            "max_retries": 0,
+            "fallback": "forbidden",
+            "streaming": False,
+        },
+        "evidence": {
+            "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+            "reachability_marker": "markers/reachability.json",
+            "reachability_report": "reports/reachability.json",
+            "batch_marker": "markers/batch.json",
+            "batch_report": "reports/batch.json",
+            "pair_directory_pattern": "pairs/{pair_id}",
+            "create_once": True,
+            "historical_evidence_reused": False,
+        },
+        "orchestration": {
+            "lifecycle_adapter": "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+            "cmake_action_policy": "scripts/forge_opaque_provenance_runtime_parity_gate.py",
+            "make_action_policy": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+            "r0_observability_required": True,
+            "full_agent_construction_required": True,
+            "single_asyncio_loop_for_batch": True,
+            "checkpoint_capture_restore_reimplemented": False,
+            "real_pair_runner_implemented": False,
+        },
+        "repair_packets": packets,
+        "terminal_taxonomy": {
+            "continue": ["valid", "endpoint_censored", "model_behavior_outcome"],
+            "stop_batch": ["mechanism_invalid", "identity_invalid", "evidence_invalid", "cleanup_failed", "orphan_detected", "token_ceiling_reached"],
+            "replacement_forbidden": True,
+            "backfill_forbidden": True,
+        },
+        "planned_authorized_amendment": {
+            "reachability_requests": 1,
+            "scheduled_pairs": parent_manifest["schedule"]["pair_count"],
+            "scheduled_arms": parent_manifest["schedule"]["arm_count"],
+            "batch_recorded_token_ceiling": parent_manifest["runtime_contract"]["batch_recorded_token_ceiling"],
+            "release_commit_required": True,
+            "separate_authorization_required": True,
+        },
+        "frozen_components": copy.deepcopy(FROZEN_COMPONENTS),
+    }
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    verify_frozen_components(repo_root)
+    preregistration = repo_root / PREREGISTRATION_PATH
+    if not preregistration.is_file():
+        raise ConfirmatoryExecutionCandidateError("execution candidate 预注册不存在")
+    value = copy.deepcopy(_parent_manifest(repo_root))
+    value["$schema"] = "../schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json"
+    value["schema_version"] = SCHEMA_VERSION
+    value["document_type"] = DOCUMENT_TYPE
+    value["runtime_contract"]["provider_identity_status"] = "selected_not_authorized"
+    value["future_state"]["execution_runner_status"] = "composition_gate_only"
+    value["execution_candidate"] = _execution_candidate(value)
+    value["preregistration"] = {"path": PREREGISTRATION_PATH, "file_sha256": file_sha256(preregistration)}
+    return value
+
+
+def validate_allowed_delta(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    normalized = copy.deepcopy(value)
+    candidate = normalized.pop("execution_candidate", None)
+    parent_value = _parent_manifest(repo_root)
+    if candidate != _execution_candidate(parent_value):
+        raise ConfirmatoryExecutionCandidateError("execution candidate metadata 发生漂移")
+    normalized["$schema"] = "../schemas/forge-opaque-provenance-confirmatory-candidate-v2.schema.json"
+    normalized["schema_version"] = parent.SCHEMA_VERSION
+    normalized["document_type"] = parent.DOCUMENT_TYPE
+    normalized["runtime_contract"]["provider_identity_status"] = parent_value["runtime_contract"]["provider_identity_status"]
+    normalized["future_state"]["execution_runner_status"] = parent_value["future_state"]["execution_runner_status"]
+    normalized["preregistration"] = copy.deepcopy(parent_value["preregistration"])
+    if normalized != parent_value:
+        raise ConfirmatoryExecutionCandidateError("execution candidate 包含未授权的父协议差异")
+    return {
+        "status": "passed",
+        "parent_manifest_sha256": PARENT_MANIFEST_SHA256,
+        "schedule_identity_sha256": value["schedule"]["identity_sha256"],
+        "provider_status": candidate["provider"]["status"],
+        "real_pair_runner_implemented": False,
+        "verifier_relaxation": False,
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    expected = generate_manifest(repo_root)
+    if not isinstance(value, dict) or value != expected:
+        raise ConfirmatoryExecutionCandidateError("confirmatory execution candidate manifest 发生漂移")
+    validate_allowed_delta(value, repo_root)
+    if value["authorization"] != _parent_manifest(repo_root)["authorization"]:
+        raise ConfirmatoryExecutionCandidateError("candidate 修改了父授权边界")
+    if any(item for key, item in value["authorization"].items() if key.endswith("_authorized")) or value["authorization"]["model_tokens_authorized"] != 0:
+        raise ConfirmatoryExecutionCandidateError("candidate 意外授权了真实执行")
+    return value
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json",
+        "title": "Forge opaque provenance confirmatory execution candidate",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    args = parser.parse_args(argv)
+    manifest = generate_manifest()
+    if args.command == "generate":
+        _write_json(DEFAULT_MANIFEST, manifest)
+        _write_json(DEFAULT_SCHEMA, schema_document(manifest))
+    else:
+        validate_manifest(json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8")))
+        if json.loads(DEFAULT_SCHEMA.read_text(encoding="utf-8")) != schema_document(manifest):
+            raise ConfirmatoryExecutionCandidateError("execution candidate const schema 发生漂移")
+    print(json.dumps({"manifest_sha256": canonical_sha256(manifest), "allowed_delta": validate_allowed_delta(manifest)}, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py
+++ b/scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Issue #235 确认性 execution candidate 的零 provider 组合门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_confirmatory_execution_candidate_protocol as protocol  # noqa: E402
+import forge_opaque_provenance_confirmatory_lifecycle_gate as lifecycle  # noqa: E402
+import forge_opaque_provenance_r3_make_agent_construction_gate as construction  # noqa: E402
+import forge_opaque_provenance_r3_make_candidate_runner as make_runtime  # noqa: E402
+import forge_opaque_provenance_r3_make_execution_failure_gate as failure_gate  # noqa: E402
+import forge_opaque_provenance_rejection_observability_gate as cmake_observability  # noqa: E402
+import forge_opaque_provenance_runtime_parity_gate as cmake_runtime  # noqa: E402
+
+
+class ConfirmatoryCompositionGateError(RuntimeError):
+    """Case dispatch、agent construction 或批次停止规则不闭合。"""
+
+
+@dataclass(frozen=True)
+class CaseDispatch:
+    case_id: str
+    build_system: str
+    policy_family: str
+    build_action: str
+    stage_action: str
+    action_policy: dict[str, Any]
+    repair_packet: dict[str, str]
+
+
+def _action_policy(adapter: Any) -> tuple[Any, Any, Any, str]:
+    if adapter.build_system == "cmake":
+        policy = cmake_runtime.FrozenActionPolicy(
+            workdir=lifecycle.WORKDIR,
+            build_directory=lifecycle.BUILD_DIRECTORY,
+            target=adapter.target,
+            build_output=adapter.stage_source,
+            staged_artifact=adapter.stage_destination,
+        )
+        return cmake_runtime, cmake_observability, policy, "cmake_runtime_parity_v1"
+    if adapter.build_system == "make":
+        policy = make_runtime.R3ActionPolicy(
+            workdir=lifecycle.WORKDIR,
+            build_directory=lifecycle.WORKDIR,
+            target=adapter.target,
+            build_output=adapter.stage_source,
+            staged_artifact=adapter.stage_destination,
+            maximum_jobs=2,
+        )
+        parity, observability = failure_gate.build_runtime_bindings()
+        return parity, observability, policy, "r3_make_runtime_parity_v1"
+    raise ConfirmatoryCompositionGateError(f"未知构建系统: {adapter.build_system}")
+
+
+def build_case_dispatch(case_id: str, repo_root: Path = REPO_ROOT) -> CaseDispatch:
+    manifest = protocol.generate_manifest(repo_root)
+    adapter = lifecycle.build_case_adapter(case_id, repo_root)
+    parity, observability, policy, family = _action_policy(adapter)
+    classifier = cmake_runtime.classify_action if adapter.build_system == "cmake" else make_runtime.classify_action
+    build_action = classifier(adapter.treatment_build_command, workdir=lifecycle.WORKDIR, command_role="build", policy=policy)
+    stage_action = classifier(adapter.treatment_stage_command, workdir=lifecycle.WORKDIR, command_role="artifact_stage", policy=policy)
+    if build_action != "repair_build" or stage_action != "artifact_stage":
+        raise ConfirmatoryCompositionGateError(f"{case_id} action dispatch 未闭合")
+    required = ((parity, "SerialToolCallMiddleware"), (observability, "RejectionObservationRegistry"), (observability, "ObservableRuntimeParityToolAdapter"))
+    if not all(hasattr(namespace, name) for namespace, name in required):
+        raise ConfirmatoryCompositionGateError(f"{case_id} runtime binding 不完整")
+    packet = manifest["execution_candidate"]["repair_packets"][case_id]
+    case = next(item for item in manifest["cases"] if item["case_id"] == case_id)
+    if packet != protocol.build_repair_packet(case):
+        raise ConfirmatoryCompositionGateError(f"{case_id} repair packet 发生漂移")
+    return CaseDispatch(case_id, adapter.build_system, family, build_action, stage_action, asdict(policy), packet)
+
+
+def build_all_dispatches(repo_root: Path = REPO_ROOT) -> tuple[CaseDispatch, ...]:
+    return tuple(build_case_dispatch(case_id, repo_root) for case_id in protocol.CASE_ORDER)
+
+
+@contextmanager
+def _construction_bindings(adapter: Any) -> Iterator[None]:
+    original = construction.failure_gate.build_runtime_bindings
+    parity, observability, policy, _family = _action_policy(adapter)
+
+    def bindings() -> tuple[SimpleNamespace, SimpleNamespace]:
+        return (
+            SimpleNamespace(FrozenActionPolicy=lambda: policy, SerialToolCallMiddleware=parity.SerialToolCallMiddleware),
+            SimpleNamespace(OBSERVATION_EVENT=observability.OBSERVATION_EVENT, RejectionObservationRegistry=observability.RejectionObservationRegistry, ObservableRuntimeParityToolAdapter=observability.ObservableRuntimeParityToolAdapter),
+        )
+
+    construction.failure_gate.build_runtime_bindings = bindings
+    try:
+        yield
+    finally:
+        construction.failure_gate.build_runtime_bindings = original
+
+
+async def validate_agent_construction_dispatch(repo_root: Path = REPO_ROOT) -> list[dict[str, Any]]:
+    reports: list[dict[str, Any]] = []
+    parent_manifest = construction.protocol.load_manifest()
+    for adapter in lifecycle.build_case_adapters(repo_root):
+        with _construction_bindings(adapter):
+            result = await construction.validate_gate(parent_manifest)
+        success = result["success_probe"]
+        if success["model_calls"] != 1 or success["bound_tool_count"] != 2 or success["parallel_tool_calls"] is not False:
+            raise ConfirmatoryCompositionGateError(f"{adapter.case_id} agent construction 未闭合")
+        reports.append(
+            {
+                "case_id": adapter.case_id,
+                "build_system": adapter.build_system,
+                "model_calls": 1,
+                "bound_tool_count": 2,
+                "parallel_tool_calls": False,
+                "provider_calls": 0,
+                "model_tokens": 0,
+                "active_experiment_released": success["active_experiment_released"],
+            }
+        )
+    return reports
+
+
+def next_batch_state(manifest: dict[str, Any], outcomes: list[dict[str, Any]]) -> dict[str, Any]:
+    schedule = manifest["schedule"]["pairs"]
+    if len(outcomes) > len(schedule):
+        raise ConfirmatoryCompositionGateError("outcome 数量超过冻结 schedule")
+    expected_ids = [pair["pair_id"] for pair in schedule[: len(outcomes)]]
+    if [outcome.get("pair_id") for outcome in outcomes] != expected_ids:
+        raise ConfirmatoryCompositionGateError("outcome 顺序偏离冻结 schedule")
+    ceiling = manifest["runtime_contract"]["batch_recorded_token_ceiling"]
+    recorded_tokens = 0
+    for outcome in outcomes:
+        tokens = outcome.get("recorded_tokens")
+        terminal = outcome.get("terminal")
+        if not isinstance(tokens, int) or tokens < 0:
+            raise ConfirmatoryCompositionGateError("pair token evidence 无效")
+        recorded_tokens += tokens
+        if recorded_tokens > ceiling:
+            raise ConfirmatoryCompositionGateError("batch recorded-token ceiling 已越界")
+        if terminal in manifest["execution_candidate"]["terminal_taxonomy"]["stop_batch"]:
+            return {"status": "stopped", "reason": terminal, "recorded_tokens": recorded_tokens, "next_pair_id": None}
+        if terminal not in manifest["execution_candidate"]["terminal_taxonomy"]["continue"]:
+            raise ConfirmatoryCompositionGateError("未知 pair terminal taxonomy")
+    if len(outcomes) == len(schedule):
+        return {"status": "completed", "reason": None, "recorded_tokens": recorded_tokens, "next_pair_id": None}
+    if recorded_tokens >= ceiling:
+        return {"status": "stopped", "reason": "token_ceiling_reached", "recorded_tokens": recorded_tokens, "next_pair_id": None}
+    return {"status": "ready", "reason": None, "recorded_tokens": recorded_tokens, "next_pair_id": schedule[len(outcomes)]["pair_id"]}
+
+
+async def validate_composition_gate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest = protocol.generate_manifest(repo_root)
+    protocol.validate_manifest(manifest, repo_root)
+    dispatches = build_all_dispatches(repo_root)
+    construction_reports = await validate_agent_construction_dispatch(repo_root)
+    pairs = manifest["schedule"]["pairs"]
+    endpoint_probe = next_batch_state(manifest, [{"pair_id": pairs[0]["pair_id"], "terminal": "endpoint_censored", "recorded_tokens": 0}])
+    if endpoint_probe["status"] != "ready" or endpoint_probe["next_pair_id"] != pairs[1]["pair_id"]:
+        raise ConfirmatoryCompositionGateError("endpoint censoring 未继续下一 pair")
+    return {
+        "status": "passed",
+        "issue_url": protocol.ISSUE_URL,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "schedule_identity_sha256": manifest["schedule"]["identity_sha256"],
+        "dispatches": [asdict(item) for item in dispatches],
+        "agent_construction": construction_reports,
+        "endpoint_censoring_continues": True,
+        "real_pair_runner_implemented": False,
+        "provider_calls": 0,
+        "credential_read": False,
+        "docker_executed": False,
+        "checkpoint_created": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "formal_evidence_writes": 0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    print(json.dumps(asyncio.run(validate_composition_gate()), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 继承 Issue #233 六 case / 12-pair identity，冻结 DeepSeek `deepseek-v4-flash` 的未授权 execution candidate
- 冻结独立 evidence、300 秒/0 retry、禁止 fallback/replacement/backfill、2,940,000 recorded-token ceiling
- 为三个 CMake 与三个 Make case 组合既有 runtime-parity、R0 和完整 fake-agent construction
- 增加纯批次状态合同：endpoint censoring/模型行为继续，mechanism/identity/evidence/cleanup/orphan 失败停止

## 验证

- 聚焦测试：`13 passed`
- 父协议与 CMake/Make/R0/agent-construction 相邻回归：`59 passed, 6 skipped`
- Ruff check/format、pycompile、确定性再生成、protocol/composition CLI 全部通过
- Manifest canonical SHA-256：`0c0a9aeba1f25365ca26e4dfc83d987819e562c3f3fb68d3bfc1ec9f31f0eaf9`

## 边界

- `real_pair_runner_implemented=false`
- 0 provider、0 credential read、0 Docker、0 checkpoint、0 formal attempt、0 model token、0 正式 evidence write
- 不修改生产 Compiler、Oracle、clean replay 或历史 evidence
- 未来真实采集必须新增 authorized amendment 并绑定 release commit

Closes #235
