### PR TITLE
研究：实现六 case 确认性采集入口

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 实现 Issue #237 六 case confirmatory authorized runner 并通过真实 fake-model 门禁
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_authorized_protocol.py`, `scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized_docker.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md`
+  - 实现: 复用现有 lifecycle checkpoint、CMake/Make pair runner、R1 continuation、R0 observability 和 behavioral v2 batch marker；修复组合层重复传入 runtime manifest 导致双臂在首个模型请求前 `TypeError` 的问题，不修改生产 Compiler 或历史 runner。
+  - 协议: 冻结 DeepSeek `deepseek-v4-flash`、300 秒/0 retry、12 pairs/24 arms、2,940,000 recorded-token ceiling，以及禁止 fallback/replacement/backfill；canonical manifest SHA-256 为 `5354c419317418a2df8af43ebbeedae1e9ebb6d77e0f09bfee1f047ce148f01a`。
+  - 验证: 聚焦非 Docker `8 passed, 2 skipped`，相邻复用链 `118 passed`，真实 `args` fake-model Docker 门禁 `1 passed in 103.16s`；Ruff check/format、确定性再生成、Schema、diff、敏感信息和后置 0 compile/replay orphan 均通过。
+  - 边界: 门禁为 0 provider、0 credential read、0 正式 evidence、0 model token；旧 minimal-canary 的一个空 evidence 假设测试因本机已存在 append-only 历史证据而失败，未删除或改写历史 evidence。
+
 - 2026-08-31 — 冻结 Issue #235 六 case confirmatory execution 未授权候选
   - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py`, `scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md`
   - 设计: 继承 Issue #233 六 case/12-pair identity，选择但不授权 DeepSeek `deepseek-v4-flash`；冻结独立 evidence、三层 terminal taxonomy、endpoint censoring 继续、mechanism/identity/cleanup 失败停止和 2,940,000-token 批次门禁。
@@ -655,6 +662,9 @@
 
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
+
+- PowerShell → WSL 命令不得嵌入 Bash `$变量`、`$()`、正则括号或多层引号；即使目的是只读 Docker 审计，也必须拆成 `wsl.exe -d Ubuntu -- docker ...` 固定参数命令。零 orphan 查询使用独立的 `docker ps -aq --filter=name=deerflow-compile-` 和 `--filter=name=deerflow-replay-`，不要再写包装 shell。
+- `test_forge_opaque_provenance_minimal_canary_authorized.py::test_collector_uses_read_only_git_docker_and_evidence_checks` 直接绑定冻结 evidence 目录并断言为空；该 append-only 目录在真实 canary 后合法非空，因此相邻回归会产生环境性失败。不得为测试全绿删除、移动或改写历史 evidence，应单独报告并依赖其余合同测试验证回归。
 
 - 上游仓库已跟踪 parser generator 产物时，空 bootstrap 不保证重放确定性：Git checkout 的 mtime 可能让 Make 在“复用生成文件”和“重新运行 Bison/Flex”之间切换，最终 artifact 路径、类型、大小相同但 build-id/SHA-256 不同。冻结协议应显式运行已审计的 generator 命令，并在 parent wrapper 中用 subshell 隔离 `cd`；不得通过放宽 clean replay SHA-256 verifier 掩盖非确定性。
 - 一次性诊断容器若在容器内执行 GitHub fetch，当前网络可能长期阻塞；诊断必须有独立短时限和精确 container ID，超时后按 ID 终止并删除，再核对 compile/replay orphan 为 0。不能把 fetch 阻塞记为 case lifecycle 失败，也不能因此启动 Docker Desktop。

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -67,7 +67,7 @@
 - 2026-08-31 — 实现 Issue #237 六 case confirmatory authorized runner 并通过真实 fake-model 门禁
   - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_authorized_protocol.py`, `scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized_docker.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md`
   - 实现: 复用现有 lifecycle checkpoint、CMake/Make pair runner、R1 continuation、R0 observability 和 behavioral v2 batch marker；修复组合层重复传入 runtime manifest 导致双臂在首个模型请求前 `TypeError` 的问题，不修改生产 Compiler 或历史 runner。
-  - 协议: 冻结 DeepSeek `deepseek-v4-flash`、300 秒/0 retry、12 pairs/24 arms、2,940,000 recorded-token ceiling，以及禁止 fallback/replacement/backfill；canonical manifest SHA-256 为 `5354c419317418a2df8af43ebbeedae1e9ebb6d77e0f09bfee1f047ce148f01a`。
+  - 协议: 冻结 DeepSeek `deepseek-v4-flash`、300 秒/0 retry、12 pairs/24 arms、2,940,000 recorded-token ceiling，以及禁止 fallback/replacement/backfill；canonical manifest SHA-256 为 `68349316cfdbe8411c49c7ffc9491760bf19fb10e0583f40a47dd0c91ea31e78`。
   - 验证: 聚焦非 Docker `8 passed, 2 skipped`，相邻复用链 `118 passed`，真实 `args` fake-model Docker 门禁 `1 passed in 103.16s`；Ruff check/format、确定性再生成、Schema、diff、敏感信息和后置 0 compile/replay orphan 均通过。
   - 边界: 门禁为 0 provider、0 credential read、0 正式 evidence、0 model token；旧 minimal-canary 的一个空 evidence 假设测试因本机已存在 append-only 历史证据而失败，未删除或改写历史 evidence。
 
@@ -665,6 +665,7 @@
 
 - PowerShell → WSL 命令不得嵌入 Bash `$变量`、`$()`、正则括号或多层引号；即使目的是只读 Docker 审计，也必须拆成 `wsl.exe -d Ubuntu -- docker ...` 固定参数命令。零 orphan 查询使用独立的 `docker ps -aq --filter=name=deerflow-compile-` 和 `--filter=name=deerflow-replay-`，不要再写包装 shell。
 - `test_forge_opaque_provenance_minimal_canary_authorized.py::test_collector_uses_read_only_git_docker_and_evidence_checks` 直接绑定冻结 evidence 目录并断言为空；该 append-only 目录在真实 canary 后合法非空，因此相邻回归会产生环境性失败。不得为测试全绿删除、移动或改写历史 evidence，应单独报告并依赖其余合同测试验证回归。
+- Authorized manifest 若冻结预注册文档或 runtime 的文件 SHA-256，任何末尾空行、格式或注释变更后都必须重新生成 manifest/schema，并在最终字节上再次执行确定性生成和聚焦测试；不能把文档清理视为不影响协议 identity 的提交前操作。
 
 - 上游仓库已跟踪 parser generator 产物时，空 bootstrap 不保证重放确定性：Git checkout 的 mtime 可能让 Make 在“复用生成文件”和“重新运行 Bison/Flex”之间切换，最终 artifact 路径、类型、大小相同但 build-id/SHA-256 不同。冻结协议应显式运行已审计的 generator 命令，并在 parent wrapper 中用 subshell 隔离 `cd`；不得通过放宽 clean replay SHA-256 verifier 掩盖非确定性。
 - 一次性诊断容器若在容器内执行 GitHub fetch，当前网络可能长期阻塞；诊断必须有独立短时限和精确 container ID，超时后按 ID 终止并删除，再核对 compile/replay orphan 为 0。不能把 fetch 阻塞记为 case lifecycle 失败，也不能因此启动 Docker Desktop。

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py
@@ -1,0 +1,283 @@
+"""Issue #237 确认性 execution authorized amendment 的零 provider 测试。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+PROTOCOL_PATH = SCRIPTS / "forge_opaque_provenance_confirmatory_execution_authorized_protocol.py"
+RUNNER_PATH = SCRIPTS / "forge_opaque_provenance_confirmatory_execution_authorized_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json"
+SCHEMA_PATH = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json"
+
+
+def _load_module(name: str, path: Path):
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+protocol = _load_module(
+    "forge_confirmatory_execution_authorized_protocol_test",
+    PROTOCOL_PATH,
+)
+runner = _load_module(
+    "forge_confirmatory_execution_authorized_runner_test",
+    RUNNER_PATH,
+)
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_manifest_schema_and_runtime_identity_are_frozen() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    assert manifest == protocol.generate_manifest(REPO_ROOT)
+    assert schema == protocol.schema_document(manifest)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(manifest)
+    protocol.verify_frozen_components(manifest, REPO_ROOT)
+    assert protocol.canonical_sha256(manifest) == "5354c419317418a2df8af43ebbeedae1e9ebb6d77e0f09bfee1f047ce148f01a"
+
+
+def test_authorized_delta_preserves_candidate_and_closes_budget() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    delta = protocol.validate_allowed_delta(manifest, REPO_ROOT)
+    assert delta["parent_manifest_sha256"] == protocol.PARENT_MANIFEST_CANONICAL_SHA256
+    assert delta["schedule_identity_sha256"] == "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    assert delta["historical_evidence_reused"] is False
+    assert delta["verifier_relaxation"] is False
+    assert manifest["authorization"]["model_tokens_authorized"] == 2_940_000
+    assert all(value is True for key, value in manifest["authorization"].items() if key.endswith("_authorized") and key != "model_tokens_authorized")
+    execution = manifest["authorized_execution"]
+    assert execution["provider"] == {
+        "status": "active_authorized",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": False,
+    }
+    assert execution["execution"]["checkpoint_capture_restore_reimplemented"] is False
+
+
+def test_six_pair_runtime_adapters_preserve_case_and_order() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    pairs = manifest["schedule"]["pairs"]
+    pair_manifests = [runner._pair_manifest(manifest, pair, Path("/tmp") / pair["pair_id"]) for pair in pairs]
+    assert [item["case"]["case_id"] for item in pair_manifests] == [pair["case_id"] for pair in pairs]
+    assert [item["continuation"]["arm_order"] for item in pair_manifests] == [pair["arm_order"] for pair in pairs]
+    assert {item["runtime_parity"]["policy_family"] for item in pair_manifests} == {
+        "cmake_runtime_parity_v1",
+        "r3_make_runtime_parity_v1",
+    }
+    assert all(item["budget"]["stage_maximum_recorded_tokens"] == 245_000 for item in pair_manifests)
+
+
+def test_preflight_is_zero_provider_and_does_not_create_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    output_dir = tmp_path / "absent-evidence"
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_: None)
+    monkeypatch.setattr(runner, "_output_dir", lambda _manifest, value: value)
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {
+            "branch": "main",
+            "revision": "a" * 40,
+            "origin_main": "a" * 40,
+        },
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+    monkeypatch.setattr(
+        runner.evidence_runtime,
+        "_provider_config_preflight",
+        lambda _manifest: None,
+    )
+    result = runner.collect_preflight(
+        manifest,
+        output_dir=output_dir,
+        repo_root=tmp_path,
+        require_empty=True,
+    )
+    assert result["ready"] is True
+    assert result["credential_check"] == "environment_variable_presence_only"
+    assert result["credential_env"] == "DEEPSEEK_API_KEY"
+    assert (result["provider_calls"], result["formal_attempts"], result["model_tokens"]) == (
+        0,
+        0,
+        0,
+    )
+    assert not output_dir.exists()
+
+
+def _outcome(pair: dict, *, delta: int = 1, terminal: str = "valid") -> dict:
+    return {
+        "schema_version": "test",
+        "document_type": "test",
+        "manifest_sha256": "ignored",
+        "pair_id": pair["pair_id"],
+        "case_id": pair["case_id"],
+        "replicate": pair["replicate"],
+        "arm_order": pair["arm_order"],
+        "terminal": terminal,
+        "arms": {},
+        "recorded_tokens": 100,
+        "primary_mechanism_eligible": terminal != "endpoint_censored",
+        "provenance_conversion": {
+            "baseline": delta < 0,
+            "treatment": delta > 0,
+        },
+        "paired_conversion_delta": (delta if terminal != "endpoint_censored" else None),
+        "cleanup_succeeded": True,
+    }
+
+
+def test_batch_state_checks_schedule_taxonomy_and_prelaunch_ceiling() -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    first, second = manifest["schedule"]["pairs"][:2]
+    state = runner.next_batch_state(
+        manifest,
+        [_outcome(first, terminal="endpoint_censored")],
+        reachability_tokens=17,
+    )
+    assert state["status"] == "ready"
+    assert state["next_pair_id"] == second["pair_id"]
+
+    ceiling_manifest = copy.deepcopy(manifest)
+    ceiling_manifest["authorized_execution"]["budget"]["batch_maximum_recorded_tokens"] = 200
+    state = runner.next_batch_state(
+        ceiling_manifest,
+        [],
+        reachability_tokens=1,
+    )
+    assert state["status"] == "stopped"
+    assert state["reason"] == "token_ceiling_reached"
+
+
+def test_batch_reuses_one_event_loop_and_computes_project_level_test(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    digest = protocol.canonical_sha256(manifest)
+    output_dir = tmp_path / "evidence"
+    output_dir.mkdir()
+    execution = manifest["authorized_execution"]
+    _write_json(
+        output_dir / execution["evidence"]["reachability_marker"],
+        {
+            "status": "passed",
+            "manifest_sha256": digest,
+            "release_revision": "b" * 40,
+        },
+    )
+    _write_json(
+        output_dir / execution["evidence"]["reachability_report"],
+        {
+            "passed": True,
+            "manifest_sha256": digest,
+            "release_revision": "b" * 40,
+            "recorded_tokens": 10,
+        },
+    )
+    monkeypatch.setattr(runner.protocol, "verify_frozen_components", lambda *_: None)
+    monkeypatch.setattr(runner, "_output_dir", lambda _manifest, value: value)
+    monkeypatch.setattr(
+        runner,
+        "require_release_identity",
+        lambda *_args: {
+            "branch": "main",
+            "revision": "b" * 40,
+            "origin_main": "b" * 40,
+        },
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    monkeypatch.setattr(runner.primary, "require_compose_dood", lambda: None)
+    monkeypatch.setattr(runner, "require_zero_managed_containers", lambda: None)
+    loop_ids: list[int] = []
+
+    def fake_pair_executor(
+        _manifest,
+        pair,
+        _pair_dir,
+        async_runner,
+        _reachability,
+        _release,
+    ):
+        loop_ids.append(id(async_runner.get_loop()))
+        value = _outcome(pair)
+        value["manifest_sha256"] = digest
+        return value
+
+    report = runner.run_batch(
+        manifest,
+        output_dir=output_dir,
+        repo_root=tmp_path,
+        pair_executor=fake_pair_executor,
+    )
+    assert len(set(loop_ids)) == 1
+    assert len(loop_ids) == 12
+    assert report["status"] == "completed"
+    assert report["all_project_blocks_estimable"] is True
+    assert report["primary_test"] == {
+        "method": "two_sided_exact_sign_flip",
+        "statistic": 6.0,
+        "permutations": 64,
+        "p_value": 0.03125,
+    }
+    assert report["recorded_tokens"] == 1_210
+    assert _load(output_dir / execution["evidence"]["batch_marker"])["status"] == "passed"
+
+
+def test_schema_rejects_identity_or_authorization_drift() -> None:
+    manifest = _load(MANIFEST_PATH)
+    schema = _load(SCHEMA_PATH)
+    drifted = copy.deepcopy(manifest)
+    drifted["authorization"]["pair_collection_authorized"] = False
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(drifted)
+    with pytest.raises(protocol.ProtocolError):
+        protocol.validate_manifest(drifted, REPO_ROOT)
+
+
+def test_runner_reuses_pair_and_checkpoint_cores_without_credentials() -> None:
+    source = RUNNER_PATH.read_text(encoding="utf-8")
+    assert ".RealLifecycleCheckpointGate(" not in source
+    assert ".capture(" not in source
+    assert ".provision_arm(" not in source
+    assert "cmake_pair_runtime" in source
+    assert "make_pair_runtime" in source
+    assert "asyncio.Runner() as async_runner" in source
+    for forbidden in ("sk-", "api_key=", "os.environ[", "OPENAI_AK"):
+        assert forbidden not in source
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py
@@ -54,7 +54,7 @@ def test_manifest_schema_and_runtime_identity_are_frozen() -> None:
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(manifest)
     protocol.verify_frozen_components(manifest, REPO_ROOT)
-    assert protocol.canonical_sha256(manifest) == "5354c419317418a2df8af43ebbeedae1e9ebb6d77e0f09bfee1f047ce148f01a"
+    assert protocol.canonical_sha256(manifest) == "68349316cfdbe8411c49c7ffc9491760bf19fb10e0583f40a47dd0c91ea31e78"
 
 
 def test_authorized_delta_preserves_candidate_and_closes_budget() -> None:

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized_docker.py
@@ -1,0 +1,220 @@
+"""Issue #237 authorized runner 的 opt-in 零 provider Docker 门禁。"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_CONFIRMATORY_AUTHORIZED_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_CONFIRMATORY_AUTHORIZED_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_module():
+    scripts = REPO_ROOT / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    spec = importlib.util.spec_from_file_location(
+        "forge_confirmatory_execution_authorized_docker_test",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_module()
+
+
+class ProvenanceRepairModel(BaseChatModel):
+    model_name: str = "deepseek-v4-flash"
+    base_url: str = "https://api.deepseek.com"
+    arm: str
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "opaque-confirmatory-authorized-docker-fake"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        tool_call: dict[str, Any] | None
+        if self.arm == "baseline":
+            tool_call = (
+                {
+                    "name": "submit_build_result",
+                    "args": {},
+                    "id": "baseline-submit",
+                    "type": "tool_call",
+                }
+                if self.calls == 1
+                else None
+            )
+        else:
+            actions = (
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "cmake --build /workspace/repo/build --target gitlike -j2",
+                        "timeout_seconds": 300,
+                        "workdir": "/workspace/repo",
+                        "command_role": "build",
+                    },
+                    "id": "treatment-build",
+                    "type": "tool_call",
+                },
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "cp /workspace/repo/build/gitlike /artifacts/gitlike",
+                        "timeout_seconds": 60,
+                        "workdir": "/workspace/repo",
+                        "command_role": "artifact_stage",
+                    },
+                    "id": "treatment-stage",
+                    "type": "tool_call",
+                },
+                {
+                    "name": "submit_build_result",
+                    "args": {},
+                    "id": "treatment-submit",
+                    "type": "tool_call",
+                },
+            )
+            tool_call = actions[self.calls - 1] if self.calls <= len(actions) else None
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="" if tool_call else "Done.",
+                        tool_calls=[] if tool_call is None else [tool_call],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={
+                            "input_tokens": 100,
+                            "output_tokens": 20,
+                            "total_tokens": 120,
+                        },
+                    )
+                )
+            ]
+        )
+
+
+def test_authorized_runner_reuses_real_checkpoint_p2_replay_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner.primary.require_compose_dood()
+    runner.require_zero_managed_containers()
+    paths = Paths()
+    output_dir = paths.compile_sessions_dir / f"issue-237-confirmatory-docker-{uuid.uuid4().hex[:12]}"
+    created_session_dirs: list[Path] = []
+    manager = CompileSessionManager(paths=paths, default_image=runner.COMPILE_IMAGE)
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_session_dirs.append(Path(session.metadata_path).parent)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    manifest = runner.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    pair = next(item for item in manifest["schedule"]["pairs"] if item["case_id"] == "args" and item["replicate"] == 1)
+    release = {
+        "branch": "main",
+        "revision": "e" * 40,
+        "origin_main": "e" * 40,
+    }
+    reachability = {"recorded_tokens": 17}
+
+    def model_factory(_provider: dict[str, Any], thread_id: str) -> Any:
+        arm = "treatment" if thread_id.startswith("treatment-") else "baseline"
+        return ProvenanceRepairModel(arm=arm)
+
+    try:
+        with asyncio.Runner() as async_runner:
+            result = runner.execute_real_pair(
+                manifest,
+                pair,
+                output_dir,
+                async_runner,
+                reachability,
+                release,
+                model_factory=model_factory,
+            )
+        assert result["terminal"] == "model_behavior_outcome"
+        assert result["primary_mechanism_eligible"] is True
+        assert result["provenance_conversion"] == {
+            "baseline": False,
+            "treatment": True,
+        }, json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True)
+        assert result["paired_conversion_delta"] == 1
+        assert result["arms"]["treatment"]["verification_outcome"]["status"] == "passed"
+        assert result["arms"]["treatment"]["p2"]["status"] == "proven"
+        assert result["arms"]["baseline"]["p2"]["status"] == "unproven"
+        runner.require_zero_managed_containers()
+    finally:
+        for session_dir in reversed(created_session_dirs):
+            shutil.rmtree(session_dir, ignore_errors=True)
+            try:
+                session_dir.parent.rmdir()
+            except OSError:
+                pass
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_manifest_file_is_json() -> None:
+    assert isinstance(json.loads(MANIFEST_PATH.read_text(encoding="utf-8")), dict)

--- a/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json
@@ -452,7 +452,7 @@
   },
   "preregistration": {
     "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
-    "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+    "file_sha256": "d54926ddbf66c4f6c3b7f094a3dbd21851b005710d41d453539e65e1a9052e8f"
   },
   "amendment": {
     "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
@@ -728,7 +728,7 @@
     },
     "preregistration": {
       "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
-      "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+      "file_sha256": "d54926ddbf66c4f6c3b7f094a3dbd21851b005710d41d453539e65e1a9052e8f"
     }
   },
   "frozen_parent_components": {

--- a/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json
+++ b/benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json
@@ -1,0 +1,743 @@
+{
+  "$schema": "../schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json",
+  "schema_version": "forge-opaque-provenance-confirmatory-execution-authorized-1.0.0",
+  "document_type": "forge_opaque_provenance_confirmatory_execution_authorized",
+  "authorization": {
+    "provider_calls_authorized": true,
+    "credential_read_authorized": true,
+    "model_creation_authorized": true,
+    "reachability_request_authorized": true,
+    "checkpoint_creation_authorized": true,
+    "pair_collection_authorized": true,
+    "formal_attempts_authorized": true,
+    "docker_execution_authorized": true,
+    "evidence_write_authorized": true,
+    "model_tokens_authorized": 2940000
+  },
+  "selection": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+    "mode": "result_blind_exact_commit_source_audit",
+    "frozen_sources": {
+      "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+      "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+      "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+    },
+    "case_count": 6,
+    "build_system_counts": {
+      "cmake": 3,
+      "make": 3
+    },
+    "artifact_type_counts": {
+      "executable": 2,
+      "static_library": 3,
+      "shared_library": 1
+    },
+    "exclusions": {
+      "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+      "janet": "local model-result evidence already exists, so the case is not result-blind",
+      "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+      "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+    }
+  },
+  "cases": [
+    {
+      "case_id": "pupnp",
+      "source_case_id": "pupnp",
+      "repository_url": "https://github.com/pupnp/pupnp",
+      "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+      "language": "C",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DUPNP_ENABLE_TESTING=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "upnp_static",
+      "artifact": {
+        "build_output_path": "build/upnp/libupnp.a",
+        "staged_relative_path": "libupnp.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+        "stage_destination": "/artifacts/libupnp.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "ada-url",
+      "source_case_id": "ada-url",
+      "repository_url": "https://github.com/ada-url/ada",
+      "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DADA_TESTING=OFF",
+        "-DADA_BENCHMARKS=OFF",
+        "-DADA_TOOLS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "ada",
+      "artifact": {
+        "build_output_path": "build/src/libada.a",
+        "staged_relative_path": "libada.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/build/src/libada.a",
+        "stage_destination": "/artifacts/libada.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "args",
+      "source_case_id": "args",
+      "repository_url": "https://github.com/Taywee/args",
+      "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+      "language": "C++",
+      "build_system": "cmake",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [],
+      "configure_arguments": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DARGS_BUILD_EXAMPLE=ON",
+        "-DARGS_BUILD_UNITTESTS=OFF",
+        "-DBUILD_FUZZERS=OFF"
+      ],
+      "required_system_packages": [
+        "build-essential",
+        "cmake"
+      ],
+      "direct_target": "gitlike",
+      "artifact": {
+        "build_output_path": "build/gitlike",
+        "staged_relative_path": "gitlike",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/build/gitlike",
+        "stage_destination": "/artifacts/gitlike"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "gpac",
+      "source_case_id": "gpac",
+      "repository_url": "https://github.com/gpac/gpac",
+      "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+      "language": "C",
+      "build_system": "make",
+      "size_stratum": "large",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --static-bin"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "pkg-config",
+        "zlib1g-dev"
+      ],
+      "direct_target": "lib",
+      "artifact": {
+        "build_output_path": "bin/gcc/libgpac_static.a",
+        "staged_relative_path": "libgpac_static.a",
+        "artifact_type": "static_library",
+        "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+        "stage_destination": "/artifacts/libgpac_static.a"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [
+          "testsuite"
+        ],
+        "submodules_on_target_dependency_path": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "fio",
+      "source_case_id": "fio",
+      "repository_url": "https://github.com/axboe/fio",
+      "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "medium",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "./configure --disable-native"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "build-essential",
+        "zlib1g-dev"
+      ],
+      "direct_target": "fio",
+      "artifact": {
+        "build_output_path": "fio",
+        "staged_relative_path": "fio",
+        "artifact_type": "executable",
+        "stage_source": "/workspace/repo/fio",
+        "stage_destination": "/artifacts/fio"
+      },
+      "oracle_correction": null,
+      "source_audit": {
+        "submodules": [],
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": {
+          "flag": "--help",
+          "expected_exit_code": 0
+        }
+      },
+      "historical_result_evidence_case_id_matches": 0
+    },
+    {
+      "case_id": "sql-parser-shared",
+      "source_case_id": "sql-parser",
+      "repository_url": "https://github.com/hyrise/sql-parser",
+      "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+      "language": "C++",
+      "build_system": "make",
+      "size_stratum": "small",
+      "build_directory": "/workspace/repo",
+      "bootstrap_commands": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ],
+      "configure_arguments": [],
+      "required_system_packages": [
+        "bison",
+        "build-essential",
+        "flex"
+      ],
+      "direct_target": "library",
+      "artifact": {
+        "build_output_path": "libsqlparser.so",
+        "staged_relative_path": "libsqlparser.so",
+        "artifact_type": "shared_library",
+        "stage_source": "/workspace/repo/libsqlparser.so",
+        "stage_destination": "/artifacts/libsqlparser.so"
+      },
+      "oracle_correction": {
+        "mode": "pre_result_exact_commit_source_correction",
+        "old_artifact": {
+          "staged_relative_path": "libsqlparser.a",
+          "build_output_path": "libsqlparser.a",
+          "artifact_type": "static_library",
+          "producing_target": "library"
+        },
+        "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+        "source_protocol_modified": false
+      },
+      "source_audit": {
+        "submodules": [],
+        "generated_parser_sources_tracked": true,
+        "direct_target_verified": true,
+        "external_fetch_on_frozen_path": false,
+        "smoke": null
+      },
+      "historical_result_evidence_case_id_matches": 0
+    }
+  ],
+  "schedule": {
+    "pair_count": 12,
+    "arm_count": 24,
+    "replicates_per_case": 2,
+    "project_internal_order_reversal_required": true,
+    "baseline_first_pairs": 6,
+    "treatment_first_pairs": 6,
+    "pairs": [
+      {
+        "pair_id": "pupnp-rep-01",
+        "case_id": "pupnp",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-01",
+        "case_id": "ada-url",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "args-rep-01",
+        "case_id": "args",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-01",
+        "case_id": "gpac",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-01",
+        "case_id": "fio",
+        "replicate": 1,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-01",
+        "case_id": "sql-parser-shared",
+        "replicate": 1,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "sql-parser-shared-rep-02",
+        "case_id": "sql-parser-shared",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "fio-rep-02",
+        "case_id": "fio",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "gpac-rep-02",
+        "case_id": "gpac",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "args-rep-02",
+        "case_id": "args",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      },
+      {
+        "pair_id": "ada-url-rep-02",
+        "case_id": "ada-url",
+        "replicate": 2,
+        "arm_order": [
+          "baseline",
+          "treatment"
+        ]
+      },
+      {
+        "pair_id": "pupnp-rep-02",
+        "case_id": "pupnp",
+        "replicate": 2,
+        "arm_order": [
+          "treatment",
+          "baseline"
+        ]
+      }
+    ],
+    "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+  },
+  "runtime_contract": {
+    "provider_and_model_single_for_batch": true,
+    "provider_identity_status": "active_authorized",
+    "request_timeout_seconds": 300,
+    "request_retries": 0,
+    "fallback_forbidden": true,
+    "parallel_tool_calls": false,
+    "action_limits": {
+      "inspection": 4,
+      "repair_build": 2,
+      "artifact_stage": 2,
+      "submit": 2
+    },
+    "request_limit_per_arm": 8,
+    "turn_limit_per_arm": 8,
+    "graph_step_limit_per_arm": 24,
+    "work_timeout_seconds_per_arm": 600,
+    "cleanup_timeout_seconds_per_arm": 120,
+    "per_arm_recorded_token_ceiling": 120000,
+    "batch_recorded_token_ceiling": 2940000,
+    "shared_tool_contract_identical_between_arms": true,
+    "treatment_exposure_only": "repair_packet"
+  },
+  "measurement_contract": {
+    "parent_fault": "opaque_build_provenance",
+    "parent_proof_status": "unproven/opaque_wrapper",
+    "treatment_required_proof_modes": {
+      "cmake": "direct_cmake",
+      "make": "direct_make"
+    },
+    "r0_companion_required": true,
+    "candidate_verification_required": true,
+    "clean_replay_required": true,
+    "cleanup_and_zero_orphan_required": true,
+    "replacement_forbidden": true,
+    "backfill_forbidden": true,
+    "batch_protocol_mutation_after_start_forbidden": true
+  },
+  "analysis": {
+    "independent_unit": "project_block",
+    "project_block_count": 6,
+    "project_score": "mean of two replicate paired conversion differences",
+    "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+    "primary_test_requires_all_project_blocks_estimable": true,
+    "infrastructure_censoring_reported_separately": true,
+    "mechanism_invalid_reported_separately": true,
+    "intervention_delivery_invalid_reported_separately": true,
+    "historical_exploratory_pairs_pooled": false,
+    "model_ranking_performed": false
+  },
+  "future_state": {
+    "checkpoint_status": "authorized_not_created",
+    "evidence_status": "authorized_not_created",
+    "execution_runner_status": "authorized_real_pair_runner",
+    "execution_requires_new_amendment": false
+  },
+  "preregistration": {
+    "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
+    "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+  },
+  "amendment": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+    "mode": "pre_result_lifecycle_reproducibility_amendment",
+    "parent_manifest": {
+      "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+      "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+      "modified": false
+    },
+    "trigger": {
+      "case_id": "sql-parser-shared",
+      "classification": "clean_replay_sha256_mismatch",
+      "provider_results_observed": false,
+      "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+    },
+    "allowed_semantic_delta": {
+      "path": "cases[sql-parser-shared].bootstrap_commands",
+      "before": [],
+      "after": [
+        "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+      ]
+    },
+    "verifier_relaxation": false,
+    "schedule_modified": false,
+    "artifact_oracle_modified": false
+  },
+  "execution_candidate": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/235",
+    "status": "composition_gate_only_not_authorized",
+    "parent": {
+      "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json",
+      "file_sha256": "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133",
+      "canonical_sha256": "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812",
+      "modified": false
+    },
+    "provider": {
+      "status": "selected_not_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "evidence": {
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+      "reachability_marker": "markers/reachability.json",
+      "reachability_report": "reports/reachability.json",
+      "batch_marker": "markers/batch.json",
+      "batch_report": "reports/batch.json",
+      "pair_directory_pattern": "pairs/{pair_id}",
+      "create_once": true,
+      "historical_evidence_reused": false
+    },
+    "orchestration": {
+      "lifecycle_adapter": "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+      "cmake_action_policy": "scripts/forge_opaque_provenance_runtime_parity_gate.py",
+      "make_action_policy": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+      "r0_observability_required": true,
+      "full_agent_construction_required": true,
+      "single_asyncio_loop_for_batch": true,
+      "checkpoint_capture_restore_reimplemented": false,
+      "real_pair_runner_implemented": false
+    },
+    "repair_packets": {
+      "pupnp": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "upnp_static",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "ada-url": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "ada",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "args": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "cmake",
+        "selected_build_system": "cmake",
+        "build_directory": "/workspace/repo/build",
+        "target": "gitlike",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "gpac": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "lib",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "fio": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "fio",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      },
+      "sql-parser-shared": {
+        "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+        "primary_classification": "build_system_unproven",
+        "mechanism_classification": "opaque_build_provenance",
+        "expected_build_system": "make",
+        "selected_build_system": "make",
+        "build_directory": "/workspace/repo",
+        "target": "library",
+        "proof_status": "opaque_wrapper",
+        "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+      }
+    },
+    "terminal_taxonomy": {
+      "continue": [
+        "valid",
+        "endpoint_censored",
+        "model_behavior_outcome"
+      ],
+      "stop_batch": [
+        "mechanism_invalid",
+        "identity_invalid",
+        "evidence_invalid",
+        "cleanup_failed",
+        "orphan_detected",
+        "token_ceiling_reached"
+      ],
+      "replacement_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "planned_authorized_amendment": {
+      "reachability_requests": 1,
+      "scheduled_pairs": 12,
+      "scheduled_arms": 24,
+      "batch_recorded_token_ceiling": 2940000,
+      "release_commit_required": true,
+      "separate_authorization_required": true
+    },
+    "frozen_components": {
+      "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+      "scripts/forge_opaque_provenance_runtime_parity_gate.py": "251cc446cc508552d85cdf82238192b702bbb2e51ee428c42d47188d0f12b40b",
+      "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+      "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+      "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+      "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+      "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+    }
+  },
+  "authorized_execution": {
+    "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/237",
+    "status": "authorized_not_started",
+    "authorization_baseline_commit": "0c5b7b4f4130fb1a2a17611b3f74b8cc90359fd6",
+    "release_revision_policy": "descendant_merged_main_recorded_before_first_request",
+    "provider": {
+      "status": "active_authorized",
+      "id": "deepseek-v4-flash",
+      "endpoint": "https://api.deepseek.com",
+      "credential_env": "DEEPSEEK_API_KEY",
+      "model": "deepseek-v4-flash",
+      "request_timeout_seconds": 300,
+      "max_retries": 0,
+      "fallback": "forbidden",
+      "streaming": false
+    },
+    "evidence": {
+      "schema_version": "forge-opaque-provenance-confirmatory-evidence-1.0.0",
+      "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+      "identity_sha256": "c2c48564a685270369eafcfb9d6c6a1570cc6ecfebcbd390e4e492650db6ddcb",
+      "reachability_marker": "markers/reachability.json",
+      "reachability_report": "reports/reachability.json",
+      "batch_marker": "markers/batch.json",
+      "batch_report": "reports/batch.json",
+      "pair_directory_pattern": "pairs/{pair_id}",
+      "pair_marker": "markers/pair.json",
+      "pair_report": "reports/pair.json",
+      "pair_outcome": "reports/pair-outcome.json",
+      "parent_ledger": "ledgers/parent.jsonl",
+      "arm_ledger_directory": "ledgers/arms",
+      "append_only": true,
+      "create_once": true,
+      "historical_evidence_reused": false,
+      "zero_provider_preflight_writes_evidence": false
+    },
+    "budget": {
+      "maximum_reachability_requests": 1,
+      "reachability_maximum_recorded_tokens": 5000,
+      "recorded_tokens_per_arm": 120000,
+      "recorded_tokens_per_pair": 240000,
+      "batch_maximum_recorded_tokens": 2940000,
+      "enforcement": "before_each_pair_and_after_each_arm"
+    },
+    "preflight": {
+      "release_branch": "main",
+      "require_clean_worktree": true,
+      "require_head_equals_origin_main": true,
+      "require_authorization_baseline_ancestor": true,
+      "docker_provider": "ubuntu-native",
+      "docker_context": "default",
+      "docker_endpoint": "/var/run/docker.sock",
+      "control_plane": "compose-dood-on-ubuntu-native-engine",
+      "allowed_network_media": [
+        "wired",
+        "wifi",
+        "mobile_hotspot"
+      ],
+      "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+      "credential_check": "environment_variable_presence_only",
+      "require_empty_evidence_directory_before_reachability": true,
+      "managed_container_prefixes": [
+        "deerflow-compile-",
+        "deerflow-replay-"
+      ],
+      "require_zero_managed_orphans": true
+    },
+    "execution": {
+      "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+      "reachability_expected_response": "CANARY_OK",
+      "single_asyncio_loop_for_batch": true,
+      "checkpoint_capture_restore_reimplemented": false,
+      "pair_runtime_reuse": {
+        "cmake": "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py",
+        "make": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+        "checkpoint": "scripts/forge_real_lifecycle_checkpoint_gate.py",
+        "batch": "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py"
+      },
+      "runtime_path": "scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py",
+      "runtime_file_sha256": "78e4877294d8501e5bd91948399e612ef2938058bd16a0f982addc3530be9540",
+      "commands": [
+        "validate",
+        "preflight",
+        "reachability",
+        "batch",
+        "report"
+      ]
+    },
+    "terminal_taxonomy": {
+      "continue": [
+        "valid",
+        "endpoint_censored",
+        "model_behavior_outcome"
+      ],
+      "stop_batch": [
+        "mechanism_invalid",
+        "identity_invalid",
+        "evidence_invalid",
+        "cleanup_failed",
+        "orphan_detected",
+        "token_ceiling_reached"
+      ],
+      "replacement_forbidden": true,
+      "backfill_forbidden": true
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
+      "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+    }
+  },
+  "frozen_parent_components": {
+    "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json": "50f35e40e47bb77cc15b134a1cf0db5beac80b73c5c5fac0114fb02082e31cad",
+    "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json": "28cd8827f6e16906a2de0107b76836c0b9051297ca72531bbc8831874b284f60",
+    "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md": "14cbebdbba1fcab7c66902739a4eec9fb81ce8981699e3129123f71fd9e0a8c8",
+    "scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py": "40554bbe55ed20c35304df2ed64034843eba44e75d1bf4b6d1df77eec0a477b7",
+    "scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py": "3c15035c1348a2277903c4cf8047c35fd3bd01632bc545f3ecd5478dd704f067",
+    "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+    "backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py": "1eb176fed28214c68911f6695d123fb91b071a313660a14e3f13d9951bb6357c"
+  }
+}

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md
@@ -1,0 +1,41 @@
+# Forge opaque provenance 六 case confirmatory execution authorized amendment
+
+- GitHub Issue：[Issue #237](https://github.com/WWFXL/Forge-AutoCompiler/issues/237)
+- 父候选：Issue #235 / PR #236
+- 授权基线：`main@0c5b7b4f4130fb1a2a17611b3f74b8cc90359fd6`
+
+## 研究问题
+
+在 state-matched 的 opaque build provenance failure checkpoint 上，仅向 treatment arm 暴露冻结 repair packet，是否提高 production verifier 与 P2 reference criterion 均认可的 provenance conversion？
+
+## 冻结设计
+
+- 六个 project block：`pupnp`、`ada-url`、`args`、`gpac`、`fio`、`sql-parser-shared`。
+- 每个项目两个独立 checkpoint replicate，共 12 pairs / 24 arms。
+- 项目内第二个 replicate 反转 arm order；batch 顺序逐字继承父候选。
+- Provider/model：DeepSeek `deepseek-v4-flash`，endpoint `https://api.deepseek.com`。
+- 每请求 300 秒、0 retry、非 streaming，禁止 fallback、replacement 和 backfill。
+- 每 arm 最多 8 请求、8 model turns、24 graph steps、600 秒工作墙钟、120,000 recorded tokens。
+- reachability 最多 1 次、5,000 recorded tokens；整个 batch 最多 2,940,000 recorded tokens。
+
+## 执行边界
+
+- 首请求前必须通过 release、父候选哈希、独立 evidence、Ubuntu 原生 Docker、0 orphan、网络介质和 credential-name-only preflight。
+- Evidence 使用新的 create-once 目录；任何已开始但没有冻结 pair outcome 的目录都不自动重跑。
+- checkpoint capture/restore 复用既有 `RealLifecycleCheckpointGate`；批次恢复复用 behavioral pilot v2 的单事件循环和 append-only outcome 模式。
+- CMake pair 复用既有 opaque provenance CMake 执行路径；Make pair 复用 R3 Make 执行路径。新增 runner 只注入冻结 case adapter、policy、P2 evaluator 和批次状态。
+- 不修改生产 Compiler、candidate verifier、clean replay、历史 runner 或历史 evidence。
+
+## 终态与停止规则
+
+- endpoint censoring 与模型行为结果保留为 observation，并继续下一预注册 pair。
+- mechanism、identity、evidence、cleanup 或 orphan 无效时立即关闭 batch。
+- 启动新 pair 前按最坏 240,000 tokens 检查剩余预算；不得启动部分 pair。
+- 所有 provider opportunity 一次性消费；禁止 retry、replacement、backfill 或 schedule extension。
+
+## 分析
+
+- 独立分析单位是 project block，不是 arm 或 pair。
+- 每个项目得分为两个 replicate 的 paired conversion difference 均值。
+- 六个 project block 均可估计时，执行双侧 exact sign-flip test；否则只报告 attrition 与描述性结果。
+- 历史 exploratory pair 不池化，不做模型排名。

--- a/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json
@@ -456,7 +456,7 @@
     },
     "preregistration": {
       "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
-      "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+      "file_sha256": "d54926ddbf66c4f6c3b7f094a3dbd21851b005710d41d453539e65e1a9052e8f"
     },
     "amendment": {
       "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
@@ -732,7 +732,7 @@
       },
       "preregistration": {
         "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
-        "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+        "file_sha256": "d54926ddbf66c4f6c3b7f094a3dbd21851b005710d41d453539e65e1a9052e8f"
       }
     },
     "frozen_parent_components": {

--- a/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json
+++ b/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json
@@ -1,0 +1,748 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json",
+  "title": "Forge opaque provenance confirmatory execution authorized amendment",
+  "const": {
+    "$schema": "../schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json",
+    "schema_version": "forge-opaque-provenance-confirmatory-execution-authorized-1.0.0",
+    "document_type": "forge_opaque_provenance_confirmatory_execution_authorized",
+    "authorization": {
+      "provider_calls_authorized": true,
+      "credential_read_authorized": true,
+      "model_creation_authorized": true,
+      "reachability_request_authorized": true,
+      "checkpoint_creation_authorized": true,
+      "pair_collection_authorized": true,
+      "formal_attempts_authorized": true,
+      "docker_execution_authorized": true,
+      "evidence_write_authorized": true,
+      "model_tokens_authorized": 2940000
+    },
+    "selection": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/230",
+      "mode": "result_blind_exact_commit_source_audit",
+      "frozen_sources": {
+        "benchmarks/preregistrations/cpp-formal-v1-cases.json": "55fc4ea1cc634376b5016fa3421736a66c284b293b9b8f10185e837e12db3fee",
+        "benchmarks/preregistrations/cpp-formal-v1.json": "3b7f1134637385f7236ea344c8b9816c04bc837143cb7ac4f8af1e007e7f08dc",
+        "benchmarks/manifests/cpp-formal-v1.json": "cb9ad04c3d5452ab6ae3e12d1ef8658b8cf52876c6aecc3b251b2dd930e6944a"
+      },
+      "case_count": 6,
+      "build_system_counts": {
+        "cmake": 3,
+        "make": 3
+      },
+      "artifact_type_counts": {
+        "executable": 2,
+        "static_library": 3,
+        "shared_library": 1
+      },
+      "exclusions": {
+        "mruby": "make all delegates to Rake and implicitly initializes the Prism submodule",
+        "janet": "local model-result evidence already exists, so the case is not result-blind",
+        "lodepng": "the unittest executable catches test failures and still returns exit code zero",
+        "sql-parser-static": "the frozen static oracle contradicts the default make library output"
+      }
+    },
+    "cases": [
+      {
+        "case_id": "pupnp",
+        "source_case_id": "pupnp",
+        "repository_url": "https://github.com/pupnp/pupnp",
+        "commit_sha": "4c4285d6af69774b7ec6a9a93dc967dc9e9e6d8e",
+        "language": "C",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DUPNP_ENABLE_TESTING=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "upnp_static",
+        "artifact": {
+          "build_output_path": "build/upnp/libupnp.a",
+          "staged_relative_path": "libupnp.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/upnp/libupnp.a",
+          "stage_destination": "/artifacts/libupnp.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "ada-url",
+        "source_case_id": "ada-url",
+        "repository_url": "https://github.com/ada-url/ada",
+        "commit_sha": "30f3f3020c5a979b62f90dc9c37fd45de3cc84d7",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DBUILD_SHARED_LIBS=OFF",
+          "-DADA_TESTING=OFF",
+          "-DADA_BENCHMARKS=OFF",
+          "-DADA_TOOLS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "ada",
+        "artifact": {
+          "build_output_path": "build/src/libada.a",
+          "staged_relative_path": "libada.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/build/src/libada.a",
+          "stage_destination": "/artifacts/libada.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "args",
+        "source_case_id": "args",
+        "repository_url": "https://github.com/Taywee/args",
+        "commit_sha": "fe4450bd9549e4e02bc2047b2a2800b09f1bb878",
+        "language": "C++",
+        "build_system": "cmake",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [],
+        "configure_arguments": [
+          "-DCMAKE_BUILD_TYPE=Release",
+          "-DARGS_BUILD_EXAMPLE=ON",
+          "-DARGS_BUILD_UNITTESTS=OFF",
+          "-DBUILD_FUZZERS=OFF"
+        ],
+        "required_system_packages": [
+          "build-essential",
+          "cmake"
+        ],
+        "direct_target": "gitlike",
+        "artifact": {
+          "build_output_path": "build/gitlike",
+          "staged_relative_path": "gitlike",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/build/gitlike",
+          "stage_destination": "/artifacts/gitlike"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "gpac",
+        "source_case_id": "gpac",
+        "repository_url": "https://github.com/gpac/gpac",
+        "commit_sha": "2aa431eaf732c1a7e9a966ea12049fc001d91e04",
+        "language": "C",
+        "build_system": "make",
+        "size_stratum": "large",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --static-bin"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "pkg-config",
+          "zlib1g-dev"
+        ],
+        "direct_target": "lib",
+        "artifact": {
+          "build_output_path": "bin/gcc/libgpac_static.a",
+          "staged_relative_path": "libgpac_static.a",
+          "artifact_type": "static_library",
+          "stage_source": "/workspace/repo/bin/gcc/libgpac_static.a",
+          "stage_destination": "/artifacts/libgpac_static.a"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [
+            "testsuite"
+          ],
+          "submodules_on_target_dependency_path": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "fio",
+        "source_case_id": "fio",
+        "repository_url": "https://github.com/axboe/fio",
+        "commit_sha": "c76c61b0fbe1b90a7886b8790805cf9903285074",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "medium",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "./configure --disable-native"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "build-essential",
+          "zlib1g-dev"
+        ],
+        "direct_target": "fio",
+        "artifact": {
+          "build_output_path": "fio",
+          "staged_relative_path": "fio",
+          "artifact_type": "executable",
+          "stage_source": "/workspace/repo/fio",
+          "stage_destination": "/artifacts/fio"
+        },
+        "oracle_correction": null,
+        "source_audit": {
+          "submodules": [],
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": {
+            "flag": "--help",
+            "expected_exit_code": 0
+          }
+        },
+        "historical_result_evidence_case_id_matches": 0
+      },
+      {
+        "case_id": "sql-parser-shared",
+        "source_case_id": "sql-parser",
+        "repository_url": "https://github.com/hyrise/sql-parser",
+        "commit_sha": "ccd3f68b50bb2b96ce69afa7b956b3bd826643cc",
+        "language": "C++",
+        "build_system": "make",
+        "size_stratum": "small",
+        "build_directory": "/workspace/repo",
+        "bootstrap_commands": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ],
+        "configure_arguments": [],
+        "required_system_packages": [
+          "bison",
+          "build-essential",
+          "flex"
+        ],
+        "direct_target": "library",
+        "artifact": {
+          "build_output_path": "libsqlparser.so",
+          "staged_relative_path": "libsqlparser.so",
+          "artifact_type": "shared_library",
+          "stage_source": "/workspace/repo/libsqlparser.so",
+          "stage_destination": "/artifacts/libsqlparser.so"
+        },
+        "oracle_correction": {
+          "mode": "pre_result_exact_commit_source_correction",
+          "old_artifact": {
+            "staged_relative_path": "libsqlparser.a",
+            "build_output_path": "libsqlparser.a",
+            "artifact_type": "static_library",
+            "producing_target": "library"
+          },
+          "reason": "Makefile defines static ?= no, so direct make library produces libsqlparser.so",
+          "source_protocol_modified": false
+        },
+        "source_audit": {
+          "submodules": [],
+          "generated_parser_sources_tracked": true,
+          "direct_target_verified": true,
+          "external_fetch_on_frozen_path": false,
+          "smoke": null
+        },
+        "historical_result_evidence_case_id_matches": 0
+      }
+    ],
+    "schedule": {
+      "pair_count": 12,
+      "arm_count": 24,
+      "replicates_per_case": 2,
+      "project_internal_order_reversal_required": true,
+      "baseline_first_pairs": 6,
+      "treatment_first_pairs": 6,
+      "pairs": [
+        {
+          "pair_id": "pupnp-rep-01",
+          "case_id": "pupnp",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-01",
+          "case_id": "ada-url",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "args-rep-01",
+          "case_id": "args",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-01",
+          "case_id": "gpac",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-01",
+          "case_id": "fio",
+          "replicate": 1,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-01",
+          "case_id": "sql-parser-shared",
+          "replicate": 1,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "sql-parser-shared-rep-02",
+          "case_id": "sql-parser-shared",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "fio-rep-02",
+          "case_id": "fio",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "gpac-rep-02",
+          "case_id": "gpac",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "args-rep-02",
+          "case_id": "args",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        },
+        {
+          "pair_id": "ada-url-rep-02",
+          "case_id": "ada-url",
+          "replicate": 2,
+          "arm_order": [
+            "baseline",
+            "treatment"
+          ]
+        },
+        {
+          "pair_id": "pupnp-rep-02",
+          "case_id": "pupnp",
+          "replicate": 2,
+          "arm_order": [
+            "treatment",
+            "baseline"
+          ]
+        }
+      ],
+      "identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134"
+    },
+    "runtime_contract": {
+      "provider_and_model_single_for_batch": true,
+      "provider_identity_status": "active_authorized",
+      "request_timeout_seconds": 300,
+      "request_retries": 0,
+      "fallback_forbidden": true,
+      "parallel_tool_calls": false,
+      "action_limits": {
+        "inspection": 4,
+        "repair_build": 2,
+        "artifact_stage": 2,
+        "submit": 2
+      },
+      "request_limit_per_arm": 8,
+      "turn_limit_per_arm": 8,
+      "graph_step_limit_per_arm": 24,
+      "work_timeout_seconds_per_arm": 600,
+      "cleanup_timeout_seconds_per_arm": 120,
+      "per_arm_recorded_token_ceiling": 120000,
+      "batch_recorded_token_ceiling": 2940000,
+      "shared_tool_contract_identical_between_arms": true,
+      "treatment_exposure_only": "repair_packet"
+    },
+    "measurement_contract": {
+      "parent_fault": "opaque_build_provenance",
+      "parent_proof_status": "unproven/opaque_wrapper",
+      "treatment_required_proof_modes": {
+        "cmake": "direct_cmake",
+        "make": "direct_make"
+      },
+      "r0_companion_required": true,
+      "candidate_verification_required": true,
+      "clean_replay_required": true,
+      "cleanup_and_zero_orphan_required": true,
+      "replacement_forbidden": true,
+      "backfill_forbidden": true,
+      "batch_protocol_mutation_after_start_forbidden": true
+    },
+    "analysis": {
+      "independent_unit": "project_block",
+      "project_block_count": 6,
+      "project_score": "mean of two replicate paired conversion differences",
+      "primary_test": "two_sided_exact_sign_flip_over_six_project_scores",
+      "primary_test_requires_all_project_blocks_estimable": true,
+      "infrastructure_censoring_reported_separately": true,
+      "mechanism_invalid_reported_separately": true,
+      "intervention_delivery_invalid_reported_separately": true,
+      "historical_exploratory_pairs_pooled": false,
+      "model_ranking_performed": false
+    },
+    "future_state": {
+      "checkpoint_status": "authorized_not_created",
+      "evidence_status": "authorized_not_created",
+      "execution_runner_status": "authorized_real_pair_runner",
+      "execution_requires_new_amendment": false
+    },
+    "preregistration": {
+      "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
+      "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+    },
+    "amendment": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/233",
+      "mode": "pre_result_lifecycle_reproducibility_amendment",
+      "parent_manifest": {
+        "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate.json",
+        "canonical_sha256": "8b7c2e193204a1f1c0b077933d716e66c1138ff3bc7ef54c490c3299652da1e3",
+        "modified": false
+      },
+      "trigger": {
+        "case_id": "sql-parser-shared",
+        "classification": "clean_replay_sha256_mismatch",
+        "provider_results_observed": false,
+        "root_cause": "checkout mtime can select tracked or regenerated Bison parser sources"
+      },
+      "allowed_semantic_delta": {
+        "path": "cases[sql-parser-shared].bootstrap_commands",
+        "before": [],
+        "after": [
+          "cd src/parser && bison bison_parser.y --output=bison_parser.cpp --defines=bison_parser.h --verbose"
+        ]
+      },
+      "verifier_relaxation": false,
+      "schedule_modified": false,
+      "artifact_oracle_modified": false
+    },
+    "execution_candidate": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/235",
+      "status": "composition_gate_only_not_authorized",
+      "parent": {
+        "path": "benchmarks/manifests/cpp-opaque-provenance-confirmatory-candidate-v2.json",
+        "file_sha256": "c9026aa28268619485f2c7b2e72dbf70b8105e8aca2253d4226debcfc1da7133",
+        "canonical_sha256": "ca2dd38f4dd298272f5e2203484857cbc72a6fc86e161dabefed2a61b54b6812",
+        "modified": false
+      },
+      "provider": {
+        "status": "selected_not_authorized",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": false
+      },
+      "evidence": {
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+        "reachability_marker": "markers/reachability.json",
+        "reachability_report": "reports/reachability.json",
+        "batch_marker": "markers/batch.json",
+        "batch_report": "reports/batch.json",
+        "pair_directory_pattern": "pairs/{pair_id}",
+        "create_once": true,
+        "historical_evidence_reused": false
+      },
+      "orchestration": {
+        "lifecycle_adapter": "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+        "cmake_action_policy": "scripts/forge_opaque_provenance_runtime_parity_gate.py",
+        "make_action_policy": "scripts/forge_opaque_provenance_r3_make_candidate_runner.py",
+        "r0_observability_required": true,
+        "full_agent_construction_required": true,
+        "single_asyncio_loop_for_batch": true,
+        "checkpoint_capture_restore_reimplemented": false,
+        "real_pair_runner_implemented": false
+      },
+      "repair_packets": {
+        "pupnp": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "upnp_static",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "ada-url": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "ada",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "args": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "cmake",
+          "selected_build_system": "cmake",
+          "build_directory": "/workspace/repo/build",
+          "target": "gitlike",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "gpac": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "lib",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "fio": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "fio",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        },
+        "sql-parser-shared": {
+          "schema_version": "forge-opaque-provenance-repair-packet-1.0.0",
+          "primary_classification": "build_system_unproven",
+          "mechanism_classification": "opaque_build_provenance",
+          "expected_build_system": "make",
+          "selected_build_system": "make",
+          "build_directory": "/workspace/repo",
+          "target": "library",
+          "proof_status": "opaque_wrapper",
+          "repair_goal": "produce a provenance-compliant direct build and submit the frozen artifact"
+        }
+      },
+      "terminal_taxonomy": {
+        "continue": [
+          "valid",
+          "endpoint_censored",
+          "model_behavior_outcome"
+        ],
+        "stop_batch": [
+          "mechanism_invalid",
+          "identity_invalid",
+          "evidence_invalid",
+          "cleanup_failed",
+          "orphan_detected",
+          "token_ceiling_reached"
+        ],
+        "replacement_forbidden": true,
+        "backfill_forbidden": true
+      },
+      "planned_authorized_amendment": {
+        "reachability_requests": 1,
+        "scheduled_pairs": 12,
+        "scheduled_arms": 24,
+        "batch_recorded_token_ceiling": 2940000,
+        "release_commit_required": true,
+        "separate_authorization_required": true
+      },
+      "frozen_components": {
+        "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+        "scripts/forge_opaque_provenance_runtime_parity_gate.py": "251cc446cc508552d85cdf82238192b702bbb2e51ee428c42d47188d0f12b40b",
+        "scripts/forge_opaque_provenance_rejection_observability_gate.py": "695c6188acf92f4e34dcbaf4c6f049ca4b024e9bdd1eb91085c0c8d5d0ace158",
+        "scripts/forge_opaque_provenance_r3_make_candidate_runner.py": "b8ec84f3835ecbbc462232b676c5ebf72e15a7f021be2a148d1b85d8138e9be0",
+        "scripts/forge_opaque_provenance_r3_make_execution_failure_gate.py": "cd36955c5256fa4376d0b5a4b60c139352ec2f8beb59c9b88741ad681b5bdb06",
+        "scripts/forge_opaque_provenance_r3_make_agent_construction_gate.py": "f5a0af19e2ff1cc7dd90f096132d537ec3db4867649571640c29d8262f890e5a",
+        "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py": "82a041ea3c7a8de762a014aaf405ccb10e62e1baaa5a79d22548c8af98dccd95"
+      }
+    },
+    "authorized_execution": {
+      "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/237",
+      "status": "authorized_not_started",
+      "authorization_baseline_commit": "0c5b7b4f4130fb1a2a17611b3f74b8cc90359fd6",
+      "release_revision_policy": "descendant_merged_main_recorded_before_first_request",
+      "provider": {
+        "status": "active_authorized",
+        "id": "deepseek-v4-flash",
+        "endpoint": "https://api.deepseek.com",
+        "credential_env": "DEEPSEEK_API_KEY",
+        "model": "deepseek-v4-flash",
+        "request_timeout_seconds": 300,
+        "max_retries": 0,
+        "fallback": "forbidden",
+        "streaming": false
+      },
+      "evidence": {
+        "schema_version": "forge-opaque-provenance-confirmatory-evidence-1.0.0",
+        "directory": "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1",
+        "identity_sha256": "c2c48564a685270369eafcfb9d6c6a1570cc6ecfebcbd390e4e492650db6ddcb",
+        "reachability_marker": "markers/reachability.json",
+        "reachability_report": "reports/reachability.json",
+        "batch_marker": "markers/batch.json",
+        "batch_report": "reports/batch.json",
+        "pair_directory_pattern": "pairs/{pair_id}",
+        "pair_marker": "markers/pair.json",
+        "pair_report": "reports/pair.json",
+        "pair_outcome": "reports/pair-outcome.json",
+        "parent_ledger": "ledgers/parent.jsonl",
+        "arm_ledger_directory": "ledgers/arms",
+        "append_only": true,
+        "create_once": true,
+        "historical_evidence_reused": false,
+        "zero_provider_preflight_writes_evidence": false
+      },
+      "budget": {
+        "maximum_reachability_requests": 1,
+        "reachability_maximum_recorded_tokens": 5000,
+        "recorded_tokens_per_arm": 120000,
+        "recorded_tokens_per_pair": 240000,
+        "batch_maximum_recorded_tokens": 2940000,
+        "enforcement": "before_each_pair_and_after_each_arm"
+      },
+      "preflight": {
+        "release_branch": "main",
+        "require_clean_worktree": true,
+        "require_head_equals_origin_main": true,
+        "require_authorization_baseline_ancestor": true,
+        "docker_provider": "ubuntu-native",
+        "docker_context": "default",
+        "docker_endpoint": "/var/run/docker.sock",
+        "control_plane": "compose-dood-on-ubuntu-native-engine",
+        "allowed_network_media": [
+          "wired",
+          "wifi",
+          "mobile_hotspot"
+        ],
+        "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+        "credential_check": "environment_variable_presence_only",
+        "require_empty_evidence_directory_before_reachability": true,
+        "managed_container_prefixes": [
+          "deerflow-compile-",
+          "deerflow-replay-"
+        ],
+        "require_zero_managed_orphans": true
+      },
+      "execution": {
+        "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+        "reachability_expected_response": "CANARY_OK",
+        "single_asyncio_loop_for_batch": true,
+        "checkpoint_capture_restore_reimplemented": false,
+        "pair_runtime_reuse": {
+          "cmake": "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py",
+          "make": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+          "checkpoint": "scripts/forge_real_lifecycle_checkpoint_gate.py",
+          "batch": "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py"
+        },
+        "runtime_path": "scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py",
+        "runtime_file_sha256": "78e4877294d8501e5bd91948399e612ef2938058bd16a0f982addc3530be9540",
+        "commands": [
+          "validate",
+          "preflight",
+          "reachability",
+          "batch",
+          "report"
+        ]
+      },
+      "terminal_taxonomy": {
+        "continue": [
+          "valid",
+          "endpoint_censored",
+          "model_behavior_outcome"
+        ],
+        "stop_batch": [
+          "mechanism_invalid",
+          "identity_invalid",
+          "evidence_invalid",
+          "cleanup_failed",
+          "orphan_detected",
+          "token_ceiling_reached"
+        ],
+        "replacement_forbidden": true,
+        "backfill_forbidden": true
+      },
+      "preregistration": {
+        "path": "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md",
+        "file_sha256": "a9f3b965bd6d3b157a1935166c9249021272775b72adc7f1da70b2ad312971c4"
+      }
+    },
+    "frozen_parent_components": {
+      "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json": "50f35e40e47bb77cc15b134a1cf0db5beac80b73c5c5fac0114fb02082e31cad",
+      "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json": "28cd8827f6e16906a2de0107b76836c0b9051297ca72531bbc8831874b284f60",
+      "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md": "14cbebdbba1fcab7c66902739a4eec9fb81ce8981699e3129123f71fd9e0a8c8",
+      "scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py": "40554bbe55ed20c35304df2ed64034843eba44e75d1bf4b6d1df77eec0a477b7",
+      "scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py": "3c15035c1348a2277903c4cf8047c35fd3bd01632bc545f3ecd5478dd704f067",
+      "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py": "e4f06fedec242b31448e5eaa1a6c271cc3e33fa197919434aac9510d2f900f64",
+      "backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py": "1eb176fed28214c68911f6695d123fb91b071a313660a14e3f13d9951bb6357c"
+    }
+  }
+}

--- a/scripts/forge_opaque_provenance_confirmatory_execution_authorized_protocol.py
+++ b/scripts/forge_opaque_provenance_confirmatory_execution_authorized_protocol.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Issue #237 六 case opaque provenance 确认性执行授权协议。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json"
+DEFAULT_SCHEMA = REPO_ROOT / "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json"
+PARENT_MANIFEST_PATH = "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-candidate.json"
+RUNTIME_PATH = "scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md"
+
+SCHEMA_VERSION = "forge-opaque-provenance-confirmatory-execution-authorized-1.0.0"
+DOCUMENT_TYPE = "forge_opaque_provenance_confirmatory_execution_authorized"
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/237"
+AUTHORIZATION_BASELINE_COMMIT = "0c5b7b4f4130fb1a2a17611b3f74b8cc90359fd6"
+PARENT_MANIFEST_CANONICAL_SHA256 = "0c0a9aeba1f25365ca26e4dfc83d987819e562c3f3fb68d3bfc1ec9f31f0eaf9"
+EVIDENCE_DIRECTORY = "/workspace/.compile-sessions/benchmark-evidence-opaque-provenance-confirmatory-v1"
+
+FROZEN_PARENT_PATHS = (
+    PARENT_MANIFEST_PATH,
+    "benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-candidate.schema.json",
+    "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-candidate.md",
+    "scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py",
+    "scripts/forge_opaque_provenance_confirmatory_execution_composition_gate.py",
+    "scripts/forge_opaque_provenance_confirmatory_lifecycle_gate.py",
+    "backend/tests/test_forge_opaque_provenance_confirmatory_execution_candidate.py",
+)
+
+
+class ProtocolError(RuntimeError):
+    """授权 identity、父候选、预算或 runtime 发生漂移。"""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_parent_protocol(repo_root: Path = REPO_ROOT):
+    path = repo_root / "scripts/forge_opaque_provenance_confirmatory_execution_candidate_protocol.py"
+    name = "forge_confirmatory_execution_authorized_parent"
+    existing = sys.modules.get(name)
+    if existing is not None and Path(existing.__file__).resolve() == path.resolve():
+        return existing
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ProtocolError("无法加载 Issue #235 parent protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parent_manifest(repo_root: Path = REPO_ROOT) -> tuple[dict[str, Any], Any]:
+    parent = _load_parent_protocol(repo_root)
+    path = repo_root / PARENT_MANIFEST_PATH
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("无法读取 Issue #235 parent manifest") from exc
+    manifest = parent.validate_manifest(value, repo_root)
+    if parent.canonical_sha256(manifest) != PARENT_MANIFEST_CANONICAL_SHA256:
+        raise ProtocolError("Issue #235 parent canonical identity 发生漂移")
+    return manifest, parent
+
+
+def _frozen_parent_sha256(repo_root: Path) -> dict[str, str]:
+    return {path: file_sha256(repo_root / path) for path in FROZEN_PARENT_PATHS}
+
+
+def _evidence_identity(parent: dict[str, Any]) -> str:
+    return canonical_sha256(
+        {
+            "issue_url": ISSUE_URL,
+            "parent_manifest_sha256": PARENT_MANIFEST_CANONICAL_SHA256,
+            "schedule_identity_sha256": parent["schedule"]["identity_sha256"],
+            "provider": parent["execution_candidate"]["provider"],
+            "directory": EVIDENCE_DIRECTORY,
+            "historical_evidence_reused": False,
+        }
+    )
+
+
+def _authorized_execution(parent: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    runtime_path = repo_root / RUNTIME_PATH
+    preregistration_path = repo_root / PREREGISTRATION_PATH
+    if not runtime_path.is_file() or not preregistration_path.is_file():
+        raise ProtocolError("authorized runtime 或预注册不存在")
+    return {
+        "issue_url": ISSUE_URL,
+        "status": "authorized_not_started",
+        "authorization_baseline_commit": AUTHORIZATION_BASELINE_COMMIT,
+        "release_revision_policy": "descendant_merged_main_recorded_before_first_request",
+        "provider": {
+            **copy.deepcopy(parent["execution_candidate"]["provider"]),
+            "status": "active_authorized",
+        },
+        "evidence": {
+            "schema_version": "forge-opaque-provenance-confirmatory-evidence-1.0.0",
+            "directory": EVIDENCE_DIRECTORY,
+            "identity_sha256": _evidence_identity(parent),
+            "reachability_marker": "markers/reachability.json",
+            "reachability_report": "reports/reachability.json",
+            "batch_marker": "markers/batch.json",
+            "batch_report": "reports/batch.json",
+            "pair_directory_pattern": "pairs/{pair_id}",
+            "pair_marker": "markers/pair.json",
+            "pair_report": "reports/pair.json",
+            "pair_outcome": "reports/pair-outcome.json",
+            "parent_ledger": "ledgers/parent.jsonl",
+            "arm_ledger_directory": "ledgers/arms",
+            "append_only": True,
+            "create_once": True,
+            "historical_evidence_reused": False,
+            "zero_provider_preflight_writes_evidence": False,
+        },
+        "budget": {
+            "maximum_reachability_requests": 1,
+            "reachability_maximum_recorded_tokens": 5000,
+            "recorded_tokens_per_arm": 120000,
+            "recorded_tokens_per_pair": 240000,
+            "batch_maximum_recorded_tokens": parent["runtime_contract"]["batch_recorded_token_ceiling"],
+            "enforcement": "before_each_pair_and_after_each_arm",
+        },
+        "preflight": {
+            "release_branch": "main",
+            "require_clean_worktree": True,
+            "require_head_equals_origin_main": True,
+            "require_authorization_baseline_ancestor": True,
+            "docker_provider": "ubuntu-native",
+            "docker_context": "default",
+            "docker_endpoint": "/var/run/docker.sock",
+            "control_plane": "compose-dood-on-ubuntu-native-engine",
+            "allowed_network_media": ["wired", "wifi", "mobile_hotspot"],
+            "network_access_medium_env": "FORGE_NETWORK_ACCESS_MEDIUM",
+            "credential_check": "environment_variable_presence_only",
+            "require_empty_evidence_directory_before_reachability": True,
+            "managed_container_prefixes": ["deerflow-compile-", "deerflow-replay-"],
+            "require_zero_managed_orphans": True,
+        },
+        "execution": {
+            "reachability_prompt": "Reply with exactly CANARY_OK and nothing else.",
+            "reachability_expected_response": "CANARY_OK",
+            "single_asyncio_loop_for_batch": True,
+            "checkpoint_capture_restore_reimplemented": False,
+            "pair_runtime_reuse": {
+                "cmake": "scripts/forge_opaque_provenance_minimal_canary_execution_runner.py",
+                "make": "scripts/forge_opaque_provenance_r3_make_execution_runner.py",
+                "checkpoint": "scripts/forge_real_lifecycle_checkpoint_gate.py",
+                "batch": "scripts/forge_checkpoint_behavioral_pilot_v2_runner.py",
+            },
+            "runtime_path": RUNTIME_PATH,
+            "runtime_file_sha256": file_sha256(runtime_path),
+            "commands": ["validate", "preflight", "reachability", "batch", "report"],
+        },
+        "terminal_taxonomy": copy.deepcopy(parent["execution_candidate"]["terminal_taxonomy"]),
+        "preregistration": {
+            "path": PREREGISTRATION_PATH,
+            "file_sha256": file_sha256(preregistration_path),
+        },
+    }
+
+
+def generate_manifest(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent, _parent_protocol = _parent_manifest(repo_root)
+    value = copy.deepcopy(parent)
+    value["$schema"] = "../schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json"
+    value["schema_version"] = SCHEMA_VERSION
+    value["document_type"] = DOCUMENT_TYPE
+    value["runtime_contract"]["provider_identity_status"] = "active_authorized"
+    value["authorization"] = {
+        "provider_calls_authorized": True,
+        "credential_read_authorized": True,
+        "model_creation_authorized": True,
+        "reachability_request_authorized": True,
+        "checkpoint_creation_authorized": True,
+        "pair_collection_authorized": True,
+        "formal_attempts_authorized": True,
+        "docker_execution_authorized": True,
+        "evidence_write_authorized": True,
+        "model_tokens_authorized": parent["runtime_contract"]["batch_recorded_token_ceiling"],
+    }
+    value["future_state"] = {
+        "checkpoint_status": "authorized_not_created",
+        "evidence_status": "authorized_not_created",
+        "execution_runner_status": "authorized_real_pair_runner",
+        "execution_requires_new_amendment": False,
+    }
+    value["authorized_execution"] = _authorized_execution(parent, repo_root)
+    value["frozen_parent_components"] = _frozen_parent_sha256(repo_root)
+    value["preregistration"] = copy.deepcopy(value["authorized_execution"]["preregistration"])
+    return value
+
+
+def validate_allowed_delta(value: dict[str, Any], repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    parent, _parent_protocol = _parent_manifest(repo_root)
+    normalized = copy.deepcopy(value)
+    authorized = normalized.pop("authorized_execution", None)
+    normalized.pop("frozen_parent_components", None)
+    normalized["$schema"] = parent["$schema"]
+    normalized["schema_version"] = parent["schema_version"]
+    normalized["document_type"] = parent["document_type"]
+    normalized["runtime_contract"] = copy.deepcopy(parent["runtime_contract"])
+    normalized["authorization"] = copy.deepcopy(parent["authorization"])
+    normalized["future_state"] = copy.deepcopy(parent["future_state"])
+    normalized["preregistration"] = copy.deepcopy(parent["preregistration"])
+    if normalized != parent:
+        raise ProtocolError("authorized amendment 包含未预注册的父协议差异")
+    if authorized != _authorized_execution(parent, repo_root):
+        raise ProtocolError("authorized execution identity 发生漂移")
+    return {
+        "status": "passed",
+        "parent_manifest_sha256": PARENT_MANIFEST_CANONICAL_SHA256,
+        "schedule_identity_sha256": parent["schedule"]["identity_sha256"],
+        "evidence_identity_sha256": authorized["evidence"]["identity_sha256"],
+        "verifier_relaxation": False,
+        "historical_evidence_reused": False,
+    }
+
+
+def validate_manifest(value: Any, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    expected = generate_manifest(repo_root)
+    if not isinstance(value, dict) or value != expected:
+        raise ProtocolError("authorized confirmatory manifest 发生漂移")
+    validate_allowed_delta(value, repo_root)
+    authorization = value["authorization"]
+    if authorization["model_tokens_authorized"] != value["authorized_execution"]["budget"]["batch_maximum_recorded_tokens"]:
+        raise ProtocolError("授权 token ceiling 发生漂移")
+    if not all(item is True for key, item in authorization.items() if key.endswith("_authorized") and key != "model_tokens_authorized"):
+        raise ProtocolError("真实执行授权未闭合")
+    return value
+
+
+def load_manifest(
+    path: Path = DEFAULT_MANIFEST,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProtocolError("无法读取 authorized confirmatory manifest") from exc
+    return validate_manifest(value, repo_root)
+
+
+def verify_frozen_components(
+    manifest: dict[str, Any],
+    repo_root: Path = REPO_ROOT,
+) -> None:
+    if manifest["frozen_parent_components"] != _frozen_parent_sha256(repo_root):
+        raise ProtocolError("Issue #235 冻结组件发生漂移")
+    execution = manifest["authorized_execution"]["execution"]
+    if file_sha256(repo_root / execution["runtime_path"]) != execution["runtime_file_sha256"]:
+        raise ProtocolError("authorized runtime 发生漂移")
+
+
+def schema_document(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    frozen = manifest or generate_manifest()
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://github.com/WWFXL/Forge-AutoCompiler/benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json",
+        "title": "Forge opaque provenance confirmatory execution authorized amendment",
+        "const": frozen,
+    }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("generate", "validate"))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        manifest = generate_manifest()
+        _write_json(args.manifest, manifest)
+        _write_json(args.schema, schema_document(manifest))
+    else:
+        manifest = load_manifest(args.manifest)
+        if json.loads(args.schema.read_text(encoding="utf-8")) != schema_document(manifest):
+            raise ProtocolError("authorized const schema 发生漂移")
+    print(
+        json.dumps(
+            {
+                "manifest_sha256": canonical_sha256(manifest),
+                "authorization": manifest["authorization"],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py
+++ b/scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py
@@ -1,0 +1,1050 @@
+#!/usr/bin/env python3
+"""执行 Issue #237 授权的六 case opaque provenance 确认性 pilot。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import json
+import os
+import shlex
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import UTC, datetime
+from itertools import product
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", SCRIPT_ROOT.parent)).resolve()
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_checkpoint_behavioral_pilot_v2_runner as batch_runtime  # noqa: E402
+import forge_opaque_provenance_confirmatory_execution_authorized_protocol as protocol  # noqa: E402
+import forge_opaque_provenance_confirmatory_execution_composition_gate as composition  # noqa: E402
+import forge_opaque_provenance_confirmatory_lifecycle_gate as lifecycle  # noqa: E402
+import forge_opaque_provenance_minimal_canary_execution_runner as cmake_pair_runtime  # noqa: E402
+import forge_opaque_provenance_r1_execution_runner as agent_runtime  # noqa: E402
+import forge_opaque_provenance_r3_make_execution_failure_gate as make_bindings  # noqa: E402
+import forge_opaque_provenance_r3_make_execution_runner as make_pair_runtime  # noqa: E402
+
+DEFAULT_MANIFEST = protocol.DEFAULT_MANIFEST
+DEFAULT_OUTPUT_DIR = Path(protocol.EVIDENCE_DIRECTORY)
+COMPILE_IMAGE = lifecycle.COMPILE_IMAGE
+ARMS = ("baseline", "treatment")
+
+primary = cmake_pair_runtime.primary
+evidence_runtime = cmake_pair_runtime.v3_runner
+
+
+class ConfirmatoryExecutionError(RuntimeError):
+    """确认性执行的 identity、evidence、预算、P2 或 cleanup 无效。"""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfirmatoryExecutionError(f"无法读取 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise ConfirmatoryExecutionError(f"JSON 根节点必须是对象: {path}")
+    return value
+
+
+def _atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary.replace(path)
+
+
+def _write_once(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2, sort_keys=True)
+            stream.write("\n")
+    except FileExistsError as exc:
+        raise ConfirmatoryExecutionError(f"不可覆盖已存在的 evidence: {path}") from exc
+
+
+def _git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo_root}", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise ConfirmatoryExecutionError("无法验证授权 release Git identity")
+    return result.stdout.strip()
+
+
+def _execution(manifest: dict[str, Any]) -> dict[str, Any]:
+    return manifest["authorized_execution"]
+
+
+def _output_dir(manifest: dict[str, Any], output_dir: Path) -> Path:
+    expected = Path(_execution(manifest)["evidence"]["directory"]).resolve(strict=False)
+    if output_dir.resolve(strict=False) != expected:
+        raise ConfirmatoryExecutionError("evidence 必须写入 Issue #237 冻结目录")
+    return output_dir
+
+
+def require_release_identity(
+    manifest: dict[str, Any],
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, str]:
+    branch = _git(repo_root, "branch", "--show-current")
+    revision = _git(repo_root, "rev-parse", "HEAD")
+    origin_main = _git(repo_root, "rev-parse", "origin/main")
+    dirty = _git(repo_root, "status", "--porcelain", "--untracked-files=normal")
+    execution = _execution(manifest)
+    if branch != execution["preflight"]["release_branch"]:
+        raise ConfirmatoryExecutionError("真实执行只能位于 main")
+    if revision != origin_main or dirty:
+        raise ConfirmatoryExecutionError("真实执行要求干净且 main == origin/main")
+    baseline = execution["authorization_baseline_commit"]
+    if _git(repo_root, "merge-base", baseline, revision) != baseline:
+        raise ConfirmatoryExecutionError("release 不是 Issue #237 授权基线的后代")
+    return {"branch": branch, "revision": revision, "origin_main": origin_main}
+
+
+def require_network_medium(manifest: dict[str, Any]) -> str:
+    preflight = _execution(manifest)["preflight"]
+    medium = os.environ.get(preflight["network_access_medium_env"])
+    if medium not in preflight["allowed_network_media"]:
+        raise ConfirmatoryExecutionError("必须通过 FORGE_NETWORK_ACCESS_MEDIUM 记录当前网络介质")
+    return medium
+
+
+def require_zero_managed_containers() -> None:
+    try:
+        evidence_runtime.require_zero_managed_containers()
+    except evidence_runtime.AuthorizedPilotError as exc:
+        raise ConfirmatoryExecutionError(str(exc)) from exc
+
+
+def _provider_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {"provider": copy.deepcopy(_execution(manifest)["provider"])}
+
+
+def collect_preflight(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    require_empty: bool,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _output_dir(manifest, output_dir)
+    release = require_release_identity(manifest, repo_root)
+    medium = require_network_medium(manifest)
+    primary.require_compose_dood()
+    require_zero_managed_containers()
+    try:
+        evidence_runtime._provider_config_preflight(_provider_manifest(manifest))
+    except evidence_runtime.AuthorizedPilotError as exc:
+        raise ConfirmatoryExecutionError(str(exc)) from exc
+    entries = sorted(str(path.relative_to(output_dir)).replace("\\", "/") for path in output_dir.rglob("*") if path.is_file()) if output_dir.exists() else []
+    if require_empty and entries:
+        raise ConfirmatoryExecutionError("reachability 前要求授权 evidence 目录为空")
+    return {
+        "ready": True,
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "release_revision": release["revision"],
+        "network_access_medium": medium,
+        "credential_check": "environment_variable_presence_only",
+        "credential_env": _execution(manifest)["provider"]["credential_env"],
+        "evidence_files": entries,
+        "zero_managed_containers": True,
+        "docker_provider": _execution(manifest)["preflight"]["docker_provider"],
+        "docker_endpoint": _execution(manifest)["preflight"]["docker_endpoint"],
+        "provider_calls": 0,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+    }
+
+
+def _runtime_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    execution = _execution(manifest)
+    evidence = execution["evidence"]
+    return {
+        "provider": copy.deepcopy(execution["provider"]),
+        "budget": {"reachability_maximum_recorded_tokens": execution["budget"]["reachability_maximum_recorded_tokens"]},
+        "evidence": {
+            "directory": evidence["directory"],
+            "reachability_marker": evidence["reachability_marker"],
+        },
+        "execution": {
+            "release_branch": execution["preflight"]["release_branch"],
+            "network_access_medium_env": execution["preflight"]["network_access_medium_env"],
+            "reachability_prompt": execution["execution"]["reachability_prompt"],
+            "reachability_expected_response": execution["execution"]["reachability_expected_response"],
+            "reachability_report": evidence["reachability_report"],
+        },
+        "parent": {"authorization_baseline_commit": execution["authorization_baseline_commit"]},
+        "preflight": copy.deepcopy(execution["preflight"]),
+    }
+
+
+@contextmanager
+def _reachability_bindings(
+    manifest: dict[str, Any],
+    runtime_manifest: dict[str, Any],
+    output_dir: Path,
+    repo_root: Path,
+) -> Iterator[None]:
+    original_protocol = cmake_pair_runtime.protocol
+    original_collect = cmake_pair_runtime.collect_preflight
+    digest = protocol.canonical_sha256(manifest)
+    cmake_pair_runtime.protocol = SimpleNamespace(canonical_sha256=lambda _value: digest)
+    cmake_pair_runtime.collect_preflight = lambda *_args, **_kwargs: collect_preflight(
+        manifest,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        require_empty=True,
+    )
+    try:
+        yield
+    finally:
+        cmake_pair_runtime.protocol = original_protocol
+        cmake_pair_runtime.collect_preflight = original_collect
+
+
+def execute_reachability(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    model_factory: Any | None = None,
+) -> dict[str, Any]:
+    runtime_manifest = _runtime_manifest(manifest)
+    with _reachability_bindings(manifest, runtime_manifest, output_dir, repo_root):
+        return cmake_pair_runtime.execute_reachability(
+            runtime_manifest,
+            output_dir=output_dir,
+            repo_root=repo_root,
+            model_factory=model_factory,
+        )
+
+
+def require_passed_reachability(
+    manifest: dict[str, Any],
+    output_dir: Path,
+    revision: str,
+) -> dict[str, Any]:
+    execution = _execution(manifest)
+    evidence = execution["evidence"]
+    marker = _load_json(output_dir / evidence["reachability_marker"])
+    report = _load_json(output_dir / evidence["reachability_report"])
+    digest = protocol.canonical_sha256(manifest)
+    if (
+        marker.get("status") != "passed"
+        or marker.get("manifest_sha256") != digest
+        or marker.get("release_revision") != revision
+        or report.get("passed") is not True
+        or report.get("manifest_sha256") != digest
+        or report.get("release_revision") != revision
+        or type(report.get("recorded_tokens")) is not int
+        or report["recorded_tokens"] > execution["budget"]["reachability_maximum_recorded_tokens"]
+    ):
+        raise ConfirmatoryExecutionError("唯一 reachability 未形成同 revision 通过终态")
+    return report
+
+
+def _case(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
+    matches = [item for item in manifest["cases"] if item["case_id"] == case_id]
+    if len(matches) != 1:
+        raise ConfirmatoryExecutionError(f"未知或重复 case: {case_id}")
+    return matches[0]
+
+
+def _pair_manifest(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+) -> dict[str, Any]:
+    case = _case(manifest, pair["case_id"])
+    adapter = lifecycle.build_case_adapter(pair["case_id"], REPO_ROOT)
+    execution = _execution(manifest)
+    evidence = execution["evidence"]
+    runtime = manifest["runtime_contract"]
+    digest = protocol.canonical_sha256(manifest)
+    return {
+        "schema_version": "forge-opaque-provenance-confirmatory-pair-runtime-1.0.0",
+        "document_type": "forge_opaque_provenance_confirmatory_pair_runtime",
+        "parent_manifest_sha256": digest,
+        "case": {
+            "case_id": case["case_id"],
+            "repository_url": case["repository_url"],
+            "commit_sha": case["commit_sha"],
+            "build_system": case["build_system"],
+            "compile_image": COMPILE_IMAGE,
+            "source_subdir": ".",
+            "target": case["direct_target"],
+            "staged_artifact": case["artifact"]["staged_relative_path"],
+            "build_output": case["artifact"]["build_output_path"],
+            "artifact_type": case["artifact"]["artifact_type"],
+        },
+        "provider": copy.deepcopy(execution["provider"]),
+        "continuation": {
+            "arm_order": copy.deepcopy(pair["arm_order"]),
+            "maximum_requests_per_arm": runtime["request_limit_per_arm"],
+            "maximum_model_turns_per_arm": runtime["turn_limit_per_arm"],
+            "maximum_graph_steps_per_arm": runtime["graph_step_limit_per_arm"],
+            "work_wall_clock_seconds_per_arm": runtime["work_timeout_seconds_per_arm"],
+            "cleanup_reserve_seconds_per_arm": runtime["cleanup_timeout_seconds_per_arm"],
+            "maximum_recorded_tokens_per_arm": runtime["per_arm_recorded_token_ceiling"],
+        },
+        "schedule": [copy.deepcopy(pair)],
+        "budget": {
+            "reachability_maximum_recorded_tokens": execution["budget"]["reachability_maximum_recorded_tokens"],
+            "stage_maximum_recorded_tokens": execution["budget"]["recorded_tokens_per_pair"] + execution["budget"]["reachability_maximum_recorded_tokens"],
+        },
+        "evidence": {
+            "directory": str(pair_dir),
+            "identity_sha256": protocol.canonical_sha256(
+                {
+                    "batch_evidence_identity": evidence["identity_sha256"],
+                    "pair": pair,
+                }
+            ),
+            "reachability_marker": evidence["reachability_marker"],
+            "pair_marker": evidence["pair_marker"],
+            "canary_report": evidence["pair_report"],
+        },
+        "execution": {
+            "release_branch": execution["preflight"]["release_branch"],
+            "network_access_medium_env": execution["preflight"]["network_access_medium_env"],
+            "pair_marker": evidence["pair_marker"],
+            "parent_ledger": evidence["parent_ledger"],
+            "arm_ledger_directory": evidence["arm_ledger_directory"],
+            "report_schema_version": "forge-opaque-provenance-confirmatory-pair-report-1.0.0",
+            "report_document_type": "forge_opaque_provenance_confirmatory_pair_report",
+        },
+        "parent": {"authorization_baseline_commit": execution["authorization_baseline_commit"]},
+        "preflight": copy.deepcopy(execution["preflight"]),
+        "repair_packet": copy.deepcopy(manifest["execution_candidate"]["repair_packets"][pair["case_id"]]),
+        "runtime_parity": {
+            "parallel_tool_calls": False,
+            "action_limits": copy.deepcopy(runtime["action_limits"]),
+            "policy_family": composition.build_case_dispatch(pair["case_id"], REPO_ROOT).policy_family,
+            "action_surface": {
+                "workdir": lifecycle.WORKDIR,
+                "build_directory": (lifecycle.BUILD_DIRECTORY if adapter.build_system == "cmake" else lifecycle.WORKDIR),
+                "target": adapter.target,
+                "build_output": adapter.stage_source,
+                "staged_artifact": adapter.stage_destination,
+            },
+        },
+        "r0_observability": {"required": True},
+    }
+
+
+def _policy(
+    manifest: dict[str, Any],
+    adapter: lifecycle.LifecycleCaseAdapter,
+    *,
+    arm: str,
+    image_id: str,
+) -> Any:
+    continuation = manifest["continuation"]
+    provider = manifest["provider"]
+    return primary.ExperimentPolicy(
+        benchmark_id="forge-opaque-provenance-confirmatory",
+        manifest_sha256=protocol.canonical_sha256(manifest),
+        case_id=adapter.case_id,
+        condition=arm,
+        repetition=manifest["schedule"][0]["replicate"],
+        expected_repo_url=adapter.repository_url,
+        expected_commit_sha=adapter.commit_sha,
+        expected_build_system=adapter.build_system,
+        compile_image=COMPILE_IMAGE,
+        image_id=image_id,
+        model_name=provider["model"],
+        endpoint=provider["endpoint"],
+        credential_env=provider["credential_env"],
+        request_timeout_seconds=provider["request_timeout_seconds"],
+        model_max_retries=provider["max_retries"],
+        compiler_max_turns=continuation["maximum_model_turns_per_arm"],
+        subagent_timeout_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        memory_enabled=False,
+        skills_enabled=False,
+        required_system_packages=(),
+        cmake_arguments=(),
+        configure_arguments=(),
+        environment=(),
+        minimum_replay_delay_seconds=0,
+        bootstrap_commands=adapter.bootstrap_commands,
+        compiler_model_turn_limit=continuation["maximum_model_turns_per_arm"],
+        compiler_graph_recursion_limit=continuation["maximum_graph_steps_per_arm"],
+        compiler_wall_clock_seconds=continuation["work_wall_clock_seconds_per_arm"],
+        compiler_post_build_reserve_seconds=continuation["cleanup_reserve_seconds_per_arm"],
+        source_subdir=".",
+        build_targets=(adapter.target,),
+        artifact_instructions=(
+            (
+                adapter.staged_artifact,
+                adapter.build_output,
+                adapter.artifact_type,
+            ),
+        ),
+    )
+
+
+def _parent_policy(
+    manifest: dict[str, Any],
+    adapter: lifecycle.LifecycleCaseAdapter,
+    *,
+    image_id: str,
+) -> Any:
+    return replace(
+        _policy(manifest, adapter, arm="controlled-parent", image_id=image_id),
+        model_name="deterministic-no-provider",
+        endpoint="https://example.invalid/v1",
+        credential_env="UNUSED_PROVIDER_KEY",
+        request_timeout_seconds=1,
+        compiler_max_turns=1,
+    )
+
+
+def _case_proxy(
+    pair_manifest: dict[str, Any],
+    adapter: lifecycle.LifecycleCaseAdapter,
+) -> Any:
+    provenance = lifecycle.cmake_reference if adapter.build_system == "cmake" else lifecycle.make_reference
+
+    def build_frozen_identity(**kwargs: Any) -> Any:
+        return lifecycle.build_frozen_identity(adapter, **kwargs)
+
+    def evaluate_parent(
+        frozen: Any,
+        *,
+        parent_command_id: str,
+    ) -> tuple[Any, tuple[Any, ...]]:
+        return lifecycle.evaluate_parent(
+            adapter,
+            frozen,
+            parent_command_id=parent_command_id,
+        )
+
+    return SimpleNamespace(
+        CASE_ID=adapter.case_id,
+        REPOSITORY_URL=adapter.repository_url,
+        COMMIT_SHA=adapter.commit_sha,
+        WORKDIR=lifecycle.WORKDIR,
+        COMPILE_IMAGE=COMPILE_IMAGE,
+        PARENT_COMMAND=adapter.parent_command,
+        BUILD_OUTPUT=adapter.build_output,
+        TARGET=adapter.target,
+        STAGED_ARTIFACT=adapter.staged_artifact,
+        provenance=provenance,
+        build_frozen_identity=build_frozen_identity,
+        evaluate_parent=evaluate_parent,
+        build_repair_packet=lambda: copy.deepcopy(pair_manifest["repair_packet"]),
+    )
+
+
+def _command_tokens(command: str) -> tuple[str, tuple[str, ...]]:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ConfirmatoryExecutionError("trusted command 无法规范化") from exc
+    if not tokens:
+        raise ConfirmatoryExecutionError("trusted command 为空")
+    return PurePosixPath(tokens[0]).name, tuple(tokens[1:])
+
+
+def _evaluate_arm_p2(
+    adapter: lifecycle.LifecycleCaseAdapter,
+    session: Any,
+    frozen: Any,
+    parent_command_id: str,
+) -> tuple[Any, tuple[Any, ...]]:
+    artifact = Path(session.leadagent_repo_dir) / adapter.build_output
+    if not artifact.is_file():
+        raise ConfirmatoryExecutionError("arm 丢失冻结 workspace artifact")
+    if artifact.stat().st_size != frozen.artifact_size or primary.lifecycle.sha256_file(artifact) != frozen.artifact_sha256:
+        raise ConfirmatoryExecutionError("arm workspace artifact identity 漂移")
+    if adapter.build_tree_relative_path is not None:
+        tree = Path(session.leadagent_repo_dir) / adapter.build_tree_relative_path
+        if not tree.is_file() or primary.lifecycle.sha256_file(tree) != frozen.build_tree_sha256:
+            raise ConfirmatoryExecutionError("arm CMake build tree identity 漂移")
+
+    parent = lifecycle._parent_invocation(adapter, frozen, parent_command_id)
+    invocations = [parent]
+    previous_hash = parent.ledger_hash
+    producer_id = session.post_build_supporting_command_id or parent_command_id
+    seen_parent = False
+    for record in session.commands:
+        if record.command_id == parent_command_id:
+            seen_parent = True
+            continue
+        if not seen_parent or record.stage != "bash":
+            continue
+        executable, argv = _command_tokens(record.command)
+        output_paths = (adapter.build_output,) if record.command_id == producer_id else ()
+        invocation = lifecycle.cmake_reference.record_invocation(
+            command_id=record.command_id,
+            physical_attempt_id=frozen.physical_attempt_id,
+            sequence=len(invocations) + 1,
+            repository_url=frozen.repository_url,
+            commit_sha=frozen.commit_sha,
+            image_id=frozen.image_id,
+            executable=executable,
+            argv=argv,
+            workdir=record.workdir or lifecycle.WORKDIR,
+            previous_hash=previous_hash,
+            exit_code=record.exit_code if record.exit_code is not None else 1,
+            timed_out=record.timed_out,
+            output_paths=output_paths,
+            model_declared_role=record.role,
+        )
+        invocations.append(invocation)
+        previous_hash = invocation.ledger_hash
+    if producer_id not in {item.command_id for item in invocations}:
+        producer_id = parent_command_id
+    identity = lifecycle._artifact(
+        frozen,
+        producer_id,
+        observed_after_sequence=len(invocations) + 1,
+    )
+    if adapter.build_system == "cmake":
+        decision = lifecycle.cmake_reference.evaluate_p2(
+            frozen,
+            tuple(invocations),
+            identity,
+        )
+    else:
+        decision = lifecycle.make_reference.evaluate_make_p2(
+            frozen,
+            tuple(invocations),
+            identity,
+        )
+    return decision, tuple(invocations)
+
+
+async def _run_arm_continuation(
+    pair_manifest: dict[str, Any],
+    adapter: lifecycle.LifecycleCaseAdapter,
+    *args: Any,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    original = {
+        "policy": agent_runtime._policy,
+        "parity": agent_runtime.parity,
+        "checkpoint": agent_runtime.checkpoint_gate,
+        "observability": agent_runtime.observability,
+    }
+    if adapter.build_system == "cmake":
+        parity = composition.cmake_runtime
+        observability = composition.cmake_observability
+    else:
+        parity, observability = make_bindings.build_runtime_bindings()
+    agent_runtime._policy = lambda _value, *, arm, image_id: _policy(
+        pair_manifest,
+        adapter,
+        arm=arm,
+        image_id=image_id,
+    )
+    agent_runtime.parity = parity
+    agent_runtime.checkpoint_gate = SimpleNamespace(
+        WORKDIR=lifecycle.WORKDIR,
+        BUILD_DIRECTORY=(lifecycle.BUILD_DIRECTORY if adapter.build_system == "cmake" else lifecycle.WORKDIR),
+        TARGET=adapter.target,
+        BUILD_OUTPUT=adapter.build_output,
+        STAGED_ARTIFACT=adapter.staged_artifact,
+    )
+    agent_runtime.observability = observability
+    try:
+        return await agent_runtime.run_arm_continuation(
+            pair_manifest,
+            *args,
+            **kwargs,
+            budget_sink={},
+        )
+    finally:
+        agent_runtime._policy = original["policy"]
+        agent_runtime.parity = original["parity"]
+        agent_runtime.checkpoint_gate = original["checkpoint"]
+        agent_runtime.observability = original["observability"]
+
+
+class _SharedRunnerContext:
+    def __init__(self, runner: asyncio.Runner):
+        self.runner = runner
+
+    def __enter__(self) -> asyncio.Runner:
+        return self.runner
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+
+class _AsyncioProxy:
+    def __init__(self, runner: asyncio.Runner):
+        self.runner = runner
+
+    def Runner(self) -> _SharedRunnerContext:  # noqa: N802
+        return _SharedRunnerContext(self.runner)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(asyncio, name)
+
+
+@contextmanager
+def _pair_bindings(
+    manifest: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    adapter: lifecycle.LifecycleCaseAdapter,
+    output_dir: Path,
+    release: dict[str, str],
+    reachability: dict[str, Any],
+    async_runner: asyncio.Runner,
+) -> Iterator[Any]:
+    from deerflow.compile import operations
+    from deerflow.tools import bound_compile_tools
+
+    base = cmake_pair_runtime if adapter.build_system == "cmake" else make_pair_runtime
+    case_proxy = _case_proxy(pair_manifest, adapter)
+    digest = protocol.canonical_sha256(pair_manifest)
+    protocol_proxy = SimpleNamespace(canonical_sha256=lambda _value: digest)
+    originals = {
+        "protocol": base.protocol,
+        "collect_preflight": base.collect_preflight,
+        "policy": base._policy,
+        "parent_policy": base._parent_policy,
+        "evaluate": base._evaluate_arm_p2,
+        "continuation": getattr(base, "run_arm_continuation", None),
+        "asyncio": base.asyncio,
+        "passed_reachability": base.legacy._passed_reachability if adapter.build_system == "make" else base._passed_reachability,
+        "primary_continuation": primary.run_arm_continuation,
+        "submit_impl": operations.submit_build_result_impl,
+    }
+    if adapter.build_system == "cmake":
+        originals["case_proxy"] = base.opaque
+    else:
+        originals["case_proxy"] = base.make_lifecycle
+
+    def local_preflight(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "ready": True,
+            "release_revision": release["revision"],
+            "network_access_medium": require_network_medium(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+
+    def continuation(_runtime_manifest: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
+        return _run_arm_continuation(pair_manifest, adapter, *args, **kwargs)
+
+    def parent_submit(
+        *,
+        session: Any,
+        supporting_command_id: str | None = None,
+    ) -> str:
+        return bound_compile_tools._submit_with_post_build_phase(
+            session,
+            supporting_command_id=supporting_command_id,
+        )
+
+    base.protocol = protocol_proxy
+    base.collect_preflight = local_preflight
+    base._policy = lambda _value, *, arm, image_id: _policy(
+        pair_manifest,
+        adapter,
+        arm=arm,
+        image_id=image_id,
+    )
+    base._parent_policy = lambda _value, *, image_id: _parent_policy(
+        pair_manifest,
+        adapter,
+        image_id=image_id,
+    )
+    base._evaluate_arm_p2 = lambda session, frozen, parent_id: _evaluate_arm_p2(
+        adapter,
+        session,
+        frozen,
+        parent_id,
+    )
+    if adapter.build_system == "make":
+        base.run_arm_continuation = continuation
+    base.asyncio = _AsyncioProxy(async_runner)
+    primary.run_arm_continuation = continuation
+    operations.submit_build_result_impl = parent_submit
+    if adapter.build_system == "cmake":
+        base.opaque = case_proxy
+        base._passed_reachability = lambda *_args, **_kwargs: reachability
+    else:
+        base.make_lifecycle = case_proxy
+        base.legacy._passed_reachability = lambda *_args, **_kwargs: reachability
+    try:
+        yield base
+    finally:
+        base.protocol = originals["protocol"]
+        base.collect_preflight = originals["collect_preflight"]
+        base._policy = originals["policy"]
+        base._parent_policy = originals["parent_policy"]
+        base._evaluate_arm_p2 = originals["evaluate"]
+        if adapter.build_system == "make":
+            base.run_arm_continuation = originals["continuation"]
+        base.asyncio = originals["asyncio"]
+        primary.run_arm_continuation = originals["primary_continuation"]
+        operations.submit_build_result_impl = originals["submit_impl"]
+        if adapter.build_system == "cmake":
+            base.opaque = originals["case_proxy"]
+            base._passed_reachability = originals["passed_reachability"]
+        else:
+            base.make_lifecycle = originals["case_proxy"]
+            base.legacy._passed_reachability = originals["passed_reachability"]
+
+
+def _pair_terminal(arms: Sequence[dict[str, Any]]) -> str:
+    if any(arm.get("infrastructure", {}).get("status") == "endpoint_censored" for arm in arms):
+        return "endpoint_censored"
+    if any(arm.get("model_behavior", {}).get("status") != "completed" for arm in arms):
+        return "model_behavior_outcome"
+    return "valid"
+
+
+def _pair_outcome(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_manifest: dict[str, Any],
+    report: dict[str, Any],
+) -> dict[str, Any]:
+    arms = report.get("arms")
+    if report.get("complete_pair") is not True or report.get("cleanup_succeeded") is not True or report.get("arm_order") != pair["arm_order"] or not isinstance(arms, list) or {item.get("arm") for item in arms} != set(ARMS):
+        raise ConfirmatoryExecutionError("pair 未形成双臂与 cleanup 终态")
+    arm_map = {item["arm"]: item for item in arms}
+    eligible = all(item.get("infrastructure", {}).get("status") == "valid" for item in arm_map.values())
+    conversion = {arm: item.get("p2", {}).get("status") == "proven" for arm, item in arm_map.items()}
+    tokens = sum(item.get("recorded_tokens", 0) for item in arm_map.values())
+    if any(type(item.get("recorded_tokens")) is not int for item in arm_map.values()) or tokens > _execution(manifest)["budget"]["recorded_tokens_per_pair"]:
+        raise ConfirmatoryExecutionError("pair recorded-token evidence 无效")
+    return {
+        "schema_version": "forge-opaque-provenance-confirmatory-pair-outcome-1.0.0",
+        "document_type": "forge_opaque_provenance_confirmatory_pair_outcome",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "pair_manifest_sha256": protocol.canonical_sha256(pair_manifest),
+        "pair_id": pair["pair_id"],
+        "case_id": pair["case_id"],
+        "replicate": pair["replicate"],
+        "arm_order": copy.deepcopy(pair["arm_order"]),
+        "terminal": _pair_terminal(arms),
+        "arms": arm_map,
+        "recorded_tokens": tokens,
+        "primary_mechanism_eligible": eligible,
+        "provenance_conversion": conversion,
+        "paired_conversion_delta": (int(conversion["treatment"]) - int(conversion["baseline"]) if eligible else None),
+        "cleanup_succeeded": True,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def execute_real_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: asyncio.Runner,
+    reachability: dict[str, Any],
+    release: dict[str, str],
+    model_factory: Callable[[dict[str, Any], str], Any] | None = None,
+) -> dict[str, Any]:
+    adapter = lifecycle.build_case_adapter(pair["case_id"], REPO_ROOT)
+    pair_manifest = _pair_manifest(manifest, pair, pair_dir)
+    with _pair_bindings(
+        manifest,
+        pair_manifest,
+        adapter,
+        pair_dir,
+        release,
+        reachability,
+        async_runner,
+    ) as base:
+        report = base._run_pair(
+            pair_manifest,
+            output_dir=pair_dir,
+            repo_root=REPO_ROOT,
+            model_factory=model_factory,
+        )
+    return _pair_outcome(manifest, pair, pair_manifest, report)
+
+
+def next_batch_state(
+    manifest: dict[str, Any],
+    outcomes: list[dict[str, Any]],
+    *,
+    reachability_tokens: int = 0,
+) -> dict[str, Any]:
+    schedule = manifest["schedule"]["pairs"]
+    if len(outcomes) > len(schedule):
+        raise ConfirmatoryExecutionError("outcome 数量超过冻结 schedule")
+    if [item.get("pair_id") for item in outcomes] != [item["pair_id"] for item in schedule[: len(outcomes)]]:
+        raise ConfirmatoryExecutionError("outcome 顺序偏离冻结 schedule")
+    execution = _execution(manifest)
+    if type(reachability_tokens) is not int or reachability_tokens < 0:
+        raise ConfirmatoryExecutionError("reachability token evidence 无效")
+    recorded_tokens = 0
+    for outcome in outcomes:
+        tokens = outcome.get("recorded_tokens")
+        if type(tokens) is not int or tokens < 0:
+            raise ConfirmatoryExecutionError("pair token evidence 无效")
+        recorded_tokens += tokens
+        terminal = outcome.get("terminal")
+        if terminal in execution["terminal_taxonomy"]["stop_batch"]:
+            return {
+                "status": "stopped",
+                "reason": terminal,
+                "recorded_tokens": recorded_tokens,
+                "next_pair_id": None,
+            }
+        if terminal not in execution["terminal_taxonomy"]["continue"]:
+            raise ConfirmatoryExecutionError("未知 pair terminal taxonomy")
+    ceiling = execution["budget"]["batch_maximum_recorded_tokens"]
+    if recorded_tokens + reachability_tokens > ceiling:
+        raise ConfirmatoryExecutionError("batch recorded-token ceiling 已越界")
+    if len(outcomes) == len(schedule):
+        return {
+            "status": "completed",
+            "reason": None,
+            "recorded_tokens": recorded_tokens,
+            "next_pair_id": None,
+        }
+    if recorded_tokens + execution["budget"]["recorded_tokens_per_pair"] > ceiling:
+        return {
+            "status": "stopped",
+            "reason": "token_ceiling_reached",
+            "recorded_tokens": recorded_tokens,
+            "next_pair_id": None,
+        }
+    return {
+        "status": "ready",
+        "reason": None,
+        "recorded_tokens": recorded_tokens,
+        "next_pair_id": schedule[len(outcomes)]["pair_id"],
+    }
+
+
+def _exact_sign_flip(project_scores: list[float]) -> dict[str, Any]:
+    observed = abs(sum(project_scores))
+    statistics = [abs(sum(sign * score for sign, score in zip(signs, project_scores))) for signs in product((-1, 1), repeat=len(project_scores))]
+    extreme = sum(value >= observed - 1e-12 for value in statistics)
+    return {
+        "method": "two_sided_exact_sign_flip",
+        "statistic": sum(project_scores),
+        "permutations": len(statistics),
+        "p_value": extreme / len(statistics),
+    }
+
+
+def summarize(
+    manifest: dict[str, Any],
+    release: dict[str, str],
+    reachability: dict[str, Any],
+    outcomes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for outcome in outcomes:
+        grouped[outcome["case_id"]].append(outcome)
+    project_blocks: list[dict[str, Any]] = []
+    for case_id in [item["case_id"] for item in manifest["cases"]]:
+        case_outcomes = grouped[case_id]
+        estimable = len(case_outcomes) == 2 and all(item["primary_mechanism_eligible"] for item in case_outcomes)
+        deltas = [item["paired_conversion_delta"] for item in case_outcomes] if estimable else []
+        project_blocks.append(
+            {
+                "case_id": case_id,
+                "pair_ids": [item["pair_id"] for item in case_outcomes],
+                "estimable": estimable,
+                "replicate_deltas": deltas,
+                "project_score": sum(deltas) / 2 if estimable else None,
+            }
+        )
+    all_estimable = all(item["estimable"] for item in project_blocks)
+    project_scores = [item["project_score"] for item in project_blocks]
+    primary_test = _exact_sign_flip(project_scores) if all_estimable else None
+    pair_tokens = sum(item["recorded_tokens"] for item in outcomes)
+    total_tokens = reachability["recorded_tokens"] + pair_tokens
+    ceiling = _execution(manifest)["budget"]["batch_maximum_recorded_tokens"]
+    if total_tokens > ceiling:
+        raise ConfirmatoryExecutionError("pilot 超过授权 batch token ceiling")
+    return {
+        "schema_version": "forge-opaque-provenance-confirmatory-batch-report-1.0.0",
+        "document_type": "forge_opaque_provenance_confirmatory_batch_report",
+        "manifest_sha256": protocol.canonical_sha256(manifest),
+        "evidence_identity_sha256": _execution(manifest)["evidence"]["identity_sha256"],
+        "release_revision": release["revision"],
+        "network_access_medium": require_network_medium(manifest),
+        "status": "completed" if all_estimable else "completed_with_attrition",
+        "scheduled_pairs": manifest["schedule"]["pair_count"],
+        "observed_pairs": len(outcomes),
+        "endpoint_censored_pair_ids": [item["pair_id"] for item in outcomes if item["terminal"] == "endpoint_censored"],
+        "project_blocks": project_blocks,
+        "all_project_blocks_estimable": all_estimable,
+        "primary_test": primary_test,
+        "reachability_recorded_tokens": reachability["recorded_tokens"],
+        "pair_recorded_tokens": pair_tokens,
+        "recorded_tokens": total_tokens,
+        "maximum_recorded_tokens": ceiling,
+        "historical_exploratory_pairs_pooled": False,
+        "model_ranking_performed": False,
+        "pairs": outcomes,
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+PairExecutor = Callable[
+    [
+        dict[str, Any],
+        dict[str, Any],
+        Path,
+        asyncio.Runner,
+        dict[str, Any],
+        dict[str, str],
+    ],
+    dict[str, Any],
+]
+
+
+def run_batch(
+    manifest: dict[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = REPO_ROOT,
+    pair_executor: PairExecutor | None = None,
+) -> dict[str, Any]:
+    protocol.verify_frozen_components(manifest, repo_root)
+    _output_dir(manifest, output_dir)
+    release = require_release_identity(manifest, repo_root)
+    require_network_medium(manifest)
+    primary.require_compose_dood()
+    require_zero_managed_containers()
+    reachability = require_passed_reachability(
+        manifest,
+        output_dir,
+        release["revision"],
+    )
+    digest = protocol.canonical_sha256(manifest)
+    evidence = _execution(manifest)["evidence"]
+    marker_path = output_dir / evidence["batch_marker"]
+    marker = batch_runtime._claim_batch_marker(
+        marker_path,
+        digest,
+        release["revision"],
+    )
+    report_path = output_dir / evidence["batch_report"]
+    if marker["status"] == "passed":
+        report = _load_json(report_path)
+        if report.get("manifest_sha256") != digest:
+            raise ConfirmatoryExecutionError("已有 batch report identity 漂移")
+        return report
+
+    outcomes: list[dict[str, Any]] = []
+    try:
+        with asyncio.Runner() as async_runner:
+            for pair in manifest["schedule"]["pairs"]:
+                pair_dir = output_dir / "pairs" / pair["pair_id"]
+                outcome_path = pair_dir / evidence["pair_outcome"]
+                if outcome_path.exists():
+                    outcome = _load_json(outcome_path)
+                    if outcome.get("manifest_sha256") != digest or outcome.get("pair_id") != pair["pair_id"]:
+                        raise ConfirmatoryExecutionError("已有 pair outcome identity 漂移")
+                else:
+                    if pair_dir.exists() and any(pair_dir.iterdir()):
+                        raise ConfirmatoryExecutionError(f"pair 已开始但没有冻结 outcome，禁止自动补跑: {pair['pair_id']}")
+                    state = next_batch_state(
+                        manifest,
+                        outcomes,
+                        reachability_tokens=reachability["recorded_tokens"],
+                    )
+                    if state["status"] != "ready" or state["next_pair_id"] != pair["pair_id"]:
+                        raise ConfirmatoryExecutionError(f"batch 已停止，禁止启动 {pair['pair_id']}: {state['reason']}")
+                    require_zero_managed_containers()
+                    executor = pair_executor or execute_real_pair
+                    outcome = executor(
+                        manifest,
+                        pair,
+                        pair_dir,
+                        async_runner,
+                        reachability,
+                        release,
+                    )
+                    _write_once(outcome_path, outcome)
+                outcomes.append(outcome)
+                require_zero_managed_containers()
+        if len(outcomes) != manifest["schedule"]["pair_count"]:
+            raise ConfirmatoryExecutionError("未形成全部 12 个预注册 pair 终态")
+        report = summarize(manifest, release, reachability, outcomes)
+        _write_once(report_path, report)
+        marker.update(
+            status="passed",
+            error_class=None,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write(marker_path, marker)
+        return report
+    except BaseException as exc:
+        marker.update(
+            status="failed",
+            error_class=type(exc).__name__,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write(marker_path, marker)
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("validate", "preflight", "reachability", "batch", "report"),
+    )
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = protocol.load_manifest(args.manifest)
+    if args.command == "validate":
+        protocol.verify_frozen_components(manifest)
+        result: Any = {
+            "status": "valid",
+            "manifest_sha256": protocol.canonical_sha256(manifest),
+            "provider_calls": 0,
+            "formal_attempts": 0,
+            "model_tokens": 0,
+        }
+    elif args.command == "preflight":
+        result = collect_preflight(
+            manifest,
+            output_dir=args.output_dir,
+            require_empty=True,
+        )
+    elif args.command == "reachability":
+        result = execute_reachability(manifest, output_dir=args.output_dir)
+    elif args.command == "batch":
+        result = run_batch(manifest, output_dir=args.output_dir)
+    else:
+        result = _load_json(args.output_dir / _execution(manifest)["evidence"]["batch_report"])
+        if result.get("manifest_sha256") != protocol.canonical_sha256(manifest):
+            raise ConfirmatoryExecutionError("batch report identity 漂移")
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 Issue #237 授权 amendment、const Schema 与预注册，冻结六 case / 12 pair / 24 arm 的确认性执行身份。
- 组合既有 lifecycle checkpoint、CMake/Make pair runner、R1 continuation、R0 observability 与 behavioral v2 batch marker，不修改生产 Compiler 和历史 runner。
- 修复组合层重复向 continuation 传入 runtime manifest 导致两臂在首个模型请求前 `TypeError` 的问题。
- 保持 DeepSeek `deepseek-v4-flash`、300 秒、0 retry、2,940,000 recorded-token ceiling，以及禁止 fallback/replacement/backfill。

## 验证

- 聚焦非 Docker：`8 passed, 2 skipped`
- 相邻复用链：`118 passed`
- 真实 `args` fake-model Docker 门禁：`1 passed in 103.16s`
- Ruff check/format、确定性再生成、Schema、diff、敏感信息扫描通过
- 后置 compile/replay orphan：0
- 全部上述门禁为 0 provider、0 credential read、0 正式 evidence、0 model token

旧 minimal-canary 的一个测试直接断言其冻结 evidence 目录为空；本机已有合法 append-only 历史 evidence，因此该环境性断言失败。未删除、移动或改写历史 evidence，其余相邻合同测试均通过。

Closes #237