### PR TITLE
修复：补齐确认性 Make runtime 身份契约

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 保全 confirmatory v1 失败证据并完成 Issue #239 Make runtime 版本化修复门禁
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_repair_adapter.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter_docker.py`, `.claude/memory/project.md`
+  - 终态: `main@b2218e4b` 的唯一 batch 完成 `pupnp/ada-url/args` 三个 rep-01 outcome 后，在首个 Make pair `gpac-rep-01` 的任何 provider 请求与容器创建前因 pair manifest 缺少 `case.reference_case_id` 触发 `KeyError`；batch marker 为 `failed/KeyError`，原批次不重跑、不 replacement、不 backfill。
+  - 证据: 三个 outcome 共 82,199 recorded tokens；`pupnp` 与 `ada-url` 为 endpoint-censored，`args` 双臂均在 8 requests 后达到 graph-step limit、0 submit/0 replay/P2 均 unproven，paired delta 为 0。只完成 3/12 pairs，不能形成六个 project block 或 primary test，也不做模型排名。
+  - 修复: v1 runner/manifest/schema/evidence 保持逐字不变；新 adapter 从冻结 `source_case_id` 派生 `reference_case_id`，并把 Make proxy 绑定到通用 provenance history evaluator。静态合同覆盖 12 pairs、6 cases 与 CMake/Make 两类 runtime。
+  - 验证: v1 + repair 聚焦 `12 passed, 1 skipped`，相邻 confirmatory/R3 Make `31 passed`，全后端 Ruff 与 358 个文件 format 检查通过；真实 `sql-parser-shared` fake-model Make gate `1 passed in 90.98s`，完成 checkpoint、双臂、treatment P2 conversion、submit/clean replay 与 cleanup，后置 compile/replay orphan 为 0。全修复阶段 0 真实 provider、0 credential read、0 model token、0 formal evidence write。
+
 - 2026-08-31 — 实现 Issue #237 六 case confirmatory authorized runner 并通过真实 fake-model 门禁
   - 文件: `scripts/forge_opaque_provenance_confirmatory_execution_authorized_protocol.py`, `scripts/forge_opaque_provenance_confirmatory_execution_authorized_runner.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_execution_authorized_docker.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-execution-authorized.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-execution-authorized.md`
   - 实现: 复用现有 lifecycle checkpoint、CMake/Make pair runner、R1 continuation、R0 observability 和 behavioral v2 batch marker；修复组合层重复传入 runtime manifest 导致双臂在首个模型请求前 `TypeError` 的问题，不修改生产 Compiler 或历史 runner。
@@ -663,6 +670,8 @@
 ## 已知问题 (Known Issues / Pitfalls)
 <!-- 工作中踩过的坑、限制或意外行为。 -->
 
+- Confirmatory v1 的真实 fake-model Docker gate 只覆盖 CMake `args`，因此没有触达 R3 Make 对 `case.reference_case_id` 与 `make_lifecycle.provenance.command_history_sha256` 的隐含依赖。跨 build-system 复用 runner 时，至少各选一个 CMake/Make case 做真实零 provider 门禁；发现冻结 runtime 缺口后必须新增版本化 adapter/test，不能原地修改 v1 或重生成旧 manifest 掩盖失败。
+- R3 Make runner 在 `gate.capture()` 的 evidence callback 抛错时，`gate` 已创建但 coordinator record 可能尚未提交；现有异常清理会跳过直接 parent container removal，留下已退出的 compile 容器。opt-in 测试必须跟踪自身创建的 Session 并在 `finally` 按精确 identity 清理；未来若授权 recovery，应先在新版本 runner 中补齐 capture-before-commit 的生产 cleanup 门禁。
 - PowerShell → WSL 命令不得嵌入 Bash `$变量`、`$()`、正则括号或多层引号；即使目的是只读 Docker 审计，也必须拆成 `wsl.exe -d Ubuntu -- docker ...` 固定参数命令。零 orphan 查询使用独立的 `docker ps -aq --filter=name=deerflow-compile-` 和 `--filter=name=deerflow-replay-`，不要再写包装 shell。
 - `test_forge_opaque_provenance_minimal_canary_authorized.py::test_collector_uses_read_only_git_docker_and_evidence_checks` 直接绑定冻结 evidence 目录并断言为空；该 append-only 目录在真实 canary 后合法非空，因此相邻回归会产生环境性失败。不得为测试全绿删除、移动或改写历史 evidence，应单独报告并依赖其余合同测试验证回归。
 - Authorized manifest 若冻结预注册文档或 runtime 的文件 SHA-256，任何末尾空行、格式或注释变更后都必须重新生成 manifest/schema，并在最终字节上再次执行确定性生成和聚焦测试；不能把文档清理视为不影响协议 identity 的提交前操作。

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib.util
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_ROOT = REPO_ROOT / "scripts"
+ADAPTER_PATH = SCRIPT_ROOT / "forge_opaque_provenance_confirmatory_execution_repair_adapter.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json"
+
+
+def _load_adapter():
+    if str(SCRIPT_ROOT) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_ROOT))
+    spec = importlib.util.spec_from_file_location("forge_confirmatory_execution_repair_adapter_test", ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter = _load_adapter()
+
+
+def test_repair_contract_covers_all_pairs_without_provider_work() -> None:
+    manifest = adapter.v1.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    result = adapter.validate_contract(manifest, repo_root=REPO_ROOT)
+
+    assert result == {
+        "status": "passed",
+        "pair_count": 12,
+        "case_count": 6,
+        "build_systems": ["cmake", "make"],
+        "reference_case_ids": {
+            "pupnp": "pupnp",
+            "ada-url": "ada-url",
+            "args": "args",
+            "gpac": "gpac",
+            "fio": "fio",
+            "sql-parser-shared": "sql-parser",
+        },
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+@pytest.mark.parametrize("case_id", ["args", "gpac"])
+def test_repaired_manifest_reaches_both_pair_runtime_families(
+    case_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = adapter.v1.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    pair = next(item for item in manifest["schedule"]["pairs"] if item["case_id"] == case_id)
+    captured: dict[str, Any] = {}
+
+    class PairRuntime:
+        make_lifecycle = SimpleNamespace(provenance=None)
+
+        @staticmethod
+        def _run_pair(pair_manifest: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+            captured["pair_manifest"] = pair_manifest
+            return {
+                "complete_pair": True,
+                "cleanup_succeeded": True,
+                "arm_order": pair["arm_order"],
+                "arms": [
+                    {
+                        "arm": arm,
+                        "infrastructure": {"status": "valid"},
+                        "model_behavior": {"status": "completed"},
+                        "p2": {"status": "unproven"},
+                        "recorded_tokens": 0,
+                    }
+                    for arm in pair["arm_order"]
+                ],
+            }
+
+    @contextmanager
+    def pair_bindings(*_args: Any, **_kwargs: Any) -> Iterator[PairRuntime]:
+        yield PairRuntime()
+
+    monkeypatch.setattr(adapter.v1, "_pair_bindings", pair_bindings)
+    with asyncio.Runner() as async_runner:
+        outcome = adapter.execute_real_pair(
+            manifest,
+            pair,
+            tmp_path / pair["pair_id"],
+            async_runner,
+            {"recorded_tokens": 17},
+            {"branch": "main", "revision": "a" * 40, "origin_main": "a" * 40},
+        )
+
+    case = next(item for item in manifest["cases"] if item["case_id"] == case_id)
+    assert captured["pair_manifest"]["case"]["reference_case_id"] == case["source_case_id"]
+    if case["build_system"] == "make":
+        assert PairRuntime.make_lifecycle.provenance is adapter.lifecycle.make_reference.provenance
+    assert outcome["pair_id"] == pair["pair_id"]
+
+
+def test_repair_fails_closed_without_source_case_identity() -> None:
+    manifest = adapter.v1.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    candidate = copy.deepcopy(manifest)
+    candidate["cases"][3].pop("source_case_id")
+    pair = next(item for item in candidate["schedule"]["pairs"] if item["case_id"] == "gpac")
+
+    with pytest.raises(adapter.ConfirmatoryRepairError, match="source case identity"):
+        adapter._pair_manifest(candidate, pair, Path("/tmp/gpac"))

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_execution_repair_adapter_docker.py
@@ -1,0 +1,186 @@
+"""Issue #239 repair adapter 的 opt-in 零 provider Make Docker 门禁。"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPT_PATH = REPO_ROOT / "scripts/forge_opaque_provenance_confirmatory_execution_repair_adapter.py"
+MANIFEST_PATH = REPO_ROOT / "benchmarks/manifests/cpp-opaque-provenance-confirmatory-execution-authorized.json"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_CONFIRMATORY_REPAIR_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_CONFIRMATORY_REPAIR_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_adapter():
+    scripts = REPO_ROOT / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    spec = importlib.util.spec_from_file_location("forge_confirmatory_execution_repair_adapter_docker_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+adapter = _load_adapter()
+
+
+class MakeProvenanceRepairModel(BaseChatModel):
+    model_name: str = "deepseek-v4-flash"
+    base_url: str = "https://api.deepseek.com"
+    arm: str
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "opaque-confirmatory-repair-docker-fake"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.arm == "baseline":
+            tool_call = {"name": "submit_build_result", "args": {}, "id": "baseline-submit", "type": "tool_call"} if self.calls == 1 else None
+        else:
+            actions = (
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "make library -j2",
+                        "timeout_seconds": 300,
+                        "workdir": "/workspace/repo",
+                        "command_role": "build",
+                    },
+                    "id": "treatment-build",
+                    "type": "tool_call",
+                },
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "cp /workspace/repo/libsqlparser.so /artifacts/libsqlparser.so",
+                        "timeout_seconds": 60,
+                        "workdir": "/workspace/repo",
+                        "command_role": "artifact_stage",
+                    },
+                    "id": "treatment-stage",
+                    "type": "tool_call",
+                },
+                {"name": "submit_build_result", "args": {}, "id": "treatment-submit", "type": "tool_call"},
+            )
+            tool_call = actions[self.calls - 1] if self.calls <= len(actions) else None
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="" if tool_call else "Done.",
+                        tool_calls=[] if tool_call is None else [tool_call],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                    )
+                )
+            ]
+        )
+
+
+def test_repair_adapter_executes_make_checkpoint_p2_replay_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter.v1.primary.require_compose_dood()
+    adapter.v1.require_zero_managed_containers()
+    paths = Paths()
+    output_dir = paths.compile_sessions_dir / f"issue-239-confirmatory-repair-docker-{uuid.uuid4().hex[:12]}"
+    created_sessions: list[Any] = []
+    manager = CompileSessionManager(paths=paths, default_image=adapter.v1.COMPILE_IMAGE)
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any):
+        session = original_create_session(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(
+        operations,
+        "_services",
+        CompileOperationsServices(manager=manager, runtime=runtime),
+    )
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    manifest = adapter.v1.protocol.load_manifest(MANIFEST_PATH, REPO_ROOT)
+    pair = next(item for item in manifest["schedule"]["pairs"] if item["case_id"] == "sql-parser-shared" and item["replicate"] == 1)
+    release = {"branch": "main", "revision": "e" * 40, "origin_main": "e" * 40}
+
+    def model_factory(_provider: dict[str, Any], thread_id: str) -> Any:
+        arm = "treatment" if thread_id.startswith("treatment-") else "baseline"
+        return MakeProvenanceRepairModel(arm=arm)
+
+    try:
+        with asyncio.Runner() as async_runner:
+            result = adapter.execute_real_pair(
+                manifest,
+                pair,
+                output_dir,
+                async_runner,
+                {"recorded_tokens": 17},
+                release,
+                model_factory=model_factory,
+            )
+        assert result["primary_mechanism_eligible"] is True
+        assert result["provenance_conversion"] == {"baseline": False, "treatment": True}, json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True)
+        assert result["arms"]["treatment"]["verification_outcome"]["status"] == "passed"
+        assert result["arms"]["treatment"]["p2"]["status"] == "proven"
+        assert result["cleanup_succeeded"] is True
+        adapter.v1.require_zero_managed_containers()
+    finally:
+        for session in reversed(created_sessions):
+            runtime.stop_and_remove_container(session)
+            session_dir = Path(session.metadata_path).parent
+            shutil.rmtree(session_dir, ignore_errors=True)
+            try:
+                session_dir.parent.rmdir()
+            except OSError:
+                pass
+        shutil.rmtree(output_dir, ignore_errors=True)

--- a/scripts/forge_opaque_provenance_confirmatory_execution_repair_adapter.py
+++ b/scripts/forge_opaque_provenance_confirmatory_execution_repair_adapter.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Issue #239 confirmatory v1 机制故障的版本化 pair runtime 修复。"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_confirmatory_execution_authorized_runner as v1  # noqa: E402
+import forge_opaque_provenance_confirmatory_lifecycle_gate as lifecycle  # noqa: E402
+
+DEFAULT_MANIFEST = v1.DEFAULT_MANIFEST
+
+
+class ConfirmatoryRepairError(RuntimeError):
+    """修复后的 pair runtime identity 或静态合同无效。"""
+
+
+def _pair_manifest(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+) -> dict[str, Any]:
+    runtime_manifest = v1._pair_manifest(manifest, pair, pair_dir)
+    case = v1._case(manifest, pair["case_id"])
+    reference_case_id = case.get("source_case_id")
+    if not isinstance(reference_case_id, str) or not reference_case_id:
+        raise ConfirmatoryRepairError(f"{pair['case_id']} 缺少冻结 source case identity")
+    runtime_manifest["case"]["reference_case_id"] = reference_case_id
+    return runtime_manifest
+
+
+def validate_contract(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    v1.protocol.verify_frozen_components(manifest, repo_root)
+    pairs = manifest["schedule"]["pairs"]
+    build_systems: set[str] = set()
+    reference_case_ids: dict[str, str] = {}
+    for pair in pairs:
+        case = v1._case(manifest, pair["case_id"])
+        adapter = lifecycle.build_case_adapter(pair["case_id"], repo_root)
+        pair_manifest = _pair_manifest(manifest, pair, Path("/tmp") / pair["pair_id"])
+        expected = case["source_case_id"]
+        if pair_manifest["case"].get("reference_case_id") != expected:
+            raise ConfirmatoryRepairError(f"{pair['pair_id']} reference identity 漂移")
+        if pair_manifest["case"]["build_system"] != adapter.build_system:
+            raise ConfirmatoryRepairError(f"{pair['pair_id']} build system identity 漂移")
+        if adapter.build_system == "make" and not callable(getattr(lifecycle.make_reference.provenance, "command_history_sha256", None)):
+            raise ConfirmatoryRepairError("Make pair 缺少通用 provenance history evaluator")
+        build_systems.add(adapter.build_system)
+        reference_case_ids[pair["case_id"]] = expected
+    if build_systems != {"cmake", "make"}:
+        raise ConfirmatoryRepairError("repair gate 未覆盖 CMake 与 Make")
+    return {
+        "status": "passed",
+        "pair_count": len(pairs),
+        "case_count": len(reference_case_ids),
+        "build_systems": sorted(build_systems),
+        "reference_case_ids": reference_case_ids,
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "evidence_writes": 0,
+    }
+
+
+def execute_real_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: asyncio.Runner,
+    reachability: dict[str, Any],
+    release: dict[str, str],
+    model_factory: Callable[[dict[str, Any], str], Any] | None = None,
+) -> dict[str, Any]:
+    adapter = lifecycle.build_case_adapter(pair["case_id"], REPO_ROOT)
+    pair_manifest = _pair_manifest(manifest, pair, pair_dir)
+    with v1._pair_bindings(
+        manifest,
+        pair_manifest,
+        adapter,
+        pair_dir,
+        release,
+        reachability,
+        async_runner,
+    ) as base:
+        if adapter.build_system == "make":
+            base.make_lifecycle.provenance = lifecycle.make_reference.provenance
+        report = base._run_pair(
+            pair_manifest,
+            output_dir=pair_dir,
+            repo_root=REPO_ROOT,
+            model_factory=model_factory,
+        )
+    return v1._pair_outcome(manifest, pair, pair_manifest, report)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    args = parser.parse_args(argv)
+    try:
+        manifest = v1.protocol.load_manifest(args.manifest)
+        result = validate_contract(manifest)
+    except (OSError, ConfirmatoryRepairError, v1.protocol.ProtocolError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景

confirmatory v1 在完成三个 CMake pair outcome 后，首个 Make pair `gpac-rep-01` 于任何 provider 请求和容器创建前触发 `KeyError: reference_case_id`。进一步的真实 Make gate 还发现 v1 case proxy 把 `provenance` 指向 Make 判定模块，而 R3 runner 需要其内部的通用 provenance history evaluator。

v1 runner、manifest、schema 和失败 evidence 已按字节冻结，不能原地修改或重生成旧 identity。

## 改动

- 新增版本化 repair adapter，从冻结 `source_case_id` 派生 `reference_case_id`。
- 为 Make proxy 注入通用 `command_history_sha256` evaluator，继续复用既有 checkpoint、P2、submit/replay 与 cleanup 主循环。
- 新增 12-pair 静态合同测试，覆盖 6 cases、CMake/Make runtime 和 `sql-parser-shared -> sql-parser` identity 映射。
- 新增 opt-in 零 provider Make Docker gate，并在测试失败路径按自身创建的 Session 精确清理容器。
- 记录 v1 batch 的失败终态、三条 outcome 和后续 recovery 决策边界。

## 验证

- v1 + repair 聚焦：`12 passed, 1 skipped`
- confirmatory/R3 Make 相邻回归：`31 passed`
- 真实 `sql-parser-shared` fake-model Make gate：`1 passed in 90.98s`
- 全后端 Ruff：通过
- 全后端 format：`358 files already formatted`
- 后置 compile/replay orphan：0
- 真实 provider 请求、credential read、model token、formal evidence write：均为 0

## 研究边界

本 PR 不修改或重跑 confirmatory v1，不 replacement、不 backfill，也不把 3/12 pair 的部分结果用于 primary test 或模型排名。是否建立透明 recovery amendment 另行决策。

Closes #239