### PR TITLE
研究：增加 independent replication 零 provider lifecycle 门禁

### DIFF
--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -64,6 +64,13 @@
 ## 最近变更 (Recent Changes)
 <!-- 倒序，最新在上。 -->
 
+- 2026-08-31 — 完成 Issue #245 independent replication lifecycle 零 provider 门禁
+  - 文件: `scripts/forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate_docker.py`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-replication-lifecycle-zero-provider-gate.md`, `.claude/memory/project.md`
+  - Identity: 严格绑定 Issue #243 candidate canonical SHA-256 `7b1817becba4ec57eb9726be0e1faaa5427af309dca7552634e3f6a3a1b5d938`、evidence identity `b136cc5669384176853f00b878dae207d89b7bce593cc8e5f1ff9ab06505b9bc`、schedule identity `3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134` 与 repair adapter byte SHA-256 `c8a13388f6c53d308b34f013bf4a9f449190a10e779667cdf73b0e8ef1da2544`。
+  - 门禁: 临时 v1-shaped runtime 强制 `example.invalid`、不存在的 credential 占位名和显式 deterministic fake model factory；临时输出不得等于或位于正式 replication evidence 目录内。CMake capture-before-commit 异常精确清理本 pair Session，Make pair 完成 checkpoint、双臂、treatment P2 conversion、candidate verification、唯一 clean replay、finalize 与 cleanup。
+  - 验证: 静态及相邻回归 `27 passed`；真实 Ubuntu-native Docker 组合门禁 `2 passed in 131.88s`；Ruff check/format、静态协议命令与 diff 检查通过，前后 0 compile/replay orphan、正式 replication evidence 为空。全阶段 0 provider、0 credential read、0 formal attempt、0 model token、0 正式 evidence write。
+  - 环境: Compose 的 `/repo` 是完整但只读的宿主 checkout，`/app` 镜像层不是完整 benchmark 仓库；静态回归从 `/repo` 读取时 pytest cache warning 可忽略。下一阶段在本门禁合并后另建 authorized amendment，未经版本化授权不得执行 reachability 或 12-pair batch。
+
 - 2026-08-31 — 冻结 Issue #243 opaque provenance independent replication 未授权候选
   - 文件: `scripts/forge_opaque_provenance_confirmatory_replication_candidate_protocol.py`, `backend/tests/test_forge_opaque_provenance_confirmatory_replication_candidate.py`, `benchmarks/manifests/cpp-opaque-provenance-confirmatory-replication-candidate.json`, `benchmarks/schemas/forge-opaque-provenance-confirmatory-replication-candidate.schema.json`, `benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-replication-candidate.md`, `.claude/memory/project.md`
   - Identity: 候选基线为 `main@c38f7381`，manifest canonical SHA-256 为 `7b1817becba4ec57eb9726be0e1faaa5427af309dca7552634e3f6a3a1b5d938`，独立 evidence identity 为 `b136cc5669384176853f00b878dae207d89b7bce593cc8e5f1ff9ab06505b9bc`。

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py
@@ -1,0 +1,113 @@
+"""Issue #245 independent replication lifecycle 的零 provider 静态门禁。"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+GATE_PATH = SCRIPTS / "forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py"
+
+
+def _load_gate():
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location("forge_confirmatory_replication_lifecycle_gate_test", GATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+
+def test_gate_contract_freezes_replication_identity_without_provider_work() -> None:
+    result = gate.validate_gate_contract(REPO_ROOT)
+
+    assert result == {
+        "schema_version": "forge-opaque-provenance-confirmatory-replication-lifecycle-gate-1.0.0",
+        "issue_url": "https://github.com/WWFXL/Forge-AutoCompiler/issues/245",
+        "status": "passed",
+        "candidate_manifest_sha256": "7b1817becba4ec57eb9726be0e1faaa5427af309dca7552634e3f6a3a1b5d938",
+        "candidate_manifest_file_sha256": "b6eb90bfc5242dec1881627101de3c0c4589c5863700293d92bec80bea2de324",
+        "evidence_identity_sha256": "b136cc5669384176853f00b878dae207d89b7bce593cc8e5f1ff9ab06505b9bc",
+        "schedule_identity_sha256": "3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134",
+        "case_count": 6,
+        "pair_count": 12,
+        "build_systems": ["cmake", "make"],
+        "capture_before_commit_cleanup_required": True,
+        "broad_docker_cleanup_forbidden": True,
+        "historical_outcomes_imported": False,
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "formal_evidence_writes": 0,
+        "docker_executed": False,
+    }
+
+
+def test_zero_provider_runtime_is_ephemeral_and_fail_closed(tmp_path: Path) -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    runtime = gate.build_zero_provider_runtime_manifest(manifest, tmp_path / "gate", repo_root=REPO_ROOT)
+
+    provider = runtime["authorized_execution"]["provider"]
+    assert provider["status"] == "deterministic_zero_provider_gate"
+    assert provider["model"] == "deterministic-zero-provider"
+    assert provider["endpoint"] == "https://example.invalid/v1"
+    assert provider["credential_env"] == "UNUSED_ZERO_PROVIDER_CREDENTIAL"
+    assert provider["request_timeout_seconds"] == 1
+    assert provider["max_retries"] == 0
+    assert runtime["authorization"] == manifest["authorization"]
+    assert runtime["gate_context"]["model_tokens_authorized"] == 0
+    assert runtime["authorized_execution"]["evidence"]["directory"] == str(tmp_path / "gate")
+    with pytest.raises(gate.ReplicationLifecycleGateError, match="不得写入正式"):
+        gate.build_zero_provider_runtime_manifest(
+            manifest,
+            Path(manifest["replication_candidate"]["evidence_candidate"]["directory"]) / "pairs" / "forbidden",
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_formal_evidence_must_remain_empty(tmp_path: Path) -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    formal = tmp_path / "formal"
+    assert gate.require_empty_formal_evidence(manifest, directory=formal) == []
+    formal.mkdir()
+    (formal / "unexpected.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(gate.ReplicationLifecycleGateError, match="不是空目录"):
+        gate.require_empty_formal_evidence(manifest, directory=formal)
+
+
+def test_gate_rejects_candidate_authorization_drift() -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    drifted = copy.deepcopy(manifest)
+    drifted["authorization"]["provider_calls_authorized"] = True
+
+    with pytest.raises(gate.candidate.ReplicationCandidateError):
+        gate.build_zero_provider_runtime_manifest(drifted, Path("/tmp/issue-245"), repo_root=REPO_ROOT)
+
+
+def test_execute_requires_explicit_fake_model(tmp_path: Path) -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    pair = manifest["schedule"]["pairs"][0]
+
+    with pytest.raises(gate.ReplicationLifecycleGateError, match="显式 deterministic model factory"):
+        gate.execute_zero_provider_pair(
+            manifest,
+            pair,
+            tmp_path / "pair",
+            object(),
+            {"branch": "main", "revision": "a" * 40, "origin_main": "a" * 40},
+            model_factory=None,
+            formal_evidence_directory=tmp_path / "formal",
+            repo_root=REPO_ROOT,
+        )

--- a/backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate_docker.py
+++ b/backend/tests/test_forge_opaque_provenance_confirmatory_replication_lifecycle_gate_docker.py
@@ -1,0 +1,232 @@
+"""Issue #245 independent replication lifecycle 的 opt-in 零 provider Docker 门禁。"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+
+from deerflow.compile import operations
+from deerflow.compile.docker_runtime import CompileDockerRuntime
+from deerflow.compile.manager import CompileSessionManager
+from deerflow.compile.operations import CompileOperationsServices
+from deerflow.config.paths import Paths
+
+REPO_ROOT = Path(os.environ.get("FORGE_REPO_ROOT", Path(__file__).resolve().parents[2])).resolve()
+SCRIPTS = REPO_ROOT / "scripts"
+GATE_PATH = SCRIPTS / "forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py"
+DOCKER_ENABLED = os.getenv("FORGE_RUN_OPAQUE_CONFIRMATORY_REPLICATION_LIFECYCLE_DOCKER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not DOCKER_ENABLED,
+    reason="set FORGE_RUN_OPAQUE_CONFIRMATORY_REPLICATION_LIFECYCLE_DOCKER=1 inside Forge Compose",
+)
+
+
+def _load_gate():
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location("forge_confirmatory_replication_lifecycle_gate_docker_test", GATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+
+class MakeRepairModel(BaseChatModel):
+    model_name: str = gate.ZERO_PROVIDER_MODEL
+    base_url: str = gate.ZERO_PROVIDER_ENDPOINT
+    arm: str
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "opaque-confirmatory-replication-lifecycle-zero-provider"
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Any | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        self.calls += 1
+        if self.arm == "baseline":
+            tool_call = {"name": "submit_build_result", "args": {}, "id": "baseline-submit", "type": "tool_call"} if self.calls == 1 else None
+        else:
+            actions = (
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "make library -j2",
+                        "timeout_seconds": 300,
+                        "workdir": "/workspace/repo",
+                        "command_role": "build",
+                    },
+                    "id": "treatment-build",
+                    "type": "tool_call",
+                },
+                {
+                    "name": "run_container_bash",
+                    "args": {
+                        "command": "cp /workspace/repo/libsqlparser.so /artifacts/libsqlparser.so",
+                        "timeout_seconds": 60,
+                        "workdir": "/workspace/repo",
+                        "command_role": "artifact_stage",
+                    },
+                    "id": "treatment-stage",
+                    "type": "tool_call",
+                },
+                {"name": "submit_build_result", "args": {}, "id": "treatment-submit", "type": "tool_call"},
+            )
+            tool_call = actions[self.calls - 1] if self.calls <= len(actions) else None
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="" if tool_call else "Done.",
+                        tool_calls=[] if tool_call is None else [tool_call],
+                        response_metadata={"model_name": self.model_name},
+                        usage_metadata={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                )
+            ]
+        )
+
+
+def _services(monkeypatch: pytest.MonkeyPatch) -> tuple[Paths, CompileDockerRuntime, list[Any]]:
+    paths = Paths()
+    manager = CompileSessionManager(paths=paths, default_image=gate.repair.v1.COMPILE_IMAGE)
+    created_sessions: list[Any] = []
+    original_create_session = manager.create_session
+
+    def create_session(*args: Any, **kwargs: Any) -> Any:
+        session = original_create_session(*args, **kwargs)
+        created_sessions.append(session)
+        return session
+
+    manager.create_session = create_session  # type: ignore[method-assign]
+    runtime = CompileDockerRuntime(manager=manager)
+    monkeypatch.setattr(operations, "_services", CompileOperationsServices(manager=manager, runtime=runtime))
+    return paths, runtime, created_sessions
+
+
+def _cleanup(runtime: CompileDockerRuntime, sessions: list[Any], output_dir: Path) -> None:
+    for session in reversed(sessions):
+        runtime.stop_and_remove_container(session)
+        session_dir = Path(session.metadata_path).parent
+        shutil.rmtree(session_dir, ignore_errors=True)
+        try:
+            session_dir.parent.rmdir()
+        except OSError:
+            pass
+    shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def _preflight(manifest: dict[str, Any]) -> None:
+    gate.repair.v1.primary.require_compose_dood()
+    gate.repair.v1.require_zero_managed_containers()
+    assert gate.require_empty_formal_evidence(manifest) == []
+
+
+def test_cmake_capture_before_commit_failure_cleans_only_created_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    _preflight(manifest)
+    paths, runtime, sessions = _services(monkeypatch)
+    output_dir = paths.compile_sessions_dir / f"issue-245-replication-cmake-failure-{uuid.uuid4().hex[:12]}"
+    pair = next(item for item in manifest["schedule"]["pairs"] if item["case_id"] == "args" and item["replicate"] == 1)
+
+    def fail_before_commit(_history: Any) -> str:
+        raise RuntimeError("replication capture evidence failed before commit")
+
+    monkeypatch.setattr(gate.repair.lifecycle.cmake_reference, "command_history_sha256", fail_before_commit)
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+    try:
+        with asyncio.Runner() as async_runner:
+            with pytest.raises(RuntimeError, match="before commit"):
+                gate.execute_zero_provider_pair(
+                    manifest,
+                    pair,
+                    output_dir,
+                    async_runner,
+                    {"branch": "main", "revision": "e" * 40, "origin_main": "e" * 40},
+                    model_factory=lambda *_args: pytest.fail("capture failure 不得调用 fake model"),
+                    repo_root=REPO_ROOT,
+                )
+        assert sessions
+        gate.repair.v1.require_zero_managed_containers()
+        assert gate.require_empty_formal_evidence(manifest) == []
+    finally:
+        _cleanup(runtime, sessions, output_dir)
+
+
+def test_make_pair_reaches_checkpoint_p2_replay_finalize_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = gate.load_candidate(REPO_ROOT)
+    _preflight(manifest)
+    paths, runtime, sessions = _services(monkeypatch)
+    output_dir = paths.compile_sessions_dir / f"issue-245-replication-make-success-{uuid.uuid4().hex[:12]}"
+    pair = next(item for item in manifest["schedule"]["pairs"] if item["case_id"] == "sql-parser-shared" and item["replicate"] == 1)
+    monkeypatch.setenv("FORGE_NETWORK_ACCESS_MEDIUM", "wifi")
+
+    def model_factory(provider: dict[str, Any], thread_id: str) -> Any:
+        assert provider["endpoint"] == gate.ZERO_PROVIDER_ENDPOINT
+        assert provider["credential_env"] == gate.ZERO_PROVIDER_CREDENTIAL_ENV
+        arm = "treatment" if thread_id.startswith("treatment-") else "baseline"
+        return MakeRepairModel(arm=arm)
+
+    try:
+        with asyncio.Runner() as async_runner:
+            result = gate.execute_zero_provider_pair(
+                manifest,
+                pair,
+                output_dir,
+                async_runner,
+                {"branch": "main", "revision": "e" * 40, "origin_main": "e" * 40},
+                model_factory=model_factory,
+                repo_root=REPO_ROOT,
+            )
+        assert result["primary_mechanism_eligible"] is True
+        assert result["provenance_conversion"] == {"baseline": False, "treatment": True}, json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True)
+        assert result["paired_conversion_delta"] == 1
+        assert result["recorded_tokens"] == 0
+        assert result["arms"]["treatment"]["verification_outcome"]["status"] == "passed"
+        assert result["arms"]["treatment"]["p2"]["status"] == "proven"
+        assert result["cleanup_succeeded"] is True
+        gate.repair.v1.require_zero_managed_containers()
+        assert gate.require_empty_formal_evidence(manifest) == []
+    finally:
+        _cleanup(runtime, sessions, output_dir)

--- a/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-replication-lifecycle-zero-provider-gate.md
+++ b/benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-replication-lifecycle-zero-provider-gate.md
@@ -1,0 +1,29 @@
+# Opaque provenance independent replication lifecycle 零 provider 门禁
+
+- GitHub Issue：[Issue #245](https://github.com/WWFXL/Forge-AutoCompiler/issues/245)
+- 状态：opt-in、零 provider、非正式实验
+- 父候选：Issue #243 independent replication candidate
+- Docker：仅允许 Ubuntu WSL2 原生 `docker.service`
+
+## 目的
+
+在任何 authorized amendment、reachability 或 12-pair batch 前，验证新 replication identity 能通过 Issue #241 的版本化 repair adapter 到达真实 Compile Session 生命周期。门禁只回答运行机制是否闭合，不估计模型效应，也不把 confirmatory v1 的三个 outcome 导入新 estimand。
+
+## 冻结检查
+
+- Candidate canonical SHA-256 固定为 `7b1817becba4ec57eb9726be0e1faaa5427af309dca7552634e3f6a3a1b5d938`。
+- Evidence identity 固定为 `b136cc5669384176853f00b878dae207d89b7bce593cc8e5f1ff9ab06505b9bc`，schedule identity 固定为 `3f35dd8c245cb7e9db6069f63cf133c98fbfdf6813a11e3fa2306a5eb34c2134`。
+- Repair adapter byte SHA-256 固定为 `c8a13388f6c53d308b34f013bf4a9f449190a10e779667cdf73b0e8ef1da2544`。
+- 新正式 evidence 目录在门禁前后都必须为空；门禁只写 pytest 临时目录。
+- 6 case、12 pair、CMake/Make 分派、arm order 和 P2 criterion 不得变化。
+
+## 最薄真实生命周期
+
+1. CMake case 在 parent capture、coordinator commit 之前注入确定性异常，必须精确删除本 pair 新建的 Compile Session，且不得扫描或删除其他任务资源。
+2. Make case 使用显式 deterministic fake model 执行一个完整 pair：parent checkpoint、baseline/treatment、treatment direct Make P2 conversion、production candidate verification、唯一 clean replay、finalize 与 cleanup。
+3. 两条路径前后都要求 0 个 `deerflow-compile-*` / `deerflow-replay-*` managed orphan。
+4. Fake model 的 endpoint 固定为 `https://example.invalid/v1`、credential env 固定为不存在的占位名；调用方不显式提供 fake model factory 时 fail closed。
+
+## 授权与停止规则
+
+本门禁固定 0 provider、0 credential read、0 formal attempt、0 model token 与 0 正式 evidence write。它不创建 authorized amendment，不执行 reachability，不运行正式 pair，不读取任何 AK，也不修改 production Compiler 或冻结的 v1/replication candidate。若门禁必须放宽 verifier、复用 v1 outcome 或写入正式 evidence 才能通过，则立即停止并重新评审。

--- a/scripts/forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py
+++ b/scripts/forge_opaque_provenance_confirmatory_replication_lifecycle_gate.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Issue #245 independent replication 的零 provider lifecycle 门禁。"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import forge_opaque_provenance_confirmatory_execution_repair_adapter as repair  # noqa: E402
+import forge_opaque_provenance_confirmatory_replication_candidate_protocol as candidate  # noqa: E402
+
+ISSUE_URL = "https://github.com/WWFXL/Forge-AutoCompiler/issues/245"
+PREREGISTRATION_PATH = "benchmarks/preregistrations/cpp-opaque-provenance-confirmatory-replication-lifecycle-zero-provider-gate.md"
+CANDIDATE_MANIFEST_PATH = (
+    "benchmarks/manifests/cpp-opaque-provenance-confirmatory-replication-candidate.json"
+)
+CANDIDATE_MANIFEST_CANONICAL_SHA256 = (
+    "7b1817becba4ec57eb9726be0e1faaa5427af309dca7552634e3f6a3a1b5d938"
+)
+CANDIDATE_MANIFEST_FILE_SHA256 = (
+    "b6eb90bfc5242dec1881627101de3c0c4589c5863700293d92bec80bea2de324"
+)
+REPAIR_ADAPTER_SHA256 = (
+    "c8a13388f6c53d308b34f013bf4a9f449190a10e779667cdf73b0e8ef1da2544"
+)
+ZERO_PROVIDER_ENDPOINT = "https://example.invalid/v1"
+ZERO_PROVIDER_CREDENTIAL_ENV = "UNUSED_ZERO_PROVIDER_CREDENTIAL"
+ZERO_PROVIDER_MODEL = "deterministic-zero-provider"
+
+
+class ReplicationLifecycleGateError(RuntimeError):
+    """Replication identity、零 provider 边界或 lifecycle 接线无效。"""
+
+
+def load_candidate(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    path = repo_root / CANDIDATE_MANIFEST_PATH
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReplicationLifecycleGateError(
+            "无法读取 replication candidate manifest"
+        ) from exc
+    try:
+        return candidate.validate_manifest(value, repo_root)
+    except candidate.ReplicationCandidateError as exc:
+        raise ReplicationLifecycleGateError(str(exc)) from exc
+
+
+def _formal_evidence_directory(manifest: dict[str, Any]) -> Path:
+    return Path(manifest["replication_candidate"]["evidence_candidate"]["directory"])
+
+
+def evidence_files(directory: Path) -> list[str]:
+    if not directory.exists():
+        return []
+    return sorted(
+        str(path.relative_to(directory)).replace("\\", "/")
+        for path in directory.rglob("*")
+        if path.is_file()
+    )
+
+
+def require_empty_formal_evidence(
+    manifest: dict[str, Any],
+    *,
+    directory: Path | None = None,
+) -> list[str]:
+    target = directory or _formal_evidence_directory(manifest)
+    entries = evidence_files(target)
+    if entries:
+        raise ReplicationLifecycleGateError(
+            "independent replication 正式 evidence 目录不是空目录"
+        )
+    return entries
+
+
+def build_zero_provider_runtime_manifest(
+    manifest: dict[str, Any],
+    output_dir: Path,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """构造只供 fake-model 门禁使用、不会持久化的 v1-shaped runtime。"""
+
+    validated = candidate.validate_manifest(manifest, repo_root)
+    formal = _formal_evidence_directory(validated).resolve(strict=False)
+    output = output_dir.resolve(strict=False)
+    if output == formal or output.is_relative_to(formal):
+        raise ReplicationLifecycleGateError(
+            "零 provider 门禁不得写入正式 replication evidence 目录"
+        )
+    parent, _parent_protocol = candidate._parent_manifest(repo_root)
+    runtime = copy.deepcopy(parent)
+    execution = runtime["authorized_execution"]
+    execution["provider"].update(
+        {
+            "status": "deterministic_zero_provider_gate",
+            "model": ZERO_PROVIDER_MODEL,
+            "endpoint": ZERO_PROVIDER_ENDPOINT,
+            "credential_env": ZERO_PROVIDER_CREDENTIAL_ENV,
+            "request_timeout_seconds": 1,
+            "max_retries": 0,
+        }
+    )
+    execution["evidence"]["directory"] = str(output_dir)
+    execution["evidence"]["identity_sha256"] = validated["replication_candidate"][
+        "evidence_candidate"
+    ]["identity_sha256"]
+    runtime["authorization"] = copy.deepcopy(validated["authorization"])
+    runtime["gate_context"] = {
+        "issue_url": ISSUE_URL,
+        "candidate_manifest_sha256": candidate.canonical_sha256(validated),
+        "provider_calls_authorized": False,
+        "credential_read_authorized": False,
+        "model_tokens_authorized": 0,
+        "formal_evidence_writes_authorized": False,
+    }
+    return runtime
+
+
+def execute_zero_provider_pair(
+    manifest: dict[str, Any],
+    pair: dict[str, Any],
+    pair_dir: Path,
+    async_runner: Any,
+    release: dict[str, str],
+    *,
+    model_factory: Callable[[dict[str, Any], str], Any] | None,
+    formal_evidence_directory: Path | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    if model_factory is None:
+        raise ReplicationLifecycleGateError(
+            "零 provider 门禁要求显式 deterministic model factory"
+        )
+    validated = load_candidate(repo_root)
+    if manifest != validated:
+        raise ReplicationLifecycleGateError("执行输入不是冻结的 replication candidate")
+    require_empty_formal_evidence(validated, directory=formal_evidence_directory)
+    runtime = build_zero_provider_runtime_manifest(
+        validated, pair_dir, repo_root=repo_root
+    )
+    result = repair.execute_real_pair(
+        runtime,
+        pair,
+        pair_dir,
+        async_runner,
+        {"recorded_tokens": 0},
+        release,
+        model_factory=model_factory,
+    )
+    require_empty_formal_evidence(validated, directory=formal_evidence_directory)
+    return result
+
+
+def validate_gate_contract(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest = load_candidate(repo_root)
+    candidate.verify_frozen_components(manifest, repo_root)
+    if candidate.canonical_sha256(manifest) != CANDIDATE_MANIFEST_CANONICAL_SHA256:
+        raise ReplicationLifecycleGateError(
+            "replication candidate canonical identity 发生漂移"
+        )
+    if (
+        candidate.file_sha256(repo_root / CANDIDATE_MANIFEST_PATH)
+        != CANDIDATE_MANIFEST_FILE_SHA256
+    ):
+        raise ReplicationLifecycleGateError(
+            "replication candidate 文件 identity 发生漂移"
+        )
+    runtime = manifest["replication_candidate"]["runtime_candidate"]
+    if runtime["runtime_file_sha256"] != REPAIR_ADAPTER_SHA256:
+        raise ReplicationLifecycleGateError("repair adapter identity 发生漂移")
+    if (
+        candidate.file_sha256(repo_root / runtime["pair_executor_adapter"])
+        != REPAIR_ADAPTER_SHA256
+    ):
+        raise ReplicationLifecycleGateError("repair adapter 文件发生漂移")
+    preregistration = repo_root / PREREGISTRATION_PATH
+    if not preregistration.is_file():
+        raise ReplicationLifecycleGateError("replication lifecycle 预注册不存在")
+    authorization = manifest["authorization"]
+    if any(
+        value for key, value in authorization.items() if key.endswith("_authorized")
+    ):
+        raise ReplicationLifecycleGateError("replication candidate 意外授权外部执行")
+    if authorization["model_tokens_authorized"] != 0:
+        raise ReplicationLifecycleGateError(
+            "replication candidate 意外授权 model token"
+        )
+    if manifest["replication_candidate"]["relationship_to_v1"][
+        "historical_outcomes_imported"
+    ]:
+        raise ReplicationLifecycleGateError("replication candidate 意外导入 v1 outcome")
+    parent, _parent_protocol = candidate._parent_manifest(repo_root)
+    repair_contract = repair.validate_contract(parent, repo_root=repo_root)
+    ephemeral = build_zero_provider_runtime_manifest(
+        manifest, Path("/tmp/forge-issue-245-zero-provider"), repo_root=repo_root
+    )
+    build_systems = {
+        repair.lifecycle.build_case_adapter(pair["case_id"], repo_root).build_system
+        for pair in ephemeral["schedule"]["pairs"]
+    }
+    if build_systems != {"cmake", "make"}:
+        raise ReplicationLifecycleGateError("零 provider runtime 未覆盖 CMake 与 Make")
+    return {
+        "schema_version": "forge-opaque-provenance-confirmatory-replication-lifecycle-gate-1.0.0",
+        "issue_url": ISSUE_URL,
+        "status": "passed",
+        "candidate_manifest_sha256": CANDIDATE_MANIFEST_CANONICAL_SHA256,
+        "candidate_manifest_file_sha256": CANDIDATE_MANIFEST_FILE_SHA256,
+        "evidence_identity_sha256": manifest["replication_candidate"][
+            "evidence_candidate"
+        ]["identity_sha256"],
+        "schedule_identity_sha256": manifest["schedule"]["identity_sha256"],
+        "case_count": repair_contract["case_count"],
+        "pair_count": repair_contract["pair_count"],
+        "build_systems": sorted(build_systems),
+        "capture_before_commit_cleanup_required": runtime[
+            "capture_before_commit_cleanup_required"
+        ],
+        "broad_docker_cleanup_forbidden": runtime["broad_docker_cleanup_forbidden"],
+        "historical_outcomes_imported": False,
+        "provider_calls": 0,
+        "credential_read": False,
+        "formal_attempts": 0,
+        "model_tokens": 0,
+        "formal_evidence_writes": 0,
+        "docker_executed": False,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate",))
+    parser.parse_args(argv)
+    try:
+        result = validate_gate_contract()
+    except (
+        OSError,
+        ReplicationLifecycleGateError,
+        candidate.ReplicationCandidateError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更

- 新增 independent replication 的零 provider lifecycle gate，冻结 candidate/evidence/schedule/repair adapter identity。
- 构造仅供门禁使用的临时 v1-shaped runtime，强制 `example.invalid`、不存在的 credential 占位名和显式 deterministic fake model factory。
- 禁止临时输出写入正式 replication evidence 目录及其任意子目录。
- 增加 CMake capture-before-commit 精确清理门禁，以及 Make checkpoint/P2/candidate/clean replay/finalize/cleanup 完整门禁。
- 增加预注册说明并更新项目状态快照。

## 验证

- 静态协议命令：通过
- 静态及相邻回归：27 passed
- Ubuntu-native Docker 组合门禁：2 passed in 131.88s
- Ruff check/format、py_compile、git diff --check：通过
- 门禁前后 0 compile/replay orphan
- 正式 replication evidence 保持为空
- 0 provider、0 credential read、0 formal attempt、0 model token、0 正式 evidence write

Closes #245